### PR TITLE
Change the place that checks whether writer output dir exists

### DIFF
--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -11,7 +11,6 @@
 
 package gobblin.publisher;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -49,7 +48,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
    */
   @Override
   protected void addWriterOutputToExistingDir(Path writerOutput, Path publisherOutput, WorkUnitState workUnitState,
-      int branchId) throws FileNotFoundException, IOException {
+      int branchId) throws IOException {
 
     for (FileStatus status : HadoopUtils.listStatusRecursive(this.fss.get(branchId), writerOutput)) {
       String filePathStr = status.getPath().toString();


### PR DESCRIPTION
Changed `if (this.fss.get(branchId).exists(writerOutputDir))` from line 135 to line 111. Originally `addWriterOutputToExistingDir` (line 124) may throw FileNotFoundException if the workunit produced no data.