### PR TITLE
Do not persist state of a job if its output data has not been committed

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -42,9 +42,6 @@ import gobblin.source.workunit.WorkUnit;
  */
 public class WorkUnitState extends State {
 
-  private static final String WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_BACKUP_KEY =
-      "workunit.state.actual.high.water.mark.backup";
-
   private Watermark actualHighWatermark;
 
   private static final JsonParser JSON_PARSER = new JsonParser();
@@ -156,29 +153,10 @@ public class WorkUnitState extends State {
   }
 
   /**
-   * Backup the actual high watermark.
-   *
-   * <p>
-   *   This method is used internally to backup the actual high watermark so we can restore the previous one in case the
-   *   final state of the {@link WorkUnit} is not {@link gobblin.configuration.WorkUnitState.WorkingState#COMMITTED}.
-   * </p>
+   * Backoff the actual high watermark to the low watermark returned by {@link WorkUnit#getLowWatermark()}.
    */
-  public void backUpActualHighWatermark() {
-    JsonElement actualHighWatermark = getActualHighWatermark();
-    if (actualHighWatermark != null) {
-      setProp(WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_BACKUP_KEY, actualHighWatermark.toString());
-    }
-  }
-
-  /**
-   * Restore the actual high watermark to the backed-up one stored with the property
-   * {@link #WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_BACKUP_KEY}.
-   */
-  public void restoreActualHighWatermark() {
-    if (contains(WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_BACKUP_KEY)) {
-      setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY,
-          getProp(WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_BACKUP_KEY));
-    }
+  public void backoffActualHighWatermark() {
+    setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, this.workunit.getLowWatermark().toString());
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -242,13 +242,15 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
 
   @Override
   public void close() throws IOException {
-
-    // Commit high watermark
     for (int i = 0; i < this.partitions.size(); i++) {
       LOG.info(String.format("Last offset pulled for partition %s = %d", this.partitions.get(i),
           this.nextWatermark.get(i) - 1));
     }
-    this.workUnitState.setActualHighWatermark(this.nextWatermark);
+
+    // Commit the actual high watermark only if the WorkUnit has succeeded
+    if (this.workUnitState.getWorkingState() == WorkUnitState.WorkingState.SUCCESSFUL) {
+      this.workUnitState.setActualHighWatermark(this.nextWatermark);
+    }
 
     // Commit avg event size
     for (KafkaPartition partition : this.partitions) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -87,6 +87,9 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     this.currentPartitionIdx = 0;
 
     switchMetricContextToCurrentPartition();
+
+    // The actual high watermark starts with the low watermark
+    this.workUnitState.setActualHighWatermark(this.lowWatermark);
   }
 
   @Override
@@ -246,11 +249,7 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
       LOG.info(String.format("Last offset pulled for partition %s = %d", this.partitions.get(i),
           this.nextWatermark.get(i) - 1));
     }
-
-    // Commit the actual high watermark only if the WorkUnit has succeeded
-    if (this.workUnitState.getWorkingState() == WorkUnitState.WorkingState.SUCCESSFUL) {
-      this.workUnitState.setActualHighWatermark(this.nextWatermark);
-    }
+    this.workUnitState.setActualHighWatermark(this.nextWatermark);
 
     // Commit avg event size
     for (KafkaPartition partition : this.partitions) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -426,13 +426,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     this.previousOffsets.clear();
     for (WorkUnitState workUnitState : state.getPreviousWorkUnitStates()) {
       List<KafkaPartition> partitions = KafkaUtils.getPartitions(workUnitState);
-      JsonElement actualHighWatermark = workUnitState.getActualHighWatermark();
-      if (actualHighWatermark == null) {
-        LOG.warn(String
-            .format("Skip previous WorkUnitState %s as there is no actual high watermark set", workUnitState.getId()));
-        continue;
-      }
-      MultiLongWatermark watermark = GSON.fromJson(actualHighWatermark, MultiLongWatermark.class);
+      MultiLongWatermark watermark = GSON.fromJson(workUnitState.getActualHighWatermark(), MultiLongWatermark.class);
       Preconditions.checkArgument(partitions.size() == watermark.size(), String.format(
           "Num of partitions doesn't match number of watermarks: partitions=%s, watermarks=%s", partitions, watermark));
       for (int i = 0; i < partitions.size(); i++) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -532,9 +532,9 @@ public abstract class AbstractJobLauncher implements JobLauncher {
    */
   private void persistJobState(JobState jobState) throws IOException {
     for (TaskState taskState : jobState.getTaskStates()) {
-      // Restore the previous actual high watermark for each task that has not been committed
+      // Backoff the actual high watermark to the low watermark for each task that has not been committed
       if (taskState.getWorkingState() != WorkUnitState.WorkingState.COMMITTED) {
-        taskState.restoreActualHighWatermark();
+        taskState.backoffActualHighWatermark();
       }
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -43,8 +43,6 @@ import gobblin.rest.Metric;
 import gobblin.rest.MetricArray;
 import gobblin.rest.MetricTypeEnum;
 import gobblin.rest.TaskExecutionInfoArray;
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.SourceState;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.runtime.util.JobMetrics;
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -112,7 +112,6 @@ public class Task implements Runnable {
 
     Closer closer = Closer.create();
     try {
-      // Build the extractor for extracting source schema and data records
       Extractor extractor = closer.register(new InstrumentedExtractorDecorator(this.taskState,
           this.taskContext.getExtractor()));
 
@@ -124,6 +123,9 @@ public class Task implements Runnable {
       int branches = forkOperator.getBranches(this.taskState);
       // Set fork.branches explicitly here so the rest task flow can pick it up
       this.taskState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, branches);
+
+      // Backup the actual high watermark before starting the extraction
+      this.taskState.backUpActualHighWatermark();
 
       // Extract, convert, and fork the source schema.
       Object schema = converter.convertSchema(extractor.getSchema(), this.taskState);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -124,9 +124,6 @@ public class Task implements Runnable {
       // Set fork.branches explicitly here so the rest task flow can pick it up
       this.taskState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, branches);
 
-      // Backup the actual high watermark before starting the extraction
-      this.taskState.backUpActualHighWatermark();
-
       // Extract, convert, and fork the source schema.
       Object schema = converter.convertSchema(extractor.getSchema(), this.taskState);
       List<Boolean> forkedSchemas = forkOperator.forkSchema(this.taskState, schema);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -40,8 +40,8 @@ import gobblin.runtime.Task;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskStateTracker;
 import gobblin.runtime.util.MetricNames;
-import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.JobLauncherUtils;
 
 
 /**
@@ -98,20 +98,9 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   @Override
   protected void runWorkUnits(List<WorkUnit> workUnits)
       throws Exception {
-
     Optional<Timer.Context> workUnitsPreparationTimer =
         Instrumented.timerContext(this.runtimeMetricContext, MetricNames.RunJobTimings.WORK_UNITS_PREPARATION);
-
-    // Figure out the actual work units to run by flattening MultiWorkUnits
-    List<WorkUnit> workUnitsToRun = Lists.newArrayList();
-    for (WorkUnit workUnit : workUnits) {
-      if (workUnit instanceof MultiWorkUnit) {
-        workUnitsToRun.addAll(((MultiWorkUnit) workUnit).getWorkUnits());
-      } else {
-        workUnitsToRun.add(workUnit);
-      }
-    }
-
+    List<WorkUnit> workUnitsToRun = JobLauncherUtils.flattenWorkUnits(workUnits);
     Instrumented.endTimer(workUnitsPreparationTimer);
 
     if (workUnitsToRun.isEmpty()) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -572,7 +572,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
       }
 
       if (workUnit instanceof MultiWorkUnit) {
-        this.workUnits.addAll(((MultiWorkUnit) workUnit).getWorkUnits());
+        this.workUnits.addAll(JobLauncherUtils.flattenWorkUnits(((MultiWorkUnit) workUnit).getWorkUnits()));
       } else {
         this.workUnits.add(workUnit);
       }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -139,13 +139,13 @@ public class MRJobLauncherTest extends BMNGRunner {
 
   /**
    * Byteman test that ensures the {@link MRJobLauncher} successfully cleans up all staging data even when
-   * an exception is thrown in the {@link MRJobLauncher#collectOutput(Path)} method. The {@link BMRule} is
-   * to inject an {@link IOException} when the {@link MRJobLauncher#collectOutput(Path)} method is called.
+   * an exception is thrown in the {@link MRJobLauncher#collectOutputTaskStates(Path)} method. The {@link BMRule} is
+   * to inject an {@link IOException} when the {@link MRJobLauncher#collectOutputTaskStates(Path)} method is called.
    */
   @Test
   @BMRule(name = "testJobCleanupOnError",
           targetClass = "gobblin.runtime.mapreduce.MRJobLauncher",
-          targetMethod = "collectOutput(Path)",
+          targetMethod = "collectOutputTaskStates(Path)",
           targetLocation = "AT ENTRY",
           condition = "true",
           action = "throw new IOException(\"Exception for testJobCleanupOnError\")")

--- a/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
@@ -72,21 +72,22 @@ public class JobLauncherUtils {
   }
 
   /**
-   * Utility method that takes in a {@link List} of {@link State}s, and flattens them. It builds up the flattened
-   * list by checking each element of the given list, and seeing if it is an instance of {@link MultiWorkUnit}.
-   * If it is then it calls itself on the {@link WorkUnit}s returned by {@link MultiWorkUnit#getWorkUnits()}.
-   * If not, then it simply adds the {@link WorkUnit} to the flattened list.
+   * Utility method that takes in a {@link List} of {@link WorkUnit}s, and flattens them. It builds up
+   * the flattened list by checking each element of the given list, and seeing if it is an instance of
+   * {@link MultiWorkUnit}. If it is then it calls itself on the {@link WorkUnit}s returned by
+   * {@link MultiWorkUnit#getWorkUnits()}. If not, then it simply adds the {@link WorkUnit} to the
+   * flattened list.
    *
-   * @param states is a {@link List} containing either {@link State}s or {@link MultiWorkUnit}s
-   * @return a {@link List} of {@link State}s
+   * @param workUnits is a {@link List} containing either {@link WorkUnit}s or {@link MultiWorkUnit}s
+   * @return a {@link List} of flattened {@link WorkUnit}s
    */
-  public static List<State> flattenWorkUnits(List<? extends State> states) {
-    List<State> flattenedWorkUnits = Lists.newArrayList();
-    for (State state : states) {
-      if (state instanceof MultiWorkUnit) {
-        flattenedWorkUnits.addAll(flattenWorkUnits(((MultiWorkUnit) state).getWorkUnits()));
+  public static List<WorkUnit> flattenWorkUnits(List<WorkUnit> workUnits) {
+    List<WorkUnit> flattenedWorkUnits = Lists.newArrayList();
+    for (WorkUnit workUnit : workUnits) {
+      if (workUnit instanceof MultiWorkUnit) {
+        flattenedWorkUnits.addAll(flattenWorkUnits(((MultiWorkUnit) workUnit).getWorkUnits()));
       } else {
-        flattenedWorkUnits.add(state);
+        flattenedWorkUnits.add(workUnit);
       }
     }
     return flattenedWorkUnits;
@@ -98,7 +99,7 @@ public class JobLauncherUtils {
    *
    * @param states a {@link List} of {@link State}s that need their staging data cleaned
    */
-  public static void cleanStagingData(List<State> states, Logger logger) throws IOException {
+  public static void cleanStagingData(List<? extends State> states, Logger logger) throws IOException {
     for (State state : states) {
       JobLauncherUtils.cleanStagingData(state, logger);
     }


### PR DESCRIPTION
This pull request is motivated by a case from the Kafka adapter that doesn't want to have job state persisted if the job failed (so to be consistent with the Camus behavior). This pull request has the following changes (UPDATED):
1. `AbstractJobLauncher` will no longer persist job state of a job if its output data has not been committed successfully.
2. Added a check in `MRJobLauncher` on the number of `TaskState`s collected from the mapper output. If this number is less than the expected number (the number of tasks launched), the job state is set to `FAILED`.
3. Code refactoring.

Signed-off-by: Yinan Li <liyinan926@gmail.com>