### PR TITLE
Fixed gobblin-mapreduce.sh to use the new version of metrics-core

### DIFF
--- a/bin/gobblin-mapreduce.sh
+++ b/bin/gobblin-mapreduce.sh
@@ -58,16 +58,16 @@ do
   shift
 done
 
-if [ -z "$JOB_CONFIG_FILE" ]; then 
+if [ -z "$JOB_CONFIG_FILE" ]; then
   die "No job configuration file set!"
 fi
 
 # User defined work directory overrides $GOBBLIN_WORK_DIR
-if [ -n "$WORK_DIR" ]; then 
+if [ -n "$WORK_DIR" ]; then
   export GOBBLIN_WORK_DIR="$WORK_DIR"
 fi
 
-if [ -z "$GOBBLIN_WORK_DIR" ]; then 
+if [ -z "$GOBBLIN_WORK_DIR" ]; then
   die "GOBBLIN_WORK_DIR is not set!"
 fi
 
@@ -76,7 +76,7 @@ fi
 USER_JARS=""
 separator=''
 set_user_jars(){
-  if [ -n "$1" ]; then 
+  if [ -n "$1" ]; then
     IFS=','
     read -ra userjars <<< "$1"
     for userjar in ${userjars[@]}; do
@@ -101,7 +101,7 @@ set_user_jars "$JARS"
 LIBJARS=$USER_JARS$separator$FWDIR_LIB/gobblin-metastore.jar,$FWDIR_LIB/gobblin-metrics.jar,\
 $FWDIR_LIB/gobblin-core.jar,$FWDIR_LIB/gobblin-api.jar,$FWDIR_LIB/gobblin-utility.jar,\
 $FWDIR_LIB/guava-15.0.jar,$FWDIR_LIB/avro-1.7.6.jar,$FWDIR_LIB/avro-mapred-1.7.6.jar,\
-$FWDIR_LIB/metrics-core-3.0.2.jar,$FWDIR_LIB/gson-2.2.4.jar,$FWDIR_LIB/joda-time-1.6.jar,$FWDIR_LIB/data-1.15.9.jar
+$FWDIR_LIB/metrics-core-3.1.0.jar,$FWDIR_LIB/gson-2.2.4.jar,$FWDIR_LIB/joda-time-1.6.jar,$FWDIR_LIB/data-1.15.9.jar
 
 # Add libraries to the Hadoop classpath
 GOBBLIN_DEP_JARS=`echo "$USER_JARS" | tr ',' ':' `

--- a/gobblin-example/src/main/resources/simplejson.pull
+++ b/gobblin-example/src/main/resources/simplejson.pull
@@ -35,5 +35,3 @@ data.publisher.type=gobblin.publisher.BaseDataPublisher
 # writer configuration properties
 writer.destination.type=HDFS
 writer.output.format=AVRO
-writer.fs.uri=file:///
-

--- a/gobblin-example/src/main/resources/wikipedia.pull
+++ b/gobblin-example/src/main/resources/wikipedia.pull
@@ -15,6 +15,5 @@ extract.namespace=gobblin.example.wikipedia
 
 writer.destination.type=HDFS
 writer.output.format=AVRO
-writer.fs.uri=file://localhost/
 
 data.publisher.type=gobblin.publisher.BaseDataPublisher


### PR DESCRIPTION
Also deleted configuration property `writer.fs.uri` from the example job config files as it is already defined in `conf/gobblin-standalone.properties` and `conf/gobblin-mapreduce.properties` and the value set there should be taken.
 
Signed-off-by: Yinan Li <liyinan926@gmail.com>