### PR TITLE
Moving log4j-extras dependency to scheduler

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -24,7 +24,6 @@ dependencies {
   compile project(":gobblin-rest-service:gobblin-rest-api")
   compile project(":gobblin-rest-service:gobblin-rest-client")
   compile project(":gobblin-rest-service:gobblin-rest-server")
-  runtime externalDependency.log4jextras
 }
 
 task build(type: Tar, overwrite: true) {

--- a/gobblin-scheduler/build.gradle
+++ b/gobblin-scheduler/build.gradle
@@ -27,6 +27,8 @@ dependencies {
   compile externalDependency.metricsCore
   compile externalDependency.metricsJvm
 
+  runtime externalDependency.log4jextras
+
   testCompile externalDependency.testng
 }
 


### PR DESCRIPTION
Repos dependent on gobblin and the gobblin stand alone scripts are failing because log4jextras is needed as a runtime dependency, but is only expressed as a runtime dependency in gobblin-distribution, which most downstream repos are not dependent on. I add the dependency to scheduler, which is where is belongs.