### PR TITLE
Make JobLauncher a Closeable so Gobblin can properly release job resources

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,7 @@ ext.externalDependency = [
   "salesforcePartner": "com.force.api:force-partner-api:29.0.0",
   "scala": "org.scala-lang:scala-library:2.10.3",
   "influxdbJava": "org.influxdb:influxdb-java:1.5",
+  "jsr305": "com.google.code.findbugs:jsr305:1.3.9",
   "byteman": "org.jboss.byteman:byteman:"+bytemanVersion,
   "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:"+bytemanVersion,
   "pegasus" : [

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
@@ -17,6 +17,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Logger;
 
 import com.google.common.base.Strings;
+import com.google.common.io.Closer;
 
 import azkaban.jobExecutor.AbstractJob;
 
@@ -78,7 +79,14 @@ public class AzkabanJobLauncher extends AbstractJob {
   @Override
   public void run()
       throws Exception {
-    this.jobLauncher.launchJob(this.properties, new EmailNotificationJobListener());
+    Closer closer = Closer.create();
+    try {
+      closer.register(this.jobLauncher).launchJob(this.properties, new EmailNotificationJobListener());
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
   }
 
   @Override

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -39,6 +39,7 @@ dependencies {
   compile externalDependency.pegasus.data
   compile externalDependency.guice
   compile externalDependency.javaxInject
+  compile externalDependency.jsr305
 
   testCompile externalDependency.testng
   testCompile externalDependency.byteman

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobLauncher.java
@@ -11,6 +11,7 @@
 
 package gobblin.runtime;
 
+import java.io.Closeable;
 import java.util.Properties;
 
 
@@ -19,7 +20,7 @@ import java.util.Properties;
  *
  * @author ynli
  */
-public interface JobLauncher {
+public interface JobLauncher extends Closeable {
 
   /**
    * Launch a Gobblin job.

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobLauncherFactory.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobLauncherFactory.java
@@ -12,6 +12,7 @@
 package gobblin.runtime;
 
 import java.util.Properties;
+import javax.annotation.Nonnull;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.runtime.local.LocalJobLauncher;
@@ -37,10 +38,14 @@ public class JobLauncherFactory {
   /**
    * Create a new {@link JobLauncher}.
    *
-   * @param properties Framework configuration properties
-   * @return Newly created {@link JobLauncher}
+   * <p>
+   *   This method will never return a {@code null}.
+   * </p>
+   *
+   * @param properties framework configuration properties
+   * @return newly created {@link JobLauncher}
    */
-  public static JobLauncher newJobLauncher(Properties properties)
+  public static @Nonnull JobLauncher newJobLauncher(Properties properties)
       throws Exception {
     JobLauncherType launcherType = JobLauncherType
         .valueOf(properties.getProperty(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY, JobLauncherType.LOCAL.name()));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/CliMRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/CliMRJobLauncher.java
@@ -27,6 +27,8 @@ import org.apache.hadoop.util.GenericOptionsParser;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 
+import com.google.common.io.Closer;
+
 import gobblin.runtime.JobException;
 
 
@@ -55,12 +57,17 @@ public class CliMRJobLauncher extends Configured implements Tool {
     // Then load job configuration properties that might overwrite system configuration properties
     jobProps.putAll(this.jobConfig);
 
+    Closer closer = Closer.create();
     try {
-      new MRJobLauncher(this.sysConfig, getConf()).launchJob(jobProps, null);
+      closer.register(new MRJobLauncher(this.sysConfig, getConf())).launchJob(jobProps, null);
     } catch (JobException je) {
       System.err.println("Failed to launch the job due to the following exception:");
       System.err.println(je.toString());
       return 1;
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
     }
 
     return 0;
@@ -77,11 +84,11 @@ public class CliMRJobLauncher extends Configured implements Tool {
 
   public static void main(String[] args)
       throws Exception {
-    
+
     Configuration conf = new Configuration();
     // Parse generic options
     String[] genericCmdLineOpts = new GenericOptionsParser(conf, args).getCommandLine().getArgs();
-    
+
     // Build command-line options
     Option sysConfigOption = OptionBuilder
         .withArgName("system configuration file")

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
@@ -103,6 +102,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   private final FileSystem fs;
 
   private volatile Job job;
+  private volatile Path mrJobDir;
   private volatile boolean isCancelled = false;
 
   public MRJobLauncher(Properties properties)
@@ -121,42 +121,100 @@ public class MRJobLauncher extends AbstractJobLauncher {
   @Override
   public void cancelJob(Properties jobProps)
       throws JobException {
-    String jobName = jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY);
-
-    if (this.isCancelled || !Optional.fromNullable(this.job).isPresent()) {
-      LOG.info(String.format("Job %s has already been cancelled or has not started yet", jobName));
-      return;
-    }
-
     try {
-      // Kill the Hadoop MR if has not completed yet
-      if (!this.job.isComplete()) {
+      if (!this.isCancelled && this.job != null && !this.job.isComplete()) {
         LOG.info("Killing Hadoop MR job " + this.job.getJobID());
         this.job.killJob();
       }
       this.isCancelled = true;
+      LOG.info("Cancelled job " + jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY));
     } catch (IOException ioe) {
       LOG.error("Failed to kill the Hadoop MR job " + this.job.getJobID(), ioe);
       throw new JobException("Failed to kill the Hadoop MR job " + this.job.getJobID(), ioe);
+    } finally {
+      cleanUpWorkingDirectory();
+    }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    if (!this.isCancelled && this.job != null && !this.job.isComplete()) {
+      LOG.info("Killing Hadoop MR job " + this.job.getJobID());
+      try {
+        this.job.killJob();
+      } finally {
+        cleanUpWorkingDirectory();
+      }
     }
   }
 
   @Override
   protected void runJob(String jobName, Properties jobProps, JobState jobState, List<WorkUnit> workUnits)
       throws Exception {
-
     // Add job config properties that also contains all framework config properties
     for (String name : jobProps.stringPropertyNames()) {
       this.conf.set(name, jobProps.getProperty(name));
     }
 
-    Path mrJobDir = new Path(jobProps.getProperty(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY), jobName);
-    if (this.fs.exists(mrJobDir)) {
+    // Let the job and all mappers finish even if some mappers fail
+    this.conf.set("mapred.max.map.failures.percent", "100"); // For Hadoop 1.x
+    this.conf.set("mapreduce.map.failures.maxpercent", "100"); // For Hadoop 2.x
+
+    // Do not cancel delegation tokens after job has completed (HADOOP-7002)
+    this.conf.setBoolean("mapreduce.job.complete.cancel.delegation.tokens", false);
+
+    this.mrJobDir = new Path(jobProps.getProperty(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY), jobName);
+    if (this.fs.exists(this.mrJobDir)) {
       LOG.warn("Job working directory already exists for job " + jobName);
-      this.fs.delete(mrJobDir, true);
+      this.fs.delete(this.mrJobDir, true);
     }
 
-    Path jarFileDir = new Path(mrJobDir, "_jars");
+    // Delete any staging directories that already exist before the Hadoop MR job starts
+    JobLauncherUtils.cleanStagingData(JobLauncherUtils.flattenWorkUnits(workUnits), LOG);
+
+    try {
+      Path jobOutputPath = prepareHadoopJob(jobName, jobProps, workUnits);
+      LOG.info("Launching Hadoop MR job " + this.job.getJobName());
+      this.job.submit();
+      // Set job tracking URL to the Hadoop job tracking URL if it is not set yet
+      if (!jobState.contains(ConfigurationKeys.JOB_TRACKING_URL_KEY)) {
+        jobState.setProp(ConfigurationKeys.JOB_TRACKING_URL_KEY, this.job.getTrackingURL());
+      }
+      // Wait for the job to complete
+      this.job.waitForCompletion(true);
+
+      if (this.isCancelled) {
+        jobState.setState(JobState.RunningState.CANCELLED);
+        return;
+      }
+
+      jobState.setState(this.job.isSuccessful() ? JobState.RunningState.SUCCESSFUL : JobState.RunningState.FAILED);
+      // Collect the output task states and add them to the job state
+      jobState.addTaskStates(
+          collectOutput(new Path(jobOutputPath, jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY))));
+
+      // Create a metrics set for this job run from the Hadoop counters.
+      // The metrics set is to be persisted to the metrics store later.
+      countersToMetrics(this.job.getCounters(),
+          JobMetrics.get(jobName, jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY)));
+    } finally {
+      cleanUpWorkingDirectory();
+    }
+  }
+
+  @Override
+  protected JobLock getJobLock(String jobName, Properties jobProps)
+      throws IOException {
+    return new FileBasedJobLock(this.fs, jobProps.getProperty(ConfigurationKeys.JOB_LOCK_DIR_KEY), jobName);
+  }
+
+  /**
+   * Prepare the Hadoop MR job, including configuring the job and setting up the input/output paths.
+   */
+  private Path prepareHadoopJob(String jobName, Properties jobProps, List<WorkUnit> workUnits)
+      throws IOException {
+    Path jarFileDir = new Path(this.mrJobDir, "_jars");
     // Add framework jars to the classpath for the mappers/reducer
     if (jobProps.containsKey(ConfigurationKeys.FRAMEWORK_JAR_FILES_KEY)) {
       addJars(jarFileDir, jobProps.getProperty(ConfigurationKeys.FRAMEWORK_JAR_FILES_KEY));
@@ -168,20 +226,13 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
     // Add other files (if any) the job depends on to DistributedCache
     if (jobProps.containsKey(ConfigurationKeys.JOB_LOCAL_FILES_KEY)) {
-      addLocalFiles(new Path(mrJobDir, "_files"), jobProps.getProperty(ConfigurationKeys.JOB_LOCAL_FILES_KEY));
+      addLocalFiles(new Path(this.mrJobDir, "_files"), jobProps.getProperty(ConfigurationKeys.JOB_LOCAL_FILES_KEY));
     }
 
     // Add files (if any) already on HDFS that the job depends on to DistributedCache
     if (jobProps.containsKey(ConfigurationKeys.JOB_HDFS_FILES_KEY)) {
       addHDFSFiles(jobProps.getProperty(ConfigurationKeys.JOB_HDFS_FILES_KEY));
     }
-
-    // Let the job and all mappers finish even if some mappers fail
-    this.conf.set("mapred.max.map.failures.percent", "100"); // For Hadoop 1.x
-    this.conf.set("mapreduce.map.failures.maxpercent", "100"); // For Hadoop 2.x
-
-    // Do not cancel delegation tokens after job has completed (HADOOP-7002)
-    this.conf.setBoolean("mapreduce.job.complete.cancel.delegation.tokens", false);
 
     // Preparing a Hadoop MR job
     this.job = Job.getInstance(this.conf, JOB_NAME_PREFIX + jobName);
@@ -199,18 +250,15 @@ public class MRJobLauncher extends AbstractJobLauncher {
     // Turn off speculative execution
     this.job.setSpeculativeExecution(false);
 
-    // Delete any staging directories that already exist
-    JobLauncherUtils.cleanStagingData(JobLauncherUtils.flattenWorkUnits(workUnits), LOG);
-
     // Job input path is where input work unit files are stored
-    Path jobInputPath = new Path(mrJobDir, "input");
+    Path jobInputPath = new Path(this.mrJobDir, "input");
 
     // Prepare job input
     Path jobInputFile = prepareJobInput(jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY), jobInputPath, workUnits);
     NLineInputFormat.addInputPath(this.job, jobInputFile);
 
     // Job output path is where serialized task states are stored
-    Path jobOutputPath = new Path(mrJobDir, "output");
+    Path jobOutputPath = new Path(this.mrJobDir, "output");
     SequenceFileOutputFormat.setOutputPath(this.job, jobOutputPath);
 
     if (jobProps.containsKey(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY)) {
@@ -224,47 +272,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
       }
     }
 
-    try {
-      LOG.info("Launching Hadoop MR job " + this.job.getJobName());
-      this.job.submit();
-      // Set job tracking URL to the Hadoop job tracking URL if it is not set yet
-      if (!jobState.contains(ConfigurationKeys.JOB_TRACKING_URL_KEY)) {
-        jobState.setProp(ConfigurationKeys.JOB_TRACKING_URL_KEY, job.getTrackingURL());
-      }
-      // Wait for the job to complete
-      this.job.waitForCompletion(true);
-
-      if (this.isCancelled) {
-        jobState.setState(JobState.RunningState.CANCELLED);
-        return;
-      }
-
-      jobState.setState(this.job.isSuccessful() ? JobState.RunningState.SUCCESSFUL : JobState.RunningState.FAILED);
-
-      // Collect the output task states and add them to the job state
-      jobState
-          .addTaskStates(collectOutput(new Path(jobOutputPath, jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY))));
-
-      // Create a metrics set for this job run from the Hadoop counters.
-      // The metrics set is to be persisted to the metrics store later.
-      countersToMetrics(this.job.getCounters(),
-          JobMetrics.get(jobName, jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY)));
-    } finally {
-      // Cleanup job working directory
-      try {
-        if (this.fs.exists(mrJobDir)) {
-          this.fs.delete(mrJobDir, true);
-        }
-      } catch (IOException ioe) {
-        LOG.error("Failed to cleanup job working directory for job " + this.job.getJobID());
-      }
-    }
-  }
-
-  @Override
-  protected JobLock getJobLock(String jobName, Properties jobProps)
-      throws IOException {
-    return new FileBasedJobLock(this.fs, jobProps.getProperty(ConfigurationKeys.JOB_LOCK_DIR_KEY), jobName);
+    return jobOutputPath;
   }
 
   /**
@@ -409,6 +417,20 @@ public class MRJobLauncher extends AbstractJobLauncher {
   }
 
   /**
+   * Cleanup the Hadoop MR working directory.
+   */
+  private void cleanUpWorkingDirectory() {
+    try {
+      if (this.mrJobDir != null && this.fs.exists(this.mrJobDir)) {
+        this.fs.delete(this.mrJobDir, true);
+        LOG.info("Deleted working directory " + this.mrJobDir);
+      }
+    } catch (IOException ioe) {
+      LOG.error("Failed to delete working directory " + this.mrJobDir);
+    }
+  }
+
+  /**
    * Create a {@link JobMetrics} instance for this job run from the Hadoop counters.
    */
   private void countersToMetrics(Counters counters, JobMetrics metrics) {
@@ -490,7 +512,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
     public void map(LongWritable key, Text value, Context context)
         throws IOException, InterruptedException {
 
-      if (!Optional.fromNullable(this.fs).isPresent() || !this.serviceManager.isHealthy()) {
+      if (this.fs == null || !this.serviceManager.isHealthy()) {
         LOG.error("Not running the task because the mapper was not setup properly");
         return;
       }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -29,6 +29,7 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
 import com.google.common.io.Files;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
@@ -58,8 +59,13 @@ public class JobLauncherTestHelper {
 
   @SuppressWarnings("unchecked")
   public void runTest(Properties jobProps) throws Exception {
-    JobLauncher jobLauncher = JobLauncherFactory.newJobLauncher(this.launcherProps);
-    jobLauncher.launchJob(jobProps, null);
+    Closer closer = Closer.create();
+    try {
+      JobLauncher jobLauncher = closer.register(JobLauncherFactory.newJobLauncher(this.launcherProps));
+      jobLauncher.launchJob(jobProps, null);
+    } finally {
+      closer.close();
+    }
     String jobName = jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY);
     String jobId = jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY);
     List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
@@ -76,8 +82,13 @@ public class JobLauncherTestHelper {
   @SuppressWarnings("unchecked")
   public void runTestWithPullLimit(Properties jobProps)
       throws Exception {
-    JobLauncher jobLauncher = JobLauncherFactory.newJobLauncher(this.launcherProps);
-    jobLauncher.launchJob(jobProps, null);
+    Closer closer = Closer.create();
+    try {
+      JobLauncher jobLauncher = closer.register(JobLauncherFactory.newJobLauncher(this.launcherProps));
+      jobLauncher.launchJob(jobProps, null);
+    } finally {
+      closer.close();
+    }
     String jobName = jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY);
     String jobId = jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY);
     List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
@@ -98,27 +109,31 @@ public class JobLauncherTestHelper {
 
   @SuppressWarnings("unchecked")
   public void runTestWithCancellation(final Properties jobProps) throws Exception {
-    final JobLauncher jobLauncher = JobLauncherFactory.newJobLauncher(this.launcherProps);
+    Closer closer = Closer.create();
+    try {
+      final JobLauncher jobLauncher = closer.register(JobLauncherFactory.newJobLauncher(this.launcherProps));
 
-    final AtomicBoolean isCancelled = new AtomicBoolean(false);
-    // This thread will cancel the job after some time
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        try {
-          Thread.sleep(500);
-          jobLauncher.cancelJob(jobProps);
-          isCancelled.set(true);
-        } catch (Exception je) {
-          // Ignored
+      final AtomicBoolean isCancelled = new AtomicBoolean(false);
+      // This thread will cancel the job after some time
+      Thread thread = new Thread(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            Thread.sleep(500);
+            jobLauncher.cancelJob(jobProps);
+            isCancelled.set(true);
+          } catch (Exception je) {
+            // Ignored
+          }
         }
-      }
-    });
-    thread.start();
+      });
+      thread.start();
 
-    jobLauncher.launchJob(jobProps, null);
-
-    Assert.assertTrue(isCancelled.get());
+      jobLauncher.launchJob(jobProps, null);
+      Assert.assertTrue(isCancelled.get());
+    } finally {
+      closer.close();
+    }
 
     String jobName = jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY);
     String jobId = jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY);
@@ -135,8 +150,13 @@ public class JobLauncherTestHelper {
   @SuppressWarnings("unchecked")
   public void runTestWithFork(Properties jobProps)
       throws Exception {
-    JobLauncher jobLauncher = JobLauncherFactory.newJobLauncher(this.launcherProps);
-    jobLauncher.launchJob(jobProps, null);
+    Closer closer = Closer.create();
+    try {
+      JobLauncher jobLauncher = closer.register(JobLauncherFactory.newJobLauncher(this.launcherProps));
+      jobLauncher.launchJob(jobProps, null);
+    } finally {
+      closer.close();
+    }
     String jobName = jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY);
     String jobId = jobProps.getProperty(ConfigurationKeys.JOB_ID_KEY);
     List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobStateStoreTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.SourceState;
@@ -85,19 +86,34 @@ public class JobStateStoreTest {
 
   @Test
   public void testLaunchFirstJob() throws Exception {
-    new LocalJobLauncher(this.properties).launchJob(this.jobProps, null);
+    Closer closer = Closer.create();
+    try {
+      closer.register(new LocalJobLauncher(this.properties)).launchJob(this.jobProps, null);
+    } finally {
+      closer.close();
+    }
     verifyJobState(1);
   }
 
   @Test(dependsOnMethods = "testLaunchFirstJob")
   public void testLaunchSecondJob() throws Exception {
-    new LocalJobLauncher(this.properties).launchJob(this.jobProps, null);
+    Closer closer = Closer.create();
+    try {
+      closer.register(new LocalJobLauncher(this.properties)).launchJob(this.jobProps, null);
+    } finally {
+      closer.close();
+    }
     verifyJobState(2);
   }
 
   @Test(dependsOnMethods = "testLaunchSecondJob")
   public void testLaunchThirdJob() throws Exception {
-    new LocalJobLauncher(this.properties).launchJob(this.jobProps, null);
+    Closer closer = Closer.create();
+    try {
+      closer.register(new LocalJobLauncher(this.properties)).launchJob(this.jobProps, null);
+    } finally {
+      closer.close();
+    }
     verifyJobState(3);
   }
 

--- a/gobblin-scheduler/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-scheduler/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -48,6 +48,7 @@ import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.io.Closer;
 import com.google.common.io.Files;
 import com.google.common.util.concurrent.AbstractIdleService;
 
@@ -257,9 +258,10 @@ public class JobScheduler extends AbstractIdleService {
     // Populate the assigned job ID
     jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, JobLauncherUtils.newJobId(jobName));
 
+    Closer closer = Closer.create();
     // Launch the job
     try {
-      JobLauncher jobLauncher = JobLauncherFactory.newJobLauncher(this.properties);
+      JobLauncher jobLauncher = closer.register(JobLauncherFactory.newJobLauncher(this.properties));
       jobLauncher.launchJob(jobProps, jobListener);
       boolean runOnce = Boolean.valueOf(jobProps.getProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "false"));
       if (runOnce && this.scheduledJobs.containsKey(jobName)) {
@@ -269,6 +271,12 @@ public class JobScheduler extends AbstractIdleService {
       String errMsg = "Failed to launch and run job " + jobName;
       LOG.error(errMsg, t);
       throw new JobException(errMsg, t);
+    } finally {
+      try {
+        closer.close();
+      } catch (IOException ioe) {
+        LOG.error("Failed to close the JobLauncher for job " + jobName, ioe);
+      }
     }
   }
 


### PR DESCRIPTION
1. Refactored JobLauncher to extend Closeable and code around its usage to properly close it.
2. In MRJobLauncher, the close() method will now kill the Hadoop job if it has not completed.

Signed-off-by: Yinan Li <liyinan926@gmail.com>