### PR TITLE
Make each forked branch have its own built-in task-level metrics

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/JobMetrics.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/JobMetrics.java
@@ -388,11 +388,11 @@ public class JobMetrics implements MetricSet {
   }
 
   /**
-   * Get metrics of the given type in the given group with the given ID (either a job ID or a task ID).
+   * Get metrics of a given type in a given group that contain a given ID in the metric names.
    *
    * @param type metric type
    * @param group metric group
-   * @param id metric ID (either a job ID or a task ID)
+   * @param id metric ID
    * @return a {@link java.util.Map} with keys being metric names and values being the
    *         {@link com.codahale.metrics.Metric}s
    */

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -107,7 +107,7 @@ public class Fork implements Closeable {
    * Update record-level metrics.
    */
   public void updateRecordMetrics() {
-    this.taskState.updateRecordMetrics(this.writer.recordsWritten());
+    this.taskState.updateRecordMetrics(this.writer.recordsWritten(), this.index);
   }
 
   /**
@@ -119,7 +119,7 @@ public class Fork implements Closeable {
    */
   public void updateByteMetrics()
       throws IOException {
-    this.taskState.updateByteMetrics(this.writer.bytesWritten());
+    this.taskState.updateByteMetrics(this.writer.bytesWritten(), this.index);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -144,7 +144,8 @@ public class TaskExecutor extends AbstractIdleService {
   public void retry(Task task) {
     if (JobMetrics.isEnabled(task.getTaskState().getWorkunit())) {
       // Adjust metrics to clean up numbers from the failed task
-      task.getTaskState().adjustJobMetricsOnRetry();
+      task.getTaskState()
+          .adjustJobMetricsOnRetry(task.getTaskState().getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY));
       // Remove task-level metrics associated with this task so
       // the retry will use fresh metrics
       task.getTaskState().removeMetrics();

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -41,6 +41,7 @@ public class LocalJobLauncherTest extends JobLauncherTestBase {
     this.properties = new Properties();
     this.properties.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
     this.properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
+    this.properties.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
     this.properties
         .setProperty(ConfigurationKeys.JOB_HISTORY_STORE_JDBC_DRIVER_KEY, "org.apache.derby.jdbc.EmbeddedDriver");
     this.properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY, "jdbc:derby:memory:gobblin1;create=true");

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -41,6 +41,7 @@ public class MRJobLauncherTest extends JobLauncherTestBase {
     this.properties = new Properties();
     this.properties.load(new FileReader("gobblin-test/resource/gobblin.mr-test.properties"));
     this.properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
+    this.properties.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
     this.properties
         .setProperty(ConfigurationKeys.JOB_HISTORY_STORE_JDBC_DRIVER_KEY, "org.apache.derby.jdbc.EmbeddedDriver");
     this.properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY, "jdbc:derby:memory:gobblin2;create=true");

--- a/gobblin-utility/src/main/java/gobblin/util/ForkOperatorUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ForkOperatorUtils.java
@@ -74,4 +74,15 @@ public class ForkOperatorUtils {
     Preconditions.checkArgument(branches >= 0, "branches is expected to be non-negative");
     return branches > 1 ? path + "/" + branchName : path;
   }
+
+  /**
+   * Get the fork branch ID of a branch of a given task.
+   *
+   * @param taskId task ID
+   * @param index  branch index
+   * @return a fork branch ID
+   */
+  public static String getForkId(String taskId, int index) {
+    return taskId + "." + index;
+  }
 }


### PR DESCRIPTION
Currently, built-in task-level metrics are shared among the forked branches of each task. This is causing metric mismatch issues. This commit fixes the issues by making each forked branch of a task have its own copies of built-in task-level metrics that have the branch index in the metric name.

Signed-off-by: Yinan Li <liyinan926@gmail.com>