### PR TITLE
Fixed a bug that caused an empty list of previous WorkUnitStates to pass into SourceState

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -68,16 +68,6 @@ public class SourceState extends State {
   }
 
   /**
-   * Constructor.
-   *
-   * @param properties job configuration properties
-   * @param previousJobState previous job state
-   */
-  public SourceState(State properties, SourceState previousJobState) {
-    this(properties, previousJobState.getPreviousWorkUnitStates());
-  }
-
-  /**
    * Get a (possibly empty) list of {@link WorkUnitState}s from the previous job run.
    *
    * @return (possibly empty) list of {@link WorkUnitState}s from the previous job run


### PR DESCRIPTION
In pull request #65, a new Constructor is added to SourceState that takes a previous SourceState and calls SourceState.getPreviousWorkUnitStates() to populate the SourceState.previousTaskStates. However, it turns out previousTaskStates is always empty and therefore the empty list gets passed into the current SourceState. This is the root cause for the issue with gobblin-stand-alone.

Signed-off-by: Yinan Li <liyinan926@gmail.com>