### PR TITLE
Fixed a bug that caused the Hudson build failures

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputCommitter.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputCommitter.java
@@ -107,22 +107,6 @@ public class GobblinOutputCommitter extends OutputCommitter {
   }
 
   @Override
-  public void commitJob(JobContext jobContext)
-      throws IOException {
-    try {
-      Configuration conf = jobContext.getConfiguration();
-      URI fsUri = URI.create(conf.get(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
-      FileSystem fs = FileSystem.get(fsUri, conf);
-      Path mrJobDir = new Path(conf.get(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY),
-          conf.get(ConfigurationKeys.JOB_NAME_KEY));
-      // Cleanup the working directory upon job completion
-      cleanUpWorkingDirectory(mrJobDir, fs);
-    } finally {
-      super.commitJob(jobContext);
-    }
-  }
-
-  @Override
   public void abortTask(TaskAttemptContext arg0) throws IOException {
   }
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -138,7 +138,7 @@ public class MRJobLauncherTest extends BMNGRunner {
    * an exception is thrown in the {@link MRJobLauncher#collectOutput(Path)} method. The {@link BMRule} is
    * to inject an {@link IOException} when the {@link MRJobLauncher#collectOutput(Path)} method is called.
    */
-  @Test(groups = { "ignore" })
+  @Test
   @BMRule(name = "testJobCleanupOnError",
           targetClass = "gobblin.runtime.mapreduce.MRJobLauncher",
           targetMethod = "collectOutput(Path)",


### PR DESCRIPTION
Recently, as part of pul request #120, the method `commitJob(JobContext jobContext)` in `OutputCommitter` was overriden in  `GobblinOutputCommitter`, which called `cleanUpWorkingDirectory` 
to delete the working directory of the MR job upon completion and committing of the MR job. However, there are two versions of the method `commitJob(JobContext jobContext)`, one using `org.apache.hadoop.mapred.JobContext`, and the other using `org.apache.hadoop.mapreduce.JobContext`. The one that was overriden is the latter, and this is the one called in Hadoop 2. The issue is that the Gobblin job needs to read the task states stored under the working directory after the Hadoop job finishes, at which point the working directory has already been deleted if run on Hadoop 2. The issue didn't show up in Hadoop 1 is because the version of that method for Hadoop 1 was not overriden.

Signed-off-by: Yinan Li <liyinan926@gmail.com>