### PR TITLE
Feature/kafka simple extractor

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
@@ -103,14 +103,4 @@ public class KafkaAvroExtractor extends KafkaExtractor<Schema, GenericRecord> {
     }
   }
 
-  private static byte[] getBytes(ByteBuffer buf) {
-    byte[] bytes = null;
-    if (buf != null) {
-      int size = buf.remaining();
-      bytes = new byte[size];
-      buf.get(bytes, buf.position(), size);
-    }
-    return bytes;
-  }
-
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -12,6 +12,7 @@
 package gobblin.source.extractor.extract.kafka;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import java.util.Iterator;
 
 import org.slf4j.Logger;
@@ -140,5 +141,15 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
       this.workUnitState.setProp(KafkaSource.getWorkUnitSizePropName(this.workUnitState), previousAvgRecordSize);
     }
     this.closer.close();
+  }
+
+  protected static byte[] getBytes(ByteBuffer buf) {
+    byte[] bytes = null;
+    if (buf != null) {
+      int size = buf.remaining();
+      bytes = new byte[size];
+      buf.get(bytes, buf.position(), size);
+    }
+    return bytes;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleExtractor.java
@@ -1,0 +1,45 @@
+/* (c) 2015 NerdWallet All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import gobblin.configuration.WorkUnitState;
+
+import java.io.IOException;
+
+import kafka.message.MessageAndOffset;
+
+/**
+ * An implementation of {@link KafkaExtractor} from which reads and returns records as an array of bytes.
+ *
+ * @author akshay@nerdwallet.com
+ */
+public class KafkaSimpleExtractor extends KafkaExtractor<String, byte[]> {
+
+  public KafkaSimpleExtractor(WorkUnitState state) {
+    super(state);
+  }
+  @Override
+  protected byte[] decodeRecord(MessageAndOffset messageAndOffset, byte[] reuse) throws SchemaNotFoundException, IOException {
+    return getBytes(messageAndOffset.message().payload());
+  }
+
+  /**
+   * Get the schema (metadata) of the extracted data records.
+   *
+   * @return the Kafka topic being extracted
+   * @throws IOException if there is problem getting the schema
+   */
+  @Override
+  public String getSchema() throws IOException {
+    return this.partition.getTopicName();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleSource.java
@@ -1,0 +1,40 @@
+/* (c) 2015 NerdWallet All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.Extractor;
+
+import java.io.IOException;
+
+/**
+ * A {@link KafkaSource} implementation for SimpleKafkaExtractor.
+ *
+ * @author akshay@nerdwallet.com
+ */
+public class KafkaSimpleSource extends KafkaSource<String, byte[]> {
+  /**
+   * Get an {@link Extractor} based on a given {@link WorkUnitState}.
+   * <p>
+   * The {@link Extractor} returned can use {@link WorkUnitState} to store arbitrary key-value pairs
+   * that will be persisted to the state store and loaded in the next scheduled job run.
+   * </p>
+   *
+   * @param state a {@link WorkUnitState} carrying properties needed by the returned {@link Extractor}
+   * @return an {@link Extractor} used to extract schema and data records from the data source
+   * @throws IOException if it fails to create an {@link Extractor}
+   */
+  @Override
+  public Extractor<String, byte[]> getExtractor(WorkUnitState state) throws IOException {
+    return new KafkaSimpleExtractor(state);
+  }
+}


### PR DESCRIPTION
Adds a Kafka Extractor for just pulling raw bytes from Kafka. This is useful if strings are being read off the Kafka log, or if no data processing is required through Gobblin.