### PR TITLE
Calculation of low watermark should honor source.timezone

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -119,7 +119,8 @@ public class Partitioner {
       int deltaForNextWatermark) {
     long lowWatermark = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
     if (this.isFullDump() || this.isWatermarkOverride()) {
-      lowWatermark = Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE));
+      lowWatermark = Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE),
+          this.state.getProp(ConfigurationKeys.SOURCE_TIMEZONE));
       LOG.info("Overriding low water mark with the given start value: " + lowWatermark);
     } else {
       if (this.isSnapshot(extractType)) {
@@ -157,7 +158,7 @@ public class Partitioner {
     } else {
       // if previous watermark is not found, override with the start value(irrespective of source.is.watermark.override flag)
       long startValue =
-          Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE));
+          Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE), timeZone);
       LOG.info("Overriding low water mark with the given start value: " + startValue);
       return startValue;
     }
@@ -184,7 +185,7 @@ public class Partitioner {
       }
     } else {
       LOG.info("Overriding low water mark with start value: " + ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE);
-      return Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE));
+      return Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE), timeZone);
     }
   }
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -119,8 +119,9 @@ public class Partitioner {
       int deltaForNextWatermark) {
     long lowWatermark = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
     if (this.isFullDump() || this.isWatermarkOverride()) {
-      lowWatermark = Utils.getLongWithCurrentDate(this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE),
-          this.state.getProp(ConfigurationKeys.SOURCE_TIMEZONE));
+      String timeZone = this.state.getProp(ConfigurationKeys.SOURCE_TIMEZONE, ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE);
+      lowWatermark = Utils.getLongWithCurrentDate(
+          this.state.getProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE), timeZone);
       LOG.info("Overriding low water mark with the given start value: " + lowWatermark);
     } else {
       if (this.isSnapshot(extractType)) {
@@ -142,7 +143,7 @@ public class Partitioner {
    */
   private long getSnapshotLowWatermark(WatermarkType watermarkType, long previousWatermark, int deltaForNextWatermark) {
     LOG.debug("Getting snapshot low water mark");
-    String timeZone = this.state.getProp(ConfigurationKeys.SOURCE_TIMEZONE);
+    String timeZone = this.state.getProp(ConfigurationKeys.SOURCE_TIMEZONE, ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE);
     if (this.isPreviousWatermarkExists(previousWatermark)) {
       if (this.isSimpleWatermark(watermarkType)) {
         return previousWatermark + deltaForNextWatermark

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -44,8 +44,7 @@ public class Utils {
   private static final String CURRENT_DAY = "CURRENTDAY";
   private static final String CURRENT_HOUR = "CURRENTHOUR";
 
-  private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern("yyyyMMddHHmmss").withZone(
-      DateTimeZone.forID(ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE));
+  private static final String CURRENT_DATE_FORMAT = "yyyyMMddHHmmss"; 
 
   public static String getClause(String clause, String datePredicate) {
     String retStr = "";
@@ -227,21 +226,23 @@ public class Utils {
   /**
    * Helper method for getting a value containing CURRENTDAY-1 or CURRENTHOUR-1 in the form yyyyMMddHHmmss
    * @param value
+   * @param timezone
    * @return
    */
-  public static long getLongWithCurrentDate(String value) {
+  public static long getLongWithCurrentDate(String value, String timezone) {
     if (Strings.isNullOrEmpty(value)) {
       return 0;
     }
 
-    DateTime time = new DateTime(DateTimeZone.forID(ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE));
+    DateTime time = getCurrentTime(timezone);
+    DateTimeFormatter dtFormatter = DateTimeFormat.forPattern(CURRENT_DATE_FORMAT).withZone(time.getZone());
     if (value.toUpperCase().startsWith(CURRENT_DAY)) {
       return Long
-          .valueOf(DATE_FORMATTER.print(time.minusDays(Integer.parseInt(value.substring(CURRENT_DAY.length() + 1)))));
+          .valueOf(dtFormatter.print(time.minusDays(Integer.parseInt(value.substring(CURRENT_DAY.length() + 1)))));
     }
     if (value.toUpperCase().startsWith(CURRENT_HOUR)) {
       return Long
-          .valueOf(DATE_FORMATTER.print(time.minusHours(Integer.parseInt(value.substring(CURRENT_HOUR.length() + 1)))));
+          .valueOf(dtFormatter.print(time.minusHours(Integer.parseInt(value.substring(CURRENT_HOUR.length() + 1)))));
     }
     return Long.parseLong(value);
   }


### PR DESCRIPTION
When the low watermark is calculated, CURRENTDAY or CURRENTHOUR is determined by using the default timezone (America/Los_Angeles). I assume, that the correct behavior would be to check for the source.timezone and if it is not set, fall back to the default one.