### PR TITLE
Refactored the code on how sys and job config properties are handled

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -32,6 +32,8 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.util.ForkOperatorUtils;
 import gobblin.util.HadoopUtils;
+import gobblin.util.WriterUtils;
+
 
 /**
  * An implementation of {@link DataWriter} that writes directly to HDFS in Avro format.
@@ -122,6 +124,10 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
       LOG.warn(String.format("Task output file %s already exists", this.outputFile));
       HadoopUtils.deletePath(this.fs, this.outputFile, false);
     }
+
+    // Setting the same HDFS properties as the original file
+    WriterUtils.setFileAttributesFromState(properties, fs, outputFile);
+
     HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile);
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -59,9 +59,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   protected static final String TASK_STATE_STORE_TABLE_SUFFIX = ".tst";
   protected static final String JOB_STATE_STORE_TABLE_SUFFIX = ".jst";
 
-  // System configuration properties
-  protected final Properties sysProps;
-
   // Job configuration properties
   protected final Properties jobProps;
 
@@ -90,18 +87,15 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   // An MetricContext to track runtime metrics only if metrics are enabled.
   protected final Optional<MetricContext> runtimeMetricContext;
 
-  public AbstractJobLauncher(Properties sysProps, Properties jobProps)
-      throws Exception {
+  public AbstractJobLauncher(Properties jobProps) throws Exception {
     Preconditions.checkArgument(
         jobProps.containsKey(ConfigurationKeys.JOB_NAME_KEY), "A job must have a job name specified by job.name");
 
     // Make a copy for both the system and job configuration properties
-    this.sysProps = new Properties();
-    this.sysProps.putAll(sysProps);
     this.jobProps = new Properties();
     this.jobProps.putAll(jobProps);
 
-    this.jobContext = new JobContext(this.sysProps, this.jobProps, LOG);
+    this.jobContext = new JobContext(this.jobProps, LOG);
 
     this.cancellationExecutor = Executors.newSingleThreadExecutor(
         ExecutorsUtils.newThreadFactory(Optional.of(LOG), Optional.of("CancellationExecutor")));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -58,7 +58,7 @@ public class JobContext {
   private final Source<?, ?> source;
 
   @SuppressWarnings("unchecked")
-  public JobContext(Properties sysProps, Properties jobProps, Logger logger) throws Exception {
+  public JobContext(Properties jobProps, Logger logger) throws Exception {
     Preconditions.checkArgument(jobProps.containsKey(ConfigurationKeys.JOB_NAME_KEY),
         "A job must have a job name specified by job.name");
 
@@ -73,14 +73,14 @@ public class JobContext {
         jobProps.getProperty(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, Boolean.TRUE.toString()));
 
     this.jobStateStore = new FsStateStore<JobState>(
-        sysProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI),
-        sysProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY),
+        jobProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI),
+        jobProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY),
         JobState.class);
 
     boolean jobHistoryStoreEnabled = Boolean.valueOf(
-        sysProps.getProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, Boolean.FALSE.toString()));
+        jobProps.getProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, Boolean.FALSE.toString()));
     if (jobHistoryStoreEnabled) {
-      Injector injector = Guice.createInjector(new MetaStoreModule(sysProps));
+      Injector injector = Guice.createInjector(new MetaStoreModule(jobProps));
       this.jobHistoryStoreOptional = Optional.of(injector.getInstance(JobHistoryStore.class));
     } else {
       this.jobHistoryStoreOptional = Optional.absent();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobLauncherFactory.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobLauncherFactory.java
@@ -18,6 +18,7 @@ import javax.annotation.Nonnull;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.runtime.local.LocalJobLauncher;
 import gobblin.runtime.mapreduce.MRJobLauncher;
+import gobblin.util.JobConfigurationUtils;
 
 
 /**
@@ -53,9 +54,9 @@ public class JobLauncherFactory {
         .valueOf(sysProps.getProperty(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY, JobLauncherType.LOCAL.name()));
     switch (launcherType) {
       case LOCAL:
-        return new LocalJobLauncher(sysProps, jobProps);
+        return new LocalJobLauncher(JobConfigurationUtils.combineSysAndJobProperties(sysProps, jobProps));
       case MAPREDUCE:
-        return new MRJobLauncher(sysProps, jobProps);
+        return new MRJobLauncher(JobConfigurationUtils.combineSysAndJobProperties(sysProps, jobProps));
       default:
         throw new RuntimeException("Unsupported job launcher type: " + launcherType.name());
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -62,15 +62,14 @@ public class LocalJobLauncher extends AbstractJobLauncher {
 
   private volatile CountDownLatch countDownLatch;
 
-  public LocalJobLauncher(Properties sysProps, Properties jobProps)
-      throws Exception {
-    super(sysProps, jobProps);
+  public LocalJobLauncher(Properties jobProps) throws Exception {
+    super(jobProps);
 
     Optional<Timer.Context> jobLocalSetupTimer =
         Instrumented.timerContext(this.runtimeMetricContext, MetricNames.RunJobTimings.JOB_LOCAL_SETUP);
 
-    this.taskExecutor = new TaskExecutor(sysProps);
-    this.taskStateTracker = new LocalTaskStateTracker2(sysProps, this.taskExecutor);
+    this.taskExecutor = new TaskExecutor(jobProps);
+    this.taskStateTracker = new LocalTaskStateTracker2(jobProps, this.taskExecutor);
 
     this.serviceManager = new ServiceManager(Lists.newArrayList(
         // The order matters due to dependencies between services
@@ -84,8 +83,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() throws IOException {
     try {
       // Stop all dependent services
       this.serviceManager.stopAsync().awaitStopped(5, TimeUnit.SECONDS);
@@ -97,8 +95,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   }
 
   @Override
-  protected void runWorkUnits(List<WorkUnit> workUnits)
-      throws Exception {
+  protected void runWorkUnits(List<WorkUnit> workUnits) throws Exception {
     Optional<Timer.Context> workUnitsPreparationTimer =
         Instrumented.timerContext(this.runtimeMetricContext, MetricNames.RunJobTimings.WORK_UNITS_PREPARATION);
     List<WorkUnit> workUnitsToRun = JobLauncherUtils.flattenWorkUnits(workUnits);
@@ -153,8 +150,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   }
 
   @Override
-  protected JobLock getJobLock()
-      throws IOException {
+  protected JobLock getJobLock() throws IOException {
     URI fsUri = URI.create(this.jobProps.getProperty(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
     return new FileBasedJobLock(FileSystem.get(fsUri, new Configuration()),
         this.jobProps.getProperty(ConfigurationKeys.JOB_LOCK_DIR_KEY), this.jobContext.getJobName());

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/CliMRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/CliMRJobLauncher.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.util.ToolRunner;
 import com.google.common.io.Closer;
 
 import gobblin.runtime.JobException;
+import gobblin.util.JobConfigurationUtils;
 
 
 /**
@@ -52,15 +53,11 @@ public class CliMRJobLauncher extends Configured implements Tool {
   @Override
   public int run(String[] args)
       throws Exception {
-    final Properties jobProps = new Properties();
-    // First load system configuration properties
-    jobProps.putAll(this.sysConfig);
-    // Then load job configuration properties that might overwrite system configuration properties
-    jobProps.putAll(this.jobConfig);
+    final Properties jobProps = JobConfigurationUtils.combineSysAndJobProperties(this.sysConfig, this.jobConfig);
 
     Closer closer = Closer.create();
     try {
-      closer.register(new MRJobLauncher(this.sysConfig, jobProps, getConf())).launchJob(null);
+      closer.register(new MRJobLauncher(jobProps, getConf())).launchJob(null);
     } catch (JobException je) {
       System.err.println("Failed to launch the job due to the following exception:");
       System.err.println(je.toString());

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobStateStoreTest.java
@@ -65,12 +65,11 @@ public class JobStateStoreTest {
   private static final String LAST_READ_RECORD_KEY = "last.read.record";
 
   private StateStore<JobState> jobStateStore;
-  private Properties properties;
-  private Properties jobProps;
+  private Properties jobConfig = new Properties();
 
   @BeforeClass
   public void setUp() throws Exception {
-    this.properties = new Properties();
+    Properties properties = new Properties();
     properties.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
 
     this.jobStateStore = new FsStateStore<JobState>(
@@ -78,18 +77,17 @@ public class JobStateStoreTest {
         properties.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY),
         JobState.class);
 
-    this.jobProps = new Properties();
-    this.jobProps.putAll(properties);
-    this.jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, JOB_NAME);
-    this.jobProps.setProperty(ConfigurationKeys.SOURCE_CLASS_KEY, DummySource.class.getName());
-    this.jobProps.setProperty(ConfigurationKeys.WRITER_BUILDER_CLASS, DummyDataWriterBuilder.class.getName());
+    this.jobConfig.putAll(properties);
+    this.jobConfig.setProperty(ConfigurationKeys.JOB_NAME_KEY, JOB_NAME);
+    this.jobConfig.setProperty(ConfigurationKeys.SOURCE_CLASS_KEY, DummySource.class.getName());
+    this.jobConfig.setProperty(ConfigurationKeys.WRITER_BUILDER_CLASS, DummyDataWriterBuilder.class.getName());
   }
 
   @Test
   public void testLaunchFirstJob() throws Exception {
     Closer closer = Closer.create();
     try {
-      closer.register(new LocalJobLauncher(this.properties, this.jobProps)).launchJob(null);
+      closer.register(new LocalJobLauncher(this.jobConfig)).launchJob(null);
     } finally {
       closer.close();
     }
@@ -100,7 +98,7 @@ public class JobStateStoreTest {
   public void testLaunchSecondJob() throws Exception {
     Closer closer = Closer.create();
     try {
-      closer.register(new LocalJobLauncher(this.properties, this.jobProps)).launchJob(null);
+      closer.register(new LocalJobLauncher(this.jobConfig)).launchJob(null);
     } finally {
       closer.close();
     }
@@ -111,7 +109,7 @@ public class JobStateStoreTest {
   public void testLaunchThirdJob() throws Exception {
     Closer closer = Closer.create();
     try {
-      closer.register(new LocalJobLauncher(this.properties, this.jobProps)).launchJob(null);
+      closer.register(new LocalJobLauncher(this.jobConfig)).launchJob(null);
     } finally {
       closer.close();
     }

--- a/gobblin-utility/src/main/java/gobblin/util/JobConfigurationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobConfigurationUtils.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+
+import gobblin.configuration.State;
+
+
+/**
+ * A utility class for working with job configurations.
+ *
+ * @author ynli
+ */
+public class JobConfigurationUtils {
+
+  /**
+   * Get a new {@link Properties} instance by combining a given system configuration {@link Properties}
+   * object (first) and a job configuration {@link Properties} object (second).
+   *
+   * @param sysProps the given system configuration {@link Properties} object
+   * @param jobProps the given job configuration {@link Properties} object
+   * @return a new {@link Properties} instance
+   */
+  public static Properties combineSysAndJobProperties(Properties sysProps, Properties jobProps) {
+    Properties combinedJobProps = new Properties();
+    combinedJobProps.putAll(sysProps);
+    combinedJobProps.putAll(jobProps);
+    return combinedJobProps;
+  }
+
+  /**
+   * Put all configuration properties in a given {@link Properties} object into a given
+   * {@link Configuration} object.
+   *
+   * @param properties the given {@link Properties} object
+   * @param configuration the given {@link Configuration} object
+   */
+  public static void putPropertiesIntoConfiguration(Properties properties, Configuration configuration) {
+    for (String name : properties.stringPropertyNames()) {
+      configuration.set(name, properties.getProperty(name));
+    }
+  }
+
+  /**
+   * Put all configuration properties in a given {@link State} object into a given
+   * {@link Configuration} object.
+   *
+   * @param state the given {@link State} object
+   * @param configuration the given {@link Configuration} object
+   */
+  public static void putStateIntoConfiguration(State state, Configuration configuration) {
+    for (String key : state.getPropertyNames()) {
+      configuration.set(key, state.getProp(key));
+    }
+  }
+}


### PR DESCRIPTION
1. Refactored the code on how system and job config properties are handled and passed around. With the changes, `AbstractJobLauncher` nows takes only a single `Properties` object that includes both system and job config properties. 
2. Added a `JobConfigurationUtils` and used it.
3. Added `WriterUtils.setFileAttributesFromState(properties, fs, outputFile);` back to `AvroHdfsDataWriter` that was deleted by accident in #123.

Signed-off-by: Yinan Li <liyinan926@gmail.com>