### PR TITLE
Fix bug in gobblin-standalone.sh

### DIFF
--- a/bin/gobblin-standalone.sh
+++ b/bin/gobblin-standalone.sh
@@ -53,7 +53,7 @@ if [ -z "$JAVA_HOME" ]; then
 fi
 
 check=false
-if [ $ACTION == "start" ] || [ $ACTION == "restart" ]; then
+if [ "$ACTION" == "start" ] || [ "$ACTION" == "restart" ]; then
   check=true
 fi
 
@@ -192,7 +192,7 @@ case "$ACTION" in
     stop
     ;;
   *)
-    echo $usage
+    print_usage
     exit 1
     ;;
 esac


### PR DESCRIPTION
I'm having a bug when try to run gobblin-standalone.sh without any parameters.

```
./bin/gobblin-standalone.sh: line 56: [: ==: unary operator expected
```