### PR TITLE
Fixed a bug with the generation of JobExecutionInfo regarding start and end dates

### DIFF
--- a/gobblin-metastore/src/main/java/gobblin/metastore/DatabaseJobHistoryStore.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/DatabaseJobHistoryStore.java
@@ -416,7 +416,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
 
   private boolean existsMetric(Connection connection, String template, String id, Metric metric)
       throws SQLException {
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
     Preconditions.checkArgument(metric.hasGroup());
     Preconditions.checkArgument(metric.hasName());
@@ -433,7 +432,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
 
   private void updateMetric(Connection connection, String template, String id, Metric metric, boolean insert)
       throws SQLException {
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
     Preconditions.checkArgument(metric.hasGroup());
     Preconditions.checkArgument(metric.hasName());
@@ -460,7 +458,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
 
   private boolean existsProperty(Connection connection, String template, String id, String key)
       throws SQLException {
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(key));
 
@@ -474,7 +471,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
   private void updateProperty(Connection connection, String template, String id, String key, String value,
       boolean insert)
       throws SQLException {
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(id));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(key));
     Preconditions.checkArgument(!Strings.isNullOrEmpty(value));
@@ -495,7 +491,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
 
   private JobExecutionInfo processQueryById(Connection connection, String jobId, Optional<String> tableFilter)
       throws SQLException {
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(jobId));
 
     // Query job execution information
@@ -579,7 +574,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
   private List<JobExecutionInfo> processQueryByJobName(Connection connection, String jobName, JobExecutionQuery query,
       Optional<String> tableFilter)
       throws SQLException {
-
     Preconditions.checkArgument(!Strings.isNullOrEmpty(jobName));
 
     // Construct the query for job IDs by a given job name
@@ -619,7 +613,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
 
   private List<JobExecutionInfo> processQueryByTable(Connection connection, JobExecutionQuery query)
       throws SQLException {
-
     Preconditions.checkArgument(query.getId().isTable());
 
     String tableFilter = constructTableFilter(query.getId().getTable());
@@ -731,7 +724,6 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
 
   private AbstractMap.SimpleEntry<String, String> resultSetToProperty(ResultSet rs)
       throws SQLException {
-
     return new AbstractMap.SimpleEntry<String, String>(rs.getString(1), rs.getString(2));
   }
 

--- a/gobblin-metastore/src/main/resources/gobblin_job_history_store.sql
+++ b/gobblin-metastore/src/main/resources/gobblin_job_history_store.sql
@@ -8,6 +8,9 @@
 -- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 -- CONDITIONS OF ANY KIND, either express or implied.
 
+
+-- MySQL DDL for the tables needed by the Gobblin job history store.
+
 CREATE TABLE IF NOT EXISTS gobblin_job_executions (
 	job_name VARCHAR(128) NOT NULL,
 	job_id VARCHAR(128) NOT NULL,

--- a/gobblin-metastore/src/test/resources/gobblin_job_history_store.sql
+++ b/gobblin-metastore/src/test/resources/gobblin_job_history_store.sql
@@ -8,6 +8,9 @@
 -- under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 -- CONDITIONS OF ANY KIND, either express or implied.
 
+
+-- Apache Derby DDL for the tables needed by the Gobblin job history store.
+
 CREATE TABLE gobblin_job_executions (
 	job_name VARCHAR(128) NOT NULL,
 	job_id VARCHAR(128) NOT NULL,
@@ -40,8 +43,8 @@ CREATE TABLE gobblin_task_executions (
 	created_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	last_modified_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (task_id),
-	FOREIGN KEY (job_id) 
-	REFERENCES gobblin_job_executions(job_id) 
+	FOREIGN KEY (job_id)
+	REFERENCES gobblin_job_executions(job_id)
 	ON DELETE CASCADE
 );
 
@@ -55,8 +58,8 @@ CREATE TABLE gobblin_job_metrics (
 	created_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	last_modified_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (metric_id),
-	FOREIGN KEY (job_id) 
-	REFERENCES gobblin_job_executions(job_id) 
+	FOREIGN KEY (job_id)
+	REFERENCES gobblin_job_executions(job_id)
 	ON DELETE CASCADE
 );
 
@@ -70,8 +73,8 @@ CREATE TABLE gobblin_task_metrics (
 	created_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	last_modified_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	PRIMARY KEY (metric_id),
-	FOREIGN KEY (task_id) 
-	REFERENCES gobblin_task_executions(task_id) 
+	FOREIGN KEY (task_id)
+	REFERENCES gobblin_task_executions(task_id)
 	ON DELETE CASCADE
 );
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -67,8 +67,8 @@ public class JobState extends SourceState {
 
   private String jobName;
   private String jobId;
-  private long startTime;
-  private long endTime;
+  private long startTime = 0;
+  private long endTime = 0;
   private long duration;
   private RunningState state = RunningState.PENDING;
   private int tasks;
@@ -383,8 +383,12 @@ public class JobState extends SourceState {
 
     jobExecutionInfo.setJobName(this.jobName);
     jobExecutionInfo.setJobId(this.jobId);
-    jobExecutionInfo.setStartTime(this.startTime);
-    jobExecutionInfo.setEndTime(this.endTime);
+    if (this.startTime > 0) {
+      jobExecutionInfo.setStartTime(this.startTime);
+    }
+    if (this.endTime > 0) {
+      jobExecutionInfo.setEndTime(this.endTime);
+    }
     jobExecutionInfo.setDuration(this.duration);
     jobExecutionInfo.setState(JobStateEnum.valueOf(this.state.name()));
     jobExecutionInfo.setLaunchedTasks(this.tasks);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -59,8 +59,8 @@ public class TaskState extends WorkUnitState {
 
   private String jobId;
   private String taskId;
-  private long startTime;
-  private long endTime;
+  private long startTime = 0;
+  private long endTime = 0;
   private long duration;
 
   // Needed for serialization/deserialization
@@ -300,8 +300,12 @@ public class TaskState extends WorkUnitState {
 
     taskExecutionInfo.setJobId(this.jobId);
     taskExecutionInfo.setTaskId(this.taskId);
-    taskExecutionInfo.setStartTime(this.startTime);
-    taskExecutionInfo.setEndTime(this.endTime);
+    if (this.startTime > 0) {
+      taskExecutionInfo.setStartTime(this.startTime);
+    }
+    if (this.endTime > 0) {
+      taskExecutionInfo.setEndTime(this.endTime);
+    }
     taskExecutionInfo.setDuration(this.duration);
     taskExecutionInfo.setState(TaskStateEnum.valueOf(getWorkingState().name()));
     if (this.contains(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY)) {


### PR DESCRIPTION
I was testing the job execution history store and I found this bug. Basically if start or end time is not set in `JobState` or `TaskState`, the default zero will be used when constructing a `JobExecutionInfo` or `TaskExecutionInfo`. However, when `DataaseJobHistoryStore.put(JobExecutionInfo)` is called, a zero start/end time maps to an invalid TIMESTAMP and will be rejected by the database.

Signed-off-by: Yinan Li <liyinan926@gmail.com>

@ydailinkedin can you help review this?