### PR TITLE
Support for running test harness on Azkaban

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -479,4 +479,5 @@ public class ConfigurationKeys {
    * Other configuration properties.
    */
   public static final Charset DEFAULT_CHARSET_ENCODING = Charsets.UTF_8;
+  public static final String TEST_HARNESS_LAUNCHER_IMPL = "gobblin.testharness.launcher.impl";
 }

--- a/gobblin-azkaban/build.gradle
+++ b/gobblin-azkaban/build.gradle
@@ -14,6 +14,7 @@ dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-compaction")
   compile project(":gobblin-runtime")
+  compile project(":gobblin-test-harness")
   compile project(":gobblin-metastore")
 
   compile externalDependency.azkaban

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanIntegrationTestLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanIntegrationTestLauncher.java
@@ -18,6 +18,7 @@ import org.apache.log4j.Logger;
 
 import azkaban.jobExecutor.AbstractJob;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.test.setup.config.TestHarnessLauncher;
 
 /**
@@ -40,6 +41,7 @@ public class AzkabanIntegrationTestLauncher extends AbstractJob {
   @Override
   public void run() throws Exception {
     // Get the test harness launcher instance
+    launcher = createTestHarnessInstance();
 
     // Read the properties file
     launcher.configure(properties);
@@ -49,5 +51,16 @@ public class AzkabanIntegrationTestLauncher extends AbstractJob {
 
     // Execute them
     launcher.launchTest();
+  }
+
+  private TestHarnessLauncher createTestHarnessInstance()
+      throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    if (!properties.containsKey(ConfigurationKeys.TEST_HARNESS_LAUNCHER_IMPL)) {
+      throw new RuntimeException("Unable to launch Test Harness. No implementation class found");
+    }
+
+    final String className = properties.getProperty(ConfigurationKeys.TEST_HARNESS_LAUNCHER_IMPL);
+    final Class<TestHarnessLauncher> clazz = (Class<TestHarnessLauncher>) Class.forName(className);
+    return clazz.newInstance();
   }
 }

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanIntegrationTestLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanIntegrationTestLauncher.java
@@ -1,0 +1,52 @@
+/* (c) 2014 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.azkaban;
+
+import java.util.Properties;
+
+import org.apache.log4j.Logger;
+
+import azkaban.jobExecutor.AbstractJob;
+
+import gobblin.test.setup.config.TestHarnessLauncher;
+
+/**
+ * This class launches the TestHarness framework using Azkaban
+ *
+ * Created by spyne on 6/8/15.
+ */
+public class AzkabanIntegrationTestLauncher extends AbstractJob {
+  private static final Logger LOG = Logger.getLogger(AzkabanIntegrationTestLauncher.class);
+
+  private final Properties properties;
+
+  private TestHarnessLauncher launcher;
+
+  public AzkabanIntegrationTestLauncher(String id, Properties properties) {
+    super(id, LOG);
+    this.properties = properties;
+  }
+
+  @Override
+  public void run() throws Exception {
+    // Get the test harness launcher instance
+
+    // Read the properties file
+    launcher.configure(properties);
+
+    // Prepare the tests to be run
+    launcher.prepareTest();
+
+    // Execute them
+    launcher.launchTest();
+  }
+}

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanIntegrationTestLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanIntegrationTestLauncher.java
@@ -1,4 +1,5 @@
-/* (c) 2014 LinkedIn Corp. All rights reserved.
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
  * this file except in compliance with the License. You may obtain a copy of the

--- a/gobblin-test-harness/src/main/java/gobblin/test/setup/config/TestHarnessLauncher.java
+++ b/gobblin-test-harness/src/main/java/gobblin/test/setup/config/TestHarnessLauncher.java
@@ -12,8 +12,7 @@
 
 package gobblin.test.setup.config;
 
-import java.io.File;
-
+import java.util.Properties;
 
 /**
  * An interface for parsing the config data for test harness.
@@ -28,9 +27,10 @@ public interface TestHarnessLauncher extends ConfigStepsGenerator {
   /**
    *  This method will parse the config based on the input provided
    *
+   * @param properties The configuration properties
    */
 
-  public void parseConfigEntry(File f);
+  public void configure(Properties properties);
 
   /**
    *  This method will validate the config implementer, this allows to customize the config validation


### PR DESCRIPTION
Added a class to enable running the test harness on Azkaban. The class reads a properties file hardcoded to testharness.gobblin.azkaban.properties in the working directory. This file may be used to run different configurations of tests using the Test Harness.