### PR TITLE
Report each metric as an individual series in InfluxDBReporter

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/graphite/GraphiteReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/graphite/GraphiteReporter.java
@@ -40,6 +40,14 @@ import gobblin.metrics.MetricContext;
  *
  * @see <a href="http://graphite.wikidot.com/">Graphite - Scalable Realtime Graphing</a>.
  *
+ * <p>
+ *   The name of the {@link MetricContext} a {@link GraphiteReporter} is associated to will
+ *   be included as the prefix in the metric names, which may or may not include the tags
+ *   of the {@link MetricContext} depending on if the {@link MetricContext} is configured to
+ *   report fully-qualified metric names or not using the method
+ *   {@link MetricContext.Builder#reportFullyQualifiedNames(boolean)}.
+ * </p>
+ *
  * @author ynli
  */
 public class GraphiteReporter extends ContextAwareScheduledReporter {

--- a/gobblin-metrics/src/test/java/gobblin/metrics/influxdb/InfluxDBReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/influxdb/InfluxDBReporterTest.java
@@ -175,9 +175,9 @@ public class InfluxDBReporterTest {
 
     @Override
     public void write(String database, TimeUnit precision, Serie... series) {
-      // There should be a single serie
-      Serie serie = series[0];
-      this.series.put(serie.getName(), serie);
+      for (Serie serie : series) {
+        this.series.put(serie.getName(), serie);
+      }
     }
 
     public Serie getSerie(String name) {


### PR DESCRIPTION
As suggested in http://influxdb.com/docs/v0.8/advanced_topics/schema_design.html, the best way to structure things is to have many series and a single column named value or something consistent across all series. This is the way InfluxDB handles metrics reported through the Graphite protocol. This commit changed the way metrics are reported in the InfluxDBReporter to use the suggest schema model.

Signed-off-by: Yinan Li <liyinan926@gmail.com>