### PR TITLE
Support for having file attributes in the State object

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -203,6 +203,10 @@ public class ConfigurationKeys {
   public static final String WRITER_FILE_NAME = WRITER_PREFIX + ".file.name";
   public static final String WRITER_FILE_PATH = WRITER_PREFIX + ".file.path";
   public static final String WRITER_FILE_PATH_TYPE = WRITER_PREFIX + ".file.path.type";
+  public static final String WRITER_FILE_OWNER = WRITER_PREFIX + ".file.owner";
+  public static final String WRITER_FILE_GROUP = WRITER_PREFIX + ".file.group";
+  public static final String WRITER_FILE_REPLICATION_FACTOR = WRITER_PREFIX + ".file.replication.factor";
+  public static final String WRITER_FILE_PERMISSIONS = WRITER_PREFIX + ".file.permissions";
   public static final String WRITER_BUFFER_SIZE = WRITER_PREFIX + ".buffer.size";
   public static final String WRITER_PRESERVE_FILE_NAME = WRITER_PREFIX + ".preserve.file.name";
   public static final String WRITER_DEFLATE_LEVEL = WRITER_PREFIX + ".deflate.level";
@@ -409,14 +413,6 @@ public class ConfigurationKeys {
   public static final String DEFAULT_JOB_HISTORY_STORE_USER = "gobblin";
   public static final String JOB_HISTORY_STORE_PASSWORD_KEY = "job.history.store.password";
   public static final String DEFAULT_JOB_HISTORY_STORE_PASSWORD = "gobblin";
-  /**
-   * HDFS file properties
-   */
-  public static final String HDFS_FILE = "hdfs.file";
-  public static final String HDFS_FILE_OWNER = HDFS_FILE + ".owner";
-  public static final String HDFS_FILE_GROUP = HDFS_FILE + ".group";
-  public static final String HDFS_FILE_REPLICATION_FACTOR = HDFS_FILE + ".replication.factor";
-  public static final String HDFS_FILE_PERMISSIONS = HDFS_FILE + ".permissions";
 
   /**
    * Other configuration properties.

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -409,6 +409,14 @@ public class ConfigurationKeys {
   public static final String DEFAULT_JOB_HISTORY_STORE_USER = "gobblin";
   public static final String JOB_HISTORY_STORE_PASSWORD_KEY = "job.history.store.password";
   public static final String DEFAULT_JOB_HISTORY_STORE_PASSWORD = "gobblin";
+  /**
+   * HDFS file properties
+   */
+  public static final String HDFS_FILE = "hdfs.file";
+  public static final String HDFS_FILE_OWNER = HDFS_FILE + ".owner";
+  public static final String HDFS_FILE_GROUP = HDFS_FILE + ".group";
+  public static final String HDFS_FILE_REPLICATION_FACTOR = HDFS_FILE + ".replication.factor";
+  public static final String HDFS_FILE_PERMISSIONS = HDFS_FILE + ".permissions";
 
   /**
    * Other configuration properties.

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -26,7 +26,6 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,26 +168,8 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
       throw new IOException("Failed to commit data from " + this.stagingFile + " to " + this.outputFile);
     }
 
-    setFileAttributes();
-  }
-
-  /**
-   * Setting the same HDFS properties as the original file
-   */
-  private void setFileAttributes() throws IOException {
-    if (properties.contains(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR)) {
-      fs.setReplication(outputFile, (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR));
-    }
-    if (properties.contains(ConfigurationKeys.WRITER_FILE_PERMISSIONS)) {
-      short permissions = (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_PERMISSIONS);
-      fs.setPermission(outputFile, new FsPermission(permissions));
-    }
-    if (properties.contains(ConfigurationKeys.WRITER_FILE_OWNER) &&
-        properties.contains(ConfigurationKeys.WRITER_FILE_GROUP)) {
-          fs.setOwner(outputFile,
-              properties.getProp(ConfigurationKeys.WRITER_FILE_OWNER),
-              properties.getProp(ConfigurationKeys.WRITER_FILE_GROUP));
-    }
+    /* Setting the same HDFS properties as the original file */
+    WriterUtils.setFileAttributesFromState(properties, fs, outputFile);
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -168,7 +168,7 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
       throw new IOException("Failed to commit data from " + this.stagingFile + " to " + this.outputFile);
     }
 
-    /* Setting the same HDFS properties as the original file */
+    // Setting the same HDFS properties as the original file
     WriterUtils.setFileAttributesFromState(properties, fs, outputFile);
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -169,23 +169,26 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
       throw new IOException("Failed to commit data from " + this.stagingFile + " to " + this.outputFile);
     }
 
-    /**
-     * Setting the same HDFS properties as the original file
-     */
-    if (properties.contains(ConfigurationKeys.HDFS_FILE_REPLICATION_FACTOR)) {
-      fs.setReplication(outputFile, (short) properties.getPropAsInt(ConfigurationKeys.HDFS_FILE_REPLICATION_FACTOR));
+    setFileAttributes();
+  }
+
+  /**
+   * Setting the same HDFS properties as the original file
+   */
+  private void setFileAttributes() throws IOException {
+    if (properties.contains(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR)) {
+      fs.setReplication(outputFile, (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR));
     }
-    if (properties.contains(ConfigurationKeys.HDFS_FILE_PERMISSIONS)) {
-      short permissions = (short) properties.getPropAsInt(ConfigurationKeys.HDFS_FILE_PERMISSIONS);
+    if (properties.contains(ConfigurationKeys.WRITER_FILE_PERMISSIONS)) {
+      short permissions = (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_PERMISSIONS);
       fs.setPermission(outputFile, new FsPermission(permissions));
     }
-    if (properties.contains(ConfigurationKeys.HDFS_FILE_OWNER) &&
-        properties.contains(ConfigurationKeys.HDFS_FILE_GROUP)) {
+    if (properties.contains(ConfigurationKeys.WRITER_FILE_OWNER) &&
+        properties.contains(ConfigurationKeys.WRITER_FILE_GROUP)) {
           fs.setOwner(outputFile,
-              properties.getProp(ConfigurationKeys.HDFS_FILE_OWNER),
-              properties.getProp(ConfigurationKeys.HDFS_FILE_GROUP));
+              properties.getProp(ConfigurationKeys.WRITER_FILE_OWNER),
+              properties.getProp(ConfigurationKeys.WRITER_FILE_GROUP));
     }
-
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -167,6 +168,24 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
     if (!this.fs.rename(this.stagingFile, this.outputFile)) {
       throw new IOException("Failed to commit data from " + this.stagingFile + " to " + this.outputFile);
     }
+
+    /**
+     * Setting the same HDFS properties as the original file
+     */
+    if (properties.contains(ConfigurationKeys.HDFS_FILE_REPLICATION_FACTOR)) {
+      fs.setReplication(outputFile, (short) properties.getPropAsInt(ConfigurationKeys.HDFS_FILE_REPLICATION_FACTOR));
+    }
+    if (properties.contains(ConfigurationKeys.HDFS_FILE_PERMISSIONS)) {
+      short permissions = (short) properties.getPropAsInt(ConfigurationKeys.HDFS_FILE_PERMISSIONS);
+      fs.setPermission(outputFile, new FsPermission(permissions));
+    }
+    if (properties.contains(ConfigurationKeys.HDFS_FILE_OWNER) &&
+        properties.contains(ConfigurationKeys.HDFS_FILE_GROUP)) {
+          fs.setOwner(outputFile,
+              properties.getProp(ConfigurationKeys.HDFS_FILE_OWNER),
+              properties.getProp(ConfigurationKeys.HDFS_FILE_GROUP));
+    }
+
   }
 
   @Override
@@ -196,7 +215,6 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
   /**
    * Create a new {@link DataFileWriter} for writing Avro records.
    *
-   * @param schema Avro schema
    * @param avroFile Avro file to write to
    * @param bufferSize Buffer size
    * @param codecType Compression codec type

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -46,6 +46,7 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AvroHdfsDataWriter.class);
 
+  private final State properties;
   private final FileSystem fs;
   private final Path stagingFile;
   private final Path outputFile;
@@ -97,7 +98,7 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
       conf.set(key, properties.getProp(key));
     }
     this.fs = FileSystem.get(URI.create(uri), conf);
-
+    this.properties = properties;
     this.stagingFile = new Path(stagingDir, fileName);
 
     // Deleting the staging file if it already exists, which can happen if the

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -1,5 +1,7 @@
 package gobblin.util;
 
+import java.io.IOException;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -10,9 +12,6 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.workunit.WorkUnit;
-
-import java.io.IOException;
-
 
 /**
  * Utility class for use with the {@link gobblin.writer.DataWriter} class.
@@ -186,11 +185,11 @@ public class WriterUtils {
       fs.setReplication(outputFile, (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR));
     }
     if (properties.contains(ConfigurationKeys.WRITER_FILE_PERMISSIONS)) {
-      short permissions = (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_PERMISSIONS);
+      final short permissions = (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_PERMISSIONS);
       fs.setPermission(outputFile, new FsPermission(permissions));
     }
 
-    /* If both owner and group is present. Only then, paste the ownership info on the file */
+    // If both owner and group is present. Only then, paste the ownership info on the file
     if (properties.contains(ConfigurationKeys.WRITER_FILE_OWNER) &&
         properties.contains(ConfigurationKeys.WRITER_FILE_GROUP)) {
       fs.setOwner(outputFile,

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -1,6 +1,8 @@
 package gobblin.util;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.google.common.base.Preconditions;
 
@@ -8,6 +10,8 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.workunit.WorkUnit;
+
+import java.io.IOException;
 
 
 /**
@@ -162,5 +166,36 @@ public class WriterUtils {
     return state.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_NAME, numBranches, branchId),
         String.format("%s.%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_BASE_NAME, writerId, formatExtension));
+  }
+
+  /**
+   * Set the following file attributes from a given State object
+   * - WRITER_FILE_REPLICATION_FACTOR
+   * - WRITER_FILE_PERMISSIONS
+   * - WRITER_FILE_OWNER
+   * - WRITER_FILE_GROUP
+   *
+   * @param properties The input state object from which the attributes are read from
+   * @param fs The current Hadoop file system object
+   * @param outputFile The output file into which these attributes are set into
+   */
+  public static void setFileAttributesFromState(final State properties,
+                                                final FileSystem fs,
+                                                final Path outputFile) throws IOException {
+    if (properties.contains(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR)) {
+      fs.setReplication(outputFile, (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR));
+    }
+    if (properties.contains(ConfigurationKeys.WRITER_FILE_PERMISSIONS)) {
+      short permissions = (short) properties.getPropAsInt(ConfigurationKeys.WRITER_FILE_PERMISSIONS);
+      fs.setPermission(outputFile, new FsPermission(permissions));
+    }
+
+    /* If both owner and group is present. Only then, paste the ownership info on the file */
+    if (properties.contains(ConfigurationKeys.WRITER_FILE_OWNER) &&
+        properties.contains(ConfigurationKeys.WRITER_FILE_GROUP)) {
+      fs.setOwner(outputFile,
+          properties.getProp(ConfigurationKeys.WRITER_FILE_OWNER),
+          properties.getProp(ConfigurationKeys.WRITER_FILE_GROUP));
+    }
   }
 }


### PR DESCRIPTION
Gobblin now preserves the owner, group, permissions and replication factor for files. The state object now supports the following configuration keys which may be used to capture these attributes and pass them on to the output file.

- HDFS_FILE_OWNER
- HDFS_FILE_GROUP
- HDFS_FILE_REPLICATION_FACTOR
- HDFS_FILE_PERMISSIONS