### PR TITLE
Added fix so that staging data still gets cleaned up even if collectOutput fails

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -11,6 +11,9 @@
 
 package gobblin.configuration;
 
+import java.util.concurrent.TimeUnit;
+
+
 /**
  * A central place for all Gobblin configuration property keys.
  */
@@ -51,11 +54,11 @@ public class ConfigurationKeys {
 
   // Job executor thread pool size
   public static final String JOB_EXECUTOR_THREAD_POOL_SIZE_KEY = "jobexecutor.threadpool.size";
-  public static final String DEFAULT_JOB_EXECUTOR_THREAD_POOL_SIZE = "5";
+  public static final int DEFAULT_JOB_EXECUTOR_THREAD_POOL_SIZE = 5;
 
   // Job configuration file monitor polling interval in milliseconds
   public static final String JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY = "jobconf.monitor.interval";
-  public static final String DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL = "300000";
+  public static final long DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL = 300000;
 
   // Comma-separated list of framework jars to include
   public static final String FRAMEWORK_JAR_FILES_KEY = "framework.jars";
@@ -68,11 +71,11 @@ public class ConfigurationKeys {
   public static final String TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE_KEY = "tasktracker.threadpool.maxsize";
   public static final String TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY = "taskretry.threadpool.coresize";
   public static final String TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY = "taskretry.threadpool.maxsize";
-  public static final String DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE = "2";
-  public static final String DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE = "1";
-  public static final String DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE = "2";
-  public static final String DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE = "1";
-  public static final String DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE = "2";
+  public static final int DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE = 2;
+  public static final int DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE = 1;
+  public static final int DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE = 2;
+  public static final int DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE = 1;
+  public static final int DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE = 2;
 
   /**
    * Common job configuration properties.
@@ -98,9 +101,9 @@ public class ConfigurationKeys {
   public static final String JOB_MAX_FAILURES_KEY = "job.max.failures";
   public static final int DEFAULT_JOB_MAX_FAILURES = 1;
   public static final String MAX_TASK_RETRIES_KEY = "task.maxretries";
-  public static final String DEFAULT_MAX_TASK_RETRIES = "5";
+  public static final int DEFAULT_MAX_TASK_RETRIES = 5;
   public static final String TASK_RETRY_INTERVAL_IN_SEC_KEY = "task.retry.intervalinsec";
-  public static final String DEFAULT_TASK_RETRY_INTERVAL_IN_SEC = "300";
+  public static final long DEFAULT_TASK_RETRY_INTERVAL_IN_SEC = 300;
   public static final String OVERWRITE_CONFIGS_IN_STATESTORE = "overwrite.configs.in.statestore";
   public static final boolean DEFAULT_OVERWRITE_CONFIGS_IN_STATESTORE = Boolean.FALSE;
 
@@ -114,6 +117,7 @@ public class ConfigurationKeys {
   public static final String TASK_RETRIES_KEY = "task.retries";
   public static final String JOB_FAILURES_KEY = "job.failures";
   public static final String JOB_TRACKING_URL_KEY = "job.tracking.url";
+  public static final String FORK_STATE_KEY = "fork.state";
 
   /**
    * Work unit related configuration properties.
@@ -166,7 +170,14 @@ public class ConfigurationKeys {
    */
   public static final String FORK_BRANCHES_KEY = "fork.branches";
   public static final String FORK_BRANCH_NAME_KEY = "fork.branch.name";
+  public static final String FORK_BRANCH_ID_KEY = "fork.branch.id";
   public static final String DEFAULT_FORK_BRANCH_NAME = "fork_";
+  public static final String FORK_BRANCH_RECORD_QUEUE_CAPACITY_KEY = "fork.record.queue.capacity";
+  public static final int DEFAULT_FORK_BRANCH_RECORD_QUEUE_CAPACITY = 1000;
+  public static final String FORK_BRANCH_RECORD_QUEUE_TIMEOUT_KEY = "fork.record.queue.timeout";
+  public static final long DEFAULT_FORK_BRANCH_RECORD_QUEUE_TIMEOUT = 1000;
+  public static final String FORK_BRANCH_RECORD_QUEUE_TIMEOUT_UNIT_KEY = "fork.record.queue.timeout.unit";
+  public static final String DEFAULT_FORK_BRANCH_RECORD_QUEUE_TIMEOUT_UNIT = TimeUnit.MILLISECONDS.name();
 
   /**
    * Writer configuration properties.
@@ -185,6 +196,7 @@ public class ConfigurationKeys {
   public static final String WRITER_PRESERVE_FILE_NAME = WRITER_PREFIX + ".preserve.file.name";
   public static final String WRITER_DEFLATE_LEVEL = WRITER_PREFIX + ".deflate.level";
   public static final String WRITER_CODEC_TYPE = WRITER_PREFIX + ".codec.type";
+  public static final String DEFAULT_WRITER_FILE_NAME = "avro";
   public static final String DEFAULT_DEFLATE_LEVEL = "9";
   public static final String DEFAULT_BUFFER_SIZE = "4096";
 

--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -68,16 +68,6 @@ public class SourceState extends State {
   }
 
   /**
-   * Constructor.
-   *
-   * @param properties job configuration properties
-   * @param previousJobState previous job state
-   */
-  public SourceState(State properties, SourceState previousJobState) {
-    this(properties, previousJobState.getPreviousWorkUnitStates());
-  }
-
-  /**
    * Get a (possibly empty) list of {@link WorkUnitState}s from the previous job run.
    *
    * @return (possibly empty) list of {@link WorkUnitState}s from the previous job run

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -11,7 +11,6 @@
 
 package gobblin.configuration;
 
-import gobblin.source.workunit.Extract;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
@@ -19,6 +18,7 @@ import java.util.Set;
 
 import com.google.common.collect.Sets;
 
+import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.ImmutableWorkUnit;
 import gobblin.source.workunit.WorkUnit;
 
@@ -76,16 +76,6 @@ public class WorkUnitState extends State {
    */
   public WorkUnit getWorkunit() {
     return new ImmutableWorkUnit(workunit);
-  }
-
-  /**
-   * @see State#addAll(State).
-   *
-   * @param otherState another {@link WorkUnitState} instance
-   */
-  public void addAll(WorkUnitState otherState) {
-    super.addAll(otherState);
-    this.workunit = otherState.workunit;
   }
 
   /**

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
@@ -37,6 +37,8 @@ public class AzkabanJobLauncher extends AbstractJob {
 
   private static final String HADOOP_FS_DEFAULT_NAME = "fs.default.name";
   private static final String AZKABAN_LINK_JOBEXEC_URL = "azkaban.link.jobexec.url";
+  private static final String HADOOP_TOKEN_FILE_LOCATION = "HADOOP_TOKEN_FILE_LOCATION";
+  private static final String MAPREDUCE_JOB_CREDENTIALS_BINARY = "mapreduce.job.credentials.binary";
 
   private final Properties properties;
   private final JobLauncher jobLauncher;
@@ -60,8 +62,14 @@ public class AzkabanJobLauncher extends AbstractJob {
     }
 
     // Set the job tracking URL to point to the Azkaban job execution link URL
-    this.properties
-        .setProperty(ConfigurationKeys.JOB_TRACKING_URL_KEY, Strings.nullToEmpty(conf.get(AZKABAN_LINK_JOBEXEC_URL)));
+    this.properties.setProperty(
+        ConfigurationKeys.JOB_TRACKING_URL_KEY, Strings.nullToEmpty(conf.get(AZKABAN_LINK_JOBEXEC_URL)));
+
+    // Necessary for compatibility with Azkaban's hadoopJava job type
+    // http://azkaban.github.io/azkaban/docs/2.5/#hadoopjava-type
+    if (System.getenv(HADOOP_TOKEN_FILE_LOCATION) != null) {
+      this.properties.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, System.getenv(HADOOP_TOKEN_FILE_LOCATION));
+    }
 
     // Create a JobLauncher instance depending on the configuration
     this.jobLauncher = JobLauncherFactory.newJobLauncher(this.properties);

--- a/gobblin-core/src/main/java/gobblin/converter/avro/AvroFieldRetrieverConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/AvroFieldRetrieverConverter.java
@@ -25,6 +25,7 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.converter.DataConversionException;
 import gobblin.converter.EmptyIterable;
 import gobblin.util.AvroUtils;
+import gobblin.util.ForkOperatorUtils;
 
 
 /**
@@ -39,11 +40,16 @@ public class AvroFieldRetrieverConverter extends Converter<Schema, Schema, Gener
 
   @Override
   public Converter<Schema, Schema, GenericRecord, Object> init(WorkUnitState workUnit) {
-    Preconditions.checkArgument(workUnit.contains(ConfigurationKeys.CONVERTER_AVRO_EXTRACTOR_FIELD_PATH),
+
+    String fieldPathKey =
+        ForkOperatorUtils.getPropertyNameForBranch(workUnit,
+            ConfigurationKeys.CONVERTER_AVRO_EXTRACTOR_FIELD_PATH);
+
+    Preconditions.checkArgument(workUnit.contains(fieldPathKey),
         "The converter " + this.getClass().getName() + " cannot be used without setting the property "
             + ConfigurationKeys.CONVERTER_AVRO_EXTRACTOR_FIELD_PATH);
 
-    this.fieldLocation = workUnit.getProp(ConfigurationKeys.CONVERTER_AVRO_EXTRACTOR_FIELD_PATH);
+    this.fieldLocation = workUnit.getProp(fieldPathKey);
     return this;
   }
 

--- a/gobblin-core/src/main/java/gobblin/converter/string/StringFilterConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/string/StringFilterConverter.java
@@ -24,6 +24,7 @@ import gobblin.converter.DataConversionException;
 import gobblin.converter.EmptyIterable;
 import gobblin.converter.SchemaConversionException;
 import gobblin.converter.SingleRecordIterable;
+import gobblin.util.ForkOperatorUtils;
 
 
 /**
@@ -38,7 +39,9 @@ public class StringFilterConverter extends Converter<Class<String>, Class<String
   @Override
   public Converter<Class<String>, Class<String>, String, String> init(WorkUnitState workUnit) {
     this.pattern =
-        Pattern.compile(Strings.nullToEmpty(workUnit.getProp(ConfigurationKeys.CONVERTER_STRING_FILTER_PATTERN)));
+        Pattern.compile(Strings.nullToEmpty(workUnit.getProp(ForkOperatorUtils.getPropertyNameForBranch(
+            workUnit, ConfigurationKeys.CONVERTER_STRING_FILTER_PATTERN))));
+
     this.matcher = Optional.absent();
 
     return this;

--- a/gobblin-core/src/main/java/gobblin/converter/string/StringSplitterConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/string/StringSplitterConverter.java
@@ -19,6 +19,7 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.converter.Converter;
 import gobblin.converter.DataConversionException;
 import gobblin.converter.SchemaConversionException;
+import gobblin.util.ForkOperatorUtils;
 
 /**
  * Implementation of {@link Converter} that splits a string based on a delimiter specified by
@@ -30,11 +31,14 @@ public class StringSplitterConverter extends Converter<Class<String>, Class<Stri
 
   @Override
   public Converter<Class<String>, Class<String>, String, String> init(WorkUnitState workUnit) {
-    Preconditions.checkArgument(workUnit.contains(ConfigurationKeys.CONVERTER_STRING_SPLITTER_DELIMITER), "Cannot use "
+    String stringSplitterDelimiterKey = ForkOperatorUtils.getPropertyNameForBranch(
+        workUnit, ConfigurationKeys.CONVERTER_STRING_SPLITTER_DELIMITER);
+
+    Preconditions.checkArgument(workUnit.contains(stringSplitterDelimiterKey), "Cannot use "
         + this.getClass().getName() + " with out specifying " + ConfigurationKeys.CONVERTER_STRING_SPLITTER_DELIMITER);
 
     this.splitter =
-        Splitter.on(workUnit.getProp(ConfigurationKeys.CONVERTER_STRING_SPLITTER_DELIMITER)).omitEmptyStrings();
+        Splitter.on(workUnit.getProp(stringSplitterDelimiterKey)).omitEmptyStrings();
 
     return this;
   }

--- a/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
+++ b/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
@@ -32,7 +32,7 @@ public class RowLevelPolicyChecker implements Closeable {
   }
 
   public boolean executePolicies(Object record, RowLevelPolicyCheckResults results)
-      throws IOException, URISyntaxException {
+      throws IOException {
     for (RowLevelPolicy p : this.list) {
       RowLevelPolicy.Result result = p.executePolicy(record);
       results.put(p, result);

--- a/gobblin-core/src/main/java/gobblin/writer/AvroDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroDataWriterBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.base.Strings;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.util.ForkOperatorUtils;
+import gobblin.util.WriterUtils;
 
 
 /**
@@ -44,15 +45,10 @@ public class AvroDataWriterBuilder extends DataWriterBuilder<Schema, GenericReco
       case HDFS:
         State properties = this.destination.getProperties();
 
-        String filePath = properties
-            .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PATH, this.branch));
-        // Add the writer ID to the file name so each writer writes to a different
-        // file of the same file group defined by the given file name
-        String fileName = String.format("%s.%s.%s", properties
-                .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_NAME, this.branch),
-                    "part"), this.writerId, this.format.getExtension());
+        String fileName =
+            WriterUtils.getWriterFileName(properties, this.branch, this.writerId, this.format.getExtension());
 
-        return new AvroHdfsDataWriter(properties, filePath, fileName, this.schema, this.branch);
+        return new AvroHdfsDataWriter(properties, fileName, this.schema, this.branch);
       case KAFKA:
         return new AvroKafkaDataWriter();
       default:

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -109,7 +109,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       workUnitState.setProp(ConfigurationKeys.TASK_ID_KEY, taskId);
 
       // Create a new task from the work unit and submit the task to run
-      Task task = new Task(new TaskContext(workUnitState), stateTracker, Optional.of(countDownLatch));
+      Task task = new Task(new TaskContext(workUnitState), stateTracker, taskExecutor, Optional.of(countDownLatch));
       stateTracker.registerNewTask(task);
       tasks.add(task);
       LOG.info(String.format("Submitting task %s to run", taskId));
@@ -179,11 +179,11 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     SourceState sourceState;
     Source<?, ?> source;
     try {
-      SourceState previousJobState = getPreviousJobState(jobName);
+      JobState previousJobState = getPreviousJobState(jobName);
       // Remember the number of consecutive failures of this job in the past
       jobState.setProp(ConfigurationKeys.JOB_FAILURES_KEY,
           previousJobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0));
-      sourceState = new SourceState(jobState, previousJobState);
+      sourceState = new SourceState(jobState, getPreviousWorkUnitStates(previousJobState));
       source = new SourceDecorator(initSource(jobProps), jobId, LOG);
     } catch (Throwable t) {
       String errMsg = "Failed to initialize the source for job " + jobId;
@@ -371,19 +371,35 @@ public abstract class AbstractJobLauncher implements JobLauncher {
    * Get the job state of the most recent run of the job.
    */
   @SuppressWarnings("unchecked")
-  private SourceState getPreviousJobState(String jobName)
+  private JobState getPreviousJobState(String jobName)
       throws IOException {
     if (this.jobStateStore.exists(jobName, "current" + JOB_STATE_STORE_TABLE_SUFFIX)) {
       // Read the job state of the most recent run of the job
-      List<SourceState> previousJobStateList =
-          (List<SourceState>) this.jobStateStore.getAll(jobName, "current" + JOB_STATE_STORE_TABLE_SUFFIX);
+      List<JobState> previousJobStateList =
+          (List<JobState>) this.jobStateStore.getAll(jobName, "current" + JOB_STATE_STORE_TABLE_SUFFIX);
       if (!previousJobStateList.isEmpty()) {
         // There should be a single job state on the list if the list is not empty
         return previousJobStateList.get(0);
       }
     }
 
-    return new SourceState();
+    LOG.warn("No previous job state found for job " + jobName);
+    return new JobState();
+  }
+
+  /**
+   * Get the list of {@link WorkUnitState}s in the given previous {@link JobState}.
+   */
+  private List<WorkUnitState> getPreviousWorkUnitStates(JobState previousJobState) {
+    List<WorkUnitState> previousWorkUnitStates = Lists.newArrayList();
+    for (TaskState taskState : previousJobState.getTaskStates()) {
+      WorkUnitState workUnitState = new WorkUnitState(taskState.getWorkunit());
+      workUnitState.setId(taskState.getId());
+      workUnitState.addAll(taskState);
+      previousWorkUnitStates.add(workUnitState);
+    }
+
+    return previousWorkUnitStates;
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
@@ -45,29 +45,27 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
     Preconditions.checkArgument(maxThreadPoolSize >= coreThreadPoolSize,
         "Maximum thread pool size must not be smaller than the core thread pool size for the "
             + "task metrics updater executor");
-    this.taskMetricsUpdaterExecutor =
-        new ScheduledThreadPoolExecutor(coreThreadPoolSize, ExecutorsUtils.newThreadFactory(Optional.of(logger)));
+    this.taskMetricsUpdaterExecutor = new ScheduledThreadPoolExecutor(
+        coreThreadPoolSize, ExecutorsUtils.newThreadFactory(Optional.of(logger), Optional.of("TaskStateTracker-%d")));
     this.taskMetricsUpdaterExecutor.setMaximumPoolSize(maxThreadPoolSize);
     this.logger = logger;
   }
 
   public AbstractTaskStateTracker(Properties properties, Logger logger) {
     this(
-        Integer.parseInt(properties.getProperty(
-            ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE)),
+        Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE))),
         Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE)),
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE))),
         logger);
   }
 
   public AbstractTaskStateTracker(Configuration configuration, Logger logger) {
     this(
-        Integer.parseInt(configuration.get(
-            ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE)),
+        Integer.parseInt(configuration.get(ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE))),
         Integer.parseInt(configuration.get(ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE)),
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE))),
         logger);
   }
 
@@ -100,7 +98,7 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
   /**
    * A base class providing a default implementation for updating task metrics.
    */
-  protected static class TaskMetricsUpdater implements Runnable {
+  protected class TaskMetricsUpdater implements Runnable {
 
     protected final Task task;
 
@@ -111,6 +109,14 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
     @Override
     public void run() {
       updateTaskMetrics();
+      // Log record queue stats/metrics of each fork
+      for (Optional<Fork> fork : task.getForks()) {
+        if (fork.isPresent() && fork.get().queueStats().isPresent()) {
+          logger.info(String.format(
+              "Queue stats of fork %d of task %s: %s", fork.get().getIndex(), this.task.getTaskId(),
+              fork.get().queueStats().get().toString()));
+        }
+      }
     }
 
     protected void updateTaskMetrics() {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/BoundedBlockingRecordQueue.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/BoundedBlockingRecordQueue.java
@@ -1,0 +1,312 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.util.concurrent.BlockingDeque;
+import java.util.concurrent.TimeUnit;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.MetricRegistry;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Queues;
+
+import gobblin.configuration.ConfigurationKeys;
+
+
+/**
+ * A class implementing a bounded blocking queue with timeout for buffering records between a producer and a consumer.
+ *
+ * <p>
+ *   In addition to the normal queue operations, this class also keeps track of the following statistics:
+ *
+ *   <ul>
+ *     <li>Queue size.</li>
+ *     <li>Queue fill ratio (queue size/queue capacity).</li>
+ *     <li>Put attempt count.</li>
+ *     <li>Mean rate of put attempts (puts/sec).</li>
+ *     <li>Get attempt count.</li>
+ *     <li>Mean rate of get attempts (gets/sec).</li>
+ *   </ul>
+ * </p>
+ *
+ * @author ynli
+ */
+public class BoundedBlockingRecordQueue<T> {
+
+  private final int capacity;
+  private final long timeout;
+  private final TimeUnit timeoutTimeUnit;
+  private final BlockingDeque<T> blockingDeque;
+
+  private final Optional<QueueStats> queueStats;
+
+  private BoundedBlockingRecordQueue(Builder<T> builder) {
+    Preconditions.checkArgument(builder.capacity > 0, "Invalid queue capacity");
+    Preconditions.checkArgument(builder.timeout > 0, "Invalid timeout time");
+
+    this.capacity = builder.capacity;
+    this.timeout = builder.timeout;
+    this.timeoutTimeUnit = builder.timeoutTimeUnit;
+    this.blockingDeque = Queues.newLinkedBlockingDeque(builder.capacity);
+
+    this.queueStats = builder.ifCollectStats ? Optional.of(new QueueStats()) : Optional.<QueueStats>absent();
+  }
+
+  /**
+   * Put a record to the tail of the queue, waiting (up to the configured timeout time)
+   * for an empty space to become available.
+   *
+   * @param record the record to put to the tail of the queue
+   * @return whether the record has been successfully put into the queue
+   * @throws InterruptedException if interrupted while waiting
+   */
+  public boolean put(T record)
+      throws InterruptedException {
+    boolean offered = this.blockingDeque.offer(record, this.timeout, this.timeoutTimeUnit);
+    if (this.queueStats.isPresent()) {
+      this.queueStats.get().putsRateMeter.mark();
+    }
+    return offered;
+  }
+
+  /**
+   * Get a record from the head of the queue, waiting (up to the configured timeout time)
+   * for a record to become available.
+   *
+   * @return the record at the head of the queue, or <code>null</code> if no record is available
+   * @throws InterruptedException if interrupted while waiting
+   */
+  public T get()
+      throws InterruptedException {
+    T record = this.blockingDeque.poll(this.timeout, this.timeoutTimeUnit);
+    if (this.queueStats.isPresent()) {
+      this.queueStats.get().getsRateMeter.mark();
+    }
+    return record;
+  }
+
+  /**
+   * Get a {@link QueueStats} object representing queue statistics of this {@link BoundedBlockingRecordQueue}.
+   *
+   * @return a {@link QueueStats} object wrapped in an {@link com.google.common.base.Optional},
+   *         which means it may be absent if collecting of queue statistics is not enabled.
+   */
+  public Optional<QueueStats> stats() {
+    return this.queueStats;
+  }
+
+  /**
+   * Clear the queue.
+   */
+  public void clear() {
+    this.blockingDeque.clear();
+  }
+
+  /**
+   * Get a new {@link BoundedBlockingRecordQueue.Builder}.
+   *
+   * @param <T> record type
+   * @return a new {@link BoundedBlockingRecordQueue.Builder}
+   */
+  public static <T> Builder<T> newBuilder() {
+    return new Builder<T>();
+  }
+
+  /**
+   * A builder class for {@link BoundedBlockingRecordQueue}.
+   *
+   * @param <T> record type
+   */
+  public static class Builder<T> {
+
+    private int capacity = ConfigurationKeys.DEFAULT_FORK_BRANCH_RECORD_QUEUE_CAPACITY;
+    private long timeout = ConfigurationKeys.DEFAULT_FORK_BRANCH_RECORD_QUEUE_TIMEOUT;
+    private TimeUnit timeoutTimeUnit = TimeUnit.MILLISECONDS;
+    private boolean ifCollectStats = false;
+
+    /**
+     * Configure the capacity of the queue.
+     *
+     * @param capacity the capacity of the queue
+     * @return this {@link Builder} instance
+     */
+    public Builder<T> hasCapacity(int capacity) {
+      this.capacity = capacity;
+      return this;
+    }
+
+    /**
+     * Configure the timeout time of queue operations.
+     *
+     * @param timeout the time timeout time
+     * @return this {@link Builder} instance
+     */
+    public Builder<T> useTimeout(long timeout) {
+      this.timeout = timeout;
+      return this;
+    }
+
+    /**
+     * Configure the timeout time unit of queue operations.
+     *
+     * @param timeoutTimeUnit the time timeout time unit
+     * @return this {@link Builder} instance
+     */
+    public Builder<T> useTimeoutTimeUnit(TimeUnit timeoutTimeUnit) {
+      this.timeoutTimeUnit = timeoutTimeUnit;
+      return this;
+    }
+
+    /**
+     * Configure whether to collect queue statistics.
+     *
+     * @return this {@link Builder} instance
+     */
+    public Builder<T> collectStats() {
+      this.ifCollectStats = true;
+      return this;
+    }
+
+    /**
+     * Build a new {@link BoundedBlockingRecordQueue}.
+     *
+     * @return the newly built {@link BoundedBlockingRecordQueue}
+     */
+    public BoundedBlockingRecordQueue<T> build() {
+      return new BoundedBlockingRecordQueue<T>(this);
+    }
+  }
+
+  /**
+   * A class for collecting queue statistics.
+   *
+   * <p>
+   *   All statistics will have zero values if collecting of statistics is not enabled.
+   * </p>
+   */
+  public class QueueStats {
+
+    public static final String QUEUE_SIZE = "queueSize";
+    public static final String FILL_RATIO = "fillRatio";
+    public static final String PUT_ATTEMPT_RATE = "putAttemptRate";
+    public static final String GET_ATTEMPT_RATE = "getAttemptRate";
+    public static final String PUT_ATTEMPT_COUNT = "putAttemptCount";
+    public static final String GET_ATTEMPT_COUNT = "getAttemptCount";
+
+    private final Gauge<Integer> queueSizeGauge;
+    private final Gauge<Double> fillRatioGauge;
+    private final Meter putsRateMeter;
+    private final Meter getsRateMeter;
+
+    public QueueStats() {
+      this.queueSizeGauge = new Gauge<Integer>() {
+        @Override
+        public Integer getValue() {
+          return blockingDeque.size();
+        }
+      };
+
+      this.fillRatioGauge = new Gauge<Double>() {
+        @Override
+        public Double getValue() {
+          return (double) blockingDeque.size() / capacity;
+        }
+      };
+
+      this.putsRateMeter = new Meter();
+      this.getsRateMeter = new Meter();
+    }
+
+    /**
+     * Return the queue size.
+     *
+     * @return the queue size
+     */
+    public int queueSize() {
+        return this.queueSizeGauge.getValue();
+    }
+
+    /**
+     * Return the queue fill ratio.
+     *
+     * @return the queue fill ratio
+     */
+    public double fillRatio() {
+      return this.fillRatioGauge.getValue();
+    }
+
+    /**
+     * Return the rate of put attempts.
+     *
+     * @return the rate of put attempts
+     */
+    public double putAttemptRate() {
+      return this.putsRateMeter.getMeanRate();
+    }
+
+    /**
+     * Return the total count of put attempts.
+     *
+     * @return the total count of put attempts
+     */
+    public long putAttemptCount() {
+      return this.putsRateMeter.getCount();
+    }
+
+    /**
+     * Return the rate of get attempts.
+     *
+     * @return the rate of get attempts
+     */
+    public double getAttemptRate() {
+      return this.getsRateMeter.getMeanRate();
+    }
+
+    /**
+     * Return the total count of get attempts.
+     *
+     * @return the total count of get attempts
+     */
+    public long getAttemptCount() {
+      return this.getsRateMeter.getCount();
+    }
+
+    /**
+     * Register all statistics as {@link com.codahale.metrics.Metric}s with a
+     * {@link com.codahale.metrics.MetricRegistry}.
+     *
+     * @param metricRegistry the {@link com.codahale.metrics.MetricRegistry} to register with
+     * @param prefix metric name prefix
+     */
+    public void registerAll(MetricRegistry metricRegistry, String prefix) {
+      metricRegistry.register(MetricRegistry.name(prefix, QUEUE_SIZE), this.queueSizeGauge);
+      metricRegistry.register(MetricRegistry.name(prefix, FILL_RATIO), this.fillRatioGauge);
+      metricRegistry.register(MetricRegistry.name(prefix, PUT_ATTEMPT_RATE), this.putsRateMeter);
+      metricRegistry.register(MetricRegistry.name(prefix, GET_ATTEMPT_RATE), this.getsRateMeter);
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder("[");
+      sb.append(QUEUE_SIZE).append("=").append(queueSize()).append(", ");
+      sb.append(FILL_RATIO).append("=").append(fillRatio()).append(", ");
+      sb.append(PUT_ATTEMPT_RATE).append("=").append(putAttemptRate()).append(", ");
+      sb.append(PUT_ATTEMPT_COUNT).append("=").append(putAttemptCount()).append(", ");
+      sb.append(GET_ATTEMPT_RATE).append("=").append(getAttemptRate()).append(", ");
+      sb.append(GET_ATTEMPT_COUNT).append("=").append(getAttemptCount()).append("]");
+      return sb.toString();
+    }
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -13,15 +13,20 @@ package gobblin.runtime;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.WorkUnitState;
 import gobblin.converter.Converter;
+import gobblin.converter.DataConversionException;
 import gobblin.converter.SchemaConversionException;
 import gobblin.metrics.JobMetrics;
 import gobblin.publisher.TaskPublisher;
@@ -29,31 +34,35 @@ import gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
 import gobblin.qualitychecker.row.RowLevelPolicyChecker;
 import gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
 import gobblin.util.ForkOperatorUtils;
+import gobblin.util.WriterUtils;
 import gobblin.writer.DataWriter;
 import gobblin.writer.Destination;
 
 
 /**
- * A class representing a forked branch of operations in a task flow.
+ * A class representing a forked branch of operations of a {@link Task} flow. The {@link Fork}s of a
+ * {@link Task} are executed in a thread pool managed by the {@link TaskExecutor}, which is different
+ * from the thread pool used to execute {@link Task}s.
  *
  * <p>
- *     A {@link Fork} consists of the following steps:
- *
+ *     Each {@link Fork} consists of the following steps:
  *     <ul>
- *         <li>Converting the input forked schema if converters are specified.</li>
- *         <li>Converting each input forked record if converters are specified.</li>
- *         <li>Performing row-level quality checking on the converted record.</li>
- *         <li>Writing out the converted data record if it passes the quality checking.</li>
- *         <li>Performing task-level quality checking after all data records are processed.</li>
- *         <li>Committing data if the task-level quality checking passes.</li>
- *         <li>Cleaning up.</li>
+ *       <li>Getting the next record off the record queue.</li>
+ *       <li>Converting the record and doing row-level quality checking if applicable.</li>
+ *       <li>Writing the record out if it passes the quality checking.</li>
+ *       <li>Cleaning up and exiting once all the records have been processed.</li>
  *     </ul>
  * </p>
  *
  * @author ynli
  */
 @SuppressWarnings("unchecked")
-public class Fork implements Closeable {
+public class Fork implements Closeable, Runnable {
+
+  // Possible state of a fork
+  enum ForkState {
+    PENDING, RUNNING, SUCCEEDED, FAILED, COMMITTED
+  }
 
   private final Logger logger;
 
@@ -70,9 +79,26 @@ public class Fork implements Closeable {
   private final RowLevelPolicyCheckResults rowLevelPolicyCheckingResult;
   private final DataWriter<Object> writer;
 
+  // This is used to signal the parent task of the completion of this fork
+  private final CountDownLatch countDownLatch;
+
+  // A bounded blocking queue in between the parent task and this fork
+  private final BoundedBlockingRecordQueue<Object> recordQueue;
+
   private final Closer closer = Closer.create();
 
-  public Fork(TaskContext taskContext, TaskState taskState, Object schema, int branches, int index)
+  // This is used by the parent task to signal that it has done pulling records and this fork
+  // should not expect any new incoming data records. This is written by the parent task and
+  // read by this fork. Since this flag will be updated by only a single thread and updates to
+  // a boolean are atomic, volatile is sufficient here.
+  private volatile boolean parentTaskDone = false;
+
+  // Writes to and reads of references are always atomic according to the Java language specs.
+  // An AtomicReference is still used here for the compareAntSet operation.
+  private final AtomicReference<ForkState> forkState;
+
+  public Fork(TaskContext taskContext, TaskState taskState, Object schema, int branches, int index,
+      CountDownLatch countDownLatch)
       throws Exception {
 
     this.logger = LoggerFactory.getLogger(Fork.class.getName() + "-" + index);
@@ -90,17 +116,83 @@ public class Fork implements Closeable {
     this.rowLevelPolicyCheckingResult = new RowLevelPolicyCheckResults();
     this.writer = buildWriter();
 
+    this.recordQueue = BoundedBlockingRecordQueue.newBuilder()
+        .hasCapacity(taskState.getPropAsInt(
+            ConfigurationKeys.FORK_BRANCH_RECORD_QUEUE_CAPACITY_KEY,
+            ConfigurationKeys.DEFAULT_FORK_BRANCH_RECORD_QUEUE_CAPACITY))
+        .useTimeout(taskState.getPropAsLong(
+            ConfigurationKeys.FORK_BRANCH_RECORD_QUEUE_TIMEOUT_KEY,
+            ConfigurationKeys.DEFAULT_FORK_BRANCH_RECORD_QUEUE_TIMEOUT))
+        .useTimeoutTimeUnit(TimeUnit.valueOf(taskState.getProp(
+            ConfigurationKeys.FORK_BRANCH_RECORD_QUEUE_TIMEOUT_UNIT_KEY,
+            ConfigurationKeys.DEFAULT_FORK_BRANCH_RECORD_QUEUE_TIMEOUT_UNIT)))
+        .collectStats()
+        .build();
+
+    this.countDownLatch = countDownLatch;
+
     this.closer.register(this.rowLevelPolicyChecker);
     this.closer.register(this.writer);
+
+    this.forkState = new AtomicReference<ForkState>(ForkState.PENDING);
   }
 
-  public void processRecord(Object record)
-      throws Exception {
-    for (Object convertedRecord : this.converter.convertRecord(this.convertedSchema, record, this.taskState)) {
-      if (this.rowLevelPolicyChecker.executePolicies(convertedRecord, this.rowLevelPolicyCheckingResult)) {
-        this.writer.write(convertedRecord);
-      }
+  @Override
+  public void run() {
+    compareAndSetForkState(ForkState.PENDING, ForkState.RUNNING);
+    try {
+      processRecords();
+      compareAndSetForkState(ForkState.RUNNING, ForkState.SUCCEEDED);
+    } catch (IOException ioe) {
+      this.forkState.set(ForkState.FAILED);
+      this.logger.error(
+          String.format("Fork %d of task %s failed to process data records", this.index, this.taskId), ioe);
+      Throwables.propagate(ioe);
+    } catch (DataConversionException dce) {
+      this.forkState.set(ForkState.FAILED);
+      this.logger.error(
+          String.format("Fork %d of task %s failed to convert data records", this.index, this.taskId), dce);
+      Throwables.propagate(dce);
+    } catch (Throwable t) {
+      this.forkState.set(ForkState.FAILED);
+      this.logger.error(String.format("Fork %d of task %s failed to process data records", this.index, this.taskId), t);
+      Throwables.propagate(t);
+    } finally {
+      // Clear the queue and count down so the parent task knows this fork is done (succeeded or failed)
+      this.recordQueue.clear();
+      this.countDownLatch.countDown();
     }
+  }
+
+  /**
+   * Put a new record into the record queue for this {@link Fork} to process.
+   *
+   * <p>
+   *   This method is used by the {@link Task} that creates this {@link Fork}.
+   * </p>
+   *
+   * @param record the new record
+   * @return whether the record has been successfully put into the queue
+   * @throws InterruptedException
+   */
+  public boolean putRecord(Object record) throws InterruptedException {
+    if (this.forkState.compareAndSet(ForkState.FAILED, ForkState.FAILED)) {
+      throw new IllegalStateException(
+          String.format("Fork %d of task %s has failed and is no longer running", this.index, this.taskId));
+    }
+    return this.recordQueue.put(record);
+  }
+
+  /**
+   * Tell this {@link Fork} that the parent task is already done pulling records and
+   * it should not expect more incoming data records.
+   *
+   * <p>
+   *   This method is used by the {@link Task} that creates this {@link Fork}.
+   * </p>
+   */
+  public void markParentTaskDone() {
+    this.parentTaskDone = true;
   }
 
   /**
@@ -125,23 +217,77 @@ public class Fork implements Closeable {
   /**
    * Commit data of this {@link Fork}.
    *
-   * @param recordsPulled number of records pulled
-   * @param expectedCount expected record count
-   * @param pullLimit pull limit
-   * @throws Exception
+   * @throws Exception if there is anything wrong committing the data
    */
-  public void commit(long recordsPulled, long expectedCount, long pullLimit)
+  public void commit()
       throws Exception {
-    if (checkDataQuality(recordsPulled, expectedCount, pullLimit, this.convertedSchema)) {
-      // Commit data if all quality checkers pass. Again, not to catch the exception
-      // it may throw so the exception gets propagated to the caller of this method.
-      commitData();
+    try {
+      if (checkDataQuality(this.convertedSchema)) {
+        // Commit data if all quality checkers pass. Again, not to catch the exception
+        // it may throw so the exception gets propagated to the caller of this method.
+        this.logger.info(String.format("Committing data for fork %d of task %s", this.index, this.taskId));
+        commitData();
+        compareAndSetForkState(ForkState.SUCCEEDED, ForkState.COMMITTED);
+      } else {
+        this.logger.error(String.format("Fork %d of task %s failed to pass quality checking", this.index, this.taskId));
+        compareAndSetForkState(ForkState.SUCCEEDED, ForkState.FAILED);
+      }
+    } catch (Throwable t) {
+      this.logger.error(String.format("Fork %d of task %s failed to commit data", this.index, this.taskId), t);
+      this.forkState.set(ForkState.FAILED);
+      Throwables.propagate(t);
     }
+  }
+
+  /**
+   * Get the ID of the task that creates this {@link Fork}.
+   *
+   * @return the ID of the task that creates this {@link Fork}
+   */
+  public String getTaskId() {
+    return this.taskId;
+  }
+
+  /**
+   * Get the branch index of this {@link Fork}.
+   *
+   * @return branch index of this {@link Fork}
+   */
+  public int getIndex() {
+    return this.index;
+  }
+
+  /**
+   * Get a {@link BoundedBlockingRecordQueue.QueueStats} object representing the record queue
+   * statistics of this {@link Fork}.
+   *
+   * @return a {@link BoundedBlockingRecordQueue.QueueStats} object representing the record queue
+   *         statistics of this {@link Fork} wrapped in an {@link com.google.common.base.Optional},
+   *         which means it may be absent if collecting of queue statistics is not enabled.
+   */
+  public Optional<BoundedBlockingRecordQueue<Object>.QueueStats> queueStats() {
+    return this.recordQueue.stats();
+  }
+
+  /**
+   * Return if this {@link Fork} has succeeded processing all records.
+   *
+   * @return if this {@link Fork} has succeeded processing all records
+   */
+  public boolean isSucceeded() {
+    return this.forkState.compareAndSet(ForkState.SUCCEEDED, ForkState.SUCCEEDED);
   }
 
   @Override
   public void close()
       throws IOException {
+    // Tell this fork that the parent task is done. This is a second chance call if the parent
+    // task failed and didn't do so through the normal way of calling markParentTaskDone().
+    this.parentTaskDone = true;
+
+    // Record the fork state into the task state that will be persisted into the state store
+    this.taskState.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_STATE_KEY, this.index),
+        this.forkState.get().name());
     try {
       this.closer.close();
     } finally {
@@ -155,15 +301,6 @@ public class Fork implements Closeable {
   @SuppressWarnings("unchecked")
   private DataWriter<Object> buildWriter()
       throws IOException, SchemaConversionException {
-    String branchName = ForkOperatorUtils
-        .getBranchName(this.taskState, this.index, ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + this.index);
-    String writerFilePathKey =
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PATH, this.branches, this.index);
-    if (!this.taskState.contains(writerFilePathKey)) {
-      this.taskState.setProp(writerFilePathKey, ForkOperatorUtils
-          .getPathForBranch(this.taskState.getExtract().getOutputFilePath(), branchName, this.branches));
-    }
-
     return this.taskContext.getDataWriterBuilder(this.branches, this.index)
         .writeTo(Destination.of(this.taskContext.getDestinationType(this.branches, this.index), this.taskState))
         .writeInFormat(this.taskContext.getWriterOutputFormat(this.branches, this.index)).withWriterId(this.taskId)
@@ -171,30 +308,55 @@ public class Fork implements Closeable {
   }
 
   /**
+   * Get new records off the record queue and process them.
+   */
+  private void processRecords() throws IOException, DataConversionException {
+    while (true) {
+      try {
+        Object record = this.recordQueue.get();
+        if (record == null) {
+          // The parent task has already done pulling records so no new record means this fork is done
+          if (this.parentTaskDone) {
+            return;
+          }
+        } else {
+          // Convert the record, check its data quality, and finally write it out if quality checking passes.
+          for (Object convertedRecord : this.converter.convertRecord(this.convertedSchema, record, this.taskState)) {
+            if (this.rowLevelPolicyChecker.executePolicies(convertedRecord, this.rowLevelPolicyCheckingResult)) {
+              this.writer.write(convertedRecord);
+            }
+          }
+        }
+      } catch (InterruptedException ie) {
+        this.logger.warn("Interrupted while trying to get a record off the queue", ie);
+        Throwables.propagate(ie);
+      }
+    }
+  }
+
+  /**
    * Check data quality.
    *
    * @return whether data publishing is successful and data should be committed
    */
-  private boolean checkDataQuality(long recordsPulled, long expectedCount, long pullLimit, Object schema)
+  private boolean checkDataQuality(Object schema)
       throws Exception {
-
-    if (pullLimit > 0) {
-      // If pull limit is set, use the actual number of records pulled.
-      this.taskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED, recordsPulled);
-    } else {
-      // Otherwise use the expected record count
-      this.taskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED, expectedCount);
+    TaskState taskStateForFork = this.taskState;
+    if (this.branches > 1) {
+      // Make a copy if there are more than one fork
+      taskStateForFork = new TaskState(this.taskState);
     }
-    this.taskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, this.writer.recordsWritten());
-    this.taskState.setProp(ConfigurationKeys.EXTRACT_SCHEMA, schema.toString());
+
+    taskStateForFork.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, this.writer.recordsWritten());
+    taskStateForFork.setProp(ConfigurationKeys.EXTRACT_SCHEMA, schema.toString());
 
     try {
       // Do task-level quality checking
       TaskLevelPolicyCheckResults taskResults =
-          this.taskContext.getTaskLevelPolicyChecker(this.taskState, this.branches > 1 ? this.index : -1)
+          this.taskContext.getTaskLevelPolicyChecker(taskStateForFork, this.branches > 1 ? this.index : -1)
               .executePolicies();
       TaskPublisher publisher =
-          this.taskContext.getTaskPublisher(this.taskState, taskResults, this.branches > 1 ? this.index : -1);
+          this.taskContext.getTaskPublisher(taskStateForFork, taskResults, this.branches > 1 ? this.index : -1);
       switch (publisher.canPublish()) {
         case SUCCESS:
           return true;
@@ -211,7 +373,6 @@ public class Fork implements Closeable {
           break;
       }
 
-      this.taskState.setWorkingState(WorkUnitState.WorkingState.FAILED);
       return false;
     } catch (Throwable t) {
       this.logger.error("Failed to check task-level data quality", t);
@@ -224,12 +385,9 @@ public class Fork implements Closeable {
    */
   private void commitData()
       throws IOException {
-    this.logger.info(String.format("Committing data of branch %d of task %s", this.index, this.taskId));
+    this.logger.info(String.format("Committing data of fork %d of task %s", this.index, this.taskId));
     // Not to catch the exception this may throw so it gets propagated
     this.writer.commit();
-    // Change the state to SUCCESSFUL upon successful commit. The state is not changed
-    // to COMMITTED as the data publisher will do that upon successful data publishing.
-    this.taskState.setWorkingState(WorkUnitState.WorkingState.SUCCESSFUL);
 
     try {
       if (JobMetrics.isEnabled(this.taskState.getWorkunit())) {
@@ -239,6 +397,17 @@ public class Fork implements Closeable {
     } catch (IOException ioe) {
       // Trap the exception as failing to update metrics should not cause the task to fail
       this.logger.error("Failed to update byte-level metrics of task " + this.taskId);
+    }
+  }
+
+  /**
+   * Compare and set the state of this {@link Fork} to a new state if and only if the current state
+   * is equal to the expected state.
+   */
+  private void compareAndSetForkState(ForkState expectedState, ForkState newState) {
+    if (!this.forkState.compareAndSet(expectedState, newState)) {
+      throw new IllegalStateException(String
+          .format("Expected fork state %s; actual fork state %s", expectedState.name(), this.forkState.get().name()));
     }
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -327,7 +327,7 @@ public class JobState extends SourceState {
     jsonWriter.name("task states");
     jsonWriter.beginArray();
     for (TaskState taskState : taskStates.values()) {
-      taskState.toJson(jsonWriter);
+      taskState.toJson(jsonWriter, keepConfig);
     }
     jsonWriter.endArray();
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -19,6 +19,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 
@@ -37,15 +38,26 @@ import gobblin.source.extractor.Extractor;
  * A physical unit of execution for a Gobblin {@link gobblin.source.workunit.WorkUnit}.
  *
  * <p>
- *     Each task will be executed by a single thread within a thread pool managed by the
- *     {@link TaskExecutor} and it consists of the following steps:
+ *     Each task is executed by a single thread in a thread pool managed by the {@link TaskExecutor}
+ *     and each {@link Fork} of the task is executed in a separate thread pool also managed by the
+ *     {@link TaskExecutor}.
  *
- * <ul>
- *     <li>Extracting, converting, and forking the source schema.</li>
- *     <li>Extracting, converting, doing row-level quality checking, and forking each data record.</li>
- *     <li>Processing the forked record in each forked branch in a {@link Fork} instance.</li>
- *     <li>Cleaning up and exiting.</li>
- * </ul>
+ *     Each {@link Task} consists of the following steps:
+ *     <ul>
+ *       <li>Extracting, converting, and forking the source schema.</li>
+ *       <li>Extracting, converting, doing row-level quality checking, and forking each data record.</li>
+ *       <li>Putting each forked record into the record queue managed by each {@link Fork}.</li>
+ *       <li>Committing output data of each {@link Fork} once all {@link Fork}s finish.</li>
+ *       <li>Cleaning up and exiting.</li>
+ *     </ul>
+ *
+ *     Each {@link Fork} consists of the following steps:
+ *     <ul>
+ *       <li>Getting the next record off the record queue.</li>
+ *       <li>Converting the record and doing row-level quality checking if applicable.</li>
+ *       <li>Writing the record out if it passes the quality checking.</li>
+ *       <li>Cleaning up and exiting once all the records have been processed.</li>
+ *     </ul>
  * </p>
  *
  * @author ynli
@@ -59,6 +71,7 @@ public class Task implements Runnable {
   private final TaskContext taskContext;
   private final TaskState taskState;
   private final TaskStateTracker taskStateTracker;
+  private final TaskExecutor taskExecutor;
   private final Optional<CountDownLatch> countDownLatch;
 
   private final List<Optional<Fork>> forks = Lists.newArrayList();
@@ -69,17 +82,20 @@ public class Task implements Runnable {
   /**
    * Instantiate a new {@link Task}.
    *
-   * @param context a {@link TaskContext} containing all necessary information
-   *                to construct and run a {@link Task}
+   * @param context a {@link TaskContext} containing all necessary information to construct and run a {@link Task}
    * @param taskStateTracker a {@link TaskStateTracker} for tracking task state
+   * @param taskExecutor a {@link TaskExecutor} for executing the {@link Task} and its {@link Fork}s
+   * @param countDownLatch an optional {@link java.util.concurrent.CountDownLatch} used to signal the task completion
    */
   @SuppressWarnings("unchecked")
-  public Task(TaskContext context, TaskStateTracker taskStateTracker, Optional<CountDownLatch> countDownLatch) {
+  public Task(TaskContext context, TaskStateTracker taskStateTracker, TaskExecutor taskExecutor,
+      Optional<CountDownLatch> countDownLatch) {
     this.taskContext = context;
     this.taskState = context.getTaskState();
     this.jobId = this.taskState.getJobId();
     this.taskId = this.taskState.getTaskId();
     this.taskStateTracker = taskStateTracker;
+    this.taskExecutor = taskExecutor;
     this.countDownLatch = countDownLatch;
   }
 
@@ -113,21 +129,28 @@ public class Task implements Runnable {
       Object schema = converter.convertSchema(extractor.getSchema(), this.taskState);
       List<Boolean> forkedSchemas = forkOperator.forkSchema(this.taskState, schema);
       if (forkedSchemas.size() != branches) {
-        throw new ForkBranchMismatchException(String
-            .format("Number of forked schemas [%d] is not equal to number of branches [%d]", forkedSchemas.size(),
-                branches));
+        throw new ForkBranchMismatchException(String.format(
+            "Number of forked schemas [%d] is not equal to number of branches [%d]", forkedSchemas.size(), branches));
       }
 
       if (inMultipleBranches(forkedSchemas) && !(schema instanceof Copyable)) {
         throw new CopyNotSupportedException(schema + " is not copyable");
       }
+      // The schema could still be Copyable even if it is not going to multiple branches
+      if (schema instanceof Copyable) {
+        schema = ((Copyable) schema).copy();
+      }
 
-      // Create one Fork for each forked branch
+      // Used for the main branch to wait for all forks to finish
+      CountDownLatch forkCountDownLatch = new CountDownLatch(branches);
+
+      // Create one fork for each forked branch
       for (int i = 0; i < branches; i++) {
         if (forkedSchemas.get(i)) {
           Fork fork = closer.register(
-              new Fork(this.taskContext, this.taskState, branches > 1 ? ((Copyable) schema).copy() : schema,
-                  branches, i));
+              new Fork(this.taskContext, this.taskState, schema, branches, i, forkCountDownLatch));
+          // Schedule the fork to run
+          this.taskExecutor.submit(fork);
           this.forks.add(Optional.of(fork));
         } else {
           this.forks.add(Optional.<Fork>absent());
@@ -152,11 +175,45 @@ public class Task implements Runnable {
       LOG.info("Extracted " + recordsPulled + " data records");
       LOG.info("Row quality checker finished with results: " + rowResults.getResults());
 
-      // Commit data of each forked branch
+      if (pullLimit > 0) {
+        // If pull limit is set, use the actual number of records pulled.
+        this.taskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED, recordsPulled);
+      } else {
+        // Otherwise use the expected record count
+        this.taskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED, extractor.getExpectedRecordCount());
+      }
+
       for (Optional<Fork> fork : this.forks) {
         if (fork.isPresent()) {
-          fork.get().commit(recordsPulled, extractor.getExpectedRecordCount(), pullLimit);
+          // Tell the fork that the main branch is done and no new incoming data records should be expected
+          fork.get().markParentTaskDone();
+        } else {
+          forkCountDownLatch.countDown();
         }
+      }
+
+      // Wait for all forks to finish
+      forkCountDownLatch.await();
+
+      // Check if all forks succeeded
+      boolean allForksSucceeded = true;
+      for (Optional<Fork> fork : this.forks) {
+        if (fork.isPresent()) {
+          if (fork.get().isSucceeded()) {
+            fork.get().commit();
+          } else {
+            allForksSucceeded = false;
+          }
+        }
+      }
+
+      if (allForksSucceeded) {
+        // Set the task state to SUCCESSFUL. The state is not set to COMMITTED
+        // as the data publisher will do that upon successful data publishing.
+        this.taskState.setWorkingState(WorkUnitState.WorkingState.SUCCESSFUL);
+      } else {
+        LOG.error(String.format("Not all forks of task %s succeeded", this.taskId));
+        this.taskState.setWorkingState(WorkUnitState.WorkingState.FAILED);
       }
     } catch (Throwable t) {
       LOG.error(String.format("Task %s failed", this.taskId), t);
@@ -209,6 +266,15 @@ public class Task implements Runnable {
    */
   public TaskState getTaskState() {
     return this.taskState;
+  }
+
+  /**
+   * Get the list of {@link Fork}s created by this {@link Task}.
+   *
+   * @return the list of {@link Fork}s created by this {@link Task}
+   */
+  public List<Optional<Fork>> getForks() {
+    return ImmutableList.copyOf(this.forks);
   }
 
   /**
@@ -291,14 +357,36 @@ public class Task implements Runnable {
               branches));
     }
 
-    boolean makesCopy = inMultipleBranches(forkedRecords);
-    if (makesCopy && !(convertedRecord instanceof Copyable)) {
+    if (inMultipleBranches(forkedRecords) && !(convertedRecord instanceof Copyable)) {
       throw new CopyNotSupportedException(convertedRecord + " is not copyable");
     }
+    // The record could still be Copyable even if it is not going to multiple branches
+    if (convertedRecord instanceof Copyable) {
+      convertedRecord = ((Copyable) convertedRecord).copy();
+    }
 
-    for (int i = 0; i < branches; i++) {
-      if (this.forks.get(i).isPresent() && forkedRecords.get(i)) {
-        this.forks.get(i).get().processRecord(makesCopy ? ((Copyable) convertedRecord).copy() : convertedRecord);
+    // If the record has been successfully put into the queues of every forks
+    boolean allPutsSucceeded = false;
+    // Use an array of primitive boolean type to avoid unnecessary boxing/unboxing
+    boolean[] succeededPuts = new boolean[branches];
+    // Put the record into the record queue of each fork. A put may timeout and return a false, in which
+    // case the put needs to be retried in the next iteration along with other failed puts. This goes on
+    // until all puts succeed, at which point the task moves to the next record.
+    while (!allPutsSucceeded) {
+      allPutsSucceeded = true;
+      for (int i = 0; i < branches; i++) {
+        if (succeededPuts[i]) {
+          continue;
+        }
+        if (this.forks.get(i).isPresent() && forkedRecords.get(i)) {
+          boolean succeeded = this.forks.get(i).get().putRecord(convertedRecord);
+          succeededPuts[i] = succeeded;
+          if (!succeeded) {
+            allPutsSucceeded = false;
+          }
+        } else {
+          succeededPuts[i] = true;
+        }
       }
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -15,7 +15,10 @@ import java.util.Properties;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
@@ -31,7 +34,7 @@ import gobblin.util.ExecutorsUtils;
 
 
 /**
- * A class for executing new {@link Task}s and retrying failed ones.
+ * A class for executing {@link Task}s and retrying failed ones as well as for executing {@link Fork}s.
  *
  * @author ynli
  */
@@ -40,10 +43,13 @@ public class TaskExecutor extends AbstractIdleService {
   private static final Logger LOG = LoggerFactory.getLogger(TaskExecutor.class);
 
   // Thread pool executor for running tasks
-  private final ExecutorService executor;
+  private final ExecutorService taskExecutor;
 
   // Scheduled thread pool executor for scheduling task retries
-  private final ScheduledThreadPoolExecutor retryExecutor;
+  private final ScheduledThreadPoolExecutor taskRetryExecutor;
+
+  // A separate thread pool executor for running forks of tasks
+  private final ExecutorService forkExecutor;
 
   // Task retry interval
   private final long retryIntervalInSeconds;
@@ -53,18 +59,32 @@ public class TaskExecutor extends AbstractIdleService {
    */
   private TaskExecutor(int taskExecutorThreadPoolSize, int coreRetryThreadPoolSize, int maxRetryThreadPoolSize,
       long retryIntervalInSeconds) {
-
-    // Currently a fixed-size thread pool is used to execute tasks.
-    // We probably need to revisit this later.
-    this.executor =
-        Executors.newFixedThreadPool(taskExecutorThreadPoolSize, ExecutorsUtils.newThreadFactory(Optional.of(LOG)));
+    // Currently a fixed-size thread pool is used to execute tasks. We probably need to revisit this later.
+    this.taskExecutor = Executors.newFixedThreadPool(
+        taskExecutorThreadPoolSize,
+        ExecutorsUtils.newThreadFactory(Optional.of(LOG), Optional.of("TaskExecutor-%d")));
 
     // Using a separate thread pool for task retries to achieve isolation
     // between normal task execution and task retries
-    this.retryExecutor = new ScheduledThreadPoolExecutor(coreRetryThreadPoolSize);
-    this.retryExecutor.setMaximumPoolSize(maxRetryThreadPoolSize);
-
+    this.taskRetryExecutor = new ScheduledThreadPoolExecutor(coreRetryThreadPoolSize);
+    this.taskRetryExecutor.setMaximumPoolSize(maxRetryThreadPoolSize);
     this.retryIntervalInSeconds = retryIntervalInSeconds;
+
+    this.forkExecutor = new ThreadPoolExecutor(
+        // The core thread pool size is equal to that of the task executor as there's at least one fork per task
+        taskExecutorThreadPoolSize,
+        // The fork executor thread pool size is essentially unbounded. This is to make sure all forks of
+        // a task get a thread to run so all forks of the task are making progress. This is necessary since
+        // otherwise the parent task will be blocked if the record queue (bounded) of some fork is full and
+        // that fork has not yet started to run because of no available thread. The task cannot proceed in
+        // this case because it has to make sure every records go to every forks.
+        Integer.MAX_VALUE,
+        0L,
+        TimeUnit.MILLISECONDS,
+        // The work queue is a SynchronousQueue. This essentially forces a new thread to be created for each fork.
+        new SynchronousQueue<Runnable>(),
+        ExecutorsUtils.newThreadFactory(Optional.of(LOG), Optional.of("ForkExecutor-%d")));
+
   }
 
   /**
@@ -72,38 +92,41 @@ public class TaskExecutor extends AbstractIdleService {
    */
   public TaskExecutor(Properties properties) {
     this(Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_EXECUTOR_THREADPOOL_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE)), Integer.parseInt(properties
-            .getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY,
-                ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE)), Integer.parseInt(properties
-            .getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY,
-                ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE)), Long.parseLong(properties
-            .getProperty(ConfigurationKeys.TASK_RETRY_INTERVAL_IN_SEC_KEY,
-                ConfigurationKeys.DEFAULT_TASK_RETRY_INTERVAL_IN_SEC)));
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE))),
+        Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE))),
+        Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE))),
+        Long.parseLong(properties.getProperty(ConfigurationKeys.TASK_RETRY_INTERVAL_IN_SEC_KEY,
+            Long.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_INTERVAL_IN_SEC))));
   }
 
   /**
    * Constructor to work with Hadoop {@link org.apache.hadoop.conf.Configuration}.
    */
   public TaskExecutor(Configuration conf) {
-    this(Integer.parseInt(conf.get(ConfigurationKeys.TASK_EXECUTOR_THREADPOOL_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE)), Integer.parseInt(
-            conf.get(ConfigurationKeys.TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY,
-                ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE)), Integer.parseInt(
-            conf.get(ConfigurationKeys.TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY,
-                ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE)), Long.parseLong(
-            conf.get(ConfigurationKeys.TASK_RETRY_INTERVAL_IN_SEC_KEY,
-                ConfigurationKeys.DEFAULT_TASK_RETRY_INTERVAL_IN_SEC)));
+    this(conf.getInt(ConfigurationKeys.TASK_EXECUTOR_THREADPOOL_SIZE_KEY,
+            ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE),
+        conf.getInt(ConfigurationKeys.TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY,
+            ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE),
+        conf.getInt(ConfigurationKeys.TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY,
+            ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE),
+        conf.getLong(ConfigurationKeys.TASK_RETRY_INTERVAL_IN_SEC_KEY,
+            ConfigurationKeys.DEFAULT_TASK_RETRY_INTERVAL_IN_SEC));
   }
 
   @Override
   protected void startUp()
       throws Exception {
     LOG.info("Starting the task executor");
-    if (this.executor.isShutdown() || this.executor.isTerminated()) {
-      throw new IllegalStateException();
+    if (this.taskExecutor.isShutdown() || this.taskExecutor.isTerminated()) {
+      throw new IllegalStateException("Task thread pool executor is shutdown or terminated");
     }
-    if (this.retryExecutor.isShutdown() || this.retryExecutor.isTerminated()) {
-      throw new IllegalStateException();
+    if (this.taskRetryExecutor.isShutdown() || this.taskRetryExecutor.isTerminated()) {
+      throw new IllegalStateException("Task retry thread pool executor is shutdown or terminated");
+    }
+    if (this.forkExecutor.isShutdown() || this.forkExecutor.isTerminated()) {
+      throw new IllegalStateException("Fork thread pool executor is shutdown or terminated");
     }
   }
 
@@ -111,8 +134,9 @@ public class TaskExecutor extends AbstractIdleService {
   protected void shutDown()
       throws Exception {
     LOG.info("Stopping the task executor ");
-    this.executor.shutdown();
-    this.retryExecutor.shutdown();
+    this.taskExecutor.shutdown();
+    this.taskRetryExecutor.shutdown();
+    this.forkExecutor.shutdown();
   }
 
   /**
@@ -122,18 +146,39 @@ public class TaskExecutor extends AbstractIdleService {
    */
   public void execute(Task task) {
     LOG.info(String.format("Executing task %s", task.getTaskId()));
-    this.executor.execute(task);
+    this.taskExecutor.execute(task);
   }
 
   /**
    * Submit a {@link Task} to run.
    *
    * @param task {@link Task} to be submitted
-   * @return A {@link java.util.concurrent.Future} for the submitted {@link Task}
+   * @return a {@link java.util.concurrent.Future} for the submitted {@link Task}
    */
   public Future<?> submit(Task task) {
     LOG.info(String.format("Submitting task %s", task.getTaskId()));
-    return this.executor.submit(task);
+    return this.taskExecutor.submit(task);
+  }
+
+  /**
+   * Execute a {@link Fork}.
+   *
+   * @param fork {@link Fork} to be executed
+   */
+  public void execute(Fork fork) {
+    LOG.info(String.format("Executing fork %d of task %s", fork.getIndex(), fork.getTaskId()));
+    this.forkExecutor.execute(fork);
+  }
+
+  /**
+   * Submit a {@link Fork} to run.
+   *
+   * @param fork {@link Fork} to be submitted
+   * @return a {@link java.util.concurrent.Future} for the submitted {@link Fork}
+   */
+  public Future<?> submit(Fork fork) {
+    LOG.info(String.format("Submitting fork %d of task %s", fork.getIndex(), fork.getTaskId()));
+    return this.forkExecutor.submit(fork);
   }
 
   /**
@@ -154,7 +199,7 @@ public class TaskExecutor extends AbstractIdleService {
     // Task retry interval increases linearly with number of retries
     long interval = task.getRetryCount() * this.retryIntervalInSeconds;
     // Schedule the retry of the failed task
-    this.retryExecutor.schedule(task, interval, TimeUnit.SECONDS);
+    this.taskRetryExecutor.schedule(task, interval, TimeUnit.SECONDS);
     LOG.info(String.format("Scheduled retry of failed task %s to run in %d seconds", task.getTaskId(), interval));
     task.incrementRetryCount();
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -69,6 +69,7 @@ public class TaskState extends WorkUnitState {
     // Since getWorkunit() returns an immutable WorkUnit object,
     // the WorkUnit object in this object is also immutable.
     super(workUnitState.getWorkunit());
+    addAll(workUnitState);
     this.jobId = workUnitState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = workUnitState.getProp(ConfigurationKeys.TASK_ID_KEY);
     this.setId(this.taskId);
@@ -271,7 +272,7 @@ public class TaskState extends WorkUnitState {
    * @param jsonWriter a {@link com.google.gson.stream.JsonWriter} used to write the json document
    * @throws IOException
    */
-  public void toJson(JsonWriter jsonWriter)
+  public void toJson(JsonWriter jsonWriter, boolean keepConfig)
       throws IOException {
     jsonWriter.beginObject();
 
@@ -287,6 +288,15 @@ public class TaskState extends WorkUnitState {
     // case that the task finally succeeds so we know what happened in the course of task execution.
     if (this.contains(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY)) {
       jsonWriter.name("exception").value(this.getProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY));
+    }
+
+    if (keepConfig) {
+      jsonWriter.name("properties");
+      jsonWriter.beginObject();
+      for (String key : this.getPropertyNames()) {
+        jsonWriter.name(key).value(this.getProp(key));
+      }
+      jsonWriter.endObject();
     }
 
     jsonWriter.endObject();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/WorkUnitManager.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/WorkUnitManager.java
@@ -131,8 +131,8 @@ public class WorkUnitManager extends AbstractIdleService {
           }
 
           // Create a task based off the work unit
-          Task task =
-              new Task(new TaskContext(workUnitState), this.taskStateTracker, Optional.<CountDownLatch>absent());
+          Task task = new Task(new TaskContext(workUnitState), this.taskStateTracker, taskExecutor,
+              Optional.<CountDownLatch>absent());
           // And then execute the task
           this.taskExecutor.execute(task);
         } catch (InterruptedException ie) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java
@@ -171,9 +171,9 @@ public class LocalJobManager extends AbstractIdleService {
     this.taskStateStore = new FsStateStore(properties.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
         properties.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY), TaskState.class);
 
-    long pollingInterval = Long.parseLong(this.properties
-        .getProperty(ConfigurationKeys.JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY,
-            ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL));
+    long pollingInterval = Long.parseLong(this.properties.getProperty(
+        ConfigurationKeys.JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY,
+        Long.toString(ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL)));
     this.fileAlterationMonitor = new FileAlterationMonitor(pollingInterval);
 
     restoreLastJobIdMap();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker.java
@@ -66,14 +66,14 @@ public class LocalTaskStateTracker extends AbstractIdleService implements TaskSt
 
   public LocalTaskStateTracker(Properties properties, TaskExecutor taskExecutor) {
     this.taskExecutor = taskExecutor;
-    this.reporterExecutor = new ScheduledThreadPoolExecutor(Integer.parseInt(properties
-        .getProperty(ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE_KEY,
-            ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE)));
-    this.reporterExecutor.setMaximumPoolSize(Integer.parseInt(properties
-            .getProperty(ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE_KEY,
-                ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE)));
-    this.maxTaskRetries = Integer.parseInt(
-        properties.getProperty(ConfigurationKeys.MAX_TASK_RETRIES_KEY, ConfigurationKeys.DEFAULT_MAX_TASK_RETRIES));
+    this.reporterExecutor = new ScheduledThreadPoolExecutor(Integer.parseInt(properties.getProperty(
+        ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE_KEY,
+        Integer.toString(ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_CORE_SIZE))));
+    this.reporterExecutor.setMaximumPoolSize(Integer.parseInt(properties.getProperty(
+        ConfigurationKeys.TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE_KEY,
+        Integer.toString(ConfigurationKeys.DEFAULT_TASK_STATE_TRACKER_THREAD_POOL_MAX_SIZE))));
+    this.maxTaskRetries = Integer.parseInt(properties.getProperty(
+        ConfigurationKeys.MAX_TASK_RETRIES_KEY, Integer.toString(ConfigurationKeys.DEFAULT_MAX_TASK_RETRIES)));
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker2.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker2.java
@@ -52,8 +52,8 @@ public class LocalTaskStateTracker2 extends AbstractTaskStateTracker {
   public LocalTaskStateTracker2(Properties properties, TaskExecutor taskExecutor) {
     super(properties, LOG);
     this.taskExecutor = taskExecutor;
-    this.maxTaskRetries = Integer.parseInt(
-        properties.getProperty(ConfigurationKeys.MAX_TASK_RETRIES_KEY, ConfigurationKeys.DEFAULT_MAX_TASK_RETRIES));
+    this.maxTaskRetries = Integer.parseInt(properties.getProperty(
+        ConfigurationKeys.MAX_TASK_RETRIES_KEY, Integer.toString(ConfigurationKeys.DEFAULT_MAX_TASK_RETRIES)));
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputCommitter.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputCommitter.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.JobLauncherUtils;
@@ -79,7 +80,7 @@ public class GobblinOutputCommitter extends OutputCommitter {
           } finally {
             workUnitFileCloser.close();
           }
-          JobLauncherUtils.cleanStagingData(wu, LOG);
+          JobLauncherUtils.cleanStagingData(new WorkUnitState(wu), LOG);
         }
 
         // If the file ends with ".mwu" de-serialize it into a MultiWorkUnit
@@ -91,7 +92,7 @@ public class GobblinOutputCommitter extends OutputCommitter {
             workUnitFileCloser.close();
           }
           for (WorkUnit wu : mwu.getWorkUnits()) {
-            JobLauncherUtils.cleanStagingData(wu, LOG);
+            JobLauncherUtils.cleanStagingData(new WorkUnitState(wu), LOG);
           }
         }
       }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTaskStateTracker.java
@@ -102,7 +102,7 @@ public class MRTaskStateTracker extends AbstractTaskStateTracker {
    * An extension to {@link AbstractTaskStateTracker.TaskMetricsUpdater} for updating task metrics
    * in the Hadoop MapReduce setting.
    */
-  private static class MRTaskMetricsUpdater extends AbstractTaskStateTracker.TaskMetricsUpdater {
+  private class MRTaskMetricsUpdater extends AbstractTaskStateTracker.TaskMetricsUpdater {
 
     private final Mapper<LongWritable, Text, NullWritable, NullWritable>.Context context;
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/BoundedBlockingRecordQueueTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/BoundedBlockingRecordQueueTest.java
@@ -1,0 +1,135 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.MetricRegistry;
+
+import com.google.common.collect.Lists;
+
+
+/**
+ * Unit tests for {@link BoundedBlockingRecordQueue}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.runtime"})
+public class BoundedBlockingRecordQueueTest {
+
+  private static final String METRIC_NAME_PREFIX = "test";
+
+  private BoundedBlockingRecordQueue<Integer> boundedBlockingRecordQueue;
+
+  @BeforeClass
+  public void setUp() {
+    this.boundedBlockingRecordQueue = BoundedBlockingRecordQueue.<Integer>newBuilder()
+        .hasCapacity(2)
+        .useTimeout(100)
+        .useTimeoutTimeUnit(TimeUnit.MILLISECONDS)
+        .collectStats()
+        .build();
+  }
+
+  @Test
+  public void testPutAndGet() throws InterruptedException {
+    final List<Integer> produced = Lists.newArrayList();
+    Thread producer = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        for (int i = 0; i < 6; i++) {
+          try {
+            boundedBlockingRecordQueue.put(i);
+            produced.add(i);
+          } catch (InterruptedException ie) {
+            throw new RuntimeException(ie);
+          }
+        }
+      }
+    });
+
+    final List<Integer> consumed = Lists.newArrayList();
+    Thread consumer = new Thread(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          for (int i = 0; i < 6; i++) {
+            consumed.add(boundedBlockingRecordQueue.get());
+          }
+        } catch (InterruptedException ie) {
+          throw new RuntimeException(ie);
+        }
+      }
+    });
+
+    producer.start();
+    consumer.start();
+
+    producer.join();
+    consumer.join();
+
+    Assert.assertEquals(produced, consumed);
+    Assert.assertNull(this.boundedBlockingRecordQueue.get());
+  }
+
+  @Test(dependsOnMethods = "testPutAndGet")
+  public void testQueueStats() throws InterruptedException {
+    BoundedBlockingRecordQueue.QueueStats stats = this.boundedBlockingRecordQueue.stats().get();
+    Assert.assertEquals(stats.queueSize(), 0);
+    Assert.assertEquals(stats.fillRatio(), 0d);
+    Assert.assertEquals(stats.getAttemptCount(), 7);
+    Assert.assertEquals(stats.putAttemptCount(), 6);
+
+    this.boundedBlockingRecordQueue.put(0);
+    this.boundedBlockingRecordQueue.put(1);
+
+    Assert.assertEquals(stats.queueSize(), 2);
+    Assert.assertEquals(stats.fillRatio(), 1d);
+    Assert.assertEquals(stats.getAttemptCount(), 7);
+    Assert.assertEquals(stats.putAttemptCount(), 8);
+  }
+
+  @Test(dependsOnMethods = "testQueueStats")
+  public void testRegisterAll() {
+    MetricRegistry metricRegistry = new MetricRegistry();
+    this.boundedBlockingRecordQueue.stats().get().registerAll(metricRegistry, METRIC_NAME_PREFIX);
+    Map<String, Gauge> gauges = metricRegistry.getGauges();
+    Assert.assertEquals(gauges.size(), 2);
+    Assert.assertEquals(
+        gauges.get(MetricRegistry.name(METRIC_NAME_PREFIX, BoundedBlockingRecordQueue.QueueStats.QUEUE_SIZE))
+            .getValue(), 2);
+    Assert.assertEquals(
+        gauges.get(MetricRegistry.name(METRIC_NAME_PREFIX, BoundedBlockingRecordQueue.QueueStats.FILL_RATIO))
+            .getValue(), 1d);
+    Assert.assertEquals(metricRegistry.getMeters().size(), 2);
+    Assert.assertEquals(metricRegistry
+        .meter(MetricRegistry.name(METRIC_NAME_PREFIX, BoundedBlockingRecordQueue.QueueStats.GET_ATTEMPT_RATE))
+        .getCount(), 7);
+    Assert.assertEquals(metricRegistry
+        .meter(MetricRegistry.name(METRIC_NAME_PREFIX, BoundedBlockingRecordQueue.QueueStats.PUT_ATTEMPT_RATE))
+        .getCount(), 8);
+  }
+
+  @AfterClass
+  public void tearDown() throws InterruptedException {
+    this.boundedBlockingRecordQueue.clear();
+    Assert.assertNull(this.boundedBlockingRecordQueue.get());
+  }
+}

--- a/gobblin-test/resource/job-conf/GobblinTest1.pull
+++ b/gobblin-test/resource/job-conf/GobblinTest1.pull
@@ -11,6 +11,8 @@ extract.namespace=gobblin.test1
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file://localhost/
+writer.staging.dir=gobblin-test/writer-staging
+writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/resource/source/test.avro.0,gobblin-test/resource/source/test.avro.1
 

--- a/gobblin-test/resource/job-conf/GobblinTest2.pull
+++ b/gobblin-test/resource/job-conf/GobblinTest2.pull
@@ -11,6 +11,8 @@ extract.namespace=gobblin.test2
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file://localhost/
+writer.staging.dir=gobblin-test/writer-staging
+writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/resource/source/test.avro.0,gobblin-test/resource/source/test.avro.1
 

--- a/gobblin-test/resource/job-conf/GobblinTest3.pull
+++ b/gobblin-test/resource/job-conf/GobblinTest3.pull
@@ -11,6 +11,8 @@ extract.namespace=gobblin.test3
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file://localhost/
+writer.staging.dir=gobblin-test/writer-staging
+writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/resource/source/test.avro.0,gobblin-test/resource/source/test.avro.1
 

--- a/gobblin-test/resource/mr-job-conf/GobblinMRTest.pull
+++ b/gobblin-test/resource/mr-job-conf/GobblinMRTest.pull
@@ -10,6 +10,8 @@ extract.namespace=gobblin.MRTest
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file:///
+writer.staging.dir=gobblin-test/writer-staging
+writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/source/test.avro.0,gobblin-test/source/test.avro.1
 

--- a/gobblin-utility/src/main/java/gobblin/util/ExecutorsUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ExecutorsUtils.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ThreadFactory;
 import org.slf4j.Logger;
 
 import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 
 /**
@@ -44,14 +45,24 @@ public class ExecutorsUtils {
    *               {@link LoggingUncaughtExceptionHandler} uses to log uncaught exceptions thrown in threads
    * @return a new {@link java.util.concurrent.ThreadFactory}
    */
-  public static ThreadFactory newThreadFactory(final Optional<Logger> logger) {
-    return new ThreadFactory() {
-      @Override
-      public Thread newThread(Runnable runnable) {
-        Thread thread = new Thread(runnable);
-        thread.setUncaughtExceptionHandler(new LoggingUncaughtExceptionHandler(logger));
-        return thread;
-      }
-    };
+  public static ThreadFactory newThreadFactory(Optional<Logger> logger) {
+    return newThreadFactory(logger, Optional.<String>absent());
+  }
+
+  /**
+   * Get a new {@link java.util.concurrent.ThreadFactory} that uses a {@link LoggingUncaughtExceptionHandler}
+   * to handle uncaught exceptions and the given thread name format.
+   *
+   * @param logger an {@link com.google.common.base.Optional} wrapping the {@link org.slf4j.Logger} that the
+   *               {@link LoggingUncaughtExceptionHandler} uses to log uncaught exceptions thrown in threads
+   * @param nameFormat an {@link com.google.common.base.Optional} wrapping a thread naming format
+   * @return a new {@link java.util.concurrent.ThreadFactory}
+   */
+  public static ThreadFactory newThreadFactory(Optional<Logger> logger, Optional<String> nameFormat) {
+    ThreadFactoryBuilder builder = new ThreadFactoryBuilder();
+    if (nameFormat.isPresent()) {
+      builder.setNameFormat(nameFormat.get());
+    }
+    return builder.setUncaughtExceptionHandler(new LoggingUncaughtExceptionHandler(logger)).build();
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -1,0 +1,71 @@
+package gobblin.util;
+
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * Utility class for use with the {@link gobblin.writer.DataWriter} class.
+ */
+public class WriterUtils {
+
+  public static Path getWriterStagingDir(State state, int branch) {
+    Preconditions.checkArgument(
+        state.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR, branch)),
+        "Missing required property " + ConfigurationKeys.WRITER_STAGING_DIR);
+
+    return new Path(state.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR,
+        branch)), WriterUtils.getWriterFilePath(state, branch));
+  }
+
+  public static Path getWriterOutputDir(State state, int branch) {
+    Preconditions.checkArgument(
+        state.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, branch)),
+        "Missing required property " + ConfigurationKeys.WRITER_OUTPUT_DIR);
+
+    return new Path(state.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR,
+        branch)), WriterUtils.getWriterFilePath(state, branch));
+  }
+
+  public static Path getDataPublisherFinalOutputDir(State state, int branch) {
+    Preconditions.checkArgument(
+        state.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, branch)),
+        "Missing required property " + ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR);
+
+    return new Path(state.getProp(ForkOperatorUtils.getPropertyNameForBranch(
+        ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, branch)), WriterUtils.getWriterFilePath(state, branch));
+  }
+
+  public static String getWriterFilePath(State state, int branch) {
+    if (state.contains(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PATH, branch))) {
+      return state.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PATH, branch));
+    }
+    return WriterUtils.getDefaultWriterFilePath(state, branch);
+  }
+
+  public static String getDefaultWriterFilePath(State state, int branch) {
+    if (state instanceof WorkUnitState) {
+      WorkUnitState workUnitState = (WorkUnitState) state;
+      return ForkOperatorUtils.getPathForBranch(workUnitState, workUnitState.getExtract().getOutputFilePath(), branch);
+
+    } else if (state instanceof WorkUnit) {
+      WorkUnit workUnit = (WorkUnit) state;
+      return ForkOperatorUtils.getPathForBranch(workUnit, workUnit.getExtract().getOutputFilePath(), branch);
+    }
+
+    throw new RuntimeException("In order to get the default value for " + ConfigurationKeys.WRITER_FILE_PATH
+        + " the given state must be of type " + WorkUnitState.class.getName() + " or " + WorkUnit.class.getName());
+  }
+
+  public static String getWriterFileName(State state, int branch, String writerId, String formatExtension) {
+    return String.format("%s.%s.%s", state.getProp(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_NAME, branch),
+        ConfigurationKeys.DEFAULT_WRITER_FILE_NAME), writerId, formatExtension);
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/ForkOperatorUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ForkOperatorUtilsTest.java
@@ -16,6 +16,7 @@ import org.testng.annotations.Test;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
 
 
 /**
@@ -58,11 +59,35 @@ public class ForkOperatorUtilsTest {
 
   @Test
   public void testGetPathForBranch() {
-    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_0, 0), PATH_FOO);
-    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_0, 1), PATH_FOO);
-    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_0, 2),
-        PATH_FOO + "/" + FORK_BRANCH_NAME_0);
-    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(PATH_FOO, FORK_BRANCH_NAME_1, 2),
-        PATH_FOO + "/" + FORK_BRANCH_NAME_1);
+    State state = new State();
+    state.setProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + ".0", FORK_BRANCH_NAME_0);
+    state.setProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + ".1", FORK_BRANCH_NAME_1);
+
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(state, PATH_FOO, -1), PATH_FOO);
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(state, PATH_FOO, 0), PATH_FOO + "/"
+        + FORK_BRANCH_NAME_0);
+    Assert.assertEquals(ForkOperatorUtils.getPathForBranch(state, PATH_FOO, 1), PATH_FOO + "/"
+        + FORK_BRANCH_NAME_1);
+  }
+
+  /**
+   * Test for {@link ForkOperatorUtils#getPropertyNameForBranch(WorkUnitState, String)}.
+   */
+  @Test
+  public void testGetPropertyNameForBranchWithWorkUnitState() {
+    WorkUnitState workUnitState = new WorkUnitState();
+    workUnitState.setProp(PROPERTY_FOO, PATH_FOO);
+
+    // Test that if the fork id key is not specified that the original property is preserved
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(workUnitState, PROPERTY_FOO), PROPERTY_FOO);
+
+    // Test that if the fork id key is set to -1 that the original property is preserved
+    workUnitState.setProp(ConfigurationKeys.FORK_BRANCH_ID_KEY, -1);
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(workUnitState, PROPERTY_FOO), PROPERTY_FOO);
+
+    // Test that if the fork id key is set to 0 that the new property is properly created
+    workUnitState.setProp(ConfigurationKeys.FORK_BRANCH_ID_KEY, 0);
+    Assert.assertEquals(ForkOperatorUtils.getPropertyNameForBranch(workUnitState, PROPERTY_FOO), PROPERTY_FOO
+        + ".0");
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/JobLauncherUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/JobLauncherUtilsTest.java
@@ -22,7 +22,11 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.Extract.TableType;
+import gobblin.source.workunit.WorkUnit;
 
 
 /**
@@ -55,6 +59,7 @@ public class JobLauncherUtilsTest {
     Assert.assertEquals(JobLauncherUtils.newMultiTaskId(this.jobId, 1), this.jobId.replace("job", "multitask") + "_1");
   }
 
+  @Test
   public void testDeleteStagingData() throws IOException {
     FileSystem fs = FileSystem.getLocal(new Configuration());
 
@@ -68,7 +73,7 @@ public class JobLauncherUtilsTest {
     String writerPath1 = "test1";
 
     try {
-      State state = new State();
+      WorkUnitState state = new WorkUnitState();
       state.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
       state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, 2, 0),
           ConfigurationKeys.LOCAL_FS_URI);
@@ -103,6 +108,76 @@ public class JobLauncherUtilsTest {
     } finally {
       fs.delete(rootDir, true);
     }
+  }
 
+  @Test
+  public void testDeleteStagingDataWithOutWriterFilePath() throws IOException {
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+
+    String branchName0 = "fork_0";
+    String branchName1 = "fork_1";
+
+    String namespace = "gobblin.test";
+    String tableName = "test-table";
+
+    Path rootDir = new Path("gobblin-test/job-launcher-utils-test");
+
+    Path writerStagingDir0 = new Path(rootDir, "staging" + Path.SEPARATOR + branchName0);
+    Path writerStagingDir1 = new Path(rootDir, "staging" + Path.SEPARATOR + branchName1);
+    Path writerOutputDir0 = new Path(rootDir, "output" + Path.SEPARATOR + branchName0);
+    Path writerOutputDir1 = new Path(rootDir, "output" + Path.SEPARATOR + branchName1);
+
+    try {
+      SourceState sourceState = new SourceState();
+      WorkUnitState state =
+          new WorkUnitState(new WorkUnit(sourceState, new Extract(sourceState, TableType.APPEND_ONLY, namespace,
+              tableName)));
+
+      state.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_BRANCH_NAME_KEY, 0), branchName0);
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_BRANCH_NAME_KEY, 1), branchName1);
+
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, 2, 0),
+          ConfigurationKeys.LOCAL_FS_URI);
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, 2, 1),
+          ConfigurationKeys.LOCAL_FS_URI);
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR, 2, 0),
+          writerStagingDir0.toString());
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_STAGING_DIR, 2, 1),
+          writerStagingDir1.toString());
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, 2, 0),
+          writerOutputDir0.toString());
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_DIR, 2, 1),
+          writerOutputDir1.toString());
+
+      Path writerStagingPath0 =
+          new Path(writerStagingDir0, ForkOperatorUtils.getPathForBranch(state, state.getExtract().getOutputFilePath(),
+              0));
+      fs.mkdirs(writerStagingPath0);
+
+      Path writerStagingPath1 =
+          new Path(writerStagingDir1, ForkOperatorUtils.getPathForBranch(state, state.getExtract().getOutputFilePath(),
+              1));
+      fs.mkdirs(writerStagingPath1);
+
+      Path writerOutputPath0 =
+          new Path(writerOutputDir0, ForkOperatorUtils.getPathForBranch(state, state.getExtract().getOutputFilePath(),
+              0));
+      fs.mkdirs(writerOutputPath0);
+
+      Path writerOutputPath1 =
+          new Path(writerOutputDir1, ForkOperatorUtils.getPathForBranch(state, state.getExtract().getOutputFilePath(),
+              1));
+      fs.mkdirs(writerOutputPath1);
+
+      JobLauncherUtils.cleanStagingData(state, LoggerFactory.getLogger(JobLauncherUtilsTest.class));
+
+      Assert.assertFalse(fs.exists(writerStagingPath0));
+      Assert.assertFalse(fs.exists(writerStagingPath1));
+      Assert.assertFalse(fs.exists(writerOutputPath0));
+      Assert.assertFalse(fs.exists(writerOutputPath1));
+    } finally {
+      fs.delete(rootDir, true);
+    }
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
@@ -187,7 +187,7 @@ public class SchedulerUtilsTest {
 
   @Test
   public void testLoadJobConfigsForCommonPropsFile()
-      throws ConfigurationException {
+      throws ConfigurationException, IOException {
     File commonPropsFile = new File(SUB_DIR1, "test.properties");
 
     Properties properties = new Properties();
@@ -224,7 +224,7 @@ public class SchedulerUtilsTest {
 
   @Test
   public void testLoadJobConfig()
-      throws ConfigurationException {
+      throws ConfigurationException, IOException {
     File jobConfigFile = new File(SUB_DIR11, "test111.pull");
     Properties properties = new Properties();
     properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, JOB_CONF_ROOT_DIR.getAbsolutePath());


### PR DESCRIPTION
The problem is that line 367 of AbstractJobLauncher.addWorkUnit() adds each WorkUnit from Source.getWorkUnits() to the jobState.taskStates Map. So the Map contains all the pre-runtime values of the WorkUnits. However, on line 308 of Fork.buildWriter(), the value of ConfigurationKeys.WRITER_FILE_PATH is set if it is not currently present in the WorkUnit. Fork.buildWriter() is only called during the runtime of each WorkUnit. So the value of ConfigurationKeys.WRITER_FILE_PATH never makes it into the JobState object. So, the JobLauncherUtils.cleanStagingData() method won’t do anything, as the WorkUnit it is looking at doesn’t have a value for  ConfigurationKeys.WRITER_FILE_PATH.

This pull request will ensure this doesn't happen again. If the WRITER_FILE_PATH does not exist in the config during cleanup, the code uses its default value to cleanup the data.