### PR TITLE
Feature/simple data writer

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -197,6 +197,8 @@ public class ConfigurationKeys {
   public static final String WRITER_FILE_SYSTEM_URI = WRITER_PREFIX + ".fs.uri";
   public static final String WRITER_STAGING_DIR = WRITER_PREFIX + ".staging.dir";
   public static final String WRITER_OUTPUT_DIR = WRITER_PREFIX + ".output.dir";
+  // WRITER_FINAL_OUTPUT_PATH is used for internal purposes only to pass the absolute writer path to the publisher
+  public static final String WRITER_FINAL_OUTPUT_PATH = WRITER_PREFIX + ".final.output.path";
   public static final String WRITER_BUILDER_CLASS = WRITER_PREFIX + ".builder.class";
   public static final String DEFAULT_WRITER_BUILDER_CLASS = "gobblin.writer.AvroDataWriterBuilder";
   public static final String WRITER_FILE_NAME = WRITER_PREFIX + ".file.name";
@@ -221,6 +223,9 @@ public class ConfigurationKeys {
   public static final String DEFAULT_WRITER_PARTITION_PATTERN = "yyyy/MM/dd";
   public static final String DEFAULT_WRITER_PARTITION_TIMEZONE = "America/Los_Angeles";
   public static final String DEFAULT_WRITER_FILE_PATH_TYPE = "default";
+
+  public static final String SIMPLE_WRITER_DELIMITER = "simple.writer.delimiter";
+  public static final String SIMPLE_WRITER_PREPEND_SIZE = "simple.writer.prepend.size";
 
   /**
    * Configuration properties used by the quality checker.

--- a/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
+++ b/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
@@ -19,6 +19,7 @@ package gobblin.writer;
 public enum WriterOutputFormat {
   AVRO("avro"),
   PARQUET("parquet"),
+  PROTOBUF("protobuf"),
   CSV("csv");
 
   /**

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -12,7 +12,6 @@
 package gobblin.writer;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.avro.Schema;
@@ -21,11 +20,8 @@ import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -34,22 +30,17 @@ import com.google.common.base.Preconditions;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.util.ForkOperatorUtils;
-import gobblin.util.WriterUtils;
-
+import gobblin.util.HadoopUtils;
 
 /**
  * An implementation of {@link DataWriter} that writes directly to HDFS in Avro format.
  *
  * @author ynli
  */
-class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
+class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AvroHdfsDataWriter.class);
 
-  private final State properties;
-  private final FileSystem fs;
-  private final Path stagingFile;
-  private final Path outputFile;
   private final DatumWriter<GenericRecord> datumWriter;
   private final DataFileWriter<GenericRecord> writer;
 
@@ -69,14 +60,7 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
 
   public AvroHdfsDataWriter(State properties, String fileName, Schema schema, int numBranches, int branchId)
       throws IOException {
-
-    String uri = properties.getProp(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
-        ConfigurationKeys.LOCAL_FS_URI);
-
-    Path stagingDir = WriterUtils.getWriterStagingDir(properties, numBranches, branchId);
-
-    Path outputDir = WriterUtils.getWriterOutputDir(properties, numBranches, branchId);
+    super(properties, fileName, numBranches, branchId);
 
     String codecType = properties
         .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId),
@@ -91,30 +75,6 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
         ConfigurationKeys.DEFAULT_DEFLATE_LEVEL));
 
     this.schema = schema;
-
-    Configuration conf = new Configuration();
-    // Add all job configuration properties so they are picked up by Hadoop
-    for (String key : properties.getPropertyNames()) {
-      conf.set(key, properties.getProp(key));
-    }
-    this.fs = FileSystem.get(URI.create(uri), conf);
-    this.properties = properties;
-    this.stagingFile = new Path(stagingDir, fileName);
-
-    // Deleting the staging file if it already exists, which can happen if the
-    // task failed and the staging file didn't get cleaned up for some reason.
-    // Deleting the staging file prevents the task retry from being blocked.
-    if (this.fs.exists(this.stagingFile)) {
-      LOG.warn(String.format("Task staging file %s already exists, deleting it", this.stagingFile));
-      this.fs.delete(this.stagingFile, false);
-    }
-
-    this.outputFile = new Path(outputDir, fileName);
-
-    // Create the parent directory of the output file if it does not exist
-    if (!this.fs.exists(this.outputFile.getParent())) {
-      this.fs.mkdirs(this.outputFile.getParent());
-    }
 
     this.datumWriter = new GenericDatumWriter<GenericRecord>();
     this.writer = createDatumWriter(this.stagingFile, bufferSize, CodecType.valueOf(codecType), deflateLevel);
@@ -159,15 +119,9 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
     // the output file if it already exists prevents task retry from being blocked.
     if (this.fs.exists(this.outputFile)) {
       LOG.warn(String.format("Task output file %s already exists", this.outputFile));
-      this.fs.delete(this.outputFile, false);
+      HadoopUtils.deletePath(this.fs, this.outputFile, false);
     }
-
-    if (!this.fs.rename(this.stagingFile, this.outputFile)) {
-      throw new IOException("Failed to commit data from " + this.stagingFile + " to " + this.outputFile);
-    }
-
-    // Setting the same HDFS properties as the original file
-    WriterUtils.setFileAttributesFromState(properties, fs, outputFile);
+    HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile);
   }
 
   @Override
@@ -175,7 +129,7 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
       throws IOException {
     // Delete the staging file
     if (this.fs.exists(this.stagingFile)) {
-      this.fs.delete(this.stagingFile, false);
+      HadoopUtils.deletePath(this.fs, this.stagingFile, false);
     }
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -1,0 +1,76 @@
+/* (c) 2015 NerdWallet All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.ForkOperatorUtils;
+import gobblin.util.HadoopUtils;
+import gobblin.util.WriterUtils;
+
+/**
+ * An implementation of {@link DataWriter} does the work of setting the output/staging dir
+ * and creating the FileSystem instance.
+ *
+ * @author akshay@nerdwallet.com
+ */
+public abstract class FsDataWriter<D> implements DataWriter<D> {
+  private static final Logger LOG = LoggerFactory.getLogger(FsDataWriter.class);
+
+  protected final FileSystem fs;
+  protected final Path stagingFile;
+  protected final Path outputFile;
+  protected final State properties;
+
+  public FsDataWriter(State properties, String fileName, int numBranches, int branchId) throws IOException {
+    this.properties = properties;
+    // initialize file system
+    String uri = properties.getProp(
+            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
+            ConfigurationKeys.LOCAL_FS_URI
+    );
+    Configuration conf = new Configuration();
+    // Add all job configuration properties so they are picked up by Hadoop
+    for (String key : properties.getPropertyNames()) {
+      conf.set(key, properties.getProp(key));
+    }
+    this.fs = FileSystem.get(URI.create(uri), conf);
+
+    // initialize staging/output dir
+    this.stagingFile = new Path(WriterUtils.getWriterStagingDir(properties, numBranches, branchId), fileName);
+    this.outputFile = new Path(WriterUtils.getWriterOutputDir(properties, numBranches, branchId), fileName);
+    properties.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, branchId),
+            this.outputFile.toString());
+
+    // Deleting the staging file if it already exists, which can happen if the
+    // task failed and the staging file didn't get cleaned up for some reason.
+    // Deleting the staging file prevents the task retry from being blocked.
+    if (this.fs.exists(this.stagingFile)) {
+      LOG.warn(String.format("Task staging file %s already exists, deleting it", this.stagingFile));
+      HadoopUtils.deletePath(this.fs, this.stagingFile, false);
+    }
+
+    // Create the parent directory of the output file if it does not exist
+    if (!this.fs.exists(this.outputFile.getParent())) {
+      this.fs.mkdirs(this.outputFile.getParent());
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -1,0 +1,177 @@
+/* (c) 2015 NerdWallet All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+
+import org.apache.commons.lang.ArrayUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.primitives.Longs;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.HadoopUtils;
+
+/**
+ * An implementation of {@link DataWriter} that writes bytes directly to HDFS.
+ *
+ * This class accepts two new configuration parameters:
+ * <ul>
+ * <li>{@link ConfigurationKeys#SIMPLE_WRITER_PREPEND_SIZE} is a boolean configuration option. If true, for each record,
+ * it will write out a big endian long representing the record size and then write the record. i.e. the file format
+ * will be the following:
+ * r := &gt;long&lt;&gt;record&lt;
+ * file := empty | r file
+ * <li>{@link ConfigurationKeys#SIMPLE_WRITER_DELIMITER} accepts a byte value. If specified, this byte will be used
+ * as a seperator between records. If unspecified, no delimter will be used between records.
+ * </ul>
+ * @author akshay@nerdwallet.com
+ */
+public class SimpleDataWriter extends FsDataWriter<byte[]> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(SimpleDataWriter.class);
+
+  private final OutputStream stagingFileOutputStream;
+  private final Optional<Byte> recordDelimiter; // optional byte to place between each record write
+  private final boolean prependSize;
+
+  private int recordsWritten;
+  private int bytesWritten;
+  private boolean closed;
+
+  public SimpleDataWriter(State properties, String fileName, int numBranches, int branchId) throws IOException {
+    super(properties, fileName, numBranches, branchId);
+    String delim;
+    if ((delim = properties.getProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, null)) == null || delim.length() == 0) {
+      this.recordDelimiter = Optional.absent();
+    } else {
+      this.recordDelimiter = Optional.of(delim.getBytes()[0]);
+    }
+
+    this.stagingFileOutputStream = this.fs.create(this.stagingFile, true);
+    this.prependSize = properties.getPropAsBoolean(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, true);
+    this.recordsWritten = 0;
+    this.bytesWritten = 0;
+    this.closed = false;
+  }
+  /**
+   * Write a source record to the staging file
+   *
+   * @param record data record to write
+   * @throws java.io.IOException if there is anything wrong writing the record
+   */
+  @Override
+  public void write(byte[] record) throws IOException {
+    Preconditions.checkNotNull(record);
+
+    byte[] toWrite = record;
+    if (recordDelimiter.isPresent()) {
+      toWrite = Arrays.copyOf(record, record.length + 1);
+      toWrite[toWrite.length - 1] = recordDelimiter.get();
+    }
+    if (prependSize) {
+      long recordSize = toWrite.length;
+      ByteBuffer buf = ByteBuffer.allocate(Longs.BYTES);
+      buf.putLong(recordSize);
+      toWrite = ArrayUtils.addAll(buf.array(), toWrite);
+    }
+    this.stagingFileOutputStream.write(toWrite);
+    bytesWritten += toWrite.length;
+    recordsWritten++;
+  }
+
+  /**
+   * Commit the data written to the final output file.
+   *
+   * @throws java.io.IOException if there is anything wrong committing the output
+   */
+  @Override
+  public void commit() throws IOException {
+    this.close();
+    if (!this.fs.exists(this.stagingFile)) {
+      throw new IOException(String.format("File %s does not exist", this.stagingFile));
+    }
+
+    LOG.info(String.format("Moving data from %s to %s", this.stagingFile, this.outputFile));
+    // For the same reason as deleting the staging file if it already exists, deleting
+    // the output file if it already exists prevents task retry from being blocked.
+    if (this.fs.exists(this.outputFile)) {
+      LOG.warn(String.format("Task output file %s already exists", this.outputFile));
+      HadoopUtils.deletePath(this.fs, this.outputFile, false);
+    }
+    HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile);
+  }
+
+  /**
+   * Cleanup context/resources.
+   *
+   * @throws java.io.IOException if there is anything wrong doing cleanup.
+   */
+  @Override
+  public void cleanup() throws IOException {
+    if (this.fs.exists(this.stagingFile)) {
+      HadoopUtils.deletePath(this.fs, this.stagingFile, false);
+    }
+  }
+
+  /**
+   * Get the number of records written.
+   *
+   * @return number of records written
+   */
+  @Override
+  public long recordsWritten() {
+    return this.recordsWritten;
+  }
+
+  /**
+   * Get the number of bytes written.
+   *
+   * @return number of bytes written
+   */
+  @Override
+  public long bytesWritten() throws IOException {
+    return this.bytesWritten;
+  }
+
+  /**
+   * Closes this stream and releases any system resources associated
+   * with it. If the stream is already closed then invoking this
+   * method has no effect.
+   * <p/>
+   * <p> As noted in {@link AutoCloseable#close()}, cases where the
+   * close may fail require careful attention. It is strongly advised
+   * to relinquish the underlying resources and to internally
+   * <em>mark</em> the {@code Closeable} as closed, prior to throwing
+   * the {@code IOException}.
+   *
+   * @throws java.io.IOException if an I/O error occurs
+   */
+  @Override
+  public void close() throws IOException {
+    if (stagingFileOutputStream != null && !this.closed) {
+      try {
+        stagingFileOutputStream.flush();
+      } finally {
+        stagingFileOutputStream.close();
+        this.closed = true;
+      }
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriterBuilder.java
@@ -1,0 +1,39 @@
+/* (c) 2015 NerdWallet All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer;
+
+import java.io.IOException;
+
+import gobblin.configuration.State;
+import gobblin.util.WriterUtils;
+
+/**
+ * A {@link DataWriterBuilder} for building {@link DataWriter} that writes bytes.
+ *
+ * @author akshay@nerdwallet.com
+ */
+public class SimpleDataWriterBuilder extends DataWriterBuilder<String, byte[]> {
+  /**
+   * Build a {@link gobblin.writer.DataWriter}.
+   *
+   * @return the built {@link gobblin.writer.DataWriter}
+   * @throws java.io.IOException if there is anything wrong building the writer
+   */
+  @Override
+  public DataWriter<byte[]> build() throws IOException {
+    State properties = this.destination.getProperties();
+    String fileName = WriterUtils.getWriterFileName(
+            properties, this.branches, this.branch, this.writerId, this.format.getExtension()
+    );
+    return new SimpleDataWriter(properties, fileName, this.branches, this.branch);
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
@@ -1,0 +1,340 @@
+/* (c) 2015 NerdWallet All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer;
+
+import java.io.BufferedReader;
+import java.io.DataInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.net.URI;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.ForkOperatorUtils;
+
+/**
+ * Unit tests for {@link SimpleDataWriter}.
+ *
+ * @author akshay@nerdwallet.com
+ */
+@Test(groups = {"gobblin.writer"})
+public class SimpleDataWriterTest {
+  private String filePath;
+  private final String schema = "";
+  private final int newLine = "\n".getBytes()[0];
+  private final State properties = new State();
+
+  @BeforeMethod
+  public void setUp()
+          throws Exception {
+    // Making the staging and/or output dirs if necessary
+    File stagingDir = new File(TestConstants.TEST_STAGING_DIR);
+    File outputDir = new File(TestConstants.TEST_OUTPUT_DIR);
+    if (!stagingDir.exists()) {
+      stagingDir.mkdirs();
+    }
+    if (!outputDir.exists()) {
+      outputDir.mkdirs();
+    }
+
+    this.filePath = TestConstants.TEST_EXTRACT_NAMESPACE.replaceAll("\\.", "/") + "/" +
+            TestConstants.TEST_EXTRACT_TABLE + "/" + TestConstants.TEST_EXTRACT_ID + "_" +
+            TestConstants.TEST_EXTRACT_PULL_TYPE;
+
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, "\n");
+    properties.setProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, TestConstants.TEST_FS_URI);
+    properties.setProp(ConfigurationKeys.WRITER_STAGING_DIR, TestConstants.TEST_STAGING_DIR);
+    properties.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, TestConstants.TEST_OUTPUT_DIR);
+    properties.setProp(ConfigurationKeys.WRITER_FILE_PATH, this.filePath);
+    properties.setProp(ConfigurationKeys.WRITER_FILE_NAME, TestConstants.TEST_FILE_NAME);
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, false);
+  }
+
+  /**
+   * Test writing records without a delimiter and make sure it works.
+   * @throws IOException
+   */
+  @Test
+  public void testWriteBytesNoDelim() throws IOException {
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, "");
+    // Build a writer to write test records
+    DataWriter<byte[]> writer = new SimpleDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
+            .forBranch(0).build();
+    byte[] rec1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    byte[] rec2 = {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
+    byte[] rec3 = {26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45};
+
+    writer.write(rec1);
+    writer.write(rec2);
+    writer.write(rec3);
+
+    writer.close();
+    writer.commit();
+
+    Assert.assertEquals(writer.recordsWritten(), 3);
+    Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length);
+
+    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    Assert.assertTrue(properties.contains(pathKey));
+    File outputFile = new File(properties.getProp(pathKey));
+    InputStream is = new FileInputStream(outputFile);
+    int c, resNum = 0, resi = 0;
+    byte[][] records = {rec1, rec2, rec3};
+    while ((c = is.read()) != -1) {
+      if (resi >= records[resNum].length) {
+        resNum++;
+        resi = 0;
+      }
+      Assert.assertEquals(c, records[resNum][resi]);
+      resi++;
+    }
+  }
+
+  /**
+   * Prepend the size to each record without delimiting the record. Each record
+   * should be prepended by the size of that record and the bytes written should
+   * include the prepended bytes.
+   */
+  @Test
+  public void testPrependSizeWithoutDelimiter() throws IOException {
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, true);
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, "");
+    DataWriter<byte[]> writer = new SimpleDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
+            .forBranch(0).build();
+    byte[] rec1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    byte[] rec2 = {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
+    byte[] rec3 = {26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45};
+    byte[][] records = {rec1, rec2, rec3};
+
+    writer.write(rec1);
+    writer.write(rec2);
+    writer.write(rec3);
+
+    writer.close();
+    writer.commit();
+
+    Assert.assertEquals(writer.recordsWritten(), 3);
+    Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length + (Long.SIZE / 8 * 3));
+
+    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    Assert.assertTrue(properties.contains(pathKey));
+    File outputFile = new File(properties.getProp(pathKey));
+    DataInputStream dis = new DataInputStream(new FileInputStream(outputFile));
+    for (int i=0; i<3; i++) {
+      long size = dis.readLong();
+      Assert.assertEquals(size, records[i].length);
+      for (int j=0; j<size; j++) {
+        Assert.assertEquals(dis.readByte(), records[i][j]);
+      }
+    }
+  }
+
+  /**
+   * Use the simple data writer to write random bytes to a file and ensure
+   * they are the same when read back.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testWriteRandomBytes()
+          throws IOException {
+    // Build a writer to write test records
+    DataWriter<byte[]> writer = new SimpleDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
+            .forBranch(0).build();
+    byte[] rec1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    byte[] rec2 = {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
+    byte[] rec3 = {26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45};
+
+    writer.write(rec1);
+    writer.write(rec2);
+    writer.write(rec3);
+
+    writer.close();
+    writer.commit();
+
+    Assert.assertEquals(writer.recordsWritten(), 3);
+    Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length + 3); // 3 bytes for newline character
+
+    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    Assert.assertTrue(properties.contains(pathKey));
+    File outputFile = new File(properties.getProp(pathKey));
+    InputStream is = new FileInputStream(outputFile);
+    int c, resNum = 0, resi = 0;
+    byte[][] records = {rec1, rec2, rec3};
+    while ((c = is.read()) != -1) {
+      if (c != newLine) {
+        Assert.assertEquals(c, records[resNum][resi]);
+        resi++;
+      } else {
+        resNum++;
+        resi = 0;
+      }
+    }
+  }
+
+  /**
+   * Prepend the size to each record and delimit the record. Each record
+   * should be prepended by the size of that record and the bytes written should
+   * include the prepended bytes.
+   */
+  @Test
+  public void testPrependSizeWithDelimiter() throws IOException {
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, true);
+    DataWriter<byte[]> writer = new SimpleDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
+            .forBranch(0).build();
+    byte[] rec1 = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    byte[] rec2 = {11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25};
+    byte[] rec3 = {26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45};
+    byte[][] records = {rec1, rec2, rec3};
+
+    writer.write(rec1);
+    writer.write(rec2);
+    writer.write(rec3);
+
+    writer.close();
+    writer.commit();
+
+    Assert.assertEquals(writer.recordsWritten(), 3);
+    Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length + (Long.SIZE / 8 * 3) + 3);
+
+    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    Assert.assertTrue(properties.contains(pathKey));
+    File outputFile = new File(properties.getProp(pathKey));
+    DataInputStream dis = new DataInputStream(new FileInputStream(outputFile));
+    for (int i=0; i<3; i++) {
+      long size = dis.readLong();
+      Assert.assertEquals(size, records[i].length + 1);
+      for (int j=0; j<size - 1; j++) {
+        Assert.assertEquals(dis.readByte(), records[i][j]);
+      }
+      Assert.assertEquals(dis.readByte(), '\n');
+    }
+  }
+
+  /**
+   * Use the simple writer to write json entries to a file and ensure that
+   * they are the same when read back.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testWrite()
+          throws IOException {
+    DataWriter<byte[]> writer = new SimpleDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
+            .forBranch(0).build();
+    int totalBytes = 3; // 3 extra bytes for the newline character
+    // Write all test records
+    for (String record : TestConstants.JSON_RECORDS) {
+      byte[] toWrite = record.getBytes();
+      Assert.assertEquals(toWrite.length, record.length()); // ensure null byte does not get added to end
+      writer.write(toWrite);
+      totalBytes += toWrite.length;
+    }
+
+    writer.close();
+    writer.commit();
+
+    Assert.assertEquals(writer.recordsWritten(), 3);
+    Assert.assertEquals(writer.bytesWritten(), totalBytes);
+
+    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    Assert.assertTrue(properties.contains(pathKey));
+    File outputFile = new File(properties.getProp(pathKey));
+    BufferedReader br = new BufferedReader(new FileReader(outputFile));
+    String line;
+    int lineNumber = 0;
+    while ((line = br.readLine()) != null) {
+      Assert.assertEquals(line, TestConstants.JSON_RECORDS[lineNumber]);
+      lineNumber++;
+    }
+    br.close();
+    Assert.assertEquals(lineNumber, 3);
+  }
+
+  /**
+   * If the staging file exists, the simple data writer should overwrite its contents.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testOverwriteExistingStagingFile() throws IOException {
+    byte[] randomBytesStage = {1, 2, 3, 4, 5, 6, 7, 8, 9, 0};
+    byte[] randomBytesWrite = {11, 12, 13, 14, 15};
+    Path stagingFile = new Path(TestConstants.TEST_STAGING_DIR + Path.SEPARATOR + this.filePath,
+            TestConstants.TEST_FILE_NAME + "." + TestConstants.TEST_WRITER_ID + "." + "tmp");
+    Configuration conf = new Configuration();
+    // Add all job configuration properties so they are picked up by Hadoop
+    for (String key : properties.getPropertyNames()) {
+      conf.set(key, properties.getProp(key));
+    }
+    FileSystem fs = FileSystem.get(URI.create(TestConstants.TEST_FS_URI), conf);
+
+    OutputStream os = fs.create(stagingFile);
+    os.write(randomBytesStage);
+    os.flush();
+    os.close();
+
+    DataWriter<byte[]> writer = new SimpleDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
+            .forBranch(0).build();
+
+    writer.write(randomBytesWrite);
+    writer.close();
+    writer.commit();
+
+    Assert.assertEquals(writer.recordsWritten(), 1);
+    Assert.assertEquals(writer.bytesWritten(), randomBytesWrite.length + 1);
+
+    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    Assert.assertTrue(properties.contains(pathKey));
+    File writeFile = new File(properties.getProp(pathKey));
+    int c, i = 0;
+    InputStream is = new FileInputStream(writeFile);
+    while ((c = is.read()) != -1) {
+      if (i == 5) {
+        Assert.assertEquals(c, (byte) newLine); // the last byte should be newline
+        i++;
+        continue;
+      }
+      Assert.assertEquals(randomBytesWrite[i], c);
+      i++;
+    }
+  }
+
+  @AfterMethod
+  public void tearDown()
+          throws IOException {
+    // Clean up the staging and/or output directories if necessary
+    File testRootDir = new File(TestConstants.TEST_ROOT_DIR);
+    if (testRootDir.exists()) {
+      FileUtil.fullyDelete(testRootDir);
+    }
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -50,6 +50,24 @@ public class HadoopUtils {
     return results;
   }
 
+  /**
+   * A wrapper around this.fs.delete which throws IOException if this.fs.delete returns False.
+   * @param f Path to be deleted
+   * @param recursive
+   * @throws IOException if the deletion fails
+   */
+  public static void deletePath(FileSystem fs, Path f, boolean recursive) throws IOException {
+    if (!fs.delete(f, recursive)) {
+      throw new IOException("Failed to delete: " + f);
+    }
+  }
+
+  public static void renamePath(FileSystem fs, Path oldName, Path newName) throws IOException {
+    if (!fs.rename(oldName, newName)) {
+      throw new IOException(String.format("Failed to rename %s to %s", oldName.toString(), newName.toString()));
+    }
+  }
+
   private static void walk(List<FileStatus> results, FileSystem fileSystem, Path path) throws FileNotFoundException,
       IOException {
     for (FileStatus status : fileSystem.listStatus(path)) {


### PR DESCRIPTION
A simple data writer which writes records as byte[] to a file. This also has some refactors around some of the common elements between writers. Adds a new configuration option to add the writer's final output path to the task properties. This can be used by a publisher to read the write file for a task.