### PR TITLE
Fixed a bug that may cause a job to hang if its tasks fail to getExtractor

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -193,7 +193,8 @@ public class TaskExecutor extends AbstractIdleService {
    * @param task failed {@link Task} to be retried
    */
   public void retry(Task task) {
-    if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit())) {
+    if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit()) &&
+        task.getTaskState().contains(ConfigurationKeys.FORK_BRANCHES_KEY)) {
       // Adjust metrics to clean up numbers from the failed task
       task.getTaskState()
           .adjustJobMetricsOnRetry(task.getTaskState().getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker2.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker2.java
@@ -75,7 +75,7 @@ public class LocalTaskStateTracker2 extends AbstractTaskStateTracker {
     }
 
     // Cancel the task state reporter associated with this task. The reporter might
-    // not be found  for the given task because the task fails before the task is
+    // not be found for the given task because the task fails before the task is
     // registered. So we need to make sure the reporter exists before calling cancel.
     if (this.scheduledReporters.containsKey(task.getTaskId())) {
       this.scheduledReporters.remove(task.getTaskId()).cancel(false);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker2.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker2.java
@@ -68,33 +68,36 @@ public class LocalTaskStateTracker2 extends AbstractTaskStateTracker {
 
   @Override
   public void onTaskCompletion(Task task) {
-    if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit())) {
-      // Update record-level metrics after the task is done
-      task.updateRecordMetrics();
-      task.updateByteMetrics();
-    }
+    try {
+      if (GobblinMetrics.isEnabled(task.getTaskState().getWorkunit())) {
+        // Update record-level metrics after the task is done
+        task.updateRecordMetrics();
+        task.updateByteMetrics();
+      }
 
-    // Cancel the task state reporter associated with this task. The reporter might
-    // not be found for the given task because the task fails before the task is
-    // registered. So we need to make sure the reporter exists before calling cancel.
-    if (this.scheduledReporters.containsKey(task.getTaskId())) {
-      this.scheduledReporters.remove(task.getTaskId()).cancel(false);
-    }
+      // Cancel the task state reporter associated with this task. The reporter might
+      // not be found for the given task because the task fails before the task is
+      // registered. So we need to make sure the reporter exists before calling cancel.
+      if (this.scheduledReporters.containsKey(task.getTaskId())) {
+        this.scheduledReporters.remove(task.getTaskId()).cancel(false);
+      }
 
-    // Check the task state and handle task retry if task failed and
-    // it has not reached the maximum number of retries
-    WorkUnitState.WorkingState state = task.getTaskState().getWorkingState();
-    if (state == WorkUnitState.WorkingState.FAILED && task.getRetryCount() < this.maxTaskRetries) {
-      this.taskExecutor.retry(task);
-      return;
+      // Check the task state and handle task retry if task failed and
+      // it has not reached the maximum number of retries
+      WorkUnitState.WorkingState state = task.getTaskState().getWorkingState();
+      if (state == WorkUnitState.WorkingState.FAILED && task.getRetryCount() < this.maxTaskRetries) {
+        this.taskExecutor.retry(task);
+        return;
+      }
+    } catch (Throwable t) {
+      LOG.error("Failed to process a task completion callback", t);
     }
 
     // Mark the completion of this task
     task.markTaskCompletion();
 
     // At this point, the task is considered being completed.
-    LOG.info(String
-        .format("Task %s completed in %dms with state %s", task.getTaskId(), task.getTaskState().getTaskDuration(),
-            state));
+    LOG.info(String.format("Task %s completed in %dms with state %s", task.getTaskId(),
+        task.getTaskState().getTaskDuration(), task.getTaskState().getWorkingState()));
   }
 }

--- a/gobblin-runtime/src/test/resources/log4j.xml
+++ b/gobblin-runtime/src/test/resources/log4j.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE log4j:configuration SYSTEM "log4j.dtd">
+
+<log4j:configuration xmlns:log4j="http://jakarta.apache.org/log4j/">
+  <appender name="console" class="org.apache.log4j.ConsoleAppender">
+    <param name="Target" value="System.out" />
+    <layout class="org.apache.log4j.PatternLayout">
+      <param name="ConversionPattern"
+        value="%d{yyyy-MM-dd HH:mm:ss z} %-5p [%t] %C %L - %m%n" />
+    </layout>
+  </appender>
+
+  <root>
+    <level value="info" />
+    <appender-ref ref="console" />
+  </root>
+
+</log4j:configuration>


### PR DESCRIPTION
This bug is affecting stand-alone jobs using `LocalJobLauncher` that may hang if any of its tasks fails to `getExtractor`. In this case, the `finally` part of the `Task.run` method will be executed, and `this.taskStateTracker.onTaskCompletion(this)` is called. In the implementation class `LocalTaskStateTracker2`, `this.taskExecutor.retry(task)` is called, which will throw an exception on `task.getTaskState().getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY)` since the key `FORK_BRANCHES_KEY` is not set because the task failed before the number of branches is known and that key is set. This runtime exception is thrown in the `finally` clause and is not caught, causing the task to hang.

Signed-off-by: Yinan Li <liyinan926@gmail.com>