### PR TITLE
Use current system time if record timestamp is not present

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/avro/AvroFieldRetrieverConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/AvroFieldRetrieverConverter.java
@@ -64,7 +64,7 @@ public class AvroFieldRetrieverConverter extends Converter<Schema, Schema, Gener
   @Override
   public Iterable<Object> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit)
       throws DataConversionException {
-    Optional<Object> field = AvroUtils.getFieldValue(inputRecord, this.fieldLocation);
+    Optional<Object> field = AvroUtils.getFieldValue(inputRecord, Optional.fromNullable(this.fieldLocation));
 
     return field.isPresent() ? new SingleRecordIterable<Object>(field.get()) : new EmptyIterable<Object>();
   }

--- a/gobblin-core/src/main/java/gobblin/converter/filter/AvroFilterConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/filter/AvroFilterConverter.java
@@ -78,7 +78,7 @@ public class AvroFilterConverter extends AvroToAvroConverterBase {
   @Override
   public Iterable<GenericRecord> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit)
       throws DataConversionException {
-    Optional<Object> fieldValue = AvroUtils.getFieldValue(inputRecord, this.fieldName);
+    Optional<Object> fieldValue = AvroUtils.getFieldValue(inputRecord, Optional.fromNullable(this.fieldName));
     if (fieldValue.isPresent() && fieldValue.get().toString().equals(this.fieldValue)) {
       return new SingleRecordIterable<GenericRecord>(inputRecord);
     }

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
+import com.google.common.primitives.Longs;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
@@ -85,7 +86,7 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
   /**
    * The name of the column that the writer will use to partition the data.
    */
-  private final String partitionColumnName;
+  private final Optional<String> partitionColumnName;
 
   /**
    * The name that separates the {@link #baseFilePath} from the path created by the {@link #timestampToPathFormatter}.
@@ -142,26 +143,13 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
         this.properties.getProp(getWriterPartitionLevel(), ConfigurationKeys.DEFAULT_WRITER_PARTITION_LEVEL);
 
     // Initialize the timestampToPathFormatter
-    this.timestampToPathFormatter =
-        DateTimeFormat.forPattern(
+    this.timestampToPathFormatter = DateTimeFormat
+        .forPattern(
             this.properties.getProp(getWriterPartitionPattern(), ConfigurationKeys.DEFAULT_WRITER_PARTITION_PATTERN))
-            .withZone(
-                DateTimeZone.forID(this.properties.getProp(ConfigurationKeys.WRITER_PARTITION_TIMEZONE,
-                    ConfigurationKeys.DEFAULT_WRITER_PARTITION_TIMEZONE)));
+        .withZone(DateTimeZone.forID(this.properties.getProp(ConfigurationKeys.WRITER_PARTITION_TIMEZONE,
+            ConfigurationKeys.DEFAULT_WRITER_PARTITION_TIMEZONE)));
 
-    // Check that ConfigurationKeys.WRITER_PARTITION_COLUMN_NAME has been specified and is properly formed
-    Preconditions.checkArgument(this.properties.contains(getWriterPartitionColumnName()), "Missing required property "
-        + ConfigurationKeys.WRITER_PARTITION_COLUMN_NAME);
-
-    this.partitionColumnName = this.properties.getProp(getWriterPartitionColumnName());
-    Optional<Schema> writerPartitionColumnSchema = AvroUtils.getFieldSchema(this.schema, this.partitionColumnName);
-
-    Preconditions.checkArgument(writerPartitionColumnSchema.isPresent(), "The column " + this.partitionColumnName
-        + " specified by " + ConfigurationKeys.WRITER_PARTITION_COLUMN_NAME + " is not in the writer input schema");
-
-    Preconditions.checkArgument(writerPartitionColumnSchema.get().getType().equals(Schema.Type.LONG), "The column "
-        + this.partitionColumnName + " specified by " + ConfigurationKeys.WRITER_PARTITION_COLUMN_NAME
-        + " must be of type " + Schema.Type.LONG);
+    this.partitionColumnName = Optional.fromNullable(this.properties.getProp(getWriterPartitionColumnName()));
   }
 
   @Override
@@ -169,9 +157,12 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
 
     // Retrieve the value of the field specified by this.partitionColumnName
     Optional<Object> writerPartitionColumnValue = AvroUtils.getFieldValue(record, this.partitionColumnName);
-    Preconditions.checkState(writerPartitionColumnValue.isPresent());
 
-    Path writerOutputPath = getPathForColumnValue((Long) writerPartitionColumnValue.get());
+    // Check if the partition column value is present and can be cast to Long. Otherwise, use current system time.
+    long recordTimestamp = isPartitionValueUsable(writerPartitionColumnValue) ? (Long) writerPartitionColumnValue.get()
+        : System.currentTimeMillis();
+
+    Path writerOutputPath = getPathForColumnValue(recordTimestamp);
 
     // If the path is not in pathToWriterMap, construct a new DataWriter, add it to the map, and write the record
     // If the path is in pathToWriterMap simply retrieve the writer, and write the record
@@ -185,6 +176,14 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
     }
 
     this.pathToWriterMap.get(writerOutputPath).write(record);
+  }
+
+  /**
+   * Checks whether the given value is present and can be cast to Long.
+   */
+  private boolean isPartitionValueUsable(Optional<Object> writerPartitionColumnValue) {
+    return writerPartitionColumnValue.isPresent()
+        && Longs.tryParse(writerPartitionColumnValue.get().toString()) != null;
   }
 
   @Override
@@ -312,8 +311,8 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
    * Helper method to get the branched configuration key for {@link ConfigurationKeys#WRITER_FILE_PATH}.
    */
   private String getWriterFilePath() {
-    return ForkOperatorUtils
-        .getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PATH, this.numBranches, this.branch);
+    return ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PATH, this.numBranches,
+        this.branch);
   }
 
   /**

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -115,12 +115,15 @@ public class AvroUtils {
    * @param fieldLocation is the location of the field
    * @return the value of the field
    */
-  public static Optional<Object> getFieldValue(GenericRecord record, String fieldLocation) {
+  public static Optional<Object> getFieldValue(GenericRecord record, Optional<String> fieldLocation) {
     Preconditions.checkNotNull(record);
-    Preconditions.checkArgument(!Strings.isNullOrEmpty(fieldLocation));
+
+    if (!fieldLocation.isPresent()) {
+      return Optional.absent();
+    }
 
     Splitter splitter = Splitter.on(FIELD_LOCATION_DELIMITER).omitEmptyStrings().trimResults();
-    List<String> pathList = splitter.splitToList(fieldLocation);
+    List<String> pathList = splitter.splitToList(fieldLocation.get());
 
     if (pathList.size() == 0) {
       return Optional.absent();


### PR DESCRIPTION
Before: `AvroHdfsTimePartitionedWriter` requires a partition field name (e.g., `header.time`), and the Avro schema must contain this field.

Now: if field name is not provided, or if Avro schema doesn't have this field, use current system time. This is consistent with Camus. There are some tracking topics whose schemas don't have a timestamp field.