### PR TITLE
Create empty workunit when skipping a Kafka partition

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -34,7 +34,6 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 import com.google.common.primitives.Longs;
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.SourceState;
@@ -378,21 +377,39 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
       SourceState state) {
     Offsets offsets = new Offsets();
 
+    boolean failedToGetKafkaOffsets = false;
+
     try {
       offsets.setEarliestOffset(kafkaWrapper.getEarliestOffset(partition));
       offsets.setLatestOffset(kafkaWrapper.getLatestOffset(partition));
-      if (shouldMoveToLatestOffset(partition, state)) {
-        offsets.startAtLatestOffset();
-      } else {
-        offsets.startAt(getPreviousOffsetForPartition(partition, state));
-      }
     } catch (KafkaOffsetRetrievalFailureException e) {
+      failedToGetKafkaOffsets = true;
+    }
+
+    long previousOffset = 0;
+    boolean previousOffsetNotFound = false;
+    try {
+      previousOffset = getPreviousOffsetForPartition(partition, state);
+    } catch (PreviousOffsetNotFoundException e) {
+      previousOffsetNotFound = true;
+    }
+
+    if (failedToGetKafkaOffsets) {
+
+      // When unable to get earliest/latest offsets from Kafka, skip the partition and create an empty workunit,
+      // so that previousOffset is persisted.
       LOG.warn(String.format(
           "Failed to retrieve earliest and/or latest offset for partition %s. This partition will be skipped.",
           partition));
-      return null;
+      return previousOffsetNotFound ? null : getEmptyWorkunit(partition, state, previousOffset);
+    }
 
-    } catch (PreviousOffsetNotFoundException e) {
+    if (shouldMoveToLatestOffset(partition, state)) {
+      offsets.startAtLatestOffset();
+    } else if (previousOffsetNotFound) {
+
+      // When previous offset cannot be found, either start at earliest offset or latest offset, or skip the partition
+      // (no need to create an empty workunit in this case since there's no offset to persist).
       String offsetNotFoundMsg = String.format("Previous offset for partition %s does not exist. ", partition);
       String offsetOption = state.getProp(BOOTSTRAP_WITH_OFFSET, DEFAULT_BOOTSTRAP_WITH_OFFSET).toLowerCase();
       if (offsetOption.equals(LATEST_OFFSET)) {
@@ -406,25 +423,31 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
         LOG.warn(offsetNotFoundMsg + "This partition will be skipped.");
         return null;
       }
+    } else {
+      try {
+        offsets.startAt(previousOffset);
+      } catch (StartOffsetOutOfRangeException e) {
 
-    } catch (StartOffsetOutOfRangeException e) {
-      String offsetOutOfRangeMsg = String.format(String.format(
-          "Start offset for partition %s is out of range. Start offset = %d, earliest offset = %d, latest offset = %d.",
-          partition, offsets.getStartOffset(), offsets.getEarliestOffset(), offsets.getLatestOffset()));
-      String offsetOption =
-          state.getProp(RESET_ON_OFFSET_OUT_OF_RANGE, DEFAULT_RESET_ON_OFFSET_OUT_OF_RANGE).toLowerCase();
-      if (offsetOption.equals(LATEST_OFFSET)
-          || (offsetOption.equals(NEAREST_OFFSET) && offsets.getStartOffset() >= offsets.getLatestOffset())) {
-        LOG.warn(
-            offsetOutOfRangeMsg + "This partition will start from the latest offset: " + offsets.getLatestOffset());
-        offsets.startAtLatestOffset();
-      } else if (offsetOption.equals(EARLIEST_OFFSET) || offsetOption.equals(NEAREST_OFFSET)) {
-        LOG.warn(
-            offsetOutOfRangeMsg + "This partition will start from the earliest offset: " + offsets.getEarliestOffset());
-        offsets.startAtEarliestOffset();
-      } else {
-        LOG.warn(offsetOutOfRangeMsg + "This partition will be skipped.");
-        return null;
+        // When previous offset is out of range, either start at earliest, latest or nearest offset, or skip the
+        // partition. If skipping, need to create an empty workunit so that previousOffset is persisted.
+        String offsetOutOfRangeMsg = String.format(String.format(
+            "Start offset for partition %s is out of range. Start offset = %d, earliest offset = %d, latest offset = %d.",
+            partition, offsets.getStartOffset(), offsets.getEarliestOffset(), offsets.getLatestOffset()));
+        String offsetOption =
+            state.getProp(RESET_ON_OFFSET_OUT_OF_RANGE, DEFAULT_RESET_ON_OFFSET_OUT_OF_RANGE).toLowerCase();
+        if (offsetOption.equals(LATEST_OFFSET)
+            || (offsetOption.equals(NEAREST_OFFSET) && offsets.getStartOffset() >= offsets.getLatestOffset())) {
+          LOG.warn(
+              offsetOutOfRangeMsg + "This partition will start from the latest offset: " + offsets.getLatestOffset());
+          offsets.startAtLatestOffset();
+        } else if (offsetOption.equals(EARLIEST_OFFSET) || offsetOption.equals(NEAREST_OFFSET)) {
+          LOG.warn(offsetOutOfRangeMsg + "This partition will start from the earliest offset: "
+              + offsets.getEarliestOffset());
+          offsets.startAtEarliestOffset();
+        } else {
+          LOG.warn(offsetOutOfRangeMsg + "This partition will be skipped.");
+          return getEmptyWorkunit(partition, state, previousOffset);
+        }
       }
     }
 
@@ -469,6 +492,14 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
           Splitter.on(',').trimResults().omitEmptyStrings().splitToList(state.getProp(TOPICS_MOVE_TO_LATEST_OFFSET)));
     }
     return this.moveToLatestTopics.contains(partition.getTopicName()) || moveToLatestTopics.contains(ALL_TOPICS);
+  }
+
+  private static WorkUnit getEmptyWorkunit(KafkaPartition partition, SourceState state, long previousOffset) {
+    Offsets offsets = new Offsets();
+    offsets.setEarliestOffset(previousOffset);
+    offsets.setLatestOffset(previousOffset);
+    offsets.startAtEarliestOffset();
+    return getWorkUnitForTopicPartition(partition, state, offsets);
   }
 
   private static WorkUnit getWorkUnitForTopicPartition(KafkaPartition partition, SourceState state, Offsets offsets) {


### PR DESCRIPTION
Before: if a partition is skipped (e.g., unable to get offsets from Kafka or other reasons), no workunit will be created. But this means the previous pulled offset will be lost.

Now: create an empty workunit, so that the previous offset can be persisted in the state store and is available for the next run.