### PR TITLE
Fixing specification of file level attributes in AvroHdfsDataWriter

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -208,6 +208,7 @@ public class ConfigurationKeys {
   public static final String WRITER_FILE_OWNER = WRITER_PREFIX + ".file.owner";
   public static final String WRITER_FILE_GROUP = WRITER_PREFIX + ".file.group";
   public static final String WRITER_FILE_REPLICATION_FACTOR = WRITER_PREFIX + ".file.replication.factor";
+  public static final String WRITER_FILE_BLOCK_SIZE = WRITER_PREFIX + ".file.block.size";
   public static final String WRITER_FILE_PERMISSIONS = WRITER_PREFIX + ".file.permissions";
   public static final String WRITER_BUFFER_SIZE = WRITER_PREFIX + ".buffer.size";
   public static final String WRITER_PRESERVE_FILE_NAME = WRITER_PREFIX + ".preserve.file.name";
@@ -218,7 +219,7 @@ public class ConfigurationKeys {
   public static final String WRITER_PARTITION_PATTERN = WRITER_PREFIX + ".partition.pattern";
   public static final String WRITER_PARTITION_TIMEZONE = WRITER_PREFIX + ".partition.timezone";
   public static final String DEFAULT_WRITER_FILE_BASE_NAME = "part";
-  public static final String DEFAULT_DEFLATE_LEVEL = "9";
+  public static final int DEFAULT_DEFLATE_LEVEL = 9;
   public static final String DEFAULT_BUFFER_SIZE = "4096";
   public static final String DEFAULT_WRITER_PARTITION_LEVEL = "daily";
   public static final String DEFAULT_WRITER_PARTITION_PATTERN = "yyyy/MM/dd";

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -235,6 +235,27 @@ public class State implements Writable {
   }
 
   /**
+   * Get the value of a property as a short.
+   *
+   * @param key property key
+   * @return short value associated with the key
+   */
+  public short getPropAsShort(String key) {
+    return Short.parseShort(getProperty(key));
+  }
+
+  /**
+   * Get the value of a property as an short, using the given default value if the property is not set.
+   *
+   * @param key property key
+   * @param def default value
+   * @return short value associated with the key or the default value if the property is not set
+   */
+  public short getPropAsShort(String key, short def) {
+    return Short.parseShort(getProperty(key, String.valueOf(def)));
+  }
+
+  /**
    * Get the value of a property as a double.
    *
    * @param key property key

--- a/gobblin-api/src/test/java/gobblin/password/PasswordManagerTest.java
+++ b/gobblin-api/src/test/java/gobblin/password/PasswordManagerTest.java
@@ -54,7 +54,8 @@ public class PasswordManagerTest {
     State state = new State();
     state.setProp(ConfigurationKeys.ENCRYPT_KEY_LOC, masterPwdFile.toString());
     String encrypted = PasswordManager.getInstance(state).encryptPassword(password);
-    String decrypted = PasswordManager.getInstance(state).decryptPassword(encrypted);
+    encrypted = "ENC(" + encrypted + ")";
+    String decrypted = PasswordManager.getInstance(state).readPassword(encrypted);
     Assert.assertEquals(decrypted, password);
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -64,6 +64,8 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
       throws IOException {
     super(properties, fileName, numBranches, branchId);
 
+    Path filePath = new Path(fileName);
+
     CodecFactory codecFactory =
         WriterUtils.getCodecFactory(Optional.fromNullable(properties.getProp(ForkOperatorUtils
             .getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId))), Optional
@@ -78,11 +80,11 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
     short replication =
         properties.getPropAsShort(ForkOperatorUtils.getPropertyNameForBranch(
             ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR, numBranches, branchId), this.fs
-            .getDefaultReplication(new Path(fileName)));
+            .getDefaultReplication(filePath));
 
     long blockSize =
         properties.getPropAsLong(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_BLOCK_SIZE,
-            numBranches, branchId), this.fs.getDefaultBlockSize(new Path(fileName)));
+            numBranches, branchId), this.fs.getDefaultBlockSize(filePath));
 
     FsPermission permissions =
         new FsPermission(properties.getPropAsShort(ForkOperatorUtils.getPropertyNameForBranch(

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -17,15 +17,18 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumWriter;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -55,37 +58,41 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   // Whether the writer has already been closed or not
   private volatile boolean closed = false;
 
-  public enum CodecType {
-    NOCOMPRESSION,
-    DEFLATE,
-    SNAPPY
-  }
-
   public AvroHdfsDataWriter(State properties, String fileName, Schema schema, int numBranches, int branchId)
       throws IOException {
     super(properties, fileName, numBranches, branchId);
 
-    String codecType = properties
-        .getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId),
-            AvroHdfsDataWriter.CodecType.DEFLATE.name());
+    CodecFactory codecFactory =
+        WriterUtils.getCodecFactory(Optional.fromNullable(properties.getProp(ForkOperatorUtils
+            .getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId))), Optional
+            .fromNullable(properties.getProp(ForkOperatorUtils.getPropertyNameForBranch(
+                ConfigurationKeys.WRITER_DEFLATE_LEVEL, numBranches, branchId))));
 
-    int bufferSize = Integer.parseInt(properties.getProp(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUFFER_SIZE, numBranches, branchId),
-        ConfigurationKeys.DEFAULT_BUFFER_SIZE));
+    int bufferSize =
+        Integer.parseInt(properties.getProp(
+            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUFFER_SIZE, numBranches, branchId),
+            ConfigurationKeys.DEFAULT_BUFFER_SIZE));
 
-    int deflateLevel = Integer.parseInt(properties.getProp(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DEFLATE_LEVEL, numBranches, branchId),
-        ConfigurationKeys.DEFAULT_DEFLATE_LEVEL));
+    short replication =
+        properties.getPropAsShort(ForkOperatorUtils.getPropertyNameForBranch(
+            ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR, numBranches, branchId), this.fs
+            .getDefaultReplication(new Path(fileName)));
+
+    long blockSize =
+        properties.getPropAsLong(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_BLOCK_SIZE,
+            numBranches, branchId), this.fs.getDefaultBlockSize(new Path(fileName)));
+
+    FsPermission permissions =
+        new FsPermission(properties.getPropAsShort(ForkOperatorUtils.getPropertyNameForBranch(
+            ConfigurationKeys.WRITER_FILE_PERMISSIONS, numBranches, branchId), FsPermission.getDefault().toShort()));
 
     this.schema = schema;
-
     this.datumWriter = new GenericDatumWriter<GenericRecord>();
-    this.writer = createDatumWriter(this.stagingFile, bufferSize, CodecType.valueOf(codecType), deflateLevel);
+    this.writer = createDatumWriter(this.stagingFile, bufferSize, codecFactory, replication, blockSize, permissions);
   }
 
   @Override
-  public void write(GenericRecord record)
-      throws IOException {
+  public void write(GenericRecord record) throws IOException {
     Preconditions.checkNotNull(record);
 
     this.writer.append(record);
@@ -94,8 +101,7 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() throws IOException {
     if (this.closed) {
       return;
     }
@@ -106,8 +112,7 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   }
 
   @Override
-  public void commit()
-      throws IOException {
+  public void commit() throws IOException {
     // Close the writer first if it has not been closed yet
     if (!this.closed) {
       this.close();
@@ -125,15 +130,11 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
       HadoopUtils.deletePath(this.fs, this.outputFile, false);
     }
 
-    // Setting the same HDFS properties as the original file
-    WriterUtils.setFileAttributesFromState(properties, fs, outputFile);
-
     HadoopUtils.renamePath(this.fs, this.stagingFile, this.outputFile);
   }
 
   @Override
-  public void cleanup()
-      throws IOException {
+  public void cleanup() throws IOException {
     // Delete the staging file
     if (this.fs.exists(this.stagingFile)) {
       HadoopUtils.deletePath(this.fs, this.stagingFile, false);
@@ -146,8 +147,7 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   }
 
   @Override
-  public long bytesWritten()
-      throws IOException {
+  public long bytesWritten() throws IOException {
     if (!this.fs.exists(this.outputFile) || !this.closed) {
       return 0;
     }
@@ -164,31 +164,17 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
    * @param deflateLevel Deflate level
    * @throws IOException if there is something wrong creating a new {@link DataFileWriter}
    */
-  private DataFileWriter<GenericRecord> createDatumWriter(Path avroFile, int bufferSize,
-      CodecType codecType, int deflateLevel)
-      throws IOException {
+  private DataFileWriter<GenericRecord> createDatumWriter(Path avroFile, int bufferSize, CodecFactory codecFactory,
+      short replication, long blockSize, FsPermission permissions) throws IOException {
 
     if (this.fs.exists(avroFile)) {
       throw new IOException(String.format("File %s already exists", avroFile));
     }
 
-    FSDataOutputStream outputStream = this.fs.create(avroFile, true, bufferSize);
+    FSDataOutputStream outputStream =
+        this.fs.create(avroFile, permissions, true, bufferSize, replication, blockSize, null);
     DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(this.datumWriter);
-
-    // Set compression type
-    switch (codecType) {
-      case DEFLATE:
-        writer.setCodec(CodecFactory.deflateCodec(deflateLevel));
-        break;
-      case SNAPPY:
-        writer.setCodec(CodecFactory.snappyCodec());
-        break;
-      case NOCOMPRESSION:
-        break;
-      default:
-        writer.setCodec(CodecFactory.deflateCodec(deflateLevel));
-        break;
-    }
+    writer.setCodec(codecFactory);
 
     // Open the file and return the DataFileWriter
     return writer.create(this.schema, outputStream);

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -181,12 +181,18 @@ public class WriterUtils {
   }
 
   /**
-   * Creates a {@link CodecFactory} based on the specified codec name and deflate level.
+   * Creates a {@link CodecFactory} based on the specified codec name and deflate level. If codecName is absent, then
+   * a {@link CodecFactory#deflateCodec(int)} is returned. Otherwise the codecName is converted into a
+   * {@link CodecFactory} via the {@link CodecFactory#fromString(String)} method.
+   *
+   * @param codecName the name of the codec to use (e.g. deflate, snappy, xz, etc.).
+   * @param deflateLevel must be an integer from [0-9], and is only applicable if the codecName is "deflate".
+   * @return a {@link CodecFactory}.
    */
   public static CodecFactory getCodecFactory(Optional<String> codecName, Optional<String> deflateLevel) {
     if (!codecName.isPresent()) {
       return CodecFactory.deflateCodec(ConfigurationKeys.DEFAULT_DEFLATE_LEVEL);
-    } else if (codecName.get().equals(DataFileConstants.DEFLATE_CODEC)) {
+    } else if (codecName.get().equalsIgnoreCase(DataFileConstants.DEFLATE_CODEC)) {
       if (!deflateLevel.isPresent()) {
         return CodecFactory.deflateCodec(ConfigurationKeys.DEFAULT_DEFLATE_LEVEL);
       } else {


### PR DESCRIPTION
This PR fixes the specification of file level attributes in AvroHdfsDataWriter. One can now specify the codec type, permissions, block size, replication factor, etc. of the avro files.