### PR TITLE
add log4jextra compile dependency

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile project(":gobblin-rest-service:gobblin-rest-api")
   compile project(":gobblin-rest-service:gobblin-rest-client")
   compile project(":gobblin-rest-service:gobblin-rest-server")
+  compile externalDependency.log4jextras
 }
 
 task build(type: Tar, overwrite: true) {

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   compile project(":gobblin-rest-service:gobblin-rest-api")
   compile project(":gobblin-rest-service:gobblin-rest-client")
   compile project(":gobblin-rest-service:gobblin-rest-server")
-  compile externalDependency.log4jextras
+  runtime externalDependency.log4jextras
 }
 
 task build(type: Tar, overwrite: true) {


### PR DESCRIPTION
This is to fix the missing apache-log4j-extras.jar. Without that getting started doesn't work. 