### PR TITLE
Adding byteman test support and example

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -159,7 +159,7 @@ subprojects {
         force = true
       }
 
-      // Required to add JDK's tool jar, which is required by to run byteman tests
+      // Required to add JDK's tool jar, which is required to run byteman tests.
       compile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
     }
   }

--- a/build.gradle
+++ b/build.gradle
@@ -33,10 +33,16 @@ if (!project.hasProperty('hadoopVersion')) {
   }
 }
 
-hiveVersion = '0.13.0'
+if (!project.hasProperty('hiveVersion')) {
+  hiveVersion = '0.13.0'
+}
 
 if (!project.hasProperty('pegasusVersion')) {
   pegasusVersion = '1.15.9'
+}
+
+if (!project.hasProperty('bytemanVersion')) {
+  bytemanVersion = '2.2.1'
 }
 
 ext.externalDependency = [
@@ -92,6 +98,8 @@ ext.externalDependency = [
   "mockito": "org.mockito:mockito-core:1.10.19",
   "salesforceWsc": "com.force.api:force-wsc:29.0.0",
   "salesforcePartner": "com.force.api:force-partner-api:29.0.0",
+  "byteman": "org.jboss.byteman:byteman:"+bytemanVersion,
+  "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:"+bytemanVersion,
   "pegasus" : [
     "data" : "com.linkedin.pegasus:data:"+pegasusVersion,
     "generator" : "com.linkedin.pegasus:generator:"+pegasusVersion,
@@ -118,6 +126,8 @@ if (!isDefaultEnvironment)
 
 task wrapper(type: Wrapper) { gradleVersion = '1.12' }
 
+import javax.tools.ToolProvider
+
 subprojects {
   apply plugin: 'java'
   apply plugin: 'idea'
@@ -140,6 +150,9 @@ subprojects {
       compile(externalDependency.guava) {
         force = true
       }
+
+      // Required to add JDK's tool jar, which is required by to run byteman tests
+      compile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
     }
   }
 

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -41,6 +41,8 @@ dependencies {
   compile externalDependency.javaxInject
 
   testCompile externalDependency.testng
+  testCompile externalDependency.byteman
+  testCompile externalDependency.bytemanBmunit
   testRuntime externalDependency.derby
 }
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -23,7 +23,8 @@ import org.testng.annotations.Test;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
-import gobblin.runtime.JobLauncherTestBase;
+import gobblin.metastore.StateStore;
+import gobblin.runtime.JobLauncherTestHelper;
 import gobblin.runtime.JobState;
 import gobblin.writer.Destination;
 import gobblin.writer.WriterOutputFormat;
@@ -32,62 +33,65 @@ import gobblin.writer.WriterOutputFormat;
 /**
  * Unit test for {@link LocalJobLauncher}.
  */
-@Test(groups = {"gobblin.runtime.local"})
-public class LocalJobLauncherTest extends JobLauncherTestBase {
+@Test(groups = { "gobblin.runtime.local" })
+public class LocalJobLauncherTest {
+
+  private Properties launcherProps;
+  private StateStore jobStateStore;
+  private JobLauncherTestHelper jobLauncherTestHelper;
 
   @BeforeClass
-  public void startUp()
-      throws Exception {
-    this.properties = new Properties();
-    this.properties.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
-    this.properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
-    this.properties.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
-    this.properties
-        .setProperty(ConfigurationKeys.JOB_HISTORY_STORE_JDBC_DRIVER_KEY, "org.apache.derby.jdbc.EmbeddedDriver");
-    this.properties.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY, "jdbc:derby:memory:gobblin1;create=true");
-    prepareJobHistoryStoreDatabase(this.properties);
-    this.jobStateStore = new FsStateStore(this.properties.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
-        this.properties.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY), JobState.class);
+  public void startUp() throws Exception {
+    this.launcherProps = new Properties();
+    this.launcherProps.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
+    this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
+    this.launcherProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
+    this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_JDBC_DRIVER_KEY,
+        "org.apache.derby.jdbc.EmbeddedDriver");
+    this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY,
+        "jdbc:derby:memory:gobblin1;create=true");
+
+    this.jobStateStore =
+        new FsStateStore(this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
+            this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY), JobState.class);
+
+    this.jobLauncherTestHelper = new JobLauncherTestHelper(launcherProps, jobStateStore);
+    this.jobLauncherTestHelper.prepareJobHistoryStoreDatabase(this.launcherProps);
   }
 
   @Test
-  public void testLaunchJob()
-      throws Exception {
-    runTest(loadJobProps());
+  public void testLaunchJob() throws Exception {
+    this.jobLauncherTestHelper.runTest(loadJobProps());
   }
 
   @Test
-  public void testLaunchJobWithPullLimit()
-      throws Exception {
+  public void testLaunchJobWithPullLimit() throws Exception {
     Properties jobProps = loadJobProps();
     jobProps.setProperty(ConfigurationKeys.EXTRACT_PULL_LIMIT, "10");
-    runTestWithPullLimit(jobProps);
+    this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
   }
 
   @Test
-  public void testLaunchJobWithMultiWorkUnit()
-      throws Exception {
+  public void testLaunchJobWithMultiWorkUnit() throws Exception {
     Properties jobProps = loadJobProps();
     jobProps.setProperty("use.multiworkunit", Boolean.toString(true));
-    runTest(jobProps);
+    this.jobLauncherTestHelper.runTest(jobProps);
   }
 
-  @Test(groups = {"ignore"})
-  public void testCancelJob()
-      throws Exception {
-    runTestWithCancellation(loadJobProps());
+  @Test(groups = { "ignore" })
+  public void testCancelJob() throws Exception {
+    this.jobLauncherTestHelper.runTestWithCancellation(loadJobProps());
   }
 
   @Test
-  public void testLaunchJobWithFork()
-      throws Exception {
+  public void testLaunchJobWithFork() throws Exception {
     Properties jobProps = loadJobProps();
     jobProps.setProperty(ConfigurationKeys.CONVERTER_CLASSES_KEY, "gobblin.test.TestConverter2");
     jobProps.setProperty(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
-    jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".0",
-        "gobblin.policies.schema.SchemaRowCheckPolicy");
-    jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".1",
-        "gobblin.policies.schema.SchemaRowCheckPolicy");
+    jobProps
+        .setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".0", "gobblin.policies.schema.SchemaRowCheckPolicy");
+    jobProps
+        .setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".1", "gobblin.policies.schema.SchemaRowCheckPolicy");
     jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE + ".0", "OPTIONAL");
     jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE + ".1", "OPTIONAL");
     jobProps.setProperty(ConfigurationKeys.TASK_LEVEL_POLICY_LIST + ".0",
@@ -106,7 +110,7 @@ public class LocalJobLauncherTest extends JobLauncherTestBase {
     jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".1", "gobblin-test/basicTest/tmp/taskOutput");
     jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".0", "gobblin-test/jobOutput");
     jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".1", "gobblin-test/jobOutput");
-    runTestWithFork(jobProps);
+    this.jobLauncherTestHelper.runTestWithFork(jobProps);
   }
 
   @AfterClass
@@ -118,15 +122,13 @@ public class LocalJobLauncherTest extends JobLauncherTestBase {
     }
   }
 
-  private Properties loadJobProps()
-      throws IOException {
+  private Properties loadJobProps() throws IOException {
     Properties jobProps = new Properties();
     jobProps.load(new FileReader("gobblin-test/resource/job-conf/GobblinTest1.pull"));
-    jobProps.putAll(this.properties);
-    jobProps.setProperty(SOURCE_FILE_LIST_KEY, "gobblin-test/resource/source/test.avro.0," +
-            "gobblin-test/resource/source/test.avro.1," +
-            "gobblin-test/resource/source/test.avro.2," +
-            "gobblin-test/resource/source/test.avro.3");
+    jobProps.putAll(this.launcherProps);
+    jobProps.setProperty(JobLauncherTestHelper.SOURCE_FILE_LIST_KEY, "gobblin-test/resource/source/test.avro.0,"
+        + "gobblin-test/resource/source/test.avro.1," + "gobblin-test/resource/source/test.avro.2,"
+        + "gobblin-test/resource/source/test.avro.3");
 
     return jobProps;
   }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -133,12 +133,16 @@ public class MRJobLauncherTest extends BMNGRunner {
 
   /**
    * Byteman test that ensures the {@link MRJobLauncher} successfully cleans up all staging data even when an exception
-   * is thrown in the {@link MRJobLauncher} collectOutput method.
+   * is thrown in the {@link MRJobLauncher} collectOutput method. The {@link BMRule} is to inject an {@link IOException}
+   * when {@link MRJobLauncher}'s collectOutput method is called.
    */
   @Test()
-  @BMRule(name = "testJobCleanupOnError", targetClass = "gobblin.runtime.mapreduce.MRJobLauncher",
-      targetMethod = "collectOutput(Path)", targetLocation = "AT ENTRY", condition = "true",
-      action = "throw new IOException(\"Exception for testJobCleanupOnError\")")
+  @BMRule(name = "testJobCleanupOnError",
+          targetClass = "gobblin.runtime.mapreduce.MRJobLauncher",
+          targetMethod = "collectOutput(Path)",
+          targetLocation = "AT ENTRY",
+          condition = "true",
+          action = "throw new IOException(\"Exception for testJobCleanupOnError\")")
   public void testJobCleanupOnError() throws IOException {
     Properties props = loadJobProps();
     try {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -19,8 +19,10 @@ import java.sql.SQLException;
 import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
+
 import org.jboss.byteman.contrib.bmunit.BMNGRunner;
 import org.jboss.byteman.contrib.bmunit.BMRule;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -141,7 +143,7 @@ public class MRJobLauncherTest extends BMNGRunner {
     Properties props = loadJobProps();
     try {
       this.jobLauncherTestHelper.runTest(props);
-      Assert.fail("Byteman is not configured properly, the testLaunchJob method should have throw an exception");
+      Assert.fail("Byteman is not configured properly, the runTest method should have throw an exception");
     } catch (Exception e) {
       // The job should throw an exception, ignore it
     }

--- a/gobblin-test/resource/job-conf/GobblinTest1.pull
+++ b/gobblin-test/resource/job-conf/GobblinTest1.pull
@@ -11,8 +11,6 @@ extract.namespace=gobblin.test1
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file://localhost/
-writer.staging.dir=gobblin-test/writer-staging
-writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/resource/source/test.avro.0,gobblin-test/resource/source/test.avro.1
 

--- a/gobblin-test/resource/job-conf/GobblinTest2.pull
+++ b/gobblin-test/resource/job-conf/GobblinTest2.pull
@@ -11,8 +11,6 @@ extract.namespace=gobblin.test2
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file://localhost/
-writer.staging.dir=gobblin-test/writer-staging
-writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/resource/source/test.avro.0,gobblin-test/resource/source/test.avro.1
 

--- a/gobblin-test/resource/job-conf/GobblinTest3.pull
+++ b/gobblin-test/resource/job-conf/GobblinTest3.pull
@@ -11,8 +11,6 @@ extract.namespace=gobblin.test3
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file://localhost/
-writer.staging.dir=gobblin-test/writer-staging
-writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/resource/source/test.avro.0,gobblin-test/resource/source/test.avro.1
 

--- a/gobblin-test/resource/mr-job-conf/GobblinMRTest.pull
+++ b/gobblin-test/resource/mr-job-conf/GobblinMRTest.pull
@@ -10,8 +10,6 @@ extract.namespace=gobblin.MRTest
 writer.destination.type=HDFS
 writer.output.format=AVRO
 writer.fs.uri=file:///
-writer.staging.dir=gobblin-test/writer-staging
-writer.output.dir=gobblin-test/writer-output
 
 source.files=gobblin-test/source/test.avro.0,gobblin-test/source/test.avro.1
 


### PR DESCRIPTION
Adding support for writing byteman tests in testng, and running the tests during ./gradlew clean build. The first byteman test is to ensure that even if MRJobLauncher.collectOuput() throws an exception, that the staging data still is cleaned-up.

I also had a do a little refactoring of the JobLauncherTestBase class and made it a helper class instead. The reason is that any testng class that uses byteman must extend the byteman class BMNGRunner