### PR TITLE
Use Guava's Charsets.UTF_8 to replace the string representation of the encoding charset

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -11,7 +11,10 @@
 
 package gobblin.configuration;
 
+import java.nio.charset.Charset;
 import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Charsets;
 
 
 /**
@@ -398,5 +401,5 @@ public class ConfigurationKeys {
   /**
    * Other configuration properties.
    */
-  public static final String DEFAULT_CHARSET_ENCODING = "UTF-8";
+  public static final Charset DEFAULT_CHARSET_ENCODING = Charsets.UTF_8;
 }

--- a/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelErrFileWriter.java
+++ b/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelErrFileWriter.java
@@ -15,7 +15,6 @@ import java.io.BufferedWriter;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
 
 import org.apache.hadoop.fs.Path;
 
@@ -37,9 +36,8 @@ public class RowLevelErrFileWriter {
    */
   public void open(Path errFilePath)
       throws IOException {
-    this.writer = new BufferedWriter(
-        new OutputStreamWriter(new FileOutputStream(errFilePath.toString()), Charset.forName(
-            ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+    this.writer = new BufferedWriter(new OutputStreamWriter(new FileOutputStream(errFilePath.toString()),
+        ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/InputStreamCSVReader.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/InputStreamCSVReader.java
@@ -11,7 +11,6 @@
 
 package gobblin.source.extractor.utils;
 
-import gobblin.configuration.ConfigurationKeys;
 import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -19,8 +18,9 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.io.StreamTokenizer;
-import java.nio.charset.Charset;
 import java.util.ArrayList;
+
+import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -40,7 +40,7 @@ public class InputStreamCSVReader {
   }
 
   public InputStreamCSVReader(InputStream input) {
-    this(new InputStreamReader(input, Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+    this(new InputStreamReader(input, ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
   }
 
   public InputStreamCSVReader(BufferedReader input) {
@@ -49,7 +49,7 @@ public class InputStreamCSVReader {
 
   public InputStreamCSVReader(String input) {
     this(new InputStreamReader(new ByteArrayInputStream(input.getBytes()),
-        Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)), ',', '\"');
+            ConfigurationKeys.DEFAULT_CHARSET_ENCODING), ',', '\"');
   }
 
   public InputStreamCSVReader(Reader input, char customizedSeparator) {
@@ -57,8 +57,7 @@ public class InputStreamCSVReader {
   }
 
   public InputStreamCSVReader(InputStream input, char customizedSeparator) {
-    this(new InputStreamReader(input, Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)), customizedSeparator,
-        '\"');
+    this(new InputStreamReader(input, ConfigurationKeys.DEFAULT_CHARSET_ENCODING), customizedSeparator, '\"');
   }
 
   public InputStreamCSVReader(BufferedReader input, char customizedSeparator) {
@@ -67,7 +66,7 @@ public class InputStreamCSVReader {
 
   public InputStreamCSVReader(String input, char customizedSeparator) {
     this(new InputStreamReader(new ByteArrayInputStream(input.getBytes()),
-        Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)), customizedSeparator, '\"');
+        ConfigurationKeys.DEFAULT_CHARSET_ENCODING), customizedSeparator, '\"');
   }
 
   public InputStreamCSVReader(Reader input, char customizedSeparator, char enclosedChar) {
@@ -75,13 +74,12 @@ public class InputStreamCSVReader {
   }
 
   public InputStreamCSVReader(InputStream input, char customizedSeparator, char enclosedChar) {
-    this(new InputStreamReader(input, Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)), customizedSeparator,
-        enclosedChar);
+    this(new InputStreamReader(input, ConfigurationKeys.DEFAULT_CHARSET_ENCODING), customizedSeparator, enclosedChar);
   }
 
   public InputStreamCSVReader(String input, char customizedSeparator, char enclosedChar) {
     this(new InputStreamReader(new ByteArrayInputStream(input.getBytes()),
-        Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)), customizedSeparator, enclosedChar);
+        ConfigurationKeys.DEFAULT_CHARSET_ENCODING), customizedSeparator, enclosedChar);
   }
 
   public InputStreamCSVReader(BufferedReader input, char separator, char enclosedChar) {

--- a/gobblin-example/src/main/java/gobblin/example/simplejson/SimpleJsonExtractor.java
+++ b/gobblin-example/src/main/java/gobblin/example/simplejson/SimpleJsonExtractor.java
@@ -14,7 +14,6 @@ package gobblin.example.simplejson;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.nio.charset.Charset;
 
 import org.apache.commons.vfs2.FileObject;
 import org.apache.commons.vfs2.FileSystemException;
@@ -75,9 +74,8 @@ public class SimpleJsonExtractor implements Extractor<String, String> {
 
     // Open the file for reading
     LOGGER.info("Opening file " + this.fileObject.getURL().toString());
-    this.bufferedReader = this.closer.register(new BufferedReader(
-        new InputStreamReader(this.fileObject.getContent().getInputStream(),
-            Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING))));
+    this.bufferedReader = this.closer.register(new BufferedReader(new InputStreamReader(
+        this.fileObject.getContent().getInputStream(), ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
   }
 
   @Override

--- a/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
+++ b/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.nio.charset.Charset;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
@@ -148,9 +147,8 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
     try {
       URL url = new URL(urlStr);
       conn = (HttpURLConnection) url.openConnection();
-      BufferedReader br =
-          closer.register(new BufferedReader(new InputStreamReader(conn.getInputStream(), Charset.forName(
-              ConfigurationKeys.DEFAULT_CHARSET_ENCODING))));
+      BufferedReader br = closer.register(
+          new BufferedReader(new InputStreamReader(conn.getInputStream(), ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
       String line;
       while ((line = br.readLine()) != null) {
         sb.append(line + "\n");

--- a/gobblin-metastore/src/test/java/gobblin/metastore/DatabaseJobHistoryStoreTest.java
+++ b/gobblin-metastore/src/test/java/gobblin/metastore/DatabaseJobHistoryStoreTest.java
@@ -13,7 +13,6 @@ package gobblin.metastore;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -186,8 +185,9 @@ public class DatabaseJobHistoryStoreTest {
       throws Exception {
     // Read the DDL statements
     List<String> statementLines = Lists.newArrayList();
-    List<String> lines = Files.readLines(new File("gobblin-metastore/src/test/resources/gobblin_job_history_store.sql"),
-        Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+    List<String> lines = Files.readLines(
+        new File("gobblin-metastore/src/test/resources/gobblin_job_history_store.sql"),
+        ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
     for (String line : lines) {
       // Skip a comment line
       if (line.startsWith("--")) {

--- a/gobblin-metrics/src/main/java/gobblin/metrics/OutputStreamReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/OutputStreamReporter.java
@@ -17,7 +17,6 @@ import java.io.OutputStream;
 import java.io.PrintStream;
 import java.text.DateFormat;
 import java.util.Date;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
@@ -34,6 +34,8 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.ScheduledReporter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
+
+import com.google.common.base.Charsets;
 import com.google.common.base.Strings;
 import com.google.common.io.Closer;
 
@@ -377,7 +379,7 @@ public class KafkaReporter extends ScheduledReporter {
   protected byte[] serializeValue(String name, Object value, String... path) {
     String str = stringifyValue(name, value, path);
     if(!Strings.isNullOrEmpty(str)) {
-      return str.getBytes();
+      return str.getBytes(Charsets.UTF_8);
     } else {
       return null;
     }

--- a/gobblin-rest-service/gobblin-rest-server/src/test/java/gobblin/rest/JobExecutionInfoServerTest.java
+++ b/gobblin-rest-service/gobblin-rest-server/src/test/java/gobblin/rest/JobExecutionInfoServerTest.java
@@ -12,7 +12,6 @@
 package gobblin.rest;
 
 import java.io.File;
-import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
@@ -154,8 +153,9 @@ public class JobExecutionInfoServerTest {
       throws Exception {
     // Read the DDL statements
     List<String> statementLines = Lists.newArrayList();
-    List<String> lines = Files.readLines(new File("gobblin-metastore/src/test/resources/gobblin_job_history_store.sql"),
-        Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+    List<String> lines = Files.readLines(
+        new File("gobblin-metastore/src/test/resources/gobblin_job_history_store.sql"),
+        ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
     for (String line : lines) {
       // Skip a comment line
       if (line.startsWith("--")) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobMetrics.java
@@ -481,10 +481,11 @@ public class JobMetrics implements MetricSet {
         append = true;
       }
 
-      PrintStream ps = append ? this.closer
-          .register(new PrintStream(fs.append(metricLogFile), true, ConfigurationKeys.DEFAULT_CHARSET_ENCODING))
-          : this.closer
-              .register(new PrintStream(fs.create(metricLogFile), true, ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+      PrintStream ps = append ?
+          this.closer.register(
+              new PrintStream(fs.append(metricLogFile), true, ConfigurationKeys.DEFAULT_CHARSET_ENCODING.name())) :
+          this.closer.register(
+              new PrintStream(fs.create(metricLogFile), true, ConfigurationKeys.DEFAULT_CHARSET_ENCODING.name()));
       this.fileReporter = Optional
           .of(ConsoleReporter.forRegistry(this.metricRegistry).outputTo(ps).convertRatesTo(TimeUnit.SECONDS)
               .convertDurationsTo(TimeUnit.MILLISECONDS).build());

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.lang.reflect.Constructor;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
@@ -585,8 +584,7 @@ public class LocalJobManager extends AbstractIdleService {
 
       private void loadJobConfig(Properties jobProps, File file) {
         try {
-          jobProps.load(new InputStreamReader(new FileInputStream(file), Charset.forName(
-              ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+          jobProps.load(new InputStreamReader(new FileInputStream(file), ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
           jobProps.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY, file.getAbsolutePath());
         } catch (Exception e) {
           LOG.error("Failed to load job configuration from file " + file.getAbsolutePath(), e);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -20,7 +20,6 @@ import java.io.OutputStream;
 import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.CountDownLatch;
@@ -338,8 +337,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
       Path jobInputFile = new Path(jobInputPath, jobId + ".wulist");
       // Open the job input file
       OutputStream os = closer.register(this.fs.create(jobInputFile));
-      Writer osw = closer.register(new OutputStreamWriter(os, Charset.forName(
-          ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+      Writer osw = closer.register(new OutputStreamWriter(os, ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
       Writer bw = closer.register(new BufferedWriter(osw));
 
       // Serialize each work unit into a file named after the task ID

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -12,7 +12,6 @@
 package gobblin.runtime;
 
 import java.io.File;
-import java.nio.charset.Charset;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.util.List;
@@ -166,7 +165,7 @@ public class JobLauncherTestHelper {
     List<String> statementLines = Lists.newArrayList();
     List<String> lines =
         Files.readLines(new File("gobblin-metastore/src/test/resources/gobblin_job_history_store.sql"),
-            Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+            ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
     for (String line : lines) {
       // Skip a comment line
       if (line.startsWith("--")) {

--- a/gobblin-salesforce/src/main/java/gobblin/salesforce/SalesforceExtractor.java
+++ b/gobblin-salesforce/src/main/java/gobblin/salesforce/SalesforceExtractor.java
@@ -38,7 +38,6 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URI;
-import java.nio.charset.Charset;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
@@ -723,8 +722,7 @@ public class SalesforceExtractor extends RestApiExtractor {
       }
 
       this.log.info("QUERY:" + query);
-      ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes(Charset.forName(
-          ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+      ByteArrayInputStream bout = new ByteArrayInputStream(query.getBytes(ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
 
       this.bulkBatchInfo = bulkConnection.createBatchFromStream(this.bulkJob, bout);
 
@@ -775,7 +773,7 @@ public class SalesforceExtractor extends RestApiExtractor {
           this.setNewBulkResultSet(true);
           this.bulkBufferedReader = new BufferedReader(new InputStreamReader(this.bulkConnection
               .getQueryResultStream(bulkJob.getId(), bulkBatchInfo.getId(), bulkResultIdList.get(bulkResultIdCount)),
-              Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+              ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
 
           this.bulkResultIdCount++;
         } else {

--- a/gobblin-utility/src/main/java/gobblin/util/HeapDumpForTaskUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HeapDumpForTaskUtils.java
@@ -14,7 +14,6 @@ package gobblin.util;
 import java.io.BufferedWriter;
 import java.io.IOException;
 import java.io.OutputStreamWriter;
-import java.nio.charset.Charset;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -63,8 +62,8 @@ public class HeapDumpForTaskUtils {
         fs.mkdirs(dumpDir);
       }
       BufferedWriter scriptWriter =
-          closer.register(new BufferedWriter(new OutputStreamWriter(fs.create(dumpScript), Charset
-              .forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING))));
+          closer.register(new BufferedWriter(new OutputStreamWriter(fs.create(dumpScript),
+              ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
 
       scriptWriter.write("#!/bin/sh\n");
       scriptWriter.write("if [ -n \"$HADOOP_PREFIX\" ]; then\n");

--- a/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
@@ -14,7 +14,6 @@ package gobblin.util;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -277,7 +276,7 @@ public class SchedulerUtilsTest {
       Files.touch(commonPropsFile);
 
       File newJobConfigFile = new File(SUB_DIR11, "test112.pull");
-      Files.append("k1=v1", newJobConfigFile, Charset.forName(ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+      Files.append("k1=v1", newJobConfigFile, ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
 
       semaphore.acquire(3);
       Assert.assertEquals(fileAltered.size(), 3);


### PR DESCRIPTION

Signed-off-by: Yinan Li <liyinan926@gmail.com>