### PR TITLE
Use avro-mapred:hadoop2 for Hadoop 2

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -48,7 +48,8 @@ if (!project.hasProperty('bytemanVersion')) {
 ext.externalDependency = [
   "antlrRuntime": "org.antlr:antlr-runtime:3.0.1",
   "avro": "org.apache.avro:avro:1.7.6",
-  "avroMapred": "org.apache.avro:avro-mapred:1.7.6",
+  "avroMapredH1": "org.apache.avro:avro-mapred:1.7.6:hadoop1",
+  "avroMapredH2": "org.apache.avro:avro-mapred:1.7.6:hadoop2",
   "commonsCli": "commons-cli:commons-cli:1.2",
   "commonsCodec": "commons-codec:commons-codec:1.10",
   "commonsDbcp": "commons-dbcp:commons-dbcp:1.4",

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile externalDependency.commonsDbcp
   compile externalDependency.commonsHttpClient
   compile externalDependency.avro
-  compile externalDependency.avroMapred
   compile externalDependency.guava
   compile externalDependency.gson
   compile externalDependency.slf4j
@@ -37,6 +36,11 @@ dependencies {
   compile externalDependency.kafkaClient
   compile externalDependency.scala
   compile externalDependency.findBugs
+  if (project.hasProperty('useHadoop2')) {
+    compile externalDependency.avroMapredH2
+  } else {
+    compile externalDependency.avroMapredH1
+  }
 
   testCompile externalDependency.testng
 }

--- a/gobblin-example/build.gradle
+++ b/gobblin-example/build.gradle
@@ -16,13 +16,17 @@ dependencies {
     compile project(":gobblin-core")
 
     compile externalDependency.avro
-    compile externalDependency.avroMapred
     compile externalDependency.guava
     compile externalDependency.jacksonCore
     compile externalDependency.slf4j
     compile externalDependency.gson
     compile externalDependency.commonsVfs
-    
+    if (project.hasProperty('useHadoop2')) {
+      compile externalDependency.avroMapredH2
+    } else {
+      compile externalDependency.avroMapredH1
+    }
+
     testCompile externalDependency.testng
 }
 

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -20,7 +20,6 @@ dependencies {
   compile project(path: ':gobblin-rest-service:gobblin-rest-api', configuration: 'restClient')
 
   compile externalDependency.avro
-  compile externalDependency.avroMapred
   compile externalDependency.commonsConfiguration
   compile externalDependency.quartz
   compile externalDependency.guava
@@ -39,6 +38,11 @@ dependencies {
   compile externalDependency.pegasus.data
   compile externalDependency.guice
   compile externalDependency.javaxInject
+  if (project.hasProperty('useHadoop2')) {
+    compile externalDependency.avroMapredH2
+  } else {
+    compile externalDependency.avroMapredH1
+  }
 
   testCompile externalDependency.testng
   testCompile externalDependency.byteman


### PR DESCRIPTION
Otherwise will run into problems like "Found interface org.apache.hadoop.mapreduce.TaskAttemptContext, but class was expected" with Hadoop 2.