### PR TITLE
change blacklist and whitelist logic

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/DatasetFilterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/DatasetFilterUtils.java
@@ -23,16 +23,15 @@ public class DatasetFilterUtils {
   }
 
   /**
-   * If whitelist is non-empty, a topic survives if it matches the whitelist.
-   * Otherwise, a topic survives if it doesn't match the blacklist.
+   * A topic survives if (1) it doesn't match the blacklist, and
+   * (2) either whitelist is empty, or it matches the whitelist.
    * Whitelist and blacklist use regex patterns (NOT glob patterns).
    */
   public static boolean survived(String topic, List<Pattern> blacklist, List<Pattern> whitelist) {
-    if (!whitelist.isEmpty()) {
-      return stringInPatterns(topic, whitelist);
-    } else {
-      return !stringInPatterns(topic, blacklist);
+    if (stringInPatterns(topic, blacklist)) {
+      return false;
     }
+    return (whitelist.isEmpty() || stringInPatterns(topic, whitelist));
   }
 
   /**


### PR DESCRIPTION
Before: is whitelist is non-empty, a topic is selected if it matches the whitelist, regardless of blacklist.
Now: topics that match blacklist will be filtered, even if they match whitelist.

This makes it easier to select a set of topics.