### PR TITLE
Parameterize KafkaSource to make it polymorphic with regards to S, D

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
@@ -24,7 +24,7 @@ import org.apache.avro.generic.GenericRecord;
  *
  * @author ziliu
  */
-public class KafkaAvroSource extends KafkaSource {
+public class KafkaAvroSource extends KafkaSource<Schema, GenericRecord> {
   @Override
   public Extractor<Schema, GenericRecord> getExtractor(WorkUnitState state) throws IOException {
     try {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -21,8 +21,6 @@ import java.util.PriorityQueue;
 import java.util.Queue;
 import java.util.Set;
 
-import org.apache.avro.Schema;
-import org.apache.avro.generic.GenericRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,7 +48,7 @@ import com.google.common.primitives.Longs;
  *
  * @author ziliu
  */
-public abstract class KafkaSource extends EventBasedSource<Schema, GenericRecord> {
+public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
 


### PR DESCRIPTION
Turned out to be a really small change, but just wanted to get this in since it might be useful to anyone else writing different KafkaExtractors.