### PR TITLE
Fixed unit tests around JobLauncher classes after recent changes on writer file naming

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/AvroDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroDataWriterBuilder.java
@@ -45,8 +45,8 @@ public class AvroDataWriterBuilder extends DataWriterBuilder<Schema, GenericReco
       case HDFS:
         State properties = this.destination.getProperties();
 
-        String fileName =
-            WriterUtils.getWriterFileName(properties, this.branches, this.branch, this.writerId, this.format.getExtension());
+        String fileName = WriterUtils
+            .getWriterFileName(properties, this.branches, this.branch, this.writerId, this.format.getExtension());
 
         return new AvroHdfsDataWriter(properties, fileName, this.schema, this.branches, this.branch);
       case KAFKA:

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -46,15 +46,13 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
 
   private static final Logger LOG = LoggerFactory.getLogger(AvroHdfsDataWriter.class);
 
-  private final State properties;
   private final FileSystem fs;
   private final Path stagingFile;
   private final Path outputFile;
   private final DatumWriter<GenericRecord> datumWriter;
   private final DataFileWriter<GenericRecord> writer;
 
-  // It is possible that the schema may change based on incoming records
-  private Schema schema;
+  private final Schema schema;
 
   // Number of records successfully written
   private final AtomicLong count = new AtomicLong(0);
@@ -71,9 +69,9 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
   public AvroHdfsDataWriter(State properties, String fileName, Schema schema, int numBranches, int branchId)
       throws IOException {
 
-    String uri = properties
-        .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
-            ConfigurationKeys.LOCAL_FS_URI);
+    String uri = properties.getProp(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
+        ConfigurationKeys.LOCAL_FS_URI);
 
     Path stagingDir = WriterUtils.getWriterStagingDir(properties, numBranches, branchId);
 
@@ -83,15 +81,14 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
         .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId),
             AvroHdfsDataWriter.CodecType.DEFLATE.name());
 
-    int bufferSize = Integer.parseInt(properties
-        .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUFFER_SIZE, numBranches, branchId),
-            ConfigurationKeys.DEFAULT_BUFFER_SIZE));
+    int bufferSize = Integer.parseInt(properties.getProp(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUFFER_SIZE, numBranches, branchId),
+        ConfigurationKeys.DEFAULT_BUFFER_SIZE));
 
-    int deflateLevel = Integer.parseInt(properties
-        .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DEFLATE_LEVEL, numBranches, branchId),
-            ConfigurationKeys.DEFAULT_DEFLATE_LEVEL));
+    int deflateLevel = Integer.parseInt(properties.getProp(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DEFLATE_LEVEL, numBranches, branchId),
+        ConfigurationKeys.DEFAULT_DEFLATE_LEVEL));
 
-    this.properties = properties;
     this.schema = schema;
 
     Configuration conf = new Configuration();
@@ -196,12 +193,11 @@ class AvroHdfsDataWriter implements DataWriter<GenericRecord> {
   /**
    * Create a new {@link DataFileWriter} for writing Avro records.
    *
-   * @param schema Avro schema
    * @param avroFile Avro file to write to
    * @param bufferSize Buffer size
    * @param codecType Compression codec type
    * @param deflateLevel Deflate level
-   * @throws IOException
+   * @throws IOException if there is something wrong creating a new {@link DataFileWriter}
    */
   private DataFileWriter<GenericRecord> createDatumWriter(Path avroFile, int bufferSize,
       CodecType codecType, int deflateLevel)

--- a/gobblin-core/src/test/java/gobblin/writer/AvroHdfsDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/AvroHdfsDataWriterTest.java
@@ -80,10 +80,14 @@ public class AvroHdfsDataWriterTest {
     properties.setProp(ConfigurationKeys.WRITER_FILE_NAME, TestConstants.TEST_FILE_NAME);
 
     // Build a writer to write test records
-    this.writer =
-        new AvroDataWriterBuilder().writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
-            .writeInFormat(WriterOutputFormat.AVRO).withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema)
-            .withBranches(1).forBranch(0).build();
+    this.writer = new AvroDataWriterBuilder()
+        .writeTo(Destination.of(Destination.DestinationType.HDFS, properties))
+        .writeInFormat(WriterOutputFormat.AVRO)
+        .withWriterId(TestConstants.TEST_WRITER_ID)
+        .withSchema(this.schema)
+        .withBranches(1)
+        .forBranch(0)
+        .build();
   }
 
   @Test

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -304,8 +304,12 @@ public class Fork implements Closeable, Runnable {
       throws IOException, SchemaConversionException {
     DataWriter<Object> writer = this.taskContext.getDataWriterBuilder(this.branches, this.index)
         .writeTo(Destination.of(this.taskContext.getDestinationType(this.branches, this.index), this.taskState))
-        .writeInFormat(this.taskContext.getWriterOutputFormat(this.branches, this.index)).withWriterId(this.taskId)
-        .withSchema(this.convertedSchema).withBranches(this.branches).forBranch(this.index).build();
+        .writeInFormat(this.taskContext.getWriterOutputFormat(this.branches, this.index))
+        .withWriterId(this.taskId)
+        .withSchema(this.convertedSchema)
+        .withBranches(this.branches)
+        .forBranch(this.index)
+        .build();
     return new InstrumentedDataWriterDecorator<Object>(writer, this.taskState);
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -91,12 +91,12 @@ public class TaskExecutor extends AbstractIdleService {
    */
   public TaskExecutor(Properties properties) {
     this(Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_EXECUTOR_THREADPOOL_SIZE_KEY,
-        Integer.toString(ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE))), Integer.parseInt(properties
-        .getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY,
-            Integer.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE))), Integer.parseInt(properties
-            .getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY,
-                Integer.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE))), Long.parseLong(properties
-        .getProperty(ConfigurationKeys.TASK_RETRY_INTERVAL_IN_SEC_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE))),
+        Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_CORE_SIZE_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_CORE_SIZE))),
+        Integer.parseInt(properties.getProperty(ConfigurationKeys.TASK_RETRY_THREAD_POOL_MAX_SIZE_KEY,
+            Integer.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_THREAD_POOL_MAX_SIZE))),
+        Long.parseLong(properties.getProperty(ConfigurationKeys.TASK_RETRY_INTERVAL_IN_SEC_KEY,
             Long.toString(ConfigurationKeys.DEFAULT_TASK_RETRY_INTERVAL_IN_SEC))));
   }
 
@@ -196,9 +196,6 @@ public class TaskExecutor extends AbstractIdleService {
       // Adjust metrics to clean up numbers from the failed task
       task.getTaskState()
           .adjustJobMetricsOnRetry(task.getTaskState().getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY));
-      // Remove task-level metrics associated with this task so
-      // the retry will use fresh metrics
-      //task.getTaskState().removeMetrics();
     }
 
     // Task retry interval increases linearly with number of retries

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -148,12 +148,6 @@ public class JobLauncherTestHelper {
 
     List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
     Assert.assertTrue(jobStateList.isEmpty());
-
-    FileSystem lfs = FileSystem.getLocal(new Configuration());
-    Path jobLockFile =
-        new Path(jobProps.getProperty(ConfigurationKeys.JOB_LOCK_DIR_KEY), jobName
-            + FileBasedJobLock.LOCK_FILE_EXTENSION);
-    Assert.assertFalse(lfs.exists(jobLockFile));
   }
 
   @SuppressWarnings("unchecked")

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -48,7 +48,6 @@ public class LocalJobLauncherTest {
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
     this.launcherProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
     this.launcherProps.setProperty(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY, "false");
-    this.launcherProps.setProperty(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, "false");
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_JDBC_DRIVER_KEY,
         "org.apache.derby.jdbc.EmbeddedDriver");
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY,

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -54,7 +54,6 @@ public class MRJobLauncherTest extends BMNGRunner {
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");
     this.launcherProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "true");
     this.launcherProps.setProperty(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY, "false");
-    this.launcherProps.setProperty(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, "false");
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_JDBC_DRIVER_KEY,
         "org.apache.derby.jdbc.EmbeddedDriver");
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY,

--- a/gobblin-test/resource/gobblin.mr-test.properties
+++ b/gobblin-test/resource/gobblin.mr-test.properties
@@ -1,18 +1,19 @@
-state.store.dir=gobblin-test/state-store
-metrics.dir=gobblin-test/metrics
 state.store.fs.uri=file:///
+state.store.dir=gobblin-test/state-store
+
 taskexecutor.threadpool.size=2
 tasktracker.threadpool.coresize=2
 tasktracker.threadpool.maxsize=2
+
+metrics.dir=gobblin-test/metrics
 metrics.report.interval=1000
 
 writer.staging.dir=gobblin-test/basicTest/tmp/taskStaging
 writer.output.dir=gobblin-test/basicTest/tmp/taskOutput
-writer.file.name=gobblin-test
 
 data.publisher.replace.final.dir=false
 data.publisher.final.dir=gobblin-test/jobOutput
 
 launcher.type=MAPREDUCE
-job.lock.dir=gobblin-test/locks
+job.lock.enabled=false
 mr.job.root.dir=gobblin-test/mr-jobs

--- a/gobblin-test/resource/gobblin.test.properties
+++ b/gobblin-test/resource/gobblin.test.properties
@@ -1,20 +1,18 @@
-state.store.dir=gobblin-test/state-store
-metrics.dir=gobblin-test/metrics
 state.store.fs.uri=file:///
+state.store.dir=gobblin-test/state-store
+
 taskexecutor.threadpool.size=2
 tasktracker.threadpool.coresize=2
 tasktracker.threadpool.maxsize=2
-metrics.report.interval=1000
 
-previousjobid.file.dir=gobblin-test/previous-job-ids
+metrics.dir=gobblin-test/metrics
+metrics.report.interval=1000
 
 writer.staging.dir=gobblin-test/basicTest/tmp/taskStaging
 writer.output.dir=gobblin-test/basicTest/tmp/taskOutput
-writer.file.name=gobblin-test
 
 data.publisher.replace.final.dir=false
 data.publisher.final.dir=gobblin-test/jobOutput
 
 launcher.type=LOCAL
-
-job.lock.dir=gobblin-test/locks
+job.lock.enabled=false

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -19,9 +19,9 @@ public class WriterUtils {
    * TABLENAME should be used for jobs that pull from multiple tables/topics and intend to write the records
    * in each table/topic to a separate folder. Otherwise, DEFAULT can be used.
    */
-  public static enum WriterFilePathType {
+  public enum WriterFilePathType {
     TABLENAME,
-    DEFAULT;
+    DEFAULT
   }
 
   /**


### PR DESCRIPTION
A recent change on writer file naming allows user to fully control the writer file name including its extension through the configuration property `writer.file.name`. This property used to be used as the prefix for writer file names that will also include the task IDs, which guarantees that each task writes to a different file. However, the test job configurations explicitly set `writer.file.name=gobblin-test`, which means every tasks of a job will write to the same file. This issue shows up in `LocalJobLauncherTest` and `MRJobLauncherTest` in the form of `WARN` messages that complained that a writer of a task is trying to write to an existing file named `gobblin-test`. This commit fixed the tests by removing `writer.file.name` from the test job configurations.

Signed-off-by: Yinan Li <liyinan926@gmail.com>