### PR TITLE
Adding support for cleaning up staging data when Gobblin is cancelled via the Azkaban UI

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
@@ -1,0 +1,151 @@
+package gobblin.runtime.mapreduce;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.ForkOperatorUtils;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.io.Closer;
+
+/**
+ * Hadoop {@link org.apache.hadoop.mapreduce.OutputFormat} implementation with a custom {@link OutputCommitter}
+ */
+public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWritable> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(GobblinOutputFormat.class);
+
+  @Override
+  public OutputCommitter getOutputCommitter(TaskAttemptContext context) {
+    return new GobblinOutputCommitter();
+  }
+
+  /**
+   * Hadoop {@link OutputCommitter} implementation that overrides the default
+   * {@link #abortJob(JobContext, org.apache.hadoop.mapreduce.JobStatus.State)} behavior. This is necessary to add
+   * functionality for cleaning up staging data when the
+   * {@link com.linkedin.uif.runtime.JobLauncher#cancelJob(Properties)} method is called via Azkaban. Azkaban only
+   * allows the cancel method run to for 5 ms until it does a hard kill on the process, so instead, we will clean up the
+   * staging data in the AM.
+   */
+  private class GobblinOutputCommitter extends OutputCommitter {
+
+    @Override
+    public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException {
+      LOG.info("Aborting Job: " + jobContext.getJobID());
+
+      Configuration conf = jobContext.getConfiguration();
+
+      URI fsUri = URI.create(conf.get(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
+      FileSystem fs = FileSystem.get(fsUri, conf);
+
+      Path mrJobDir =
+          new Path(conf.get(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY), conf.get(ConfigurationKeys.JOB_NAME_KEY));
+      Path jobInputDir = new Path(mrJobDir, "input");
+
+      for (FileStatus status : fs.listStatus(jobInputDir)) {
+
+        Closer workUnitFileCloser = Closer.create();
+        if (status.getPath().getName().endsWith(".wu")) {
+
+          WorkUnit wu = new WorkUnit();
+          wu.readFields(workUnitFileCloser.register(new DataInputStream(fs.open(status.getPath()))));
+          workUnitFileCloser.close();
+
+          LOG.info("Cleaning up staging data for WorkUnit: " + wu.getId());
+          int numBranches = wu.getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY, 1);
+          for (int i = 0; i < numBranches; i++) {
+
+            String branchName = ForkOperatorUtils.getBranchName(wu, i, ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + i);
+
+            Path writerFilePath =
+                new Path(ForkOperatorUtils.getPathForBranch(wu.getExtract().getOutputFilePath(), branchName,
+                    numBranches));
+
+            String uri =
+                wu.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, i),
+                    ConfigurationKeys.LOCAL_FS_URI);
+
+            FileSystem wufs = FileSystem.get(URI.create(uri), new Configuration());
+
+            if (wu.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR,
+                numBranches, i))) {
+              Path stagingDir =
+                  new Path(wu.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR,
+                      i)), writerFilePath);
+
+              LOG.info("Deleting staging dir:   " + stagingDir);
+              if (wufs.exists(stagingDir)) {
+                wufs.delete(stagingDir, true);
+              }
+            }
+
+            if (wu.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR,
+                numBranches, i))) {
+              Path outputDir =
+                  new Path(wu.getProp(ForkOperatorUtils
+                      .getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, i)), writerFilePath);
+
+              LOG.info("Deleting output dir:    " + outputDir);
+              if (wufs.exists(outputDir)) {
+                wufs.delete(outputDir, true);
+              }
+            }
+          }
+        }
+        // TODO add support for MultiWorkUnits
+      }
+      fs.delete(mrJobDir, true);
+    }
+
+    @Override
+    public void abortTask(TaskAttemptContext arg0) throws IOException { }
+
+    @Override
+    public void commitTask(TaskAttemptContext arg0) throws IOException { }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext arg0) throws IOException {
+      return false;
+    }
+
+    @Override
+    public void setupJob(JobContext arg0) throws IOException { }
+
+    @Override
+    public void setupTask(TaskAttemptContext arg0) throws IOException { }
+
+    /**
+     * Replicates the default behavior of the {@link OutputCommitter} used by {@link NullOutputFormat}. The method is
+     * part of {@link OutputCommitter} class in Hadoop 2.x, but not 1.x
+     * @return true
+     */
+    @SuppressWarnings("unused")
+    public boolean isRecoverySupported() {
+      return true;
+    }
+
+    /**
+     * Replicates the default behavior of the {@link OutputCommitter} used by {@link NullOutputFormat}. The method is
+     * part of {@link OutputCommitter} class in Hadoop 2.x, but not 1.x
+     */
+    @SuppressWarnings("unused")
+    public void recoverTask(TaskAttemptContext taskContext) throws IOException { }
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
@@ -74,7 +74,7 @@ public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWrit
       Path jobInputDir = new Path(mrJobDir, "input");
 
       if (!fs.exists(jobInputDir) || !fs.getFileStatus(jobInputDir).isDir()) {
-        LOG.warn("Folder " + jobInputDir + " containg serialized WorkUnits doesn't exist. No data will cleaned up.");
+        LOG.warn("Folder " + jobInputDir + " containing serialized WorkUnits doesn't exist. No data will cleaned up.");
         return;
       }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
@@ -74,6 +74,7 @@ public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWrit
       Path jobInputDir = new Path(mrJobDir, "input");
 
       if (!fs.exists(jobInputDir) || !fs.getFileStatus(jobInputDir).isDir()) {
+        LOG.warn("Folder " + jobInputDir + " containg serialized WorkUnits doesn't exist. No data will cleaned up.");
         return;
       }
 
@@ -152,7 +153,7 @@ public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWrit
     private class WorkUnitFilter implements PathFilter {
       @Override
       public boolean accept(Path path) {
-        return path.getName().endsWith(".wu") || path.toString().endsWith(".mwu");
+        return path.getName().endsWith(".wu") || path.getName().endsWith(".mwu");
       }
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputFormat.java
@@ -1,9 +1,5 @@
 package gobblin.runtime.mapreduce;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.source.workunit.WorkUnit;
-import gobblin.util.ForkOperatorUtils;
-
 import java.io.DataInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -12,6 +8,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.JobStatus;
@@ -23,6 +20,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.source.workunit.MultiWorkUnit;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.JobLauncherUtils;
+
 
 /**
  * Hadoop {@link org.apache.hadoop.mapreduce.OutputFormat} implementation with a custom {@link OutputCommitter}
@@ -41,14 +44,14 @@ public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWrit
    * {@link #abortJob(JobContext, org.apache.hadoop.mapreduce.JobStatus.State)} behavior. This is necessary to add
    * functionality for cleaning up staging data when the
    * {@link com.linkedin.uif.runtime.JobLauncher#cancelJob(Properties)} method is called via Azkaban. Azkaban only
-   * allows the cancel method run to for 5 ms until it does a hard kill on the process, so instead, we will clean up the
-   * staging data in the AM.
+   * allows the cancel method run to for 5 ms until it does a hard kill on the process. In order to make sure the
+   * staging data still gets cleaned-up, the cleanup will take place in the AM.
    */
-  private class GobblinOutputCommitter extends OutputCommitter {
+  public class GobblinOutputCommitter extends OutputCommitter {
 
     @Override
     public void abortJob(JobContext jobContext, JobStatus.State state) throws IOException {
-      LOG.info("Aborting Job: " + jobContext.getJobID());
+      LOG.info("Aborting Job: " + jobContext.getJobID() + " with state: " + state);
 
       Configuration conf = jobContext.getConfiguration();
 
@@ -58,67 +61,38 @@ public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWrit
       Path mrJobDir =
           new Path(conf.get(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY), conf.get(ConfigurationKeys.JOB_NAME_KEY));
       Path jobInputDir = new Path(mrJobDir, "input");
-
-      for (FileStatus status : fs.listStatus(jobInputDir)) {
+      System.out.println("Checking: " + jobInputDir);
+      // Iterate through all files in the jobInputDir, each file should correspond to a serialized wu or mwu
+      for (FileStatus status : fs.listStatus(jobInputDir, new WorkUnitFilter())) {
 
         Closer workUnitFileCloser = Closer.create();
         if (status.getPath().getName().endsWith(".wu")) {
-
           WorkUnit wu = new WorkUnit();
           wu.readFields(workUnitFileCloser.register(new DataInputStream(fs.open(status.getPath()))));
           workUnitFileCloser.close();
 
-          LOG.info("Cleaning up staging data for WorkUnit: " + wu.getId());
-          int numBranches = wu.getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY, 1);
-          for (int i = 0; i < numBranches; i++) {
+          JobLauncherUtils.cleanStagingData(wu, LOG);
+        }
+        if (status.getPath().getName().endsWith(".mwu")) {
+          MultiWorkUnit mwu = new MultiWorkUnit();
+          mwu.readFields(workUnitFileCloser.register(new DataInputStream(fs.open(status.getPath()))));
+          workUnitFileCloser.close();
 
-            String branchName = ForkOperatorUtils.getBranchName(wu, i, ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + i);
-
-            Path writerFilePath =
-                new Path(ForkOperatorUtils.getPathForBranch(wu.getExtract().getOutputFilePath(), branchName,
-                    numBranches));
-
-            String uri =
-                wu.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, i),
-                    ConfigurationKeys.LOCAL_FS_URI);
-
-            FileSystem wufs = FileSystem.get(URI.create(uri), new Configuration());
-
-            if (wu.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR,
-                numBranches, i))) {
-              Path stagingDir =
-                  new Path(wu.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR,
-                      i)), writerFilePath);
-
-              LOG.info("Deleting staging dir:   " + stagingDir);
-              if (wufs.exists(stagingDir)) {
-                wufs.delete(stagingDir, true);
-              }
-            }
-
-            if (wu.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR,
-                numBranches, i))) {
-              Path outputDir =
-                  new Path(wu.getProp(ForkOperatorUtils
-                      .getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, i)), writerFilePath);
-
-              LOG.info("Deleting output dir:    " + outputDir);
-              if (wufs.exists(outputDir)) {
-                wufs.delete(outputDir, true);
-              }
-            }
+          for (WorkUnit wu : mwu.getWorkUnits()) {
+            JobLauncherUtils.cleanStagingData(wu, LOG);
           }
         }
-        // TODO add support for MultiWorkUnits
       }
       fs.delete(mrJobDir, true);
     }
 
     @Override
-    public void abortTask(TaskAttemptContext arg0) throws IOException { }
+    public void abortTask(TaskAttemptContext arg0) throws IOException {
+    }
 
     @Override
-    public void commitTask(TaskAttemptContext arg0) throws IOException { }
+    public void commitTask(TaskAttemptContext arg0) throws IOException {
+    }
 
     @Override
     public boolean needsTaskCommit(TaskAttemptContext arg0) throws IOException {
@@ -126,26 +100,32 @@ public class GobblinOutputFormat extends NullOutputFormat<NullWritable, NullWrit
     }
 
     @Override
-    public void setupJob(JobContext arg0) throws IOException { }
+    public void setupJob(JobContext arg0) throws IOException {
+    }
 
     @Override
-    public void setupTask(TaskAttemptContext arg0) throws IOException { }
+    public void setupTask(TaskAttemptContext arg0) throws IOException {
+    }
 
     /**
-     * Replicates the default behavior of the {@link OutputCommitter} used by {@link NullOutputFormat}. The method is
-     * part of {@link OutputCommitter} class in Hadoop 2.x, but not 1.x
+     * Replicates the default behavior of the {@link OutputCommitter} used by {@link NullOutputFormat}.
      * @return true
      */
-    @SuppressWarnings("unused")
     public boolean isRecoverySupported() {
       return true;
     }
 
     /**
-     * Replicates the default behavior of the {@link OutputCommitter} used by {@link NullOutputFormat}. The method is
-     * part of {@link OutputCommitter} class in Hadoop 2.x, but not 1.x
+     * Replicates the default behavior of the {@link OutputCommitter} used by {@link NullOutputFormat}.
      */
-    @SuppressWarnings("unused")
-    public void recoverTask(TaskAttemptContext taskContext) throws IOException { }
+    public void recoverTask(TaskAttemptContext taskContext) throws IOException {
+    }
+
+    private class WorkUnitFilter implements PathFilter {
+      @Override
+      public boolean accept(Path path) {
+        return path.toString().endsWith(".wu") || path.toString().endsWith(".mwu");
+      }
+    }
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -199,6 +199,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
     // Job input path is where input work unit files are stored
     Path jobInputPath = new Path(mrJobDir, "input");
+
     // Prepare job input
     Path jobInputFile = prepareJobInput(jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY), jobInputPath, workUnits);
     NLineInputFormat.addInputPath(this.job, jobInputFile);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -43,7 +43,6 @@ import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.NLineInputFormat;
-import org.apache.hadoop.mapreduce.lib.output.NullOutputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -190,7 +189,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
     this.job.setNumReduceTasks(0);
 
     this.job.setInputFormatClass(NLineInputFormat.class);
-    this.job.setOutputFormatClass(NullOutputFormat.class);
+    this.job.setOutputFormatClass(GobblinOutputFormat.class);
     this.job.setMapOutputKeyClass(NullWritable.class);
     this.job.setMapOutputValueClass(NullWritable.class);
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputFormatTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputFormatTest.java
@@ -1,0 +1,134 @@
+package gobblin.runtime.mapreduce;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.OutputCommitter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.source.workunit.MultiWorkUnit;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.ForkOperatorUtils;
+
+
+/**
+ * Unit tests for {@link GobblinOutputFormat}
+ */
+@Test(groups = { "gobblin.runtime.mapreduce" })
+public class GobblinOutputFormatTest {
+
+  private Configuration conf;
+  private FileSystem fs;
+  private List<Path> stagingDirs;
+
+  private static final Path OUTPUT_PATH = new Path("gobblin-test/output-format-test");
+
+  private static final String STAGING_DIR_NAME = "staging";
+  private static final String OUTPUT_DIR_NAME = "output";
+  private static final String JOB_NAME = "GobblinOutputFormatTest";
+
+  @BeforeClass
+  public void setupWorkUnitFiles() throws IOException {
+    this.conf = new Configuration();
+    this.fs = FileSystem.getLocal(this.conf);
+    this.stagingDirs = Lists.newArrayList();
+
+    // Create a list of WorkUnits to serialize
+    WorkUnit wu1 = createAndSetWorkUnit("wu1");
+    WorkUnit wu2 = createAndSetWorkUnit("wu2");
+    WorkUnit wu3 = createAndSetWorkUnit("wu3");
+    WorkUnit wu4 = createAndSetWorkUnit("wu4");
+
+    // Create a MultiWorkUnit to serialize
+    MultiWorkUnit mwu1 = new MultiWorkUnit();
+    mwu1.setProp(ConfigurationKeys.TASK_ID_KEY, System.nanoTime());
+    mwu1.addWorkUnits(Arrays.asList(wu3, wu4));
+
+    Path inputDir = new Path(OUTPUT_PATH, "input");
+
+    // Writer each WorkUnit to a separate file under inputDir
+    Closer closer = Closer.create();
+    try {
+      wu1.write(closer.register(this.fs.create(new Path(inputDir, wu1.getProp(ConfigurationKeys.TASK_ID_KEY)
+          + Path.SEPARATOR + "_").suffix("wu"))));
+      wu2.write(closer.register(this.fs.create(new Path(inputDir, wu2.getProp(ConfigurationKeys.TASK_ID_KEY)
+          + Path.SEPARATOR + "_").suffix("wu"))));
+      mwu1.write(closer.register(this.fs.create(new Path(inputDir, mwu1.getProp(ConfigurationKeys.TASK_ID_KEY)
+          + Path.SEPARATOR + "_").suffix("mwu"))));
+    } finally {
+      closer.close();
+    }
+  }
+
+  @Test()
+  public void testAbortJob() throws IOException {
+    // Make sure all the staging dirs have been created
+    for (Path stagingDir : this.stagingDirs) {
+      Assert.assertTrue(this.fs.exists(stagingDir));
+    }
+
+    // Cleanup the staging dirs
+    Configuration conf = new Configuration();
+    conf.set(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI);
+    conf.set(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY, OUTPUT_PATH.toString());
+    conf.set(ConfigurationKeys.JOB_NAME_KEY, JOB_NAME);
+
+    TaskAttemptID taskAttemptId = new TaskAttemptID();
+    TaskAttemptContext context = new TaskAttemptContext(conf, taskAttemptId);
+    OutputCommitter ouputCommitter = new GobblinOutputFormat().getOutputCommitter(context);
+    ouputCommitter.abortJob(Job.getInstance(conf), JobStatus.State.RUNNING);
+
+    // Make sure all the staging dirs have been deleted
+    for (Path stagingDir : this.stagingDirs) {
+      Assert.assertTrue(!this.fs.exists(stagingDir));
+    }
+  }
+
+  /**
+   * Helper method to create a {@link WorkUnit}, set it's staging directories, and create the staging directories on the
+   * local fs
+   * @param workUnitName is the name of the {@link WorkUnit} to create
+   * @return the {@link WorkUnit} that was created
+   * @throws IOException
+   */
+  private WorkUnit createAndSetWorkUnit(String workUnitName) throws IOException {
+    WorkUnit wu = new WorkUnit();
+    wu.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.TASK_ID_KEY, 1, 0), System.nanoTime());
+
+    Path wuStagingDir =
+        new Path(OUTPUT_PATH, JOB_NAME + Path.SEPARATOR + workUnitName + Path.SEPARATOR + STAGING_DIR_NAME);
+    wu.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR, 1, 0),
+        wuStagingDir.toString());
+    this.fs.mkdirs(wuStagingDir);
+    this.stagingDirs.add(wuStagingDir);
+
+    Path wuOutputDir =
+        new Path(OUTPUT_PATH, JOB_NAME + Path.SEPARATOR + workUnitName + Path.SEPARATOR + OUTPUT_DIR_NAME);
+    wu.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, 1, 0),
+        wuOutputDir.toString());
+    this.fs.mkdirs(wuOutputDir);
+    this.stagingDirs.add(wuOutputDir);
+    return wu;
+  }
+
+  @AfterClass
+  public void deleteWorkUnitFiles() throws IOException {
+    this.fs.delete(OUTPUT_PATH, true);
+  }
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputFormatTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputFormatTest.java
@@ -1,3 +1,14 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.runtime.mapreduce;
 
 import java.io.IOException;

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputFormatTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputFormatTest.java
@@ -71,7 +71,7 @@ public class GobblinOutputFormatTest {
     mwu1.setProp(ConfigurationKeys.TASK_ID_KEY, System.nanoTime());
     mwu1.addWorkUnits(Arrays.asList(wu3, wu4));
 
-    Path inputDir = new Path(OUTPUT_PATH, "input");
+    Path inputDir = new Path(new Path(OUTPUT_PATH, JOB_NAME), "input");
 
     // Writer each WorkUnit to a separate file under inputDir
     Closer closer = Closer.create();


### PR DESCRIPTION
Here is the first version. I still need to do some cleanup, add some comments, and write a test. Making this pull request to see what everyone thinks of the approach.

Azkaban only lets the cancel method run for 5 ms, before doing a hard kill on the process. This isn't enough time to cleanup staging data, but should be enough time to kill the Hadoop job (at least based on historical behavior). The OutputCommitter allows the user to hook into the lifecycle of the task and the jobs, so when killJob is called by the client, the AM will call OutputCommitter.abortJob() method. I have over--ridden this method, and added logic to clean up the staging data. Since the AM is in a different process than the client (running on Azkaban), the code de-serializes the WorkUnit files written to HDFS in order to obtain the writer output folder locations. Once it constructs the writer output paths, it deletes them.

@liyinan926 what do you think of this approach?