### PR TITLE
Make reporting task-level counters as Hadoop counters optional

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -308,6 +308,8 @@ public class ConfigurationKeys {
    */
   public static final String MR_JOB_ROOT_DIR_KEY = "mr.job.root.dir";
   public static final String MR_JOB_MAX_MAPPERS_KEY = "mr.job.max.mappers";
+  public static final String MR_INCLUDE_TASK_COUNTERS_KEY = "mr.include.task.counters";
+  public static final boolean DEFAULT_MR_INCLUDE_TASK_COUNTERS = Boolean.FALSE;
 
   /**
    * Configuration properties for email settings.


### PR DESCRIPTION
Since Hadoop imposes a system-level limit (default to 120) on the number of counters, a Gobblin MR job may easily go beyond that limit if the job has a large number of tasks and each task has a few counters. This commit makes it optional to report task-level counters as Hadoop counters. 

Signed-off-by: Yinan Li <liyinan926@gmail.com>