### PR TITLE
Do not throw and IOException when a given state store already exists

### DIFF
--- a/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
@@ -79,11 +79,7 @@ public class FsStateStore implements StateStore {
   public boolean create(String storeName)
       throws IOException {
     Path storePath = new Path(this.storeRootDir, storeName);
-    if (this.fs.exists(storePath)) {
-      throw new IOException(String.format("Store directory %s already exists for store %s", storePath, storeName));
-    }
-
-    return this.fs.mkdirs(storePath);
+    return this.fs.exists(storePath) || this.fs.mkdirs(storePath);
   }
 
   @Override


### PR DESCRIPTION
Currently FsStateStore throws an IOException if a given state store already exists while treating to create the store directory. The right behavior should be to do an no-op and return if the store directory already exists. This commit fixes it.

Signed-off-by: Yinan Li <liyinan926@gmail.com>