### PR TITLE
Various fixes to metrics emitted to Kafka in MR mode.

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -370,10 +370,11 @@ public class ConfigurationKeys {
   public static final String METRICS_CONFIGURATIONS_PREFIX = "metrics.";
   public static final String METRICS_LOG_DIR_KEY = METRICS_CONFIGURATIONS_PREFIX + "log.dir";
   public static final String METRICS_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "enabled";
+  public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(true);
   public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
-  public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(false);
+  public static final String DEFAULT_METRICS_FILE_SUFFIX = "";
   public static final String METRICS_REPORTING_FILE_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
-  public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(true);
+  public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(false);
   public static final String METRICS_REPORTING_JMX_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
   public static final String DEFAULT_METRICS_REPORTING_JMX_ENABLED = Boolean.toString(false);
   public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -367,21 +367,26 @@ public class ConfigurationKeys {
   /**
    * Common metrics configuration properties.
    */
-  public static final String METRICS_LOG_DIR_KEY = "metrics.log.dir";
-  public static final String METRICS_ENABLED_KEY = "metrics.enabled";
+  public static final String METRICS_CONFIGURATIONS_PREFIX = "metrics.";
+  public static final String METRICS_LOG_DIR_KEY = METRICS_CONFIGURATIONS_PREFIX + "log.dir";
+  public static final String METRICS_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "enabled";
+  public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
   public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_FILE_ENABLED_KEY = "metrics.reporting.file.enabled";
+  public static final String METRICS_REPORTING_FILE_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
   public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(true);
-  public static final String METRICS_REPORTING_JMX_ENABLED_KEY = "metrics.reporting.jmx.enabled";
+  public static final String METRICS_REPORTING_JMX_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
   public static final String DEFAULT_METRICS_REPORTING_JMX_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY = "metrics.reporting.kafka.enabled";
+  public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_KAFKA_FORMAT = "metrics.reporting.kafka.format";
+  public static final String METRICS_REPORTING_KAFKA_FORMAT = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.format";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_FORMAT = "json";
-  public static final String METRICS_KAFKA_BROKERS = "metrics.reporting.kafka.brokers";
-  public static final String METRICS_KAFKA_TOPIC = "metrics.reporting.kafka.topic";
-  public static final String METRICS_CUSTOM_BUILDERS = "metrics.reporting.custom.builders";
-  public static final String METRICS_REPORT_INTERVAL_KEY = "metrics.report.interval";
+  public static final String METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY = METRICS_CONFIGURATIONS_PREFIX +
+      "reporting.kafka.avro.use.schema.registry";
+  public static final String DEFAULT_METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY = Boolean.toString(false);
+  public static final String METRICS_KAFKA_BROKERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.brokers";
+  public static final String METRICS_KAFKA_TOPIC = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic";
+  public static final String METRICS_CUSTOM_BUILDERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.custom.builders";
+  public static final String METRICS_REPORT_INTERVAL_KEY = METRICS_CONFIGURATIONS_PREFIX + "report.interval";
   public static final String DEFAULT_METRICS_REPORT_INTERVAL = "30000";
 
   /**

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -39,7 +39,7 @@ public class State implements Writable {
   /**
    * Return a copy of the underlying {@link java.util.Properties} object.
    *
-   * @return Underlying {@link java.util.Properties} object.
+   * @return A copy of the underlying {@link java.util.Properties} object.
    */
   public Properties getProperties() {
     Properties props = new Properties();

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -37,6 +37,17 @@ public class State implements Writable {
   private final Properties properties = new Properties();
 
   /**
+   * Return a copy of the underlying {@link java.util.Properties} object.
+   *
+   * @return Underlying {@link java.util.Properties} object.
+   */
+  public Properties getProperties() {
+    Properties props = new Properties();
+    props.putAll(this.properties);
+    return props;
+  }
+
+  /**
    * Populates this instance with properties of the other instance.
    *
    * @param otherState the other {@link State} instance

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -14,6 +14,7 @@ package gobblin.configuration;
 import java.io.DataInput;
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.Properties;
 import java.util.Set;
 
 import com.google.common.collect.Sets;
@@ -168,6 +169,14 @@ public class WorkUnitState extends State {
   @Deprecated
   public void setHighWaterMark(long value) {
     setProp(ConfigurationKeys.WORK_UNIT_STATE_RUNTIME_HIGH_WATER_MARK, value);
+  }
+
+  @Override
+  public Properties getProperties() {
+    Properties props = new Properties();
+    props.putAll(this.workunit.getProperties());
+    props.putAll(super.getProperties());
+    return props;
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
@@ -13,8 +13,6 @@ package gobblin.metrics;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -264,7 +262,7 @@ public class GobblinMetrics {
     }
 
     buildFileMetricReporter(properties);
-    buidlKafkaMetricReporter(properties);
+    buildKafkaMetricReporter(properties);
     buildCustomMetricReporters(properties);
 
     for (ScheduledReporter reporter : this.scheduledReporters) {
@@ -334,7 +332,8 @@ public class GobblinMetrics {
       }
 
       // Add a suffix to file name if specified in properties.
-      String metricsFileSuffix = properties.getProperty(ConfigurationKeys.METRICS_FILE_SUFFIX, "");
+      String metricsFileSuffix = properties.getProperty(ConfigurationKeys.METRICS_FILE_SUFFIX,
+          ConfigurationKeys.DEFAULT_METRICS_FILE_SUFFIX);
       if(!Strings.isNullOrEmpty(metricsFileSuffix) && !metricsFileSuffix.startsWith(".")) {
         metricsFileSuffix = "." + metricsFileSuffix;
       }
@@ -365,7 +364,7 @@ public class GobblinMetrics {
     this.jmxReporter = Optional.of(closer.register(JmxReporter.forRegistry(this.metricContext).convertRatesTo(TimeUnit.SECONDS).convertDurationsTo(TimeUnit.MILLISECONDS).build()));
   }
 
-  private void buidlKafkaMetricReporter(Properties properties) {
+  private void buildKafkaMetricReporter(Properties properties) {
     if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_ENABLED))) {
       LOGGER.info("Not reporting metrics to Kafka");
@@ -399,7 +398,7 @@ public class GobblinMetrics {
 
     Optional<KafkaAvroSchemaRegistry> registry = Optional.absent();
     try {
-      if ( formatEnum == KafkaReportingFormats.AVRO &&
+      if (formatEnum == KafkaReportingFormats.AVRO &&
           Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY,
           ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY))) {
         registry = Optional.of(new KafkaAvroSchemaRegistry(properties));
@@ -418,7 +417,6 @@ public class GobblinMetrics {
 
     this.scheduledReporters.add(
         this.closer.register(builder.build(brokers, topic)));
-
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
@@ -12,6 +12,7 @@
 package gobblin.source.extractor.extract.kafka;
 
 import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.kafka.SchemaNotFoundException;
 import gobblin.source.extractor.Extractor;
 
 import java.io.IOException;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -30,6 +30,7 @@ import com.google.gson.Gson;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.metrics.Tag;
+import gobblin.metrics.kafka.SchemaNotFoundException;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.extract.EventBasedExtractor;
@@ -169,6 +170,9 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
   }
 
   private void switchMetricContextToCurrentPartition() {
+    if (this.currentPartitionIdx >= this.partitions.size()) {
+      return;
+    }
     int currentPartitionId = this.getCurrentPartition().getId();
     switchMetricContext(Lists.<Tag<?>>newArrayList(new Tag<Integer>("kafka_partition", currentPartitionId)));
   }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleExtractor.java
@@ -12,6 +12,7 @@
 package gobblin.source.extractor.extract.kafka;
 
 import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.kafka.SchemaNotFoundException;
 
 import java.io.IOException;
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -126,7 +126,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
    * @param workUnits A two-dimensional list of workunits, each corresponding to a single Kafka partition, grouped
    * by topics.
    * @param numOfMultiWorkunits Desired number of MultiWorkUnits.
-   * @param state 
+   * @param state
    * @return A list of MultiWorkUnits.
    */
   private List<WorkUnit> getMultiWorkunits(List<List<WorkUnit>> workUnits, int numOfMultiWorkunits, SourceState state) {

--- a/gobblin-metrics/build.gradle
+++ b/gobblin-metrics/build.gradle
@@ -28,6 +28,8 @@ dependencies {
   compile externalDependency.jodaTime
   compile externalDependency.influxdbJava
   compile externalDependency.findBugs
+  compile externalDependency.commonsHttpClient
+  compile externalDependency.commonsCodec
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito

--- a/gobblin-metrics/src/main/java/gobblin/metrics/SerializedMetricReportReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/SerializedMetricReportReporter.java
@@ -98,6 +98,25 @@ public abstract class SerializedMetricReportReporter extends MetricReportReporte
   }
 
   /**
+   * Write schema versioning information to the {@link java.io.DataOutputStream} that will hold the serialized
+   * {@link gobblin.metrics.MetricReport}.
+   *
+   * <p>
+   *   This method will be called before the {@link gobblin.metrics.MetricReport} is serialized. As such,
+   *   any information written by this method to the {@link java.io.DataOutputStream} will appear at the
+   *   beginning of messages emitted by the reporter.
+   * </p>
+   *
+   * @param outputStream Empty {@link java.io.DataOutputStream} that will hold the serialized
+   *                     {@link gobblin.metrics.MetricReport}. Any data written by this method
+   *                     will appear at the beginning of the emitted message.
+   * @throws IOException
+   */
+  protected void writeSchemaVersioningInformation(DataOutputStream outputStream) throws IOException {
+    outputStream.writeInt(MetricReportUtils.SCHEMA_VERSION);
+  }
+
+  /**
    * Converts a {@link gobblin.metrics.MetricReport} to bytes to send through Kafka.
    * @param report MetricReport to serialize.
    * @return Serialized bytes.
@@ -109,8 +128,8 @@ public abstract class SerializedMetricReportReporter extends MetricReportReporte
 
     try {
       this.byteArrayOutputStream.reset();
-      // Write version number at the beginning of the message.
-      this.out.writeInt(MetricReportUtils.SCHEMA_VERSION);
+      // Write schema versioning information.
+      writeSchemaVersioningInformation(this.out);
       // Now write the report itself.
       this.writerOpt.get().write(report, this.encoder);
       this.encoder.flush();

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroReporter.java
@@ -120,6 +120,27 @@ public class KafkaAvroReporter extends KafkaReporter {
     return EncoderFactory.get().binaryEncoder(out, null);
   }
 
+  /**
+   * Implementation of {@link gobblin.metrics.SerializedMetricReportReporter#writeSchemaVersioningInformation} supporting
+   * a {@link gobblin.metrics.kafka.KafkaAvroSchemaRegistry}.
+   *
+   * <p>
+   * If a {@link gobblin.metrics.kafka.KafkaAvroSchemaRegistry} is provided to the reporter, this method writes
+   * the {@link gobblin.metrics.kafka.KafkaAvroSchemaRegistry} id for the {@link gobblin.metrics.MetricReport} schema
+   * instead of the static {@link gobblin.metrics.MetricReportUtils#SCHEMA_VERSION}. This allows processors like
+   * Camus to retrieve the correct {@link org.apache.avro.Schema} from a REST schema registry. This method will also
+   * automatically register the {@link org.apache.avro.Schema} to the REST registry. It is assumed that calling
+   * {@link gobblin.metrics.kafka.KafkaAvroSchemaRegistry#register} more than once for the same
+   * {@link org.apache.avro.Schema} is not a problem, as it will be called at least once per JVM.
+   *
+   * If no {@link gobblin.metrics.kafka.KafkaAvroSchemaRegistry} is provided, this method simply calls the super method.
+   * </p>
+   *
+   * @param outputStream Empty {@link java.io.DataOutputStream} that will hold the serialized
+   *                     {@link gobblin.metrics.MetricReport}. Any data written by this method
+   *                     will appear at the beginning of the emitted message.
+   * @throws IOException
+   */
   @Override
   protected void writeSchemaVersioningInformation(DataOutputStream outputStream)
       throws IOException {

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroSchemaRegistry.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroSchemaRegistry.java
@@ -9,10 +9,11 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.source.extractor.extract.kafka;
+package gobblin.metrics.kafka;
 
 import java.io.IOException;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
@@ -34,9 +35,6 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
 
-import gobblin.configuration.State;
-
-
 /**
  * A schema registry class that provides two services: get the latest schema of a topic, and register a schema.
  *
@@ -44,6 +42,7 @@ import gobblin.configuration.State;
  */
 public class KafkaAvroSchemaRegistry {
 
+  public static final int SCHEMA_ID_LENGTH_BYTE = 16;
   private static final Logger LOG = LoggerFactory.getLogger(KafkaAvroSchemaRegistry.class);
 
   private static final int GET_SCHEMA_BY_ID_MAX_TIRES = 3;
@@ -52,31 +51,34 @@ public class KafkaAvroSchemaRegistry {
   private static final String GET_RESOURCE_BY_TYPE = "/latest_with_type=";
   private static final String SCHEMA_ID_HEADER_NAME = "Location";
   private static final String SCHEMA_ID_HEADER_PREFIX = "/id=";
-  private static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
+  public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
   private static final String KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = "kafka.schema.registry.max.cache.size";
-  private static final int DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = 1000;
+  private static final String DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = "1000";
   private static final String KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN =
       "kafka.schema.registry.cache.expire.after.write.min";
-  private static final int DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN = 10;
+  private static final String DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN = "10";
+  public static final byte MAGIC_BYTE = 0x0;
 
   private final LoadingCache<String, Schema> cachedSchemasById;
   private final HttpClient httpClient;
   private final String url;
 
   /**
-   * @param state state should contain property "kafka.schema.registry.url", and optionally
+   * @param properties properties should contain property "kafka.schema.registry.url", and optionally
    * "kafka.schema.registry.max.cache.size" (default = 1000) and
    * "kafka.schema.registry.cache.expire.after.write.min" (default = 10).
    */
-  public KafkaAvroSchemaRegistry(State state) {
-    Preconditions.checkArgument(state.contains(KAFKA_SCHEMA_REGISTRY_URL), "Schema registry URL not provided.");
+  public KafkaAvroSchemaRegistry(Properties properties) {
+    LOG.info(properties.toString());
+    Preconditions.checkArgument(properties.containsKey(KAFKA_SCHEMA_REGISTRY_URL), "Schema registry URL not provided.");
 
-    this.url = state.getProp(KAFKA_SCHEMA_REGISTRY_URL);
+    this.url = properties.getProperty(KAFKA_SCHEMA_REGISTRY_URL);
     int maxCacheSize =
-        state.getPropAsInt(KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE, DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE);
+        Integer.parseInt(
+            properties.getProperty(KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE, DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE));
     int expireAfterWriteMin =
-        state.getPropAsInt(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
-            DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN);
+        Integer.parseInt(properties.getProperty(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
+            DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN));
     this.cachedSchemasById =
         CacheBuilder.newBuilder().maximumSize(maxCacheSize).expireAfterWrite(expireAfterWriteMin, TimeUnit.MINUTES)
             .build(new KafkaSchemaCacheLoader());

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroSchemaRegistry.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroSchemaRegistry.java
@@ -42,7 +42,6 @@ import com.google.common.collect.Maps;
  */
 public class KafkaAvroSchemaRegistry {
 
-  public static final int SCHEMA_ID_LENGTH_BYTE = 16;
   private static final Logger LOG = LoggerFactory.getLogger(KafkaAvroSchemaRegistry.class);
 
   private static final int GET_SCHEMA_BY_ID_MAX_TIRES = 3;
@@ -51,12 +50,14 @@ public class KafkaAvroSchemaRegistry {
   private static final String GET_RESOURCE_BY_TYPE = "/latest_with_type=";
   private static final String SCHEMA_ID_HEADER_NAME = "Location";
   private static final String SCHEMA_ID_HEADER_PREFIX = "/id=";
-  public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
   private static final String KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = "kafka.schema.registry.max.cache.size";
   private static final String DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = "1000";
   private static final String KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN =
       "kafka.schema.registry.cache.expire.after.write.min";
   private static final String DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN = "10";
+
+  public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
+  public static final int SCHEMA_ID_LENGTH_BYTE = 16;
   public static final byte MAGIC_BYTE = 0x0;
 
   private final LoadingCache<String, Schema> cachedSchemasById;
@@ -69,15 +70,14 @@ public class KafkaAvroSchemaRegistry {
    * "kafka.schema.registry.cache.expire.after.write.min" (default = 10).
    */
   public KafkaAvroSchemaRegistry(Properties properties) {
-    LOG.info(properties.toString());
     Preconditions.checkArgument(properties.containsKey(KAFKA_SCHEMA_REGISTRY_URL), "Schema registry URL not provided.");
 
     this.url = properties.getProperty(KAFKA_SCHEMA_REGISTRY_URL);
     int maxCacheSize =
         Integer.parseInt(
             properties.getProperty(KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE, DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE));
-    int expireAfterWriteMin =
-        Integer.parseInt(properties.getProperty(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
+    int expireAfterWriteMin = Integer.parseInt(properties
+        .getProperty(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
             DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN));
     this.cachedSchemasById =
         CacheBuilder.newBuilder().maximumSize(maxCacheSize).expireAfterWrite(expireAfterWriteMin, TimeUnit.MINUTES)

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/SchemaNotFoundException.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/SchemaNotFoundException.java
@@ -9,7 +9,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.source.extractor.extract.kafka;
+package gobblin.metrics.kafka;
 
 @SuppressWarnings("serial")
 public class SchemaNotFoundException extends Exception {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -585,9 +585,10 @@ public class MRJobLauncher extends AbstractJobLauncher {
       String jobId = workUnits.get(0).getProp(ConfigurationKeys.JOB_ID_KEY);
 
       // Setup and start metrics reporting
-      Properties metricReportingProperties = new WorkUnitState(workUnits.get(0)).getProperties();
+      Properties metricReportingProperties = workUnits.get(0).getProperties();
       JobMetrics jobMetrics = JobMetrics.get(null, jobId);
-      String metricFileSuffix = metricReportingProperties.getProperty(ConfigurationKeys.METRICS_FILE_SUFFIX, "");
+      String metricFileSuffix = metricReportingProperties.getProperty(ConfigurationKeys.METRICS_FILE_SUFFIX,
+          ConfigurationKeys.DEFAULT_METRICS_FILE_SUFFIX);
       // If running in MR mode, all mappers will try to write metrics to the same file, which will fail.
       // Instead, append the taskAttemptId to each file name.
       if(Strings.isNullOrEmpty(metricFileSuffix)) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -51,6 +51,7 @@ import com.codahale.metrics.Timer;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ServiceManager;
@@ -533,7 +534,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
           this.map(context.getCurrentKey(), context.getCurrentValue(), context);
         }
         // Actually run the list of WorkUnits
-        runWorkUnits(this.workUnits);
+        runWorkUnits(this.workUnits, context);
       } finally {
         this.cleanup(context);
       }
@@ -575,14 +576,27 @@ public class MRJobLauncher extends AbstractJobLauncher {
      * Run the given list of {@link WorkUnit}s sequentially. If any work unit/task fails,
      * an {@link java.io.IOException} is thrown so the mapper is failed and retried.
      */
-    private void runWorkUnits(List<WorkUnit> workUnits) throws IOException, InterruptedException {
+    private void runWorkUnits(List<WorkUnit> workUnits, Context context) throws IOException, InterruptedException {
       if (workUnits.isEmpty()) {
         LOG.warn("No work units to run");
         return;
       }
 
       String jobId = workUnits.get(0).getProp(ConfigurationKeys.JOB_ID_KEY);
+
+      // Setup and start metrics reporting
+      Properties metricReportingProperties = new WorkUnitState(workUnits.get(0)).getProperties();
       JobMetrics jobMetrics = JobMetrics.get(null, jobId);
+      String metricFileSuffix = metricReportingProperties.getProperty(ConfigurationKeys.METRICS_FILE_SUFFIX, "");
+      // If running in MR mode, all mappers will try to write metrics to the same file, which will fail.
+      // Instead, append the taskAttemptId to each file name.
+      if(Strings.isNullOrEmpty(metricFileSuffix)) {
+        metricFileSuffix = context.getTaskAttemptID().getTaskID().toString();
+      } else {
+        metricFileSuffix += "." + context.getTaskAttemptID().getTaskID().toString();
+      }
+      metricReportingProperties.setProperty(ConfigurationKeys.METRICS_FILE_SUFFIX, metricFileSuffix);
+      jobMetrics.startMetricReporting(metricReportingProperties);
 
       for (WorkUnit workUnit : workUnits) {
         workUnit.setProp(Instrumented.METRIC_CONTEXT_NAME_KEY, jobMetrics.getName());


### PR DESCRIPTION
Summary of changes:
* Added getProperties method to State.
* File metrics reporting can add a suffix to the filename. This is useful in MR jobs where, before, all mappers would attempt to write to the same file.
* Added schema registry functionality to Kafka metrics reporting. Since this needed KafkaAvroSchemaRegistry, refactored this class from gobblin-core to gobblin-metrics.