### PR TITLE
Refactor the Kafka adapter to accommodate new Kafka API

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
@@ -19,6 +19,7 @@ import java.io.IOException;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 
+
 /**
  * A {@link gobblin.source.Source} class for Kafka where events are in Avro format.
  *

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaEvent.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaEvent.java
@@ -1,0 +1,44 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+/**
+ * A KafkaEvent contains key, value, offset and nextOffset. In the old Kafka API, they are contained
+ * in the MessageAndOffset class. In the new Kafka API, they are contained in the ConsumerRecord<K, V> class.
+ *
+ * @param <K> Type of key. When using the Kafka Old API, K should be ByteBuffer.
+ * @param <V> Type of value. When using the Kafka Old API, V should be ByteBuffer.
+ *
+ * @author ziliu
+ */
+public interface KafkaEvent<K, V> {
+
+  /**
+   * Retrieve the key of the event.
+   */
+  public K key();
+
+  /**
+   * Retrieve the value of the event.
+   */
+  public V value();
+
+  /**
+   * Retrieve the offset of the event.
+   */
+  public long offset();
+
+  /**
+   * Retrieve the next offset of the event.
+   */
+  public long nextOffset();
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaOldEvent.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaOldEvent.java
@@ -1,0 +1,67 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.nio.ByteBuffer;
+
+import kafka.message.MessageAndOffset;
+
+
+/**
+ * An implementation of KafkaEvent based on the old Kafka API.
+ *
+ * This class wraps a MessageAndOffset object, which is a class
+ * in the old Kafka API.
+ *
+ * @author ziliu
+ */
+public class KafkaOldEvent implements KafkaEvent<ByteBuffer, ByteBuffer> {
+
+  private final MessageAndOffset messageAndOffset;
+
+  public KafkaOldEvent(MessageAndOffset messageAndOffset) {
+    this.messageAndOffset = messageAndOffset;
+  }
+
+  /**
+   * Retrieve the key of the event.
+   */
+  @Override
+  public ByteBuffer key() {
+    return messageAndOffset.message().key();
+  }
+
+  /**
+   * Retrieve the value of the event.
+   */
+  @Override
+  public ByteBuffer value() {
+    return messageAndOffset.message().payload();
+  }
+
+  /**
+   * Retrieve the offset of the event.
+   */
+  @Override
+  public long offset() {
+    return messageAndOffset.offset();
+  }
+
+  /**
+   * Retrieve the next offset of the event.
+   */
+  @Override
+  public long nextOffset() {
+    return messageAndOffset.nextOffset();
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -92,7 +92,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     List<List<WorkUnit>> workUnits = Lists.newArrayList();
     Closer closer = Closer.create();
     try {
-      KafkaWrapper kafkaWrapper = closer.register(KafkaWrapper.create(state));
+      KafkaWrapper<?, ?> kafkaWrapper = closer.register(new KafkaWrapper<Object, Object>(state));
       List<KafkaTopic> topics = getFilteredTopics(kafkaWrapper, state);
       for (KafkaTopic topic : topics) {
         workUnits.add(getWorkUnitsForTopic(kafkaWrapper, topic, state));
@@ -298,7 +298,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     return state.getProp(TOPIC_NAME) + "." + state.getPropAsInt(PARTITION_ID) + "." + AVG_EVENT_SIZE;
   }
 
-  private List<WorkUnit> getWorkUnitsForTopic(KafkaWrapper kafkaWrapper, KafkaTopic topic, SourceState state) {
+  private List<WorkUnit> getWorkUnitsForTopic(KafkaWrapper<?, ?> kafkaWrapper, KafkaTopic topic, SourceState state) {
     List<WorkUnit> workUnits = Lists.newArrayList();
     for (KafkaPartition partition : topic.getPartitions()) {
       WorkUnit workUnit = getWorkUnitForTopicPartition(kafkaWrapper, partition, state);
@@ -309,7 +309,8 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     return workUnits;
   }
 
-  private WorkUnit getWorkUnitForTopicPartition(KafkaWrapper kafkaWrapper, KafkaPartition partition, SourceState state) {
+  private WorkUnit getWorkUnitForTopicPartition(KafkaWrapper<?, ?> kafkaWrapper, KafkaPartition partition,
+      SourceState state) {
     Offsets offsets = new Offsets();
 
     try {
@@ -430,7 +431,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     return state.getPropAsBoolean(MOVE_TO_EARLIEST_OFFSET_ALLOWED, DEFAULT_MOVE_TO_EARLIEST_OFFSET_ALLOWED);
   }
 
-  private List<KafkaTopic> getFilteredTopics(KafkaWrapper kafkaWrapper, SourceState state) {
+  private List<KafkaTopic> getFilteredTopics(KafkaWrapper<?, ?> kafkaWrapper, SourceState state) {
     Set<String> blacklist =
         state.contains(TOPIC_BLACKLIST) ? state.getPropAsCaseInsensitiveSet(TOPIC_BLACKLIST) : new HashSet<String>();
     Set<String> whitelist =


### PR DESCRIPTION
In the old Kafka API, the type of message key and value are both ByteBuffer. In the new API they've become generic. Also, currently the Kafka adapter depends on `MessageAndOffset`, which is part of the old API, and doesn't exist in the new API. So the following changes have been made to the Kafka adapter:
- `MessageAndOffset` is replaced by interface `KafkaEvent<K, V>`, so that `KafkaExtractor` and `KafkaAvroExtractor` no longer depend on `MessageAndOffset`. When using the old API, `KafkaEvent` is implemented by `KafkaOldEvent`, which wraps a `MessageAndOffset` object. When using the new API, `KafkaEvent` is implemented by `KafkaNewEvent` (not yet created, new API will be in a separate branch), which wraps a `ConsumerRecord<K, V>` object.
- `KafkaExtractor<S, D>` becomes `KafkaExtractor<S, K, V, D>`. 
- `KafkaWrapper` becomes `KafkaWrapper<K, V>`.
- `KafkaAvroExtractor` now extends `KafkaExtractor<Schema, ByteBuffer, ByteBuffer, GenericRecord>`. A different subclass of KafkaExtractor that uses the new API may use different key and value types than `ByteBuffer`. However, if the old API is used, key and value type should always be ByteBuffer.
- Replaced `KafkaWrapper.Builder` with a constructor `KafkaWrapper(State state)`.