### PR TITLE
Kafka converter and row level policies

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/filter/AvroProjectionConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/filter/AvroProjectionConverter.java
@@ -16,6 +16,8 @@ import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
+import com.google.common.base.Optional;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
 import gobblin.converter.AvroToAvroConverterBase;
@@ -35,7 +37,7 @@ public class AvroProjectionConverter extends AvroToAvroConverterBase {
 
   public static final String REMOVE_FIELDS = ".remove.fields";
 
-  private AvroSchemaFieldRemover fieldRemover;
+  private Optional<AvroSchemaFieldRemover> fieldRemover;
 
   /**
    * To remove certain fields from the Avro schema or records of a topic/table, set property
@@ -48,9 +50,9 @@ public class AvroProjectionConverter extends AvroToAvroConverterBase {
     if (workUnit.contains(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY)) {
       String removeFieldsPropName = workUnit.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY) + REMOVE_FIELDS;
       if (workUnit.contains(removeFieldsPropName)) {
-        this.fieldRemover = new AvroSchemaFieldRemover(workUnit.getProp(removeFieldsPropName));
+        this.fieldRemover = Optional.of(new AvroSchemaFieldRemover(workUnit.getProp(removeFieldsPropName)));
       } else {
-        this.fieldRemover = null;
+        this.fieldRemover = Optional.absent();
       }
     }
     return this;
@@ -61,8 +63,8 @@ public class AvroProjectionConverter extends AvroToAvroConverterBase {
    */
   @Override
   public Schema convertSchema(Schema inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
-    if (this.fieldRemover != null) {
-      return this.fieldRemover.removeFields(inputSchema);
+    if (this.fieldRemover.isPresent()) {
+      return this.fieldRemover.get().removeFields(inputSchema);
     } else {
       return inputSchema;
     }

--- a/gobblin-core/src/main/java/gobblin/converter/filter/AvroProjectionConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/filter/AvroProjectionConverter.java
@@ -1,0 +1,84 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.filter;
+
+import java.io.IOException;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.AvroToAvroConverterBase;
+import gobblin.converter.Converter;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.converter.SingleRecordIterable;
+import gobblin.util.AvroUtils;
+
+
+/**
+ * A {@link Converter} that removes certain fields from an Avro schema or an Avro record.
+ *
+ * @author ziliu
+ */
+public class AvroProjectionConverter extends AvroToAvroConverterBase {
+
+  public static final String REMOVE_FIELDS = ".remove.fields";
+
+  private AvroSchemaFieldRemover fieldRemover;
+
+  /**
+   * To remove certain fields from the Avro schema or records of a topic/table, set property
+   * {topic/table name}.remove.fields={comma-separated, fully qualified field names} in workUnit.
+   *
+   * E.g., PageViewEvent.remove.fields=header.memberId,mobileHeader.osVersion
+   */
+  @Override
+  public AvroProjectionConverter init(WorkUnitState workUnit) {
+    if (workUnit.contains(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY)) {
+      String removeFieldsPropName = workUnit.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY) + REMOVE_FIELDS;
+      if (workUnit.contains(removeFieldsPropName)) {
+        this.fieldRemover = new AvroSchemaFieldRemover(workUnit.getProp(removeFieldsPropName));
+      } else {
+        this.fieldRemover = null;
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Remove the specified fields from inputSchema.
+   */
+  @Override
+  public Schema convertSchema(Schema inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
+    if (this.fieldRemover != null) {
+      return this.fieldRemover.removeFields(inputSchema);
+    } else {
+      return inputSchema;
+    }
+  }
+
+  /**
+   * Convert the schema of inputRecord to outputSchema.
+   */
+  @Override
+  public Iterable<GenericRecord> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit)
+      throws DataConversionException {
+    try {
+      return new SingleRecordIterable<GenericRecord>(AvroUtils.convertRecordSchema(inputRecord, outputSchema));
+    } catch (IOException e) {
+      throw new DataConversionException(e);
+    }
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/converter/filter/AvroSchemaFieldRemover.java
+++ b/gobblin-core/src/main/java/gobblin/converter/filter/AvroSchemaFieldRemover.java
@@ -1,0 +1,133 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.filter;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+
+/**
+ * A class that removes specific fields from a (possibly recursive) Avro schema.
+ *
+ * @author ziliu
+ */
+public class AvroSchemaFieldRemover {
+
+  private final Map<String, AvroSchemaFieldRemover> children;
+  private final Map<String, Schema> schemaMap;
+
+  /**
+   * @param fieldNames Field names to be removed from the Avro schema. Contains comma-separated fully-qualified 
+   * field names, e.g., "header.memberId,mobileHeader.osVersion".
+   */
+  public AvroSchemaFieldRemover(String fieldNames) {
+    this();
+    this.addChildren(fieldNames);
+  }
+
+  private AvroSchemaFieldRemover() {
+    this.children = Maps.newHashMap();
+    this.schemaMap = Maps.newHashMap();
+  }
+
+  private void addChildren(String fieldNames) {
+    for (String fieldName : Splitter.on(',').trimResults().omitEmptyStrings().splitToList(fieldNames)) {
+      List<String> fieldNameComponents = Splitter.on('.').trimResults().omitEmptyStrings().splitToList(fieldName);
+      if (!fieldNameComponents.isEmpty()) {
+        this.addChildren(fieldNameComponents, 0);
+      }
+    }
+  }
+
+  private void addChildren(List<String> fieldNameComponents, int level) {
+    if (!this.children.containsKey(fieldNameComponents.get(level))) {
+      this.children.put(fieldNameComponents.get(level), new AvroSchemaFieldRemover());
+    }
+    if (level < fieldNameComponents.size() - 1) {
+      this.children.get(fieldNameComponents.get(level)).addChildren(fieldNameComponents, level + 1);
+    }
+  }
+
+  /**
+   * @param schema The Avro schema where the specified fields should be removed from.
+   * @return A new Avro schema with the specified fields removed.
+   */
+  public Schema removeFields(Schema schema) {
+
+    switch (schema.getType()) {
+      case RECORD:
+        if (this.schemaMap.containsKey(schema.getFullName())) {
+          return this.schemaMap.get(schema.getFullName());
+        } else {
+          return this.removeFieldsFromRecords(schema);
+        }
+      case UNION:
+        return this.removeFieldsFromUnion(schema);
+      case ARRAY:
+        return this.removeFieldsFromArray(schema);
+      case MAP:
+        return this.removeFieldsFromMap(schema);
+      default:
+        return schema;
+    }
+  }
+
+  private Schema removeFieldsFromRecords(Schema schema) {
+    List<Field> newFields = Lists.newArrayList();
+    for (Field field : schema.getFields()) {
+      if (this.shouldRemove(field) == false) {
+        Field newField;
+        if (this.children.containsKey(field.name())) {
+          newField =
+              new Field(field.name(), this.children.get(field.name()).removeFields(field.schema()), field.doc(),
+                  field.defaultValue());
+        } else {
+          newField = new Field(field.name(), field.schema(), field.doc(), field.defaultValue());
+        }
+        newFields.add(newField);
+      }
+    }
+
+    Schema newRecord = Schema.createRecord(schema.getName(), schema.getDoc(), schema.getNamespace(), schema.isError());
+    newRecord.setFields(newFields);
+    this.schemaMap.put(schema.getFullName(), newRecord);
+    return newRecord;
+  }
+
+  private boolean shouldRemove(Field field) {
+    return this.children.containsKey(field.name()) && this.children.get(field.name()).children.isEmpty();
+  }
+
+  private Schema removeFieldsFromUnion(Schema schema) {
+    List<Schema> newUnion = Lists.newArrayList();
+    for (Schema unionType : schema.getTypes()) {
+      newUnion.add(this.removeFields(unionType));
+    }
+    return Schema.createUnion(newUnion);
+  }
+
+  private Schema removeFieldsFromArray(Schema schema) {
+    return Schema.createArray(this.removeFields(schema.getElementType()));
+  }
+
+  private Schema removeFieldsFromMap(Schema schema) {
+    return Schema.createMap(this.removeFields(schema.getValueType()));
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/policies/avro/AvroHeaderGuidPolicy.java
+++ b/gobblin-core/src/main/java/gobblin/policies/avro/AvroHeaderGuidPolicy.java
@@ -1,0 +1,41 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.policies.avro;
+
+import org.apache.avro.generic.GenericRecord;
+
+import gobblin.configuration.State;
+import gobblin.qualitychecker.row.RowLevelPolicy;
+
+/**
+ * A policy that checks whether an Avro record has header.guid field.
+ *
+ * @author ziliu
+ */
+public class AvroHeaderGuidPolicy extends RowLevelPolicy {
+  public AvroHeaderGuidPolicy(State state, Type type) {
+    super(state, type);
+  }
+
+  @Override
+  public Result executePolicy(Object record) {
+    if (!(record instanceof GenericRecord)) {
+      return RowLevelPolicy.Result.FAILED;
+    }
+
+    GenericRecord header = (GenericRecord) ((GenericRecord) record).get("header");
+    if (header == null || header.get("guid") == null) {
+      return RowLevelPolicy.Result.FAILED;
+    }
+    return RowLevelPolicy.Result.PASSED;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/policies/avro/AvroHeaderTimestampPolicy.java
+++ b/gobblin-core/src/main/java/gobblin/policies/avro/AvroHeaderTimestampPolicy.java
@@ -1,0 +1,49 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.policies.avro;
+
+import org.apache.avro.generic.GenericRecord;
+
+import gobblin.configuration.State;
+import gobblin.qualitychecker.row.RowLevelPolicy;
+
+
+/**
+ * A class that checks whether an Avro record has header.time or header.timestamp field.
+ *
+ * @author ziliu
+ */
+public class AvroHeaderTimestampPolicy extends RowLevelPolicy {
+
+  public AvroHeaderTimestampPolicy(State state, Type type) {
+    super(state, type);
+  }
+
+  /**
+   * Return PASS if the record has either header.time or header.timestamp field.
+   */
+  @Override
+  public Result executePolicy(Object record) {
+    if (!(record instanceof GenericRecord)) {
+      return RowLevelPolicy.Result.FAILED;
+    }
+
+    GenericRecord header = (GenericRecord) ((GenericRecord) record).get("header");
+    if (header == null) {
+      return RowLevelPolicy.Result.FAILED;
+    }
+    if (header.get("time") != null || header.get("timestamp") != null) {
+      return RowLevelPolicy.Result.PASSED;
+    }
+    return RowLevelPolicy.Result.FAILED;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -11,6 +11,8 @@
 
 package gobblin.util;
 
+import gobblin.converter.DataConversionException;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.List;
@@ -32,6 +34,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
 
 import static org.apache.avro.SchemaCompatibility.*;
 import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.*;
@@ -132,10 +135,11 @@ public class AvroUtils {
   public static GenericRecord convertRecordSchema(GenericRecord record, Schema newSchema) throws IOException {
     Preconditions.checkArgument(checkReaderWriterCompatibility(newSchema, record.getSchema()).getType() == COMPATIBLE);
 
-    ByteArrayOutputStream out = new ByteArrayOutputStream();
-    Encoder encoder = new EncoderFactory().directBinaryEncoder(out, null);
-    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(record.getSchema());
+    Closer closer = Closer.create();
     try {
+      ByteArrayOutputStream out = closer.register(new ByteArrayOutputStream());
+      Encoder encoder = new EncoderFactory().directBinaryEncoder(out, null);
+      DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(record.getSchema());
       writer.write(record, encoder);
       BinaryDecoder decoder = new DecoderFactory().binaryDecoder(out.toByteArray(), null);
       DatumReader<GenericRecord> reader = new GenericDatumReader<GenericRecord>(record.getSchema(), newSchema);
@@ -144,6 +148,8 @@ public class AvroUtils {
       throw new IOException(String.format(
           "Cannot convert avro record to new schema. Origianl schema = %s, new schema = %s", record.getSchema(),
           newSchema), e);
+    } finally {
+      closer.close();
     }
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -11,17 +11,30 @@
 
 package gobblin.util;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData.Record;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.io.BinaryDecoder;
+import org.apache.avro.io.DatumReader;
+import org.apache.avro.io.DatumWriter;
+import org.apache.avro.io.DecoderFactory;
+import org.apache.avro.io.Encoder;
+import org.apache.avro.io.EncoderFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
+
+import static org.apache.avro.SchemaCompatibility.*;
+import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.*;
 
 
 /**
@@ -106,6 +119,31 @@ public class AvroUtils {
       return Optional.fromNullable(((Record) data).get(pathList.get(field)));
     } else {
       return AvroUtils.getFieldHelper(((Record) data).get(pathList.get(field)), pathList, ++field);
+    }
+  }
+
+  /**
+   * Change the schema of an Avro record.
+   * @param record The Avro record whose schema is to be changed.
+   * @param newSchema The target schema. It must be compatible as reader schema with record.getSchema() as writer schema.
+   * @return a new Avro record with the new schema.
+   * @throws IOException if conversion failed.
+   */
+  public static GenericRecord convertRecordSchema(GenericRecord record, Schema newSchema) throws IOException {
+    Preconditions.checkArgument(checkReaderWriterCompatibility(newSchema, record.getSchema()).getType() == COMPATIBLE);
+
+    ByteArrayOutputStream out = new ByteArrayOutputStream();
+    Encoder encoder = new EncoderFactory().directBinaryEncoder(out, null);
+    DatumWriter<GenericRecord> writer = new GenericDatumWriter<GenericRecord>(record.getSchema());
+    try {
+      writer.write(record, encoder);
+      BinaryDecoder decoder = new DecoderFactory().binaryDecoder(out.toByteArray(), null);
+      DatumReader<GenericRecord> reader = new GenericDatumReader<GenericRecord>(record.getSchema(), newSchema);
+      return reader.read(null, decoder);
+    } catch (IOException e) {
+      throw new IOException(String.format(
+          "Cannot convert avro record to new schema. Origianl schema = %s, new schema = %s", record.getSchema(),
+          newSchema), e);
     }
   }
 }


### PR DESCRIPTION
- Implemented AvroProjectionConverter for removing certain fields from an Avro schema or an Avro record.

- Added two row-level policies for Kafka avro records: one for timestamp and one for GUID.