### PR TITLE
Multiworkunit (bin packing) for kafka source

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -204,7 +204,6 @@ public class ConfigurationKeys {
   public static final String WRITER_PARTITION_LEVEL = WRITER_PREFIX + ".partition.level";
   public static final String WRITER_PARTITION_PATTERN = WRITER_PREFIX + ".partition.pattern";
   public static final String WRITER_PARTITION_TIMEZONE = WRITER_PREFIX + ".partition.timezone";
-  public static final String WRITER_SET_SCHEMA_PER_RECORD = WRITER_PREFIX + ".set.schema.per.record";
   public static final String DEFAULT_WRITER_FILE_NAME = "part";
   public static final String DEFAULT_DEFLATE_LEVEL = "9";
   public static final String DEFAULT_BUFFER_SIZE = "4096";
@@ -212,7 +211,6 @@ public class ConfigurationKeys {
   public static final String DEFAULT_WRITER_PARTITION_PATTERN = "yyyy/MM/dd";
   public static final String DEFAULT_WRITER_PARTITION_TIMEZONE = "America/Los_Angeles";
   public static final String DEFAULT_WRITER_FILE_PATH_TYPE = "default";
-  public static final boolean DEFAULT_WRITER_SET_SCHEMA_PER_RECORD = false;
 
   /**
    * Configuration properties used by the quality checker.

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -340,6 +340,7 @@ public class ConfigurationKeys {
   public static final String MR_JOB_MAX_MAPPERS_KEY = "mr.job.max.mappers";
   public static final String MR_INCLUDE_TASK_COUNTERS_KEY = "mr.include.task.counters";
   public static final boolean DEFAULT_MR_INCLUDE_TASK_COUNTERS = Boolean.FALSE;
+  public static final int DEFAULT_MR_JOB_MAX_MAPPERS = 100;
 
   /**
    * Configuration properties for email settings.

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -42,6 +42,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
+import com.google.common.primitives.Longs;
 
 
 /**
@@ -77,14 +78,14 @@ public abstract class KafkaSource extends EventBasedSource<Schema, GenericRecord
   private final Comparator<WorkUnit> sortBySizeAscComparator = new Comparator<WorkUnit>() {
     @Override
     public int compare(WorkUnit w1, WorkUnit w2) {
-      return ((Long) getWorkUnitEstSize(w1)).compareTo(getWorkUnitEstSize(w2));
+      return Longs.compare(getWorkUnitEstSize(w1), getWorkUnitEstSize(w2));
     }
   };
 
   private final Comparator<WorkUnit> sortBySizeDescComparator = new Comparator<WorkUnit>() {
     @Override
     public int compare(WorkUnit w1, WorkUnit w2) {
-      return ((Long) getWorkUnitEstSize(w2)).compareTo(getWorkUnitEstSize(w1));
+      return Longs.compare(getWorkUnitEstSize(w2), getWorkUnitEstSize(w1));
     }
   };
 
@@ -132,7 +133,7 @@ public abstract class KafkaSource extends EventBasedSource<Schema, GenericRecord
     for (List<WorkUnit> workUnitsForTopic : workUnits) {
       for (WorkUnit workUnit : workUnitsForTopic) {
         setWorkUnitEstSize(workUnit);
-        totalEstDataSize = getWorkUnitEstSize(workUnit);
+        totalEstDataSize += getWorkUnitEstSize(workUnit);
       }
     }
     long avgGroupSize = (long) ((double) totalEstDataSize / (double) numOfMultiWorkunits / 3.0);

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -127,13 +127,6 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
       throws IOException {
     Preconditions.checkNotNull(record);
 
-    // It is possible that each record has a different schema
-    if (this.properties.getPropAsBoolean(ConfigurationKeys.WRITER_SET_SCHEMA_PER_RECORD,
-        ConfigurationKeys.DEFAULT_WRITER_SET_SCHEMA_PER_RECORD) && !this.schema.equals(record.getSchema())) {
-      this.schema = record.getSchema();
-      this.datumWriter.setSchema(record.getSchema());
-    }
-
     this.writer.append(record);
     // Only increment when write is successful
     this.count.incrementAndGet();

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -11,17 +11,32 @@
 
 package gobblin.util;
 
+import gobblin.converter.DataConversionException;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+
+import static org.apache.avro.SchemaCompatibility.*;
+import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.*;
 
 
 /**
@@ -106,6 +121,31 @@ public class AvroUtils {
       return Optional.fromNullable(((Record) data).get(pathList.get(field)));
     } else {
       return AvroUtils.getFieldHelper(((Record) data).get(pathList.get(field)), pathList, ++field);
+    }
+  }
+
+  /**
+   * Change the schema of an Avro record.
+   * @param record The Avro record whose schema is to be changed.
+   * @param newSchema The target schema. It must be compatible as reader schema with record.getSchema() as writer schema.
+   * @return a new Avro record with the new schema.
+   * @throws IOException if conversion failed.
+   */
+  public static GenericRecord convertRecordSchema(GenericRecord record, Schema newSchema) throws IOException {
+    Preconditions.checkArgument(checkReaderWriterCompatibility(newSchema, record.getSchema()).getType() == COMPATIBLE);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Encoder encoder = new EncoderFactory().directBinaryEncoder(out, null);
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(record.getSchema());
+    try {
+      writer.write(record, encoder);
+      BinaryDecoder decoder = new DecoderFactory().binaryDecoder(out.toByteArray(), null);
+      DatumReader<GenericRecord> reader = new GenericDatumReader<GenericRecord>(record.getSchema(), newSchema);
+      return reader.read(null, decoder);
+    } catch (IOException e) {
+      throw new IOException(String.format(
+          "Cannot convert avro record to new schema. Origianl schema = %s, new schema = %s", record.getSchema(),
+          newSchema), e);
     }
   }
 }


### PR DESCRIPTION
- Implemented Kafka multiworkunit using bin packing algorithms. The goal is to evenly assign all workunits (each corresponding to a kafka partition) to the multiWorkUnits, while preferring to assign partitions of the same topic to the same multiWorkUnit (to avoid generating many small files).

*Note that currently it is not possible to avoid generating small files. Even if we assign multiple partitions of the same topic to the same multiWorkUnit, it will still create one file for each partition, rather than one file for the whole topic. It is currently neither possible to let multiple tasks share a writer (since tasks may run in parallel) nor possible to let each workUnit process multiple partitions (since each workUnit can only have one highwatermark). However, in the future if we change the design of watermarks such that it can hold multiple values, then a multiWorkUnit will be able to create one file for each topic, rather than each partition.*

The algorithm is slightly improved from Camus'. It first groups workUnits into approximately 3 * numOfMultiWorkunits groups using best-fit-decreasing, such that partitions of the same topic are in the same group (Camus uses an inferior algorithm for this step that may mix different topics in the same group). Then, assemble these groups into multiWorkunits using worst-fit-decreasing.

The first step uses best-fit-decreasing since the target is to group the partitions of each topic into as few groups as possible given a group size limit, so that partitions of the same topic are more likely to be assigned to the same mapper. Using a group size limit ensures that there are a sufficient number of groups for the second step, which is necessary for the second step to do an even assignment.

The reason behind 3* is that the worst-fit-decreasing algorithm should work well if the number of items is more than 3 times the number of bins.

The second step uses worst-fit-decreasing since the target is to evenly assign groups to multiWorkUnits.

- Changed the way Avro records from Kafka are written. Previously the AvroHdfsDataWriter calls setSchema() for each record whose schema is different from the current schema. This actually doesn't work since an avro file can only have one schema, and if we write records with different schemas to one file, the file cannot be decoded. Now KafkaAvroExtractor will convert the schema of a record if its schema is different from the latest schema of that topic.