### PR TITLE
Refactor Kafka adapter for complex watermark

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import gobblin.source.extractor.WatermarkInterval;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.source.workunit.Extract;
 
@@ -47,8 +48,8 @@ public class SourceState extends State {
 
   private final List<WorkUnitState> previousTaskStates = Lists.newArrayList();
   private static final Set<Extract> extractSet = Sets.newConcurrentHashSet();
-  private static final DateTimeFormatter DTF =
-      DateTimeFormat.forPattern("yyyyMMddHHmmss").withLocale(Locale.US).withZone(DateTimeZone.UTC);
+  private static final DateTimeFormatter DTF = DateTimeFormat.forPattern("yyyyMMddHHmmss").withLocale(Locale.US)
+      .withZone(DateTimeZone.UTC);
 
   /**
    * Default constructor.
@@ -67,13 +68,17 @@ public class SourceState extends State {
     this.previousTaskStates.addAll(previousTaskStates);
   }
 
+  public void setWatermarkInterval(WatermarkInterval interval) {
+    setProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY, interval.toJson());
+  }
+
   /**
    * Get a (possibly empty) list of {@link WorkUnitState}s from the previous job run.
    *
    * @return (possibly empty) list of {@link WorkUnitState}s from the previous job run
    */
   public List<WorkUnitState> getPreviousWorkUnitStates() {
-    return ImmutableList.<WorkUnitState>builder().addAll(this.previousTaskStates).build();
+    return ImmutableList.<WorkUnitState> builder().addAll(this.previousTaskStates).build();
   }
 
   /**
@@ -109,8 +114,7 @@ public class SourceState extends State {
   }
 
   @Override
-  public void write(DataOutput out)
-      throws IOException {
+  public void write(DataOutput out) throws IOException {
     out.writeInt(this.previousTaskStates.size());
     for (WorkUnitState state : this.previousTaskStates) {
       state.write(out);
@@ -119,8 +123,7 @@ public class SourceState extends State {
   }
 
   @Override
-  public void readFields(DataInput in)
-      throws IOException {
+  public void readFields(DataInput in) throws IOException {
     int size = in.readInt();
     for (int i = 0; i < size; i++) {
       WorkUnitState state = new WorkUnitState();

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
 import gobblin.source.extractor.Watermark;
@@ -43,8 +42,6 @@ public class WorkUnitState extends State {
 
   private Watermark actualHighWatermark;
 
-  private static final Gson GSON = new Gson();
-
   /**
    * Runtime state of the {@link WorkUnit}.
    *
@@ -55,7 +52,12 @@ public class WorkUnitState extends State {
    * </p>
    */
   public enum WorkingState {
-    PENDING, RUNNING, SUCCESSFUL, COMMITTED, FAILED, CANCELLED
+    PENDING,
+    RUNNING,
+    SUCCESSFUL,
+    COMMITTED,
+    FAILED,
+    CANCELLED
   }
 
   private WorkUnit workunit;
@@ -107,10 +109,10 @@ public class WorkUnitState extends State {
   /**
    * Get the actual high {@link Watermark} as a {@link JsonElement}.
    *
-   * @return a {@link JsonElement} representing the actual high {@link Watermark}.
+   * @return a JSON string representing the actual high {@link Watermark}.
    */
-  public JsonElement getActualHighWatermark() {
-    return GSON.toJsonTree(getProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY));
+  public String getActualHighWatermark() {
+    return getProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY);
   }
 
   /**
@@ -224,15 +226,13 @@ public class WorkUnitState extends State {
   }
 
   @Override
-  public void readFields(DataInput in)
-      throws IOException {
+  public void readFields(DataInput in) throws IOException {
     this.workunit.readFields(in);
     super.readFields(in);
   }
 
   @Override
-  public void write(DataOutput out)
-      throws IOException {
+  public void write(DataOutput out) throws IOException {
     this.workunit.write(out);
     super.write(out);
   }

--- a/gobblin-api/src/main/java/gobblin/source/extractor/Watermark.java
+++ b/gobblin-api/src/main/java/gobblin/source/extractor/Watermark.java
@@ -13,7 +13,7 @@ import com.google.gson.JsonElement;
  *  {@link Watermark} into a {@link JsonElement}.
  * </p>
  */
-public interface Watermark extends Comparable<Watermark> {
+public interface Watermark {
 
   /**
    * Convert this {@link Watermark} into a {@link JsonElement}.

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -19,8 +19,9 @@ import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
 
-import com.google.gson.Gson;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.Watermark;
@@ -40,8 +41,6 @@ import gobblin.source.extractor.WatermarkInterval;
 public class WorkUnit extends State {
 
   private Extract extract;
-
-  private static final Gson GSON = new Gson();
 
   /**
    * Default constructor.
@@ -115,7 +114,7 @@ public class WorkUnit extends State {
    * @return a {@link JsonElement} representing the low {@link Watermark}.
    */
   public JsonElement getLowWatermark() {
-    return GSON.toJsonTree(getProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY)).getAsJsonObject()
+    return ((JsonObject) (new JsonParser().parse(getProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY))))
         .get(WatermarkInterval.LOW_WATERMARK_TO_JSON_KEY);
   }
 
@@ -125,7 +124,7 @@ public class WorkUnit extends State {
    * @return a {@link JsonElement} representing the expected high {@link Watermark}.
    */
   public JsonElement getExpectedHighWatermark() {
-    return GSON.toJsonTree(getProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY)).getAsJsonObject()
+    return ((JsonObject) (new JsonParser().parse(getProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY))))
         .get(WatermarkInterval.EXPECTED_HIGH_WATERMARK_TO_JSON_KEY);
   }
 
@@ -174,15 +173,13 @@ public class WorkUnit extends State {
   }
 
   @Override
-  public void readFields(DataInput in)
-      throws IOException {
+  public void readFields(DataInput in) throws IOException {
     super.readFields(in);
     this.extract.readFields(in);
   }
 
   @Override
-  public void write(DataOutput out)
-      throws IOException {
+  public void write(DataOutput out) throws IOException {
     super.write(out);
     this.extract.write(out);
   }

--- a/gobblin-api/src/test/java/gobblin/source/extractor/TestWatermark.java
+++ b/gobblin-api/src/test/java/gobblin/source/extractor/TestWatermark.java
@@ -1,6 +1,5 @@
 package gobblin.source.extractor;
 
-import com.google.common.primitives.Longs;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
 
@@ -12,12 +11,6 @@ public class TestWatermark implements Watermark {
   private static final Gson GSON = new Gson();
 
   private long watermark = -1;
-
-  @Override
-  public int compareTo(Watermark watermark) {
-    TestWatermark testWatermark = GSON.fromJson(watermark.toJson(), this.getClass());
-    return Longs.compare(this.watermark, testWatermark.getLongWatermark());
-  }
 
   @Override
   public JsonElement toJson() {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -121,7 +121,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
           nextValidMessage = this.messageIterator.next();
         } while (nextValidMessage.offset() < this.nextWatermark.get(this.currentPartitionIdx));
 
-        this.nextWatermark.set(this.currentPartitionIdx, nextValidMessage.offset() + 1);
+        this.nextWatermark.set(this.currentPartitionIdx, nextValidMessage.nextOffset());
         try {
           D record = decodeRecord(nextValidMessage);
           this.maintainStats(nextValidMessage);

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -14,23 +14,28 @@ package gobblin.source.extractor.extract.kafka;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import kafka.message.MessageAndOffset;
 
+import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
+import com.google.gson.Gson;
 
-import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.extract.EventBasedExtractor;
+import gobblin.util.KafkaUtils;
 
 
 /**
- * An implementation of {@link Extractor} from Apache Kafka.
+ * An implementation of {@link Extractor} from Apache Kafka. Each extractor processes
+ * one or more partitions of the same topic.
  *
  * @author ziliu
  */
@@ -38,107 +43,187 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaExtractor.class);
 
+  protected static final Gson GSON = new Gson();
+  protected static final Integer MAX_LOG_DECODING_ERRORS = 5;
+
   protected final WorkUnitState workUnitState;
-  protected final KafkaPartition partition;
-  protected final long lowWatermark;
-  protected final long highWatermark;
+  protected final String topicName;
+  protected final List<KafkaPartition> partitions;
+  protected final MultiLongWatermark lowWatermark;
+  protected final MultiLongWatermark highWatermark;
+  protected final MultiLongWatermark nextWatermark;
   protected final Closer closer;
   protected final KafkaWrapper kafkaWrapper;
 
+  protected final Map<KafkaPartition, Integer> decodingErrorCount;
+  protected final Map<KafkaPartition, Long> totalEventSizes;
+  protected final Map<KafkaPartition, Integer> eventCounts;
+  protected final Map<KafkaPartition, Long> avgEventSizes;
+
   protected Iterator<MessageAndOffset> messageIterator;
-  protected long nextWatermark;
-  private long totalRecordSize;
-  private int recordCount;
-  private long avgRecordSize;
+  protected int currentPartitionIdx;
 
   public KafkaExtractor(WorkUnitState state) {
     this.workUnitState = state;
-    this.partition =
-        new KafkaPartition.Builder().withId(state.getPropAsInt(KafkaSource.PARTITION_ID))
-            .withTopicName(state.getProp(KafkaSource.TOPIC_NAME))
-            .withLeaderId(state.getPropAsInt(KafkaSource.LEADER_ID))
-            .withLeaderHost(state.getProp(KafkaSource.LEADER_HOST))
-            .withLeaderPort(state.getPropAsInt(KafkaSource.LEADER_PORT)).build();
-    this.lowWatermark = state.getPropAsLong(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY);
-    this.highWatermark = state.getPropAsLong(ConfigurationKeys.WORK_UNIT_HIGH_WATER_MARK_KEY);
+    this.topicName = KafkaUtils.getTopicName(state);
+    this.partitions = KafkaUtils.getPartitions(state);
+    this.lowWatermark = GSON.fromJson(state.getWorkunit().getLowWatermark(), MultiLongWatermark.class);
+    this.highWatermark = GSON.fromJson(state.getWorkunit().getExpectedHighWatermark(), MultiLongWatermark.class);
+    this.nextWatermark = new MultiLongWatermark(this.lowWatermark);
     this.closer = Closer.create();
     this.kafkaWrapper = closer.register(KafkaWrapper.create(state));
+
+    this.decodingErrorCount = Maps.newHashMap();
+    this.totalEventSizes = Maps.newHashMapWithExpectedSize(this.partitions.size());
+    this.eventCounts = Maps.newHashMapWithExpectedSize(this.partitions.size());
+    this.avgEventSizes = Maps.newHashMapWithExpectedSize(this.partitions.size());
+
     this.messageIterator = null;
-    this.nextWatermark = this.lowWatermark;
-    this.totalRecordSize = 0;
-    this.recordCount = 0;
-    this.avgRecordSize = 0;
+    this.currentPartitionIdx = 0;
   }
 
+  /**
+   * Return the next decodable event from the current partition. If the current partition has no more
+   * decodable event, move on to the next partition. If all partitions have been processed, return null.
+   */
   @Override
   public D readRecord(D reuse) throws DataRecordException, IOException {
-    if (this.nextWatermark >= this.highWatermark) {
-      return null;
+    if (currentPartitionFinished()) {
+      moveToNextPartition();
     }
-    if (this.messageIterator == null || !this.messageIterator.hasNext()) {
-      this.messageIterator =
-          this.kafkaWrapper.fetchNextMessageBuffer(this.partition, this.nextWatermark, this.highWatermark);
+
+    while (!allPartitionsFinished()) {
       if (this.messageIterator == null || !this.messageIterator.hasNext()) {
-        return null;
+        try {
+          this.messageIterator = fetchNextMessageBuffer();
+        } catch (Exception e) {
+          LOG.error(String.format("Failed to fetch next message buffer for partition %s. Will skip this partition.",
+              getCurrentPartition()));
+          moveToNextPartition();
+          continue;
+        }
+        if (this.messageIterator == null || !this.messageIterator.hasNext()) {
+          moveToNextPartition();
+          continue;
+        }
       }
+
+      MessageAndOffset nextValidMessage = null;
+      do {
+        if (!this.messageIterator.hasNext()) {
+          break;
+        }
+
+        // Even though we ask Kafka to give us a message buffer starting from offset x, it may
+        // return a buffer that starts from offset smaller than x, so we need to skip messages
+        // until we get to x.
+        do {
+          nextValidMessage = this.messageIterator.next();
+        } while (nextValidMessage.offset() < this.nextWatermark.get(this.currentPartitionIdx));
+
+        this.nextWatermark.set(this.currentPartitionIdx, nextValidMessage.offset() + 1);
+        try {
+          D record = decodeRecord(nextValidMessage);
+          this.maintainStats(nextValidMessage);
+          return record;
+        } catch (SchemaNotFoundException e) {
+          if (shouldLogError()) {
+            LOG.error(String.format(
+                "An event from partition %s has a schema ID that doesn't exist in the schema registry.",
+                getCurrentPartition()));
+          }
+        } catch (Exception e) {
+          if (shouldLogError()) {
+            LOG.error(String.format("An event from partition %s cannot be decoded.", getCurrentPartition()));
+          }
+        }
+      } while (!currentPartitionFinished());
     }
+    return null;
+  }
 
-    MessageAndOffset nextValidMessage = null;
-    do {
-      if (!this.messageIterator.hasNext()) {
-        return null;
-      }
-      nextValidMessage = this.messageIterator.next();
-    } while (nextValidMessage.offset() < this.nextWatermark);
+  private boolean allPartitionsFinished() {
+    return this.currentPartitionIdx >= this.highWatermark.size();
+  }
 
-    this.nextWatermark = nextValidMessage.offset() + 1;
-    try {
-      D record = decodeRecord(nextValidMessage, null);
-      this.maintainStats(nextValidMessage);
-      return record;
-    } catch (SchemaNotFoundException e) {
-      throw new RuntimeException(e);
+  private boolean currentPartitionFinished() {
+    return this.nextWatermark.get(this.currentPartitionIdx) >= this.highWatermark.get(this.currentPartitionIdx);
+  }
+
+  private void moveToNextPartition() {
+    this.currentPartitionIdx++;
+    this.messageIterator = null;
+  }
+
+  private Iterator<MessageAndOffset> fetchNextMessageBuffer() {
+    return this.kafkaWrapper.fetchNextMessageBuffer(this.partitions.get(this.currentPartitionIdx),
+        this.nextWatermark.get(this.currentPartitionIdx), this.highWatermark.get(this.currentPartitionIdx));
+  }
+
+  private boolean shouldLogError() {
+    return this.decodingErrorCount.containsKey(getCurrentPartition())
+        && this.decodingErrorCount.get(getCurrentPartition()) <= MAX_LOG_DECODING_ERRORS;
+  }
+
+  protected KafkaPartition getCurrentPartition() {
+    return this.partitions.get(this.currentPartitionIdx);
+  }
+
+  /**
+   * Given the message/event just pulled, maintain the average event size of the partition.
+   */
+  private void maintainStats(MessageAndOffset messageJustPulled) {
+    increaseTotalEventSize(getCurrentPartition(), messageJustPulled.message().payloadSize());
+    incrementEventCount(getCurrentPartition());
+    this.avgEventSizes.put(getCurrentPartition(),
+        this.totalEventSizes.get(getCurrentPartition()) / this.eventCounts.get(getCurrentPartition()));
+  }
+
+  private void increaseTotalEventSize(KafkaPartition partition, long size) {
+    if (this.totalEventSizes.containsKey(partition)) {
+      this.totalEventSizes.put(partition, this.totalEventSizes.get(partition) + size);
+    } else {
+      this.totalEventSizes.put(partition, size);
     }
   }
 
-  private void maintainStats(MessageAndOffset nextValidMessage) {
-    this.totalRecordSize += nextValidMessage.message().payloadSize();
-    this.recordCount++;
-    this.avgRecordSize = this.totalRecordSize / this.recordCount;
+  private void incrementEventCount(KafkaPartition partition) {
+    if (this.eventCounts.containsKey(partition)) {
+      this.eventCounts.put(partition, this.eventCounts.get(partition) + 1);
+    } else {
+      this.eventCounts.put(partition, 1);
+    }
   }
 
-  protected abstract D decodeRecord(MessageAndOffset messageAndOffset, D reuse) throws SchemaNotFoundException,
-      IOException;
+  protected abstract D decodeRecord(MessageAndOffset messageAndOffset) throws SchemaNotFoundException, IOException;
 
   @Override
   public long getExpectedRecordCount() {
-    return this.highWatermark - this.lowWatermark;
-  }
-
-  @Override
-  public long getHighWatermark() {
-    return this.highWatermark;
+    return this.lowWatermark.getGap(this.highWatermark);
   }
 
   @Override
   public void close() throws IOException {
 
     // Commit high watermark
-    LOG.info(String.format("Last offset pulled for partition %s:%d = %d", this.partition.getTopicName(),
-        this.partition.getId(), this.nextWatermark - 1));
-    this.workUnitState.setHighWaterMark(this.nextWatermark);
+    for (int i = 0; i < this.partitions.size(); i++) {
+      LOG.info(String.format("Last offset pulled for partition %s = %d", this.partitions.get(i),
+          this.nextWatermark.get(i) - 1));
+    }
+    this.workUnitState.setActualHighWatermark(this.nextWatermark);
 
     // Commit avg event size
-    if (this.avgRecordSize > 0) {
-      LOG.info(String.format("Avg event size pulled for partition %s:%d = %d", this.partition.getTopicName(),
-          this.partition.getId(), this.avgRecordSize));
-      this.workUnitState.setProp(KafkaSource.getWorkUnitSizePropName(this.workUnitState), this.avgRecordSize);
-    } else {
-      LOG.info(String.format("Partition %s:%d not pulled", this.partition.getTopicName(), this.partition.getId()));
-      long previousAvgRecordSize =
-          this.workUnitState.getPropAsLong(KafkaSource.getWorkUnitSizePropName(this.workUnitState),
-              KafkaSource.DEFAULT_AVG_EVENT_SIZE);
-      this.workUnitState.setProp(KafkaSource.getWorkUnitSizePropName(this.workUnitState), previousAvgRecordSize);
+    for (KafkaPartition partition : this.partitions) {
+      if (this.avgEventSizes.containsKey(partition)) {
+        long avgSize = this.avgEventSizes.get(partition);
+        LOG.info(String.format("Avg event size pulled for partition %s = %d", partition, avgSize));
+        KafkaUtils.setPartitionAvgEventSize(this.workUnitState, partition, avgSize);
+      } else {
+        LOG.info(String.format("Partition %s not pulled", partition));
+        long previousAvgRecordSize =
+            KafkaUtils.getPartitionAvgEventSize(this.workUnitState, partition, KafkaSource.DEFAULT_AVG_EVENT_SIZE);
+        KafkaUtils.setPartitionAvgEventSize(this.workUnitState, partition, previousAvgRecordSize);
+      }
     }
     this.closer.close();
   }
@@ -151,5 +236,11 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
       buf.get(bytes, buf.position(), size);
     }
     return bytes;
+  }
+
+  @Deprecated
+  @Override
+  public long getHighWatermark() {
+    return 0;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -30,7 +30,6 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.extract.EventBasedExtractor;
-import gobblin.util.KafkaUtils;
 
 
 /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaPartition.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaPartition.java
@@ -11,6 +11,9 @@
 
 package gobblin.source.extractor.extract.kafka;
 
+import com.google.common.net.HostAndPort;
+
+
 /**
  * A kafka topic partition.
  * Two partitions are considered equivalent if they have the same topic name and partition id. They may have different leaders.
@@ -27,8 +30,7 @@ public final class KafkaPartition {
     private int id = 0;
     private String topicName = "";
     private int leaderId = 0;
-    private String leaderHost = "";
-    private int leaderPort = 0;
+    private HostAndPort leaderHostAndPort;
 
     public Builder withId(int id) {
       this.id = id;
@@ -45,13 +47,13 @@ public final class KafkaPartition {
       return this;
     }
 
-    public Builder withLeaderHost(String leaderHost) {
-      this.leaderHost = leaderHost;
+    public Builder withLeaderHostAndPort(String hostPortString) {
+      this.leaderHostAndPort = HostAndPort.fromString(hostPortString);
       return this;
     }
 
-    public Builder withLeaderPort(int leaderPort) {
-      this.leaderPort = leaderPort;
+    public Builder withLeaderHostAndPort(String host, int port) {
+      this.leaderHostAndPort = HostAndPort.fromParts(host, port);
       return this;
     }
 
@@ -63,13 +65,13 @@ public final class KafkaPartition {
   public KafkaPartition(KafkaPartition other) {
     this.topicName = other.topicName;
     this.id = other.id;
-    this.leader = new KafkaLeader(other.leader.id, other.leader.host, other.leader.port);
+    this.leader = new KafkaLeader(other.leader.id, other.leader.hostAndPort);
   }
 
   private KafkaPartition(Builder builder) {
     this.id = builder.id;
     this.topicName = builder.topicName;
-    this.leader = new KafkaLeader(builder.leaderId, builder.leaderHost, builder.leaderPort);
+    this.leader = new KafkaLeader(builder.leaderId, builder.leaderHostAndPort);
   }
 
   public KafkaLeader getLeader() {
@@ -85,7 +87,12 @@ public final class KafkaPartition {
   }
 
   public void setLeader(int leaderId, String leaderHost, int leaderPort) {
-    this.leader = new KafkaLeader(leaderId, leaderHost, leaderPort);
+    this.leader = new KafkaLeader(leaderId, HostAndPort.fromParts(leaderHost, leaderPort));
+  }
+
+  @Override
+  public String toString() {
+    return this.getTopicName() + ":" + this.getId();
   }
 
   @Override
@@ -118,25 +125,19 @@ public final class KafkaPartition {
 
   public final static class KafkaLeader {
     private final int id;
-    private final String host;
-    private final int port;
+    private final HostAndPort hostAndPort;
 
     public int getId() {
-      return id;
+      return this.id;
     }
 
-    public String getHost() {
-      return host;
+    public HostAndPort getHostAndPort() {
+      return this.hostAndPort;
     }
 
-    public int getPort() {
-      return port;
-    }
-
-    public KafkaLeader(int id, String host, int port) {
+    public KafkaLeader(int id, HostAndPort hostAndPort) {
       this.id = id;
-      this.host = host;
-      this.port = port;
+      this.hostAndPort = hostAndPort;
     }
   }
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleExtractor.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import kafka.message.MessageAndOffset;
 
+
 /**
  * An implementation of {@link KafkaExtractor} from which reads and returns records as an array of bytes.
  *
@@ -27,8 +28,9 @@ public class KafkaSimpleExtractor extends KafkaExtractor<String, byte[]> {
   public KafkaSimpleExtractor(WorkUnitState state) {
     super(state);
   }
+
   @Override
-  protected byte[] decodeRecord(MessageAndOffset messageAndOffset, byte[] reuse) throws SchemaNotFoundException, IOException {
+  protected byte[] decodeRecord(MessageAndOffset messageAndOffset) throws SchemaNotFoundException, IOException {
     return getBytes(messageAndOffset.message().payload());
   }
 
@@ -40,6 +42,6 @@ public class KafkaSimpleExtractor extends KafkaExtractor<String, byte[]> {
    */
   @Override
   public String getSchema() throws IOException {
-    return this.partition.getTopicName();
+    return this.topicName;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -18,7 +18,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.PriorityQueue;
-import java.util.Queue;
 import java.util.Set;
 
 import org.slf4j.Logger;
@@ -26,21 +25,24 @@ import org.slf4j.LoggerFactory;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.SourceState;
-import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.WatermarkInterval;
 import gobblin.source.extractor.extract.EventBasedSource;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.KafkaUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.collect.MinMaxPriorityQueue;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 import com.google.common.primitives.Longs;
+import com.google.gson.Gson;
 
 
 /**
@@ -51,6 +53,7 @@ import com.google.common.primitives.Longs;
 public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaSource.class);
+  private static final Gson GSON = new Gson();
 
   public static final String TOPIC_BLACKLIST = "topic.blacklist";
   public static final String TOPIC_WHITELIST = "topic.whitelist";
@@ -60,8 +63,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   public static final String TOPIC_NAME = "topic.name";
   public static final String PARTITION_ID = "partition.id";
   public static final String LEADER_ID = "leader.id";
-  public static final String LEADER_HOST = "leader.host";
-  public static final String LEADER_PORT = "leader.port";
+  public static final String LEADER_HOSTANDPORT = "leader.hostandport";
   public static final Extract.TableType DEFAULT_TABLE_TYPE = Extract.TableType.APPEND_ONLY;
   public static final String DEFAULT_NAMESPACE_NAME = "KAFKA";
   public static final String ALL_TOPICS = "all";
@@ -69,23 +71,23 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   public static final long DEFAULT_AVG_EVENT_SIZE = 1024;
   public static final String ESTIMATED_DATA_SIZE = "estimated.data.size";
 
-  private final Set<String> moveToLatestTopics = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
-  private final Map<KafkaPartition, Long> previousOffsets = Maps.newHashMap();
-  private final Map<KafkaPartition, Long> previousAvgSizes = Maps.newHashMap();
-
-  private final Comparator<WorkUnit> sortBySizeAscComparator = new Comparator<WorkUnit>() {
+  private static final Comparator<WorkUnit> SIZE_ASC_COMPARATOR = new Comparator<WorkUnit>() {
     @Override
     public int compare(WorkUnit w1, WorkUnit w2) {
       return Longs.compare(getWorkUnitEstSize(w1), getWorkUnitEstSize(w2));
     }
   };
 
-  private final Comparator<WorkUnit> sortBySizeDescComparator = new Comparator<WorkUnit>() {
+  private static final Comparator<WorkUnit> SIZE_DESC_COMPARATOR = new Comparator<WorkUnit>() {
     @Override
     public int compare(WorkUnit w1, WorkUnit w2) {
       return Longs.compare(getWorkUnitEstSize(w2), getWorkUnitEstSize(w1));
     }
   };
+
+  private final Set<String> moveToLatestTopics = Sets.newTreeSet(String.CASE_INSENSITIVE_ORDER);
+  private final Map<KafkaPartition, Long> previousOffsets = Maps.newHashMap();
+  private final Map<KafkaPartition, Long> previousAvgSizes = Maps.newHashMap();
 
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {
@@ -100,7 +102,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       int numOfMultiWorkunits =
           state.getPropAsInt(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, ConfigurationKeys.DEFAULT_MR_JOB_MAX_MAPPERS);
       this.getAllPreviousAvgSizes(state);
-      return ImmutableList.copyOf(getMultiWorkunits(workUnits, numOfMultiWorkunits));
+      return ImmutableList.copyOf(getMultiWorkunits(workUnits, numOfMultiWorkunits, state));
     } finally {
       try {
         closer.close();
@@ -111,20 +113,24 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   }
 
   /**
-   * Group workUnits into multiWorkUnits. Each workUnit corresponds to a (topic, partition).
-   * The goal is to group the workUnits as evenly as possible into numOfMultiWorkunits multiWorkunits,
-   * while preferring to put partitions of the same topic into the same multiWorkUnits.
+   * Group workUnits into multiWorkUnits. Each input workUnit corresponds to a (topic, partition).
    *
-   * The algorithm is to first group workUnits into approximately 3 * numOfMultiWorkunits groups using
-   * best-fit-decreasing, such that partitions of the same topic are in the same group. Then, 
-   * assemble these groups into multiWorkunits using worst-fit-decreasing.
+   * There are two levels of grouping. In the first level, some workunits corresponding to partitions
+   * of the same topic are grouped together into a single workunit. This reduces the number of small
+   * output files since these partitions will share output files, rather than each creating individual
+   * output files. The number of grouped workunits is approximately 3 * numOfMultiWorkunits, since the
+   * worst-fit-decreasing algorithm (used by the second level) should work well if the number of items
+   * is more than 3 times the number of bins.
    *
-   * The reason behind 3 is that the worst-fit-decreasing algorithm should work well if the number of
-   * items is more than 3 times the number of bins.
+   * In the second level, these grouped workunits are assembled into multiWorkunits using worst-fit-decreasing.
    *
-   * The input workUnits are partitioned by topic.
+   * @param workUnits A two-dimensional list of workunits, each corresponding to a single Kafka partition, grouped
+   * by topics.
+   * @param numOfMultiWorkunits Desired number of MultiWorkUnits.
+   * @param state 
+   * @return A list of MultiWorkUnits.
    */
-  private List<WorkUnit> getMultiWorkunits(List<List<WorkUnit>> workUnits, int numOfMultiWorkunits) {
+  private List<WorkUnit> getMultiWorkunits(List<List<WorkUnit>> workUnits, int numOfMultiWorkunits, SourceState state) {
     Preconditions.checkArgument(numOfMultiWorkunits >= 1);
 
     long totalEstDataSize = 0;
@@ -136,86 +142,135 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     }
     long avgGroupSize = (long) ((double) totalEstDataSize / (double) numOfMultiWorkunits / 3.0);
 
-    List<MultiWorkUnit> groups = Lists.newArrayList();
+    List<MultiWorkUnit> mwuGroups = Lists.newArrayList();
     for (List<WorkUnit> workUnitsForTopic : workUnits) {
       long estimatedDataSizeForTopic = calcTotalEstSizeForTopic(workUnitsForTopic);
       if (estimatedDataSizeForTopic < avgGroupSize) {
 
         // If the total estimated size of a topic is smaller than group size, put all partitions of this
         // topic in a single group.
-        MultiWorkUnit group = new MultiWorkUnit();
-        this.addWorkUnitsToMultiWorkUnit(workUnitsForTopic, group);
-        groups.add(group);
+        MultiWorkUnit mwuGroup = new MultiWorkUnit();
+        addWorkUnitsToMultiWorkUnit(workUnitsForTopic, mwuGroup);
+        mwuGroups.add(mwuGroup);
       } else {
 
         // Use best-fit-decreasing to group workunits for a topic into multiple groups.
-        groups.addAll(bestFitDecreasingBinPacking(workUnitsForTopic, avgGroupSize));
+        mwuGroups.addAll(bestFitDecreasingBinPacking(workUnitsForTopic, avgGroupSize));
       }
     }
+
+    List<WorkUnit> groups = squeezeMultiWorkUnits(mwuGroups, state);
 
     return worstFitDecreasingBinPacking(groups, numOfMultiWorkunits);
   }
 
   private void setWorkUnitEstSize(WorkUnit workUnit) {
-    long avgSize = this.getPreviousAvgSizeForPartition(this.getKafkaPartitionFromState(workUnit));
+    long avgSize = this.getPreviousAvgSizeForPartition(KafkaUtils.getPartition(workUnit));
     long numOfEvents =
         workUnit.getPropAsLong(ConfigurationKeys.WORK_UNIT_HIGH_WATER_MARK_KEY)
             - workUnit.getPropAsLong(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY);
     workUnit.setProp(ESTIMATED_DATA_SIZE, avgSize * numOfEvents);
   }
 
-  private void setWorkUnitEstSize(WorkUnit workUnit, long estSize) {
+  private static void setWorkUnitEstSize(WorkUnit workUnit, long estSize) {
     workUnit.setProp(ESTIMATED_DATA_SIZE, estSize);
   }
 
-  private long getWorkUnitEstSize(WorkUnit workUnit) {
+  private static long getWorkUnitEstSize(WorkUnit workUnit) {
     Preconditions.checkArgument(workUnit.contains(ESTIMATED_DATA_SIZE));
     return workUnit.getPropAsLong(ESTIMATED_DATA_SIZE);
   }
 
   /**
-   * Pack a list of multiWorkUnits into a smaller number of multiWorkUnits, using the worst-fit-decreasing algorithm.
+   * For each input MultiWorkUnit, combine all workunits in it into a single workunit.
    */
-  private List<WorkUnit> worstFitDecreasingBinPacking(List<MultiWorkUnit> groups, int numOfMultiWorkUnits) {
+  private static List<WorkUnit> squeezeMultiWorkUnits(List<MultiWorkUnit> multiWorkUnits, SourceState state) {
+    List<WorkUnit> workUnits = Lists.newArrayList();
+    for (MultiWorkUnit multiWorkUnit : multiWorkUnits) {
+      workUnits.add(squeezeMultiWorkUnit(multiWorkUnit, state));
+    }
+    return workUnits;
+  }
+
+  /**
+   * Combine all workunits in the multiWorkUnit into a single workunit.
+   */
+  private static WorkUnit squeezeMultiWorkUnit(MultiWorkUnit multiWorkUnit, SourceState state) {
+    WatermarkInterval interval = getWatermarkIntervalFromMultiWorkUnit(multiWorkUnit);
+    List<KafkaPartition> partitions = getPartitionsFromMultiWorkUnit(multiWorkUnit);
+    Preconditions.checkArgument(!partitions.isEmpty(), "There must be at least one partition in the multiWorkUnit");
+    SourceState partitionState = createAndPopulateMultiPartitionState(partitions, interval, state);
+    partitionState.setProp(ESTIMATED_DATA_SIZE, multiWorkUnit.getProp(ESTIMATED_DATA_SIZE));
+    Extract extract = createExtract(partitionState, partitions.get(0).getTopicName());
+    LOG.info(String.format("Creating workunit for partitions %s", partitions));
+    return partitionState.createWorkUnit(extract);
+  }
+
+  @SuppressWarnings("deprecation")
+  private static WatermarkInterval getWatermarkIntervalFromMultiWorkUnit(MultiWorkUnit multiWorkUnit) {
+    MultiLongWatermark lowWatermark = new MultiLongWatermark();
+    MultiLongWatermark expectedHighWatermark = new MultiLongWatermark();
+    for (WorkUnit workUnit : multiWorkUnit.getWorkUnits()) {
+      lowWatermark.add(workUnit.getLowWaterMark());
+      expectedHighWatermark.add(workUnit.getHighWaterMark());
+    }
+    return new WatermarkInterval(lowWatermark, expectedHighWatermark);
+  }
+
+  private static List<KafkaPartition> getPartitionsFromMultiWorkUnit(MultiWorkUnit multiWorkUnit) {
+    List<KafkaPartition> partitions = Lists.newArrayList();
+
+    for (WorkUnit workUnit : multiWorkUnit.getWorkUnits()) {
+      partitions.add(KafkaUtils.getPartition(workUnit));
+    }
+
+    return partitions;
+  }
+
+  /**
+   * Pack a list of WorkUnits into a smaller number of MultiWorkUnits, using the worst-fit-decreasing algorithm.
+   *
+   * Each WorkUnit is assigned to the MultiWorkUnit with the smallest load.
+   */
+  private List<WorkUnit> worstFitDecreasingBinPacking(List<WorkUnit> groups, int numOfMultiWorkUnits) {
 
     // Sort workunit groups by data size desc
-    Collections.sort(groups, this.sortBySizeDescComparator);
+    Collections.sort(groups, SIZE_DESC_COMPARATOR);
 
-    Queue<MultiWorkUnit> pQueue = new PriorityQueue<MultiWorkUnit>(numOfMultiWorkUnits, this.sortBySizeAscComparator);
-
+    MinMaxPriorityQueue<MultiWorkUnit> pQueue =
+        MinMaxPriorityQueue.orderedBy(SIZE_ASC_COMPARATOR).expectedSize(numOfMultiWorkUnits).create();
     for (int i = 0; i < numOfMultiWorkUnits; i++) {
       MultiWorkUnit multiWorkUnit = new MultiWorkUnit();
-      this.setWorkUnitEstSize(multiWorkUnit, 0);
+      setWorkUnitEstSize(multiWorkUnit, 0);
       pQueue.add(multiWorkUnit);
     }
 
-    for (MultiWorkUnit group : groups) {
+    for (WorkUnit group : groups) {
       MultiWorkUnit lightestMultiWorkUnit = pQueue.poll();
-      this.addWorkUnitsToMultiWorkUnit(group.getWorkUnits(), lightestMultiWorkUnit);
+      addWorkUnitToMultiWorkUnit(group, lightestMultiWorkUnit);
       pQueue.add(lightestMultiWorkUnit);
     }
 
-    List<WorkUnit> multiWorkUnits = Lists.newArrayList();
-    multiWorkUnits.addAll(pQueue);
-    Collections.sort(multiWorkUnits, this.sortBySizeAscComparator);
-    long minLoad = this.getWorkUnitEstSize(multiWorkUnits.get(0));
-    long maxLoad = this.getWorkUnitEstSize(multiWorkUnits.get(multiWorkUnits.size() - 1));
+    long minLoad = getWorkUnitEstSize(pQueue.peekFirst());
+    long maxLoad = getWorkUnitEstSize(pQueue.peekLast());
     LOG.info(String.format("Min data size of multiWorkUnit = %d; Max data size of multiWorkUnit = %d; Diff = %f%%",
         minLoad, maxLoad, (double) (maxLoad - minLoad) / (double) maxLoad * 100.0));
 
+    List<WorkUnit> multiWorkUnits = Lists.newArrayList();
+    multiWorkUnits.addAll(pQueue);
     return multiWorkUnits;
   }
 
   /**
-   * Group workUnits into groups. Each group has a capacity of avgGroupSize. If there's a single
-   * workUnit whose size is larger than avgGroupSize, it forms a group itself.
+   * Group workUnits into groups. Each group is a MultiWorkUnit. Each group has a capacity of avgGroupSize.
+   * If there's a single workUnit whose size is larger than avgGroupSize, it forms a group itself.
    */
   private List<MultiWorkUnit> bestFitDecreasingBinPacking(List<WorkUnit> workUnits, long avgGroupSize) {
 
     // Sort workunits by data size desc
-    Collections.sort(workUnits, this.sortBySizeDescComparator);
+    Collections.sort(workUnits, SIZE_DESC_COMPARATOR);
 
-    Queue<MultiWorkUnit> pQueue = new PriorityQueue<MultiWorkUnit>(workUnits.size(), this.sortBySizeDescComparator);
+    PriorityQueue<MultiWorkUnit> pQueue = new PriorityQueue<MultiWorkUnit>(workUnits.size(), SIZE_DESC_COMPARATOR);
     for (WorkUnit workUnit : workUnits) {
       MultiWorkUnit bestGroup = findAndPopBestFitGroup(workUnit, pQueue, avgGroupSize);
       if (bestGroup != null) {
@@ -229,54 +284,61 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     return Lists.newArrayList(pQueue);
   }
 
-  private void addWorkUnitToMultiWorkUnit(WorkUnit workUnit, MultiWorkUnit multiWorkUnit) {
+  private static void addWorkUnitToMultiWorkUnit(WorkUnit workUnit, MultiWorkUnit multiWorkUnit) {
     multiWorkUnit.addWorkUnit(workUnit);
     long size = multiWorkUnit.getPropAsLong(ESTIMATED_DATA_SIZE, 0);
     multiWorkUnit.setProp(ESTIMATED_DATA_SIZE, size + getWorkUnitEstSize(workUnit));
   }
 
-  private void addWorkUnitsToMultiWorkUnit(List<WorkUnit> workUnits, MultiWorkUnit multiWorkUnit) {
+  private static void addWorkUnitsToMultiWorkUnit(List<WorkUnit> workUnits, MultiWorkUnit multiWorkUnit) {
     for (WorkUnit workUnit : workUnits) {
-      this.addWorkUnitToMultiWorkUnit(workUnit, multiWorkUnit);
+      addWorkUnitToMultiWorkUnit(workUnit, multiWorkUnit);
     }
-
   }
 
   /**
    * Find the best group using the best-fit-decreasing algorithm.
+   * The best group is the fullest group that has enough capacity for the new workunit.
    * If no existing group has enough capacity for the new workUnit, return null.
-   * @param avgGroupSize 
    */
-  private MultiWorkUnit findAndPopBestFitGroup(WorkUnit workUnit, Queue<MultiWorkUnit> pQueue, long avgGroupSize) {
-    if (pQueue.isEmpty()) {
-      return null;
+  private MultiWorkUnit findAndPopBestFitGroup(WorkUnit workUnit, PriorityQueue<MultiWorkUnit> pQueue, long avgGroupSize) {
+
+    List<MultiWorkUnit> fullWorkUnits = Lists.newArrayList();
+    MultiWorkUnit bestFit = null;
+
+    while (!pQueue.isEmpty()) {
+      MultiWorkUnit candidate = pQueue.poll();
+      if (getWorkUnitEstSize(candidate) + getWorkUnitEstSize(workUnit) <= avgGroupSize) {
+        bestFit = candidate;
+        break;
+      } else {
+        fullWorkUnits.add(candidate);
+      }
     }
 
-    long currGroupSize = getWorkUnitEstSize(pQueue.peek());
-
-    if (currGroupSize + getWorkUnitEstSize(workUnit) <= avgGroupSize) {
-      return pQueue.poll();
-    } else {
-      return null;
+    for (MultiWorkUnit fullWorkUnit : fullWorkUnits) {
+      pQueue.add(fullWorkUnit);
     }
+
+    return bestFit;
   }
 
-  private long calcTotalEstSizeForTopic(List<WorkUnit> workUnitsForTopic) {
+  private static long calcTotalEstSizeForTopic(List<WorkUnit> workUnitsForTopic) {
     long totalSize = 0;
     for (WorkUnit w : workUnitsForTopic) {
-      totalSize += this.getWorkUnitEstSize(w);
+      totalSize += getWorkUnitEstSize(w);
     }
     return totalSize;
   }
 
   private long getPreviousAvgSizeForPartition(KafkaPartition partition) {
     if (this.previousAvgSizes.containsKey(partition)) {
-      LOG.info(String.format("Estimated avg event size for partition %s:%d is %d", partition.getTopicName(),
-          partition.getId(), this.previousAvgSizes.get(partition)));
+      LOG.info(String.format("Estimated avg event size for partition %s is %d", partition,
+          this.previousAvgSizes.get(partition)));
       return this.previousAvgSizes.get(partition);
     } else {
-      LOG.warn(String.format("Avg event size for partition %s:%d not available, using default size %d",
-          partition.getTopicName(), partition.getId(), DEFAULT_AVG_EVENT_SIZE));
+      LOG.warn(String.format("Avg event size for partition %s not available, using default size %d", partition,
+          DEFAULT_AVG_EVENT_SIZE));
       return DEFAULT_AVG_EVENT_SIZE;
     }
   }
@@ -284,18 +346,12 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   private void getAllPreviousAvgSizes(SourceState state) {
     this.previousAvgSizes.clear();
     for (WorkUnitState workUnitState : state.getPreviousWorkUnitStates()) {
-      KafkaPartition partition = getKafkaPartitionFromState(workUnitState);
-      if (partition == null) {
-        continue;
+      List<KafkaPartition> partitions = KafkaUtils.getPartitions(workUnitState);
+      for (KafkaPartition partition : partitions) {
+        long previousAvgSize = KafkaUtils.getPartitionAvgEventSize(workUnitState, partition, DEFAULT_AVG_EVENT_SIZE);
+        this.previousAvgSizes.put(partition, previousAvgSize);
       }
-      long previousAvgSize =
-          workUnitState.getPropAsLong(getWorkUnitSizePropName(workUnitState), DEFAULT_AVG_EVENT_SIZE);
-      this.previousAvgSizes.put(partition, previousAvgSize);
     }
-  }
-
-  static String getWorkUnitSizePropName(State state) {
-    return state.getProp(TOPIC_NAME) + "." + state.getPropAsInt(PARTITION_ID) + "." + AVG_EVENT_SIZE;
   }
 
   private List<WorkUnit> getWorkUnitsForTopic(KafkaWrapper kafkaWrapper, KafkaTopic topic, SourceState state) {
@@ -368,22 +424,15 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
   private void getAllPreviousOffsets(SourceState state) {
     this.previousOffsets.clear();
     for (WorkUnitState workUnitState : state.getPreviousWorkUnitStates()) {
-      KafkaPartition partition = getKafkaPartitionFromState(workUnitState);
-      if (partition == null) {
-        continue;
-      }
-      long previousOffset = workUnitState.getHighWaterMark();
-      if (previousOffset != ConfigurationKeys.DEFAULT_WATERMARK_VALUE) {
-        this.previousOffsets.put(partition, previousOffset);
+      List<KafkaPartition> partitions = KafkaUtils.getPartitions(workUnitState);
+      MultiLongWatermark watermark = GSON.fromJson(workUnitState.getActualHighWatermark(), MultiLongWatermark.class);
+      Preconditions.checkArgument(partitions.size() == watermark.size(), String.format(
+          "Num of partitions doesn't match number of watermarks: partitions=%s, watermarks=%s", partitions, watermark));
+      for (int i = 0; i < partitions.size(); i++) {
+        if (watermark.get(i) != ConfigurationKeys.DEFAULT_WATERMARK_VALUE)
+          this.previousOffsets.put(partitions.get(i), watermark.get(i));
       }
     }
-  }
-
-  private KafkaPartition getKafkaPartitionFromState(State state) {
-    Preconditions.checkArgument(state.contains(TOPIC_NAME) && state.contains(PARTITION_ID));
-
-    return new KafkaPartition.Builder().withTopicName(state.getProp(TOPIC_NAME))
-        .withId(state.getPropAsInt(PARTITION_ID)).build();
   }
 
   /**
@@ -400,30 +449,53 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     return this.moveToLatestTopics.contains(partition.getTopicName()) || moveToLatestTopics.contains(ALL_TOPICS);
   }
 
-  private WorkUnit getWorkUnitForTopicPartition(KafkaPartition partition, SourceState state, Offsets offsets) {
+  private static WorkUnit getWorkUnitForTopicPartition(KafkaPartition partition, SourceState state, Offsets offsets) {
     SourceState partitionState = createAndPopulatePartitionState(partition, state, offsets);
     Extract extract = createExtract(partitionState, partition.getTopicName());
-    LOG.info(String.format("Creating workunit for topic %s, partition %d: lowWatermark=%d, highWatermark=%d",
-        partition.getTopicName(), partition.getId(), offsets.getStartOffset(), offsets.getLatestOffset()));
+    LOG.info(String.format("Creating workunit for partition %s: lowWatermark=%d, highWatermark=%d", partition,
+        offsets.getStartOffset(), offsets.getLatestOffset()));
     return partitionState.createWorkUnit(extract);
   }
 
-  private Extract createExtract(SourceState partitionState, String topicName) {
+  private static Extract createExtract(SourceState partitionState, String topicName) {
     return partitionState.createExtract(DEFAULT_TABLE_TYPE, DEFAULT_NAMESPACE_NAME, topicName);
   }
 
-  private SourceState createAndPopulatePartitionState(KafkaPartition partition, SourceState state, Offsets offsets) {
+  private static SourceState createAndPopulatePartitionState(KafkaPartition partition, SourceState state,
+      Offsets offsets) {
     SourceState partitionState = new SourceState();
     partitionState.addAll(state);
     partitionState.setProp(TOPIC_NAME, partition.getTopicName());
     partitionState.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partition.getTopicName());
     partitionState.setProp(PARTITION_ID, partition.getId());
     partitionState.setProp(LEADER_ID, partition.getLeader().getId());
-    partitionState.setProp(LEADER_HOST, partition.getLeader().getHost());
-    partitionState.setProp(LEADER_PORT, partition.getLeader().getPort());
+    partitionState.setProp(LEADER_HOSTANDPORT, partition.getLeader().getHostAndPort().toString());
     partitionState.setProp(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY, offsets.getStartOffset());
     partitionState.setProp(ConfigurationKeys.WORK_UNIT_HIGH_WATER_MARK_KEY, offsets.getLatestOffset());
     return partitionState;
+  }
+
+  /**
+   * Create a SourceState object from a list of partitions used to construct a workunit.
+   * All input partitions should have the same topic name.
+   * The size of the watermark should equal the size of the partitions.
+   */
+  private static SourceState createAndPopulateMultiPartitionState(List<KafkaPartition> partitions,
+      WatermarkInterval interval, SourceState state) {
+    Preconditions.checkArgument(!partitions.isEmpty(), "There should be at least one partition");
+    SourceState partitionsState = new SourceState();
+    partitionsState.addAll(state);
+    partitionsState.setProp(TOPIC_NAME, partitions.get(0).getTopicName());
+    partitionsState.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partitions.get(0).getTopicName());
+    for (int i = 0; i < partitions.size(); i++) {
+      partitionsState.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PARTITION_ID, i), partitions.get(i).getId());
+      partitionsState.setProp(KafkaUtils.getPartitionPropName(KafkaSource.LEADER_ID, i), partitions.get(i).getLeader()
+          .getId());
+      partitionsState.setProp(KafkaUtils.getPartitionPropName(KafkaSource.LEADER_HOSTANDPORT, i), partitions.get(i)
+          .getLeader().getHostAndPort());
+      partitionsState.setWatermarkInterval(interval);
+    }
+    return partitionsState;
   }
 
   private boolean movingToEarliestOffsetAllowed(SourceState state) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -208,13 +208,14 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
 
   @SuppressWarnings("deprecation")
   private static WatermarkInterval getWatermarkIntervalFromMultiWorkUnit(MultiWorkUnit multiWorkUnit) {
-    MultiLongWatermark lowWatermark = new MultiLongWatermark();
-    MultiLongWatermark expectedHighWatermark = new MultiLongWatermark();
+    List<Long> lowWatermarkValues = Lists.newArrayList();
+    List<Long> expectedHighWatermarkValues = Lists.newArrayList();
     for (WorkUnit workUnit : multiWorkUnit.getWorkUnits()) {
-      lowWatermark.add(workUnit.getLowWaterMark());
-      expectedHighWatermark.add(workUnit.getHighWaterMark());
+      lowWatermarkValues.add(workUnit.getLowWaterMark());
+      expectedHighWatermarkValues.add(workUnit.getHighWaterMark());
     }
-    return new WatermarkInterval(lowWatermark, expectedHighWatermark);
+    return new WatermarkInterval(new MultiLongWatermark(lowWatermarkValues), new MultiLongWatermark(
+        expectedHighWatermarkValues));
   }
 
   private static List<KafkaPartition> getPartitionsFromMultiWorkUnit(MultiWorkUnit multiWorkUnit) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -31,7 +31,6 @@ import gobblin.source.extractor.extract.EventBasedSource;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
-import gobblin.util.KafkaUtils;
 
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaUtils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaUtils.java
@@ -9,11 +9,9 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.util;
+package gobblin.source.extractor.extract.kafka;
 
 import gobblin.configuration.State;
-import gobblin.source.extractor.extract.kafka.KafkaPartition;
-import gobblin.source.extractor.extract.kafka.KafkaSource;
 
 import java.util.List;
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/MultiLongWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/MultiLongWatermark.java
@@ -1,0 +1,159 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.math.RoundingMode;
+import java.util.List;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ComparisonChain;
+import com.google.common.math.LongMath;
+import com.google.common.primitives.Shorts;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import gobblin.source.extractor.Watermark;
+
+
+/**
+ * A {@link gobblin.source.extractor.Watermark} that holds multiple long values.
+ *
+ * @author ziliu
+ */
+public class MultiLongWatermark implements Watermark {
+
+  private static final Gson GSON = new Gson();
+
+  private final List<Long> values;
+
+  /**
+   * Copy constructor.
+   */
+  public MultiLongWatermark(MultiLongWatermark other) {
+    this.values = Lists.newArrayList(other.values);
+  }
+
+  public MultiLongWatermark() {
+    this.values = Lists.newArrayList();
+  }
+
+  /**
+   * Increment the idx'th value. idx must be between 0 and size()-1.
+   */
+  public void increment(int idx) {
+    Preconditions.checkElementIndex(idx, this.values.size());
+    Preconditions.checkArgument(this.values.get(idx) < Long.MAX_VALUE);
+    this.values.set(idx, this.values.get(idx) + 1);
+  }
+
+  /**
+   * A MultiLongWatermark w1 is less than w2, if there exists i, such that
+   * the 0th to (i-1)th values of w1 are equivalent as those of w2, and the ith
+   * value of w1 is less than the that of w2.
+   *
+   * @param wm must be an instance of MultiLongWatermark, and this.size() must
+   * equal wm.size().
+   */
+  @Override
+  public int compareTo(Watermark wm) {
+    Preconditions.checkArgument(wm instanceof MultiLongWatermark);
+    MultiLongWatermark other = (MultiLongWatermark) wm;
+    Preconditions.checkArgument(
+        this.values.size() == other.values.size(),
+        String.format("%s.%s can only compare two watermarks with the same number of values",
+            MultiLongWatermark.class.getSimpleName(), Thread.currentThread().getStackTrace()[1].getMethodName()));
+
+    ComparisonChain cc = ComparisonChain.start();
+    for (int i = 0; i < this.values.size(); i++) {
+      cc.compare(this.values.get(i), other.values.get(i));
+    }
+    return cc.result();
+  }
+
+  /**
+   * Serializes the MultiLongWatermark into a JsonElement.
+   */
+  @Override
+  public JsonElement toJson() {
+    return GSON.toJsonTree(this);
+  }
+
+  /**
+   * Given a low watermark (starting point) and a high watermark (target), returns the percentage
+   * of events pulled.
+   *
+   * @return a percentage value between 0 and 100.
+   */
+  @Override
+  public short calculatePercentCompletion(Watermark lowWatermark, Watermark highWatermark) {
+    Preconditions.checkArgument(lowWatermark instanceof MultiLongWatermark, String.format(
+        "Arguments of %s.%s must be of type %s", MultiLongWatermark.class.getSimpleName(), Thread.currentThread()
+            .getStackTrace()[1].getMethodName(), MultiLongWatermark.class.getSimpleName()));
+
+    long pulled = ((MultiLongWatermark) lowWatermark).getGap(this);
+    long all = ((MultiLongWatermark) lowWatermark).getGap((MultiLongWatermark) highWatermark);
+    Preconditions.checkArgument(all > 0);
+    long percent = LongMath.divide(pulled * 100, all, RoundingMode.HALF_UP);
+    return Shorts.checkedCast(percent);
+  }
+
+  /**
+   * Get the number of records that need to be pulled given the high watermark.
+   */
+  public long getGap(MultiLongWatermark highWatermark) {
+    Preconditions.checkNotNull(highWatermark);
+    Preconditions.checkArgument(this.values.size() == highWatermark.values.size());
+    long diff = 0;
+    for (int i = 0; i < this.values.size(); i++) {
+      Preconditions.checkArgument(this.values.get(i) <= highWatermark.values.get(i));
+      diff += highWatermark.values.get(i) - this.values.get(i);
+    }
+    return diff;
+  }
+
+  /**
+   * @return the number of long values this watermark holds.
+   */
+  public int size() {
+    return this.values.size();
+  }
+
+  /**
+   * The idx'th value of this watermark. idx must be between 0 and size()-1.
+   * @return
+   */
+  public long get(int idx) {
+    Preconditions.checkElementIndex(idx, this.values.size());
+    return this.values.get(idx);
+  }
+
+  /**
+   * Set the idx'th value of this watermark. idx must be between 0 and size()-1.
+   */
+  public long set(int idx, long value) {
+    Preconditions.checkElementIndex(idx, this.values.size());
+    return this.values.set(idx, value);
+  }
+
+  /**
+   * Add a value to the watermark. This will increase size() by 1.
+   */
+  public void add(long value) {
+    this.values.add(value);
+  }
+
+  @Override
+  public String toString() {
+    return this.values.toString();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/MultiLongWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/MultiLongWatermark.java
@@ -14,9 +14,8 @@ package gobblin.source.extractor.extract.kafka;
 import java.math.RoundingMode;
 import java.util.List;
 
-import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ComparisonChain;
+import com.google.common.collect.Lists;
 import com.google.common.math.LongMath;
 import com.google.common.primitives.Shorts;
 import com.google.gson.Gson;
@@ -57,28 +56,6 @@ public class MultiLongWatermark implements Watermark {
   }
 
   /**
-   * A MultiLongWatermark w1 is less than w2, if there exists i, such that
-   * the 0th to (i-1)th values of w1 are equivalent as those of w2, and the ith
-   * value of w1 is less than the that of w2.
-   *
-   * @param wm must be an instance of MultiLongWatermark, and this.size() must
-   * equal wm.size().
-   */
-  @Override
-  public int compareTo(Watermark wm) {
-    if (!(wm instanceof MultiLongWatermark)) {
-      throw new ClassCastException("Cannot compare MultiLongWatermark with " + wm.getClass().getSimpleName());
-    }
-    MultiLongWatermark other = (MultiLongWatermark) wm;
-
-    ComparisonChain cc = ComparisonChain.start().compare(this.size(), other.size());
-    for (int i = 0; i < this.values.size(); i++) {
-      cc.compare(this.values.get(i), other.values.get(i));
-    }
-    return cc.result();
-  }
-
-  /**
    * Serializes the MultiLongWatermark into a JsonElement.
    */
   @Override
@@ -94,9 +71,10 @@ public class MultiLongWatermark implements Watermark {
    */
   @Override
   public short calculatePercentCompletion(Watermark lowWatermark, Watermark highWatermark) {
-    Preconditions.checkArgument(lowWatermark instanceof MultiLongWatermark, String.format(
-        "Arguments of %s.%s must be of type %s", MultiLongWatermark.class.getSimpleName(), Thread.currentThread()
-            .getStackTrace()[1].getMethodName(), MultiLongWatermark.class.getSimpleName()));
+    Preconditions.checkArgument(
+        lowWatermark instanceof MultiLongWatermark && highWatermark instanceof MultiLongWatermark,
+        String.format("Arguments of %s.%s must be of type %s", MultiLongWatermark.class.getSimpleName(),
+            Thread.currentThread().getStackTrace()[1].getMethodName(), MultiLongWatermark.class.getSimpleName()));
 
     long pulled = ((MultiLongWatermark) lowWatermark).getGap(this);
     long all = ((MultiLongWatermark) lowWatermark).getGap((MultiLongWatermark) highWatermark);

--- a/gobblin-utility/src/main/java/gobblin/util/KafkaUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/KafkaUtils.java
@@ -1,0 +1,106 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import gobblin.configuration.State;
+import gobblin.source.extractor.extract.kafka.KafkaPartition;
+import gobblin.source.extractor.extract.kafka.KafkaSource;
+
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+
+/**
+ * A Utils class for Kafka.
+ */
+public class KafkaUtils {
+
+  /**
+   * Get topic name from a state object. The state should contain property
+   * "topic.name".
+   */
+  public static String getTopicName(State state) {
+    Preconditions.checkArgument(state.contains(KafkaSource.TOPIC_NAME));
+
+    return state.getProp(KafkaSource.TOPIC_NAME);
+  }
+
+  /**
+   * Get kafka partition from a state object. The state should contain properties
+   * "topic.name", "partition.id", and may optionally contain "leader.id" and
+   * "leader.hostandport".
+   */
+  public static KafkaPartition getPartition(State state) {
+    Preconditions.checkArgument(state.contains(KafkaSource.TOPIC_NAME) && state.contains(KafkaSource.PARTITION_ID));
+
+    KafkaPartition.Builder builder =
+        new KafkaPartition.Builder().withTopicName(state.getProp(KafkaSource.TOPIC_NAME)).withId(
+            state.getPropAsInt(KafkaSource.PARTITION_ID));
+    if (state.contains(KafkaSource.LEADER_ID)) {
+      builder = builder.withLeaderId(state.getPropAsInt(KafkaSource.LEADER_ID));
+    }
+    if (state.contains(KafkaSource.LEADER_HOSTANDPORT)) {
+      builder = builder.withLeaderHostAndPort(state.getProp(KafkaSource.LEADER_HOSTANDPORT));
+    }
+    return builder.build();
+  }
+
+  /**
+   * Get a list of Kafka partitions from a state object. The state should contain properties
+   * "topic.name", "partition.id.i", "leader.id.i" and "leader.hostandport.i", i = 0,1,2,...
+   *
+   * All partitions should have the same topic name.
+   */
+  public static List<KafkaPartition> getPartitions(State state) {
+    List<KafkaPartition> partitions = Lists.newArrayList();
+    String topicName = state.getProp(KafkaSource.TOPIC_NAME);
+    for (int i = 0;; i++) {
+      if (!state.contains(KafkaUtils.getPartitionPropName(KafkaSource.PARTITION_ID, i))) {
+        break;
+      }
+      KafkaPartition partition =
+          new KafkaPartition.Builder().withTopicName(topicName)
+              .withId(state.getPropAsInt(KafkaUtils.getPartitionPropName(KafkaSource.PARTITION_ID, i)))
+              .withLeaderId(state.getPropAsInt(KafkaUtils.getPartitionPropName(KafkaSource.LEADER_ID, i)))
+              .withLeaderHostAndPort(state.getProp(KafkaUtils.getPartitionPropName(KafkaSource.LEADER_HOSTANDPORT, i)))
+              .build();
+      partitions.add(partition);
+    }
+    return partitions;
+  }
+
+  /**
+   * This method returns baseName + '.' + idx.
+   */
+  public static String getPartitionPropName(String baseName, int idx) {
+    return baseName + "." + idx;
+  }
+
+  /**
+   * Get the average event size of a partition, which is stored in property "[topicname].[partitionid].avg.event.size".
+   * If state doesn't contain this property, it returns defaultSize.
+   */
+  public static long getPartitionAvgEventSize(State state, KafkaPartition partition, long defaultSize) {
+    return state.getPropAsLong(KafkaSource.TOPIC_NAME + "." + KafkaSource.PARTITION_ID + "."
+        + KafkaSource.AVG_EVENT_SIZE, defaultSize);
+  }
+
+  /**
+   * Set the average event size of a partition, which will be stored in property
+   * "[topicname].[partitionid].avg.event.size".
+   */
+  public static void setPartitionAvgEventSize(State state, KafkaPartition partition, long size) {
+    state.setProp(KafkaSource.TOPIC_NAME + "." + KafkaSource.PARTITION_ID + "." + KafkaSource.AVG_EVENT_SIZE, size);
+  }
+
+}


### PR DESCRIPTION
- Refactored `KafkaSource` and `KafkaExtractor` for the complex watermark:

Now each WorkUnit in a MultiWorkUnit returned by `KafkaSource.getWorkUnits()` is
responsible for pulling multiple Kafka partitions of the same topic, so that
these partitions can share output files rather than creating its own output files.

To this end, a method `KafkaSource.squeezeMultiWorkUnits()` is added to combine all WorkUnits in a MultiWorkUnit into a single WorkUnit.

`KafkaExtractor.readRecord()` is rewritten to pull from multiple partitions.


- Small modification to complex watermark:

  - Changed the implementation of `WorkUnit.getLowWatermark` and
`WorkUnit.getExpectedHighWatermark`. The original implementation doesn't work and
throws "Not a JsonObject" exceptions. 
  - Changed return type of
`WorkUnitState.getActualHighWatermark()` from `JsonElement` to `String`. In the
original implementation, `GSON.toJsonTree(String)` will convert `"` in the input
string to `\"` in the JsonElement, which will break if we pass this JsonElement to GSON.fromJson.
  - Added method `setWatermarkInterval` to `SourceState`, since we need a way to assign watermarks to workunits.

- Modified the best fit implementation in KafkaSource, the original one was incorrect.

- Modified the worst fit implementation in KafkaSource, using a MinMaxPriorityQueue to improve efficiency.

- Use `com.google.common.net.HostAndPort`

- Other small refactoring for better readability.