### PR TITLE
Changing semantics of writer.file.name

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -205,7 +205,7 @@ public class ConfigurationKeys {
   public static final String WRITER_PARTITION_LEVEL = WRITER_PREFIX + ".partition.level";
   public static final String WRITER_PARTITION_PATTERN = WRITER_PREFIX + ".partition.pattern";
   public static final String WRITER_PARTITION_TIMEZONE = WRITER_PREFIX + ".partition.timezone";
-  public static final String DEFAULT_WRITER_FILE_NAME = "part";
+  public static final String DEFAULT_WRITER_FILE_BASE_NAME = "part";
   public static final String DEFAULT_DEFLATE_LEVEL = "9";
   public static final String DEFAULT_BUFFER_SIZE = "4096";
   public static final String DEFAULT_WRITER_PARTITION_LEVEL = "daily";

--- a/gobblin-core/src/test/java/gobblin/writer/AvroHdfsDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/AvroHdfsDataWriterTest.java
@@ -99,9 +99,8 @@ public class AvroHdfsDataWriterTest {
     this.writer.close();
     this.writer.commit();
 
-    File outputFile = new File(TestConstants.TEST_OUTPUT_DIR + Path.SEPARATOR + this.filePath,
-        TestConstants.TEST_FILE_NAME + "." + TestConstants.TEST_WRITER_ID + "." +
-            TestConstants.TEST_FILE_EXTENSION);
+    File outputFile =
+        new File(TestConstants.TEST_OUTPUT_DIR + Path.SEPARATOR + this.filePath, TestConstants.TEST_FILE_NAME);
     DataFileReader<GenericRecord> reader =
         new DataFileReader<GenericRecord>(outputFile, new GenericDatumReader<GenericRecord>(this.schema));
 

--- a/gobblin-core/src/test/java/gobblin/writer/AvroHdfsTimePartitionedWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/AvroHdfsTimePartitionedWriterTest.java
@@ -41,7 +41,7 @@ public class AvroHdfsTimePartitionedWriterTest {
   private static final String STAGING_DIR = TEST_ROOT_DIR + Path.SEPARATOR + "staging";
   private static final String OUTPUT_DIR = TEST_ROOT_DIR + Path.SEPARATOR + "output";
   private static final String BASE_FILE_PATH = "base";
-  private static final String FILE_NAME = SIMPLE_CLASS_NAME + "-name";
+  private static final String FILE_NAME = SIMPLE_CLASS_NAME + "-name.avro";
   private static final String PARTITION_COLUMN_NAME = "timestamp";
   private static final String WRITER_ID = "writer-1";
 
@@ -121,23 +121,21 @@ public class AvroHdfsTimePartitionedWriterTest {
     // Check that 3 files were created
     Assert.assertEquals(FileUtils.listFiles(new File(TEST_ROOT_DIR), new String[] { "avro" }, true).size(), 3);
 
-    String fileName = FILE_NAME + "." + WRITER_ID + ".avro";
-
     // Check if each file exists, and in the correct location
     File baseOutputDir =
         new File(OUTPUT_DIR, BASE_FILE_PATH + Path.SEPARATOR + ConfigurationKeys.DEFAULT_WRITER_PARTITION_LEVEL);
     Assert.assertTrue(baseOutputDir.exists());
 
     File outputDir20150101 =
-        new File(baseOutputDir, "2015" + Path.SEPARATOR + "01" + Path.SEPARATOR + "01" + Path.SEPARATOR + fileName);
+        new File(baseOutputDir, "2015" + Path.SEPARATOR + "01" + Path.SEPARATOR + "01" + Path.SEPARATOR + FILE_NAME);
     Assert.assertTrue(outputDir20150101.exists());
 
     File outputDir20150102 =
-        new File(baseOutputDir, "2015" + Path.SEPARATOR + "01" + Path.SEPARATOR + "02" + Path.SEPARATOR + fileName);
+        new File(baseOutputDir, "2015" + Path.SEPARATOR + "01" + Path.SEPARATOR + "02" + Path.SEPARATOR + FILE_NAME);
     Assert.assertTrue(outputDir20150102.exists());
 
     File outputDir20150103 =
-        new File(baseOutputDir, "2015" + Path.SEPARATOR + "01" + Path.SEPARATOR + "03" + Path.SEPARATOR + fileName);
+        new File(baseOutputDir, "2015" + Path.SEPARATOR + "01" + Path.SEPARATOR + "03" + Path.SEPARATOR + FILE_NAME);
     Assert.assertTrue(outputDir20150103.exists());
   }
 

--- a/gobblin-core/src/test/java/gobblin/writer/TestConstants.java
+++ b/gobblin-core/src/test/java/gobblin/writer/TestConstants.java
@@ -41,7 +41,7 @@ public class TestConstants {
 
   public static final String TEST_OUTPUT_DIR = TEST_ROOT_DIR + "/output";
 
-  public static final String TEST_FILE_NAME = "test";
+  public static final String TEST_FILE_NAME = "test.avro";
 
   public static final String TEST_WRITER_ID = "writer-1";
 

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -161,6 +161,6 @@ public class WriterUtils {
       String formatExtension) {
     return state.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_NAME, numBranches, branchId),
-        String.format("%s.%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_NAME, writerId, formatExtension));
+        String.format("%s.%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_BASE_NAME, writerId, formatExtension));
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -159,8 +159,8 @@ public class WriterUtils {
    */
   public static String getWriterFileName(State state, int numBranches, int branchId, String writerId,
       String formatExtension) {
-    return String.format("%s.%s.%s", state.getProp(
+    return state.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_NAME, numBranches, branchId),
-        ConfigurationKeys.DEFAULT_WRITER_FILE_NAME), writerId, formatExtension);
+        String.format("%s.%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_NAME, writerId, formatExtension));
   }
 }


### PR DESCRIPTION
When first looking at `writer.file.name`, one would assume it allows you to control the name of the file that gets written for a specific `WorkUnit`. However, Gobblin actually takes the value specified by `writer.file.name` and sets the file name to `value.writerId.avro`. This PR changes the usage of `writer.file.name` to give the user full control of what the output file name will be.