### PR TITLE
Generifying convertJsonToWatermark method in WatermarkSerializerHelper class

### DIFF
--- a/gobblin-api/src/main/java/gobblin/source/extractor/WatermarkSerializerHelper.java
+++ b/gobblin-api/src/main/java/gobblin/source/extractor/WatermarkSerializerHelper.java
@@ -31,7 +31,7 @@ public class WatermarkSerializerHelper {
    * @param clazz is the {@link Class} that the {@link JsonElement} will be converted into.
    * @return an instance of a class that extends {@link Watermark}.
    */
-  public static Watermark convertJsonToWatermark(JsonElement jsonElement, Class<? extends Watermark> clazz) {
+  public static <T extends Watermark> T convertJsonToWatermark(JsonElement jsonElement, Class<T> clazz) {
     return GSON.fromJson(jsonElement, clazz);
   }
 }

--- a/gobblin-api/src/test/java/gobblin/source/extractor/WatermarkTest.java
+++ b/gobblin-api/src/test/java/gobblin/source/extractor/WatermarkTest.java
@@ -27,10 +27,10 @@ public class WatermarkTest {
     WorkUnit workUnit = new WorkUnit(null, null, watermarkInterval);
 
     TestWatermark deserializedLowWatermark =
-        (TestWatermark) WatermarkSerializerHelper.convertJsonToWatermark(workUnit.getLowWatermark(),
+        WatermarkSerializerHelper.convertJsonToWatermark(workUnit.getLowWatermark(),
             TestWatermark.class);
     TestWatermark deserializedExpectedHighWatermark =
-        (TestWatermark) WatermarkSerializerHelper.convertJsonToWatermark(workUnit.getExpectedHighWatermark(),
+        WatermarkSerializerHelper.convertJsonToWatermark(workUnit.getExpectedHighWatermark(),
             TestWatermark.class);
 
     Assert.assertEquals(deserializedLowWatermark.getLongWatermark(), lowWatermarkValue);
@@ -48,7 +48,7 @@ public class WatermarkTest {
     workUnitState.setActualHighWatermark(actualHighWatermark);
 
     TestWatermark deserializedActualHighWatermark =
-        (TestWatermark) WatermarkSerializerHelper.convertJsonToWatermark(workUnitState.getActualHighWatermark(),
+        WatermarkSerializerHelper.convertJsonToWatermark(workUnitState.getActualHighWatermark(),
             TestWatermark.class);
 
     Assert.assertEquals(deserializedActualHighWatermark.getLongWatermark(), actualHighWatermarkValue);


### PR DESCRIPTION
Generifying convertJsonToWatermark method in WatermarkSerializerHelper class to return objects typed with the parameter provided
