### PR TITLE
Improvement and bug fix for MR-based compaction

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -393,11 +393,9 @@ public class ConfigurationKeys {
   public static final String COMPACTION_WHITELIST = COMPACTION_PREFIX + "whitelist";
   public static final String COMPACTION_HIGH_PRIORITY_TOPICS = COMPACTION_PREFIX + "high.priority.topics";
   public static final String COMPACTION_NORMAL_PRIORITY_TOPICS = COMPACTION_PREFIX + "normal.priority.topics";
-  public static final String COMPACTION_FORCE_REPROCESS = COMPACTION_PREFIX + "force.reprocess";
-  public static final boolean DEFAULT_COMPACTION_FORCE_REPROCESS = false;
   public static final String COMPACTION_JOBPROPS_CREATOR_CLASS = COMPACTION_PREFIX + "jobprops.creator.class";
   public static final String DEFAULT_COMPACTION_JOBPROPS_CREATOR_CLASS =
-      "gobblin.compaction.mapreduce.MRCompactorJobPropCreator";
+      "gobblin.compaction.mapreduce.MRCompactorTimeBasedJobPropCreator";
   public static final String COMPACTION_TIMEBASED_FOLDER_PATTERN = COMPACTION_PREFIX + "timebased.folder.pattern";
   public static final String DEFAULT_COMPACTION_TIMEBASED_FOLDER_PATTERN = "YYYY/MM/dd";
   public static final String COMPACTION_TIMEZONE = COMPACTION_PREFIX + "timezone";
@@ -428,6 +426,10 @@ public class ConfigurationKeys {
   public static final String COMPACTION_FILE_SYSTEM_URI = COMPACTION_PREFIX + "file.system.uri";
   public static final String COMPACTION_MR_JOB_TIMEOUT_MINUTES = COMPACTION_PREFIX + "mr.job.timeout.minutes";
   public static final int DEFAULT_COMPACTION_MR_JOB_TIMEOUT_MINUTES = Integer.MAX_VALUE;
+  public static final String COMPACTION_COMPLETE_FILE_NAME = "_COMPACTION_COMPLETE";
+  public static final String COMPACTION_ENABLE_SUCCESS_FILE = "mapreduce.fileoutputcommitter.marksuccessfuljobs";
+  public static final String COMPACTION_OVERWRITE_OUTPUT_DIR = COMPACTION_PREFIX + "overwrite.output.dir";
+  public static final boolean DEFAULT_COMPACTION_OVERWRITE_OUTPUT_DIR = false;
 
   /**
    * Common metrics configuration properties.
@@ -438,16 +440,19 @@ public class ConfigurationKeys {
   public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(true);
   public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
   public static final String DEFAULT_METRICS_FILE_SUFFIX = "";
-  public static final String METRICS_REPORTING_FILE_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
+  public static final String METRICS_REPORTING_FILE_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
   public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_JMX_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
+  public static final String METRICS_REPORTING_JMX_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
   public static final String DEFAULT_METRICS_REPORTING_JMX_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
+  public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_ENABLED = Boolean.toString(false);
   public static final String METRICS_REPORTING_KAFKA_FORMAT = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.format";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_FORMAT = "json";
-  public static final String METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY = METRICS_CONFIGURATIONS_PREFIX +
-      "reporting.kafka.avro.use.schema.registry";
+  public static final String METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.avro.use.schema.registry";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY = Boolean.toString(false);
   public static final String METRICS_KAFKA_BROKERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.brokers";
   public static final String METRICS_KAFKA_TOPIC = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic";

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -158,7 +158,7 @@ public class State implements Writable {
    * @return value (the default value if the property is not set) associated with the key as a list of strings
    */
   public List<String> getPropAsList(String key, String def) {
-    return Splitter.on(",").trimResults().splitToList(getProperty(key, def));
+    return Splitter.on(",").trimResults().omitEmptyStrings().splitToList(getProperty(key, def));
   }
 
   /**


### PR DESCRIPTION
- (Improvement) Before: the compactor checks whether the outputdir exists. If exists, it checks the property `compaction.force.reprocess`. If true, it will reprocess inputdir. If false, will skip inputdir.

This is problematic if inputdir and outputdir are the same. Then the fact that outputdir exists doesn't indicate whether it has been compacted or not.

Now: after compaction is done, a file named `_COMPACTION_COMPLETE` will be created in outputdir. Property `compaction.force.reprocess` is no longer used. Now if outputdir exists and has `_COMPACTION_COMPLETE`, will skip inputdir. Otherwise, will process inputdir.

- (Bug) Before: the outputdir is deleted immediately when it decides to process inputdir.

Again, this doesn't work if inputdir and outputdir are the same. Now: delete outputdir after the MR job is done.

We don't have a use case where inputdir = outputdir. But I think it's good to support it.