### PR TITLE
Fix Hadoop conf files loading/processing in the Compaction tool

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/AvroExternalTable.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/AvroExternalTable.java
@@ -24,7 +24,6 @@ import org.apache.avro.file.SeekableInput;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -194,8 +193,9 @@ public class AvroExternalTable extends HiveTable {
   public void createTable(HiveJdbcConnector conn, String jobID) throws SQLException {
     String tableName = getNameWithJobId(jobID);
     String dropTableStmt = String.format(DROP_TABLE_STMT, tableName);
+    String hdfsUri = HdfsIO.getHdfsUri();
     String createTableStmt =
-        String.format(CREATE_TABLE_STMT, tableName, HdfsIO.getHdfsUri() + this.dataLocationInHdfs, HdfsIO.getHdfsUri()
+        String.format(CREATE_TABLE_STMT, tableName, hdfsUri + this.dataLocationInHdfs, hdfsUri
             + this.schemaLocationInHdfs);
 
     conn.executeStatements(dropTableStmt, createTableStmt);

--- a/gobblin-compaction/src/main/java/gobblin/compaction/HdfsIO.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/HdfsIO.java
@@ -17,9 +17,11 @@ import java.util.Set;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 
 
@@ -84,10 +86,13 @@ public abstract class HdfsIO {
   }
 
   private static void addResourceToConf(Configuration conf) {
-    conf.setStrings(getHdfsUriHadoopPropertyName(), HDFS_URI_DEFAULT);
     addHadoopConfigPropertiesToConf(conf);
+    String hdfsUriProp = getHdfsUriHadoopPropertyName();
     if (CompactionRunner.properties.containsKey(HDFS_URI)) {
-      conf.setStrings(getHdfsUriHadoopPropertyName(), CompactionRunner.properties.getProperty(HDFS_URI));
+      conf.setStrings(hdfsUriProp, CompactionRunner.properties.getProperty(HDFS_URI));
+    }
+    if (Strings.isNullOrEmpty(conf.get(hdfsUriProp))) {
+      conf.set(hdfsUriProp, HDFS_URI_DEFAULT);
     }
   }
 
@@ -96,7 +101,7 @@ public abstract class HdfsIO {
     for (String propertyName : propertyNames) {
       if (propertyName.startsWith(HADOOP_CONFIGFILE_)) {
         String hadoopConfigFile = CompactionRunner.properties.getProperty(propertyName);
-        conf.addResource(hadoopConfigFile);
+        conf.addResource(new Path(hadoopConfigFile));
         LOG.info("Added Hadoop Config File: " + hadoopConfigFile);
       }
     }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/HdfsIO.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/HdfsIO.java
@@ -87,13 +87,14 @@ public abstract class HdfsIO {
 
   private static void addResourceToConf(Configuration conf) {
     addHadoopConfigPropertiesToConf(conf);
-    String hdfsUriProp = getHdfsUriHadoopPropertyName();
+    String hdfsUriKey = getHdfsUriHadoopPropertyName();
     if (CompactionRunner.properties.containsKey(HDFS_URI)) {
-      conf.setStrings(hdfsUriProp, CompactionRunner.properties.getProperty(HDFS_URI));
+      conf.set(hdfsUriKey, CompactionRunner.properties.getProperty(HDFS_URI));
     }
-    if (Strings.isNullOrEmpty(conf.get(hdfsUriProp))) {
-      conf.set(hdfsUriProp, HDFS_URI_DEFAULT);
+    if (Strings.isNullOrEmpty(conf.get(hdfsUriKey))) {
+      conf.set(hdfsUriKey, HDFS_URI_DEFAULT);
     }
+    CompactionRunner.properties.setProperty(HDFS_URI, conf.get(hdfsUriKey));
   }
 
   private static void addHadoopConfigPropertiesToConf(Configuration conf) {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/HiveTable.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/HiveTable.java
@@ -13,12 +13,13 @@ package gobblin.compaction;
 
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
 import org.apache.commons.lang.StringUtils;
+
+import com.google.common.base.Splitter;
 
 import gobblin.hive.util.HiveJdbcConnector;
 
@@ -56,9 +57,9 @@ public abstract class HiveTable {
     }
 
     @SuppressWarnings("unchecked")
-    public T withPrimaryKeys(String firstKeyAttr, String... remainingKeyAttr) {
-      this.primaryKeys.add(firstKeyAttr);
-      this.primaryKeys.addAll(Arrays.asList(remainingKeyAttr));
+    public T withPrimaryKeys(String keyAttrs) {
+      List<String> keyAttrsList = Splitter.on(",").trimResults().omitEmptyStrings().splitToList(keyAttrs);
+      this.primaryKeys.addAll(keyAttrsList);
       return (T) this;
     }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/SerialCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/SerialCompactor.java
@@ -14,7 +14,6 @@ package gobblin.compaction;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.List;
-import java.util.Properties;
 import java.util.UUID;
 
 import org.slf4j.Logger;
@@ -310,6 +309,7 @@ public class SerialCompactor implements Compactor {
         sb.append(" AND ");
       }
       sb.append(table.getNameWithJobId(this.jobId) + "." + keyAttribute + " IS NULL");
+      addAnd = true;
     }
 
     return sb.toString();

--- a/gobblin-compaction/src/main/java/gobblin/hive/util/HiveJdbcConnector.java
+++ b/gobblin-compaction/src/main/java/gobblin/hive/util/HiveJdbcConnector.java
@@ -89,9 +89,8 @@ public class HiveJdbcConnector implements Closeable {
     HiveJdbcConnector hiveJdbcConnector = new HiveJdbcConnector();
 
     // Set the Hive Server type
-    if (compactRunProps.containsKey(HIVESERVER_VERSION)) {
-      hiveJdbcConnector.withHiveServerVersion(Integer.parseInt(compactRunProps.getProperty(HIVESERVER_VERSION, DEFAULT_HIVESERVER_VERSION)));
-    }
+    hiveJdbcConnector.withHiveServerVersion(Integer.parseInt(compactRunProps.getProperty(HIVESERVER_VERSION,
+        DEFAULT_HIVESERVER_VERSION)));
 
     // Add the Hive Site Dir to the classpath
     if (compactRunProps.containsKey(HIVESITE_DIR)) {


### PR DESCRIPTION
This patch addresses the following issues:

1.
Fix conf files loading:
The Configuration object is populated from the Hadoop conf xmls defined in the ```hadoop.configfile.*``` properties. However, ```HdfsIO#addHadoopConfigPropertiesToConf``` calls
 ```Configuration#addResource(String)```. This method only examines the classpath for the given file name. Thus if the file is not on the classpath, the Configuration object will remain empty

2.
Ensure the correct order of the HDFS_URI resolution:
If ```fs.defaultFS``` is set to the default value before the conf files are loaded, then it won't get overridden by either the value in ```core-site.xml``` or in ```hdfs.uri```. The resolved ```hdfs.uri``` should not only be set to the Configuration object, but to the ```CompactionRunner.properties```, because ```HdfsIO#getHdfsUri``` use that object for the resolution.

3.
Load Hive JDBC driver with the default hiveserver.version value if it is not set:
The docs states that the default ```hiveserver.version``` is 2. But if it is not set by the user, the ```HiveJdbcConnector#newConnectorWithProps``` will not load the driver.

4.
Fix the splitting of comma separated column names in snapshot.pkey and delta.i.pkey:
```CompactionRunner#buildAvroExternalTable``` passes ```jobProperties.getProperty(tableType + PKEY))``` as parameter to ```HiveTable#withPrimaryKeys(String firstKeyAttr, String... remainingKeyAttr)``` . Even if the parameter contains commas, it won't be split automaticaly 
between the first and variable length paramteres; ```firstKeyAttr``` will store the whole string.

5.
If multiple primary keys are defined in the ```task.conf```, the LEFT JOIN and the WHERE clause of the INSERT OVERWRITE statement will be broken, e.g:
INSERT OVERWRITE TABLE not_updated
SELECT merged_delta.* FROM merged_delta LEFT OUTER JOIN delta2 ON merged_delta.my_id1,my_id2 = delta2.my_id1,my_id2
WHERE delta2.my_id1,my_id2 IS NULL