### PR TITLE
Fix bug in AvroUtils, add default schema to KafkaAvroExtractor, add logdir option to gobblin-standalone.sh

### DIFF
--- a/bin/gobblin-standalone.sh
+++ b/bin/gobblin-standalone.sh
@@ -10,6 +10,7 @@ function print_usage(){
   echo "  --workdir <job work dir>                       Gobblin's base work directory: if not set, taken from \${GOBBLIN_WORK_DIR}"
   echo "  --jars <comma-separated list of job jars>      Job jar(s): if not set, "$FWDIR_LIB" is examined"
   echo "  --conf <directory of job configuration files>  Directory of job configuration files: if not set, taken from ${GOBBLIN_JOB_CONFIG_DIR}"
+  echo "  --logdir <directory of log files>              Directory of log files: if not set, "$FWDIR_LIB/logs" is used"
   echo "  --help                                         Display this help and exit"
 }
 
@@ -36,6 +37,10 @@ do
       ;;
     --conf)
       JOB_CONFIG_DIR="$2"
+      shift
+      ;;
+    --logdir)
+      LOG_DIR="$2"
       shift
       ;;
     --help)
@@ -75,6 +80,10 @@ if [ -z "$GOBBLIN_WORK_DIR" ] && [ "$check" == true ]; then
   die "GOBBLIN_WORK_DIR is not set!"
 fi
 
+if [ -z "$LOG_DIR" ]; then
+  LOG_DIR="$FWDIR/logs"
+fi
+
 . $FWDIR_CONF/gobblin-env.sh
 
 CONFIG_FILE=$FWDIR_CONF/gobblin-standalone.properties
@@ -87,8 +96,8 @@ else
   PID_VALUE=""
 fi
 
-if [ ! -d "$FWDIR/logs" ]; then
-  mkdir "$FWDIR/logs"
+if [ ! -d "$LOG_DIR" ]; then
+  mkdir "$LOG_DIR"
 fi
 
 set_user_jars(){
@@ -130,9 +139,9 @@ start() {
   COMMAND+="-XX:+UseConcMarkSweepGC -XX:+UseParNewGC "
   COMMAND+="-XX:+PrintGCDetails -XX:+PrintGCDateStamps -XX:+PrintTenuringDistribution "
   COMMAND+="-XX:+UseCompressedOops "
-  COMMAND+="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$FWDIR/logs/ "
-  COMMAND+="-Xloggc:$FWDIR/logs/gobblin-gc.log "
-  COMMAND+="-Dgobblin.logs.dir=$FWDIR/logs "
+  COMMAND+="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=$LOG_DIR/ "
+  COMMAND+="-Xloggc:$LOG_DIR/gobblin-gc.log "
+  COMMAND+="-Dgobblin.logs.dir=$LOG_DIR "
   COMMAND+="-Dlog4j.configuration=file://$FWDIR_CONF/log4j-standalone.xml "
   COMMAND+="-cp $CLASSPATH "
   COMMAND+="-Dorg.quartz.properties=$FWDIR_CONF/quartz.properties "

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -416,7 +416,7 @@ public class ConfigurationKeys {
   public static final boolean DEFAULT_COMPACTION_USE_ALL_ATTRIBUTES = false;
   public static final String COMPACTION_JOB_RUNNER_CLASS = COMPACTION_PREFIX + "job.runner.class";
   public static final String DEFAULT_COMPACTION_JOB_RUNNER_CLASS =
-      "gobblin.compaction.mapreduce.avro.MRCompactorAvroKeyJobRunner";
+      "gobblin.compaction.mapreduce.avro.MRCompactorAvroKeyDedupJobRunner";
   public static final String COMPACTION_COMPACTOR_CLASS = COMPACTION_PREFIX + "compactor.class";
   public static final String DEFAULT_COMPACTION_COMPACTOR_CLASS = "gobblin.compaction.mapreduce.MRCompactor";
   public static final String COMPACTION_FILE_SYSTEM_URI = COMPACTION_PREFIX + "file.system.uri";

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
@@ -17,19 +17,22 @@ import java.util.Arrays;
 import kafka.message.MessageAndOffset;
 
 import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.Decoder;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.commons.codec.binary.Hex;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
+
 import gobblin.configuration.WorkUnitState;
 import gobblin.metrics.kafka.KafkaAvroSchemaRegistry;
 import gobblin.metrics.kafka.SchemaNotFoundException;
+import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.util.AvroUtils;
 
@@ -42,10 +45,13 @@ import gobblin.util.AvroUtils;
 public class KafkaAvroExtractor extends KafkaExtractor<Schema, GenericRecord> {
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaAvroExtractor.class);
+  private static final Schema DEFAULT_SCHEMA = SchemaBuilder.record("DefaultSchema").fields().name("header")
+      .type(SchemaBuilder.record("header").fields().name("time").type("long").withDefault(0).endRecord()).noDefault()
+      .endRecord();
 
-  private final Schema schema;
+  private final Optional<Schema> schema;
   private final KafkaAvroSchemaRegistry schemaRegistry;
-  private final DatumReader<Record> reader;
+  private final Optional<GenericDatumReader<Record>> reader;
 
   /**
    * @param state state should contain property "kafka.schema.registry.url", and optionally
@@ -54,20 +60,37 @@ public class KafkaAvroExtractor extends KafkaExtractor<Schema, GenericRecord> {
    * @throws SchemaNotFoundException if the latest schema of the topic cannot be retrieved
    * from the schema registry.
    */
-  public KafkaAvroExtractor(WorkUnitState state) throws SchemaNotFoundException {
+  public KafkaAvroExtractor(WorkUnitState state) {
     super(state);
     this.schemaRegistry = new KafkaAvroSchemaRegistry(state.getProperties());
-    this.schema = getLatestSchemaByTopic();
-    this.reader = new GenericDatumReader<Record>(this.schema);
+    this.schema = Optional.fromNullable(getLatestSchemaByTopic());
+    if (this.schema.isPresent()) {
+      this.reader = Optional.of(new GenericDatumReader<Record>(this.schema.get()));
+    } else {
+      this.reader = Optional.absent();
+    }
   }
 
-  private Schema getLatestSchemaByTopic() throws SchemaNotFoundException {
-    return this.schemaRegistry.getLatestSchemaByTopic(this.topicName);
+  private Schema getLatestSchemaByTopic() {
+    try {
+      return this.schemaRegistry.getLatestSchemaByTopic(this.topicName);
+    } catch (SchemaNotFoundException e) {
+      LOG.error(String.format("Cannot find latest schema for topic %s. This topic will be skipped", this.topicName), e);
+      return null;
+    }
+  }
+
+  @Override
+  public GenericRecord readRecordImpl(GenericRecord reuse) throws DataRecordException, IOException {
+    if (!this.schema.isPresent()) {
+      return null;
+    }
+    return super.readRecordImpl(reuse);
   }
 
   @Override
   public Schema getSchema() {
-    return this.schema;
+    return this.schema.or(DEFAULT_SCHEMA);
   }
 
   @Override
@@ -81,14 +104,14 @@ public class KafkaAvroExtractor extends KafkaExtractor<Schema, GenericRecord> {
     String schemaId = Hex.encodeHexString(schemaIdByteArray);
     Schema schema = null;
     schema = this.schemaRegistry.getSchemaById(schemaId);
-    reader.setSchema(schema);
+    reader.get().setSchema(schema);
     Decoder binaryDecoder =
         DecoderFactory.get().binaryDecoder(payload, 1 + KafkaAvroSchemaRegistry.SCHEMA_ID_LENGTH_BYTE,
             payload.length - 1 - KafkaAvroSchemaRegistry.SCHEMA_ID_LENGTH_BYTE, null);
     try {
-      GenericRecord record = reader.read(null, binaryDecoder);
+      GenericRecord record = reader.get().read(null, binaryDecoder);
       if (!record.getSchema().equals(this.schema)) {
-        record = AvroUtils.convertRecordSchema(record, this.schema);
+        record = AvroUtils.convertRecordSchema(record, this.schema.get());
       }
       return record;
     } catch (IOException e) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroSource.java
@@ -12,13 +12,13 @@
 package gobblin.source.extractor.extract.kafka;
 
 import gobblin.configuration.WorkUnitState;
-import gobblin.metrics.kafka.SchemaNotFoundException;
 import gobblin.source.extractor.Extractor;
 
 import java.io.IOException;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+
 
 /**
  * A {@link gobblin.source.Source} class for Kafka where events are in Avro format.
@@ -28,10 +28,6 @@ import org.apache.avro.generic.GenericRecord;
 public class KafkaAvroSource extends KafkaSource<Schema, GenericRecord> {
   @Override
   public Extractor<Schema, GenericRecord> getExtractor(WorkUnitState state) throws IOException {
-    try {
-      return new KafkaAvroExtractor(state);
-    } catch (SchemaNotFoundException e) {
-      throw new IOException(e);
-    }
+    return new KafkaAvroExtractor(state);
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -96,6 +96,9 @@ public class AvroUtils {
    * @return the schema of the field
    */
   private static Optional<Schema> getFieldSchemaHelper(Schema schema, List<String> pathList, int field) {
+    if (schema.getField(pathList.get(field)) == null) {
+      return Optional.absent();
+    }
     if ((field + 1) == pathList.size()) {
       return Optional.fromNullable(schema.getField(pathList.get(field)).schema());
     } else {


### PR DESCRIPTION
- Added an option to specify the log dir in gobblin-standalone.sh, which is needed for the Kafka adapter test harness.
- In KafkaAvroExtractor, if the topic schema of the workunit is not found, give it a default schema. Because currently even if a workunit extracts 0 record, a data writer is still created, and we need an Avro schema in order to create an Avro data writer.
- In `AvroUtils.getFieldSchemaHelper`, added a `if` block to avoid NPE.