### PR TITLE
Remove multi-level data conversion in JdbcExtractor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -103,6 +103,8 @@ ext.externalDependency = [
   "salesforcePartner": "com.force.api:force-partner-api:29.0.0",
   "scala": "org.scala-lang:scala-library:2.10.3",
   "influxdbJava": "org.influxdb:influxdb-java:1.5",
+  "lombok":"org.projectlombok:lombok:1.16.4",
+  "mockRunnerJdbc":"com.mockrunner:mockrunner-jdbc:1.0.8",
   "byteman": "org.jboss.byteman:byteman:"+bytemanVersion,
   "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:"+bytemanVersion,
   "pegasus" : [

--- a/build.gradle
+++ b/build.gradle
@@ -105,6 +105,7 @@ ext.externalDependency = [
   "influxdbJava": "org.influxdb:influxdb-java:1.5",
   "lombok":"org.projectlombok:lombok:1.16.4",
   "mockRunnerJdbc":"com.mockrunner:mockrunner-jdbc:1.0.8",
+  "xerces":"xercesImpl:2.11.0",
   "byteman": "org.jboss.byteman:byteman:"+bytemanVersion,
   "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:"+bytemanVersion,
   "pegasus" : [
@@ -150,6 +151,11 @@ subprojects {
     excludeFilter = file(rootProject.projectDir.path + "/ligradle/findbugs/findbugsExclude.xml")
   }
 */
+  // MockRunner brings outdated dependency of xerces-impl 2.4.0 which fails MRJobLauncher tests.
+  configurations.all {
+    resolutionStrategy.force 'xerces:xercesImpl:2.11.0'
+  }
+
   configurations {
     compile
     dependencies {

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -35,6 +35,9 @@ dependencies {
   compile externalDependency.kafkaClient
   compile externalDependency.scala
   compile externalDependency.findBugs
+  compile externalDependency.mockito
+  compile externalDependency.lombok
+  compile externalDependency.mockRunnerJdbc
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2
   } else {

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/jdbc/JdbcExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/jdbc/JdbcExtractorTest.java
@@ -1,0 +1,90 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.jdbc;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+import java.sql.ResultSet;
+import java.sql.Types;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.commons.lang.StringUtils;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.mockrunner.mock.jdbc.MockResultSet;
+
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.extract.CommandOutput;
+import gobblin.source.extractor.extract.jdbc.JdbcCommand;
+import gobblin.source.extractor.extract.jdbc.JdbcCommandOutput;
+import gobblin.source.extractor.extract.jdbc.JdbcExtractor;
+import gobblin.source.extractor.extract.jdbc.MysqlExtractor;
+
+@Test(groups = { "gobblin.source.extractor.extract.jdbc" })
+public class JdbcExtractorTest {
+
+  private final static List<MockJdbcColumn> COLUMNS = ImmutableList.of(new MockJdbcColumn("id", "1", Types.INTEGER),
+      new MockJdbcColumn("name", "name_1", Types.VARCHAR), new MockJdbcColumn("age", "20", Types.INTEGER));
+
+  @Test
+  public void testGetData() throws Exception {
+
+    CommandOutput<JdbcCommand, ResultSet> output = new JdbcCommandOutput();
+    output.put(new JdbcCommand(), buildMockResultSet());
+
+    State state = new WorkUnitState();
+    state.setId("id");
+    JdbcExtractor jdbcExtractor = new MysqlExtractor((WorkUnitState) state);
+
+    List<String> columnNames = Lists.newArrayListWithCapacity(COLUMNS.size());
+
+    for (MockJdbcColumn mockJdbcColumn:COLUMNS) {
+      columnNames.add(mockJdbcColumn.getColumnName());
+    }
+
+    jdbcExtractor.setHeaderRecord(columnNames);
+
+    Iterator<JsonElement> itr = jdbcExtractor.getData(output);
+
+    // Make sure there is an element in the iterator
+    assertTrue(itr.hasNext());
+
+    JsonObject obj = itr.next().getAsJsonObject();
+
+    // Verify the columns
+    for (MockJdbcColumn column : COLUMNS) {
+      assertEquals(obj.get(column.getColumnName()).getAsString(), column.getValue());
+    }
+  }
+
+  /*
+   * Build a mock implementation of Result using Mockito
+   */
+  private ResultSet buildMockResultSet() throws Exception {
+
+    MockResultSet mrs = new MockResultSet(StringUtils.EMPTY);
+
+    for (MockJdbcColumn column : COLUMNS) {
+      mrs.addColumn(column.getColumnName(), ImmutableList.of(column.getValue()));
+    }
+
+    return mrs;
+  }
+
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/jdbc/MockJdbcColumn.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/jdbc/MockJdbcColumn.java
@@ -1,0 +1,25 @@
+/* (c) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.jdbc;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MockJdbcColumn {
+
+  private final String columnName;
+  private final String value;
+  private final int type;
+
+}


### PR DESCRIPTION
1. Replaced conversion logic from resultSet to JsonObject
Previously -- ResultSet -> List -> Map -> Json - > gson -> JsonObject
Now -- ResultSet -> JsonObject 
2. Added unit tests
3. Verified in standalone mode for sample MySql table running locally