### PR TITLE
Disabling FindBugs plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -122,16 +122,17 @@ subprojects {
   apply plugin: 'java'
   apply plugin: 'idea'
   apply plugin: 'eclipse'
-  apply plugin: 'findbugs'
+// Disabling the FindBugs plugin for now because FindBugs 2.x is not compatible with Java8
+//  apply plugin: 'findbugs'
 
   sourceCompatibility = JavaVersion.VERSION_1_6
 
-  findbugs {
+/*  findbugs {
     ignoreFailures = true
     effort = "max"
     excludeFilter = file(rootProject.projectDir.path + "/ligradle/findbugs/findbugsExclude.xml")
   }
-
+*/
   configurations {
     compile
     dependencies {


### PR DESCRIPTION
Disabling FindBugs plugin because FindBugs 2.x is not compatible with Java8