### PR TITLE
Removed a duplicate call to TaskStateTracker.registerNewTask()

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -88,7 +88,6 @@ public class Task implements Runnable {
   public void run() {
     long startTime = System.currentTimeMillis();
     this.taskState.setStartTime(startTime);
-    this.taskStateTracker.registerNewTask(this);
     this.taskState.setWorkingState(WorkUnitState.WorkingState.RUNNING);
 
     // Clear the list so it starts with a fresh list of forks for each run/retry


### PR DESCRIPTION
The method is called in AbstractJobLauncher when each new task gets created. Removed this duplicate call in Task.java.

Signed-off-by: Yinan Li <liyinan926@gmail.com>