### PR TITLE
Fixing FindBugs warnings

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/workunit/MultiWorkUnitWeightedQueue.java
+++ b/gobblin-core/src/main/java/gobblin/source/workunit/MultiWorkUnitWeightedQueue.java
@@ -88,7 +88,7 @@ public class MultiWorkUnitWeightedQueue {
    * weight, which is the sum of the file sizes assigned to it. It also implements Comparable, based on the weight value.
    * @author ydai
    */
-  private class WeightedMultiWorkUnit extends MultiWorkUnit implements Comparable<WeightedMultiWorkUnit> {
+  private static class WeightedMultiWorkUnit extends MultiWorkUnit implements Comparable<WeightedMultiWorkUnit> {
 
     private long weight = 0l;
 
@@ -109,6 +109,12 @@ public class MultiWorkUnitWeightedQueue {
     @Override
     public int compareTo(WeightedMultiWorkUnit weightedMultiWorkUnit) {
       return Longs.compare(this.weight, weightedMultiWorkUnit.getWeight());
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      WeightedMultiWorkUnit weightedMultiWorkUnit = (WeightedMultiWorkUnit) obj;
+      return this.weight == weightedMultiWorkUnit.getWeight();
     }
 
     public long getWeight() {

--- a/gobblin-core/src/main/java/gobblin/source/workunit/MultiWorkUnitWeightedQueue.java
+++ b/gobblin-core/src/main/java/gobblin/source/workunit/MultiWorkUnitWeightedQueue.java
@@ -113,6 +113,9 @@ public class MultiWorkUnitWeightedQueue {
 
     @Override
     public boolean equals(Object obj) {
+      if (!(obj instanceof WeightedMultiWorkUnit)) {
+        return false;
+      }
       WeightedMultiWorkUnit weightedMultiWorkUnit = (WeightedMultiWorkUnit) obj;
       return this.weight == weightedMultiWorkUnit.getWeight();
     }


### PR DESCRIPTION
FindBugs Warnings:

1:

gobblin.source.workunit.MultiWorkUnitWeightedQueue$WeightedMultiWorkUnit defines compareTo(MultiWorkUnitWeightedQueue$WeightedMultiWorkUnit) and uses Object.equals()

This class defines a compareTo(...) method but inherits its equals() method from java.lang.Object. Generally, the value of compareTo should return zero if and only if equals returns true. If this is violated, weird and unpredictable failures will occur in classes such as PriorityQueue. In Java 5 the PriorityQueue.remove method uses the compareTo method, while in Java 6 it uses the equals method.

From the JavaDoc for the compareTo method in the Comparable interface:

    It is strongly recommended, but not strictly required that (x.compareTo(y)==0) == (x.equals(y)). Generally speaking, any class that implements the Comparable interface and violates this condition should clearly indicate this fact. The recommended language is "Note: this class has a natural ordering that is inconsistent with equals." 

2:

Should gobblin.source.workunit.MultiWorkUnitWeightedQueue$WeightedMultiWorkUnit be a _static_ inner class?

This class is an inner class, but does not use its embedded reference to the object which created it.  This reference makes the instances of the class larger, and may keep the reference to the creator object alive longer than necessary.  If possible, the class should be made static. 