### PR TITLE
add log4jextras runtime dependency

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -24,6 +24,7 @@ dependencies {
   compile project(":gobblin-rest-service:gobblin-rest-api")
   compile project(":gobblin-rest-service:gobblin-rest-client")
   compile project(":gobblin-rest-service:gobblin-rest-server")
+  compile externalDependency.log4jextras
 }
 
 task build(type: Tar, overwrite: true) {

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -24,7 +24,7 @@ dependencies {
   compile project(":gobblin-rest-service:gobblin-rest-api")
   compile project(":gobblin-rest-service:gobblin-rest-client")
   compile project(":gobblin-rest-service:gobblin-rest-server")
-  compile externalDependency.log4jextras
+  runtime externalDependency.log4jextras
 }
 
 task build(type: Tar, overwrite: true) {


### PR DESCRIPTION
Change log4jextras to runtime as log4j internally depends on additional features provided by the library. 
BTW, gradle runtime dependency extends compile dependency. That's why it was working before. 