### PR TITLE
 Fix query for multiple delta fields in case of simple watermark (cont. of #58) 

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcExtractor.java
@@ -304,7 +304,7 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
 
       String outputColProjection = Joiner.on(",").useForNull("null").join(this.columnList);
       outputColProjection =
-          outputColProjection.replace(derivedWatermarkColumnName, getWatermarkColumnName(watermarkColumn) + " AS "
+          outputColProjection.replace(derivedWatermarkColumnName, Utils.getCoalesceColumnNames(watermarkColumn) + " AS "
               + derivedWatermarkColumnName);
       this.setOutputColumnProjection(outputColProjection);
       String extractQuery = this.getExtractQuery(schema, entity, inputQuery);
@@ -773,29 +773,6 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
     }
     query = query + Utils.getClause(predicate, predicateCond);
     return query;
-  }
-
-  /**
-   * Get coalesce of water mark columns if there are multiple water mark columns
-   *
-   * @param water mark column
-   * @return water mark column
-   */
-  protected String getWatermarkColumnName(String waterMarkColumn) {
-    int waterMarkColumnCount = 0;
-
-    if (waterMarkColumn != null) {
-      waterMarkColumnCount = Arrays.asList(waterMarkColumn.split(",")).size();
-    }
-
-    switch (waterMarkColumnCount) {
-      case 0:
-        return null;
-      case 1:
-        return waterMarkColumn;
-      default:
-        return "COALESCE(" + waterMarkColumn + ")";
-    }
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/MysqlExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/MysqlExtractor.java
@@ -53,21 +53,21 @@ public class MysqlExtractor extends JdbcExtractor {
   public String getHourPredicateCondition(String column, long value, String valueFormat, String operator) {
     this.log.debug("Getting hour predicate for Mysql");
     String formattedvalue = Utils.toDateTimeFormat(Long.toString(value), valueFormat, MYSQL_HOUR_FORMAT);
-    return this.getWatermarkColumnName(column) + " " + operator + " '" + formattedvalue + "'";
+    return Utils.getCoalesceColumnNames(column) + " " + operator + " '" + formattedvalue + "'";
   }
 
   @Override
   public String getDatePredicateCondition(String column, long value, String valueFormat, String operator) {
     this.log.debug("Getting date predicate for Mysql");
     String formattedvalue = Utils.toDateTimeFormat(Long.toString(value), valueFormat, MYSQL_DATE_FORMAT);
-    return this.getWatermarkColumnName(column) + " " + operator + " '" + formattedvalue + "'";
+    return Utils.getCoalesceColumnNames(column) + " " + operator + " '" + formattedvalue + "'";
   }
 
   @Override
   public String getTimestampPredicateCondition(String column, long value, String valueFormat, String operator) {
     this.log.debug("Getting timestamp predicate for Mysql");
     String formattedvalue = Utils.toDateTimeFormat(Long.toString(value), valueFormat, MYSQL_TIMESTAMP_FORMAT);
-    return this.getWatermarkColumnName(column) + " " + operator + " '" + formattedvalue + "'";
+    return Utils.getCoalesceColumnNames(column) + " " + operator + " '" + formattedvalue + "'";
   }
 
   @Override
@@ -99,7 +99,7 @@ public class MysqlExtractor extends JdbcExtractor {
     this.log.debug("Build query to get high watermark");
     List<Command> commands = new ArrayList<Command>();
 
-    String columnProjection = "max(" + this.getWatermarkColumnName(watermarkColumn) + ")";
+    String columnProjection = "max(" + Utils.getCoalesceColumnNames(watermarkColumn) + ")";
     String watermarkFilter = this.concatPredicates(predicateList);
     String query = this.getExtractSql();
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/SqlServerExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/SqlServerExtractor.java
@@ -77,7 +77,7 @@ public class SqlServerExtractor extends JdbcExtractor {
     this.log.debug("Build query to get high watermark");
     List<Command> commands = new ArrayList<Command>();
 
-    String columnProjection = "max(" + this.getWatermarkColumnName(watermarkColumn) + ")";
+    String columnProjection = "max(" + Utils.getCoalesceColumnNames(watermarkColumn) + ")";
     String watermarkFilter = this.concatPredicates(predicateList);
     String query = this.getExtractSql();
 
@@ -266,20 +266,20 @@ public class SqlServerExtractor extends JdbcExtractor {
   public String getHourPredicateCondition(String column, long value, String valueFormat, String operator) {
     this.log.debug("Getting hour predicate for Sqlserver");
     String formattedvalue = Utils.toDateTimeFormat(Long.toString(value), valueFormat, HOUR_FORMAT);
-    return this.getWatermarkColumnName(column) + " " + operator + " '" + formattedvalue + "'";
+    return Utils.getCoalesceColumnNames(column) + " " + operator + " '" + formattedvalue + "'";
   }
 
   @Override
   public String getDatePredicateCondition(String column, long value, String valueFormat, String operator) {
     this.log.debug("Getting date predicate for Sqlserver");
     String formattedvalue = Utils.toDateTimeFormat(Long.toString(value), valueFormat, DATE_FORMAT);
-    return this.getWatermarkColumnName(column) + " " + operator + " '" + formattedvalue + "'";
+    return Utils.getCoalesceColumnNames(column) + " " + operator + " '" + formattedvalue + "'";
   }
 
   @Override
   public String getTimestampPredicateCondition(String column, long value, String valueFormat, String operator) {
     this.log.debug("Getting timestamp predicate for Sqlserver");
     String formattedvalue = Utils.toDateTimeFormat(Long.toString(value), valueFormat, TIMESTAMP_FORMAT);
-    return this.getWatermarkColumnName(column) + " " + operator + " '" + formattedvalue + "'";
+    return Utils.getCoalesceColumnNames(column) + " " + operator + " '" + formattedvalue + "'";
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -58,7 +58,7 @@ public class Utils {
    * Get coalesce of columns if there are multiple comma-separated columns
    */
   public static String getCoalesceColumnNames(String columnOrColumnList) {
-    if (columnOrColumnList == null) {
+    if (Strings.isNullOrEmpty(columnOrColumnList)) {
       return null;
     }
     if (columnOrColumnList.contains(",")) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -56,23 +56,15 @@ public class Utils {
   
   /**
    * Get coalesce of columns if there are multiple comma-separated columns
-   *
-   * @param column
-   * @return column
    */
-  public static String getCoalesceColumnNames(String column) {
-    int columnCount = 0;
-    if (column != null) {
-      columnCount = Arrays.asList(column.split(",")).size();
+  public static String getCoalesceColumnNames(String columnOrColumnList) {
+    if (columnOrColumnList == null) {
+      return null;
     }
-    switch (columnCount) {
-      case 0:
-        return null;
-      case 1:
-        return column;
-      default:
-        return "COALESCE(" + column + ")";
+    if (columnOrColumnList.contains(",")) {
+      return "COALESCE(" + columnOrColumnList + ")";
     }
+    return columnOrColumnList;
   }
   
   public static JsonArray removeElementFromJsonArray(JsonArray inputJsonArray, String key) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -53,7 +53,28 @@ public class Utils {
     }
     return retStr;
   }
-
+  
+  /**
+   * Get coalesce of columns if there are multiple comma-separated columns
+   *
+   * @param column
+   * @return column
+   */
+  public static String getCoalesceColumnNames(String column) {
+    int columnCount = 0;
+    if (column != null) {
+      columnCount = Arrays.asList(column.split(",")).size();
+    }
+    switch (columnCount) {
+      case 0:
+        return null;
+      case 1:
+        return column;
+      default:
+        return "COALESCE(" + column + ")";
+    }
+  }
+  
   public static JsonArray removeElementFromJsonArray(JsonArray inputJsonArray, String key) {
     JsonArray outputJsonArray = new JsonArray();
     for (int i = 0; i < inputJsonArray.size(); i += 1) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/watermark/SimpleWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/watermark/SimpleWatermark.java
@@ -12,6 +12,8 @@
 package gobblin.source.extractor.watermark;
 
 import gobblin.source.extractor.extract.QueryBasedExtractor;
+import gobblin.source.extractor.utils.Utils;
+
 import java.math.RoundingMode;
 import java.util.HashMap;
 
@@ -33,7 +35,7 @@ public class SimpleWatermark implements Watermark {
 
   @Override
   public String getWatermarkCondition(QueryBasedExtractor extractor, long watermarkValue, String operator) {
-    return this.watermarkColumn + " " + operator + " " + watermarkValue;
+    return Utils.getCoalesceColumnNames(this.watermarkColumn) + " " + operator + " " + watermarkValue;
   }
 
   @Override


### PR DESCRIPTION
When ```source.querybased.watermark.type=simple``` and ```extract.delta.fields``` contains a comma separated list of fields (e.g: id, type), one of the initial MySQL query looks like this during the job initialization:

```SELECT max(COALESCE(id,type)) FROM test  where  (id,type >= 477 and id,type <= 544);```

The query syntax seems to be invalid which leads to the following error:
```java.sql.SQLException: Operand should contain 1 column(s)```

After checking the generated queries of other watermark types, I suspect that here the fields in the where clause should be coalesced too (e.g: COALESCE(id,type) >=477...etc)
If this is the case (and the where clause is not intended to be a row subquery for instance) then the patch would address this issue.
