### PR TITLE
Add more parallelization during job finialization

### DIFF
--- a/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
@@ -25,7 +25,7 @@ import gobblin.configuration.WorkUnitState;
  */
 public abstract class DataPublisher implements Closeable {
 
-  private final State state;
+  protected final State state;
 
   public DataPublisher(State state) {
     this.state = state;

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -22,6 +22,7 @@ import org.slf4j.LoggerFactory;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.util.HadoopUtils;
+import gobblin.util.ParallelRunner;
 
 
 /**
@@ -37,7 +38,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
 
   private static final Logger LOG = LoggerFactory.getLogger(TimePartitionedDataPublisher.class);
 
-  public TimePartitionedDataPublisher(State state) {
+  public TimePartitionedDataPublisher(State state) throws IOException {
     super(state);
   }
 
@@ -49,7 +50,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
    */
   @Override
   protected void addWriterOutputToExistingDir(Path writerOutput, Path publisherOutput, WorkUnitState workUnitState,
-      int branchId) throws IOException {
+      int branchId, ParallelRunner parallelRunner) throws IOException {
 
     for (FileStatus status : HadoopUtils.listStatusRecursive(this.fss.get(branchId), writerOutput)) {
       String filePathStr = status.getPath().toString();
@@ -61,11 +62,8 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
         this.fss.get(branchId).mkdirs(outputPath.getParent());
       }
 
-      if (this.fss.get(branchId).rename(status.getPath(), outputPath)) {
-        LOG.info(String.format("Moved %s to %s", status.getPath(), outputPath));
-      } else {
-        throw new IOException("Failed to move from " + status.getPath() + " to " + outputPath);
-      }
+      LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));
+      parallelRunner.renamePath(status.getPath(), outputPath);
     }
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -44,8 +44,7 @@ public class HadoopUtils {
     return conf;
   }
 
-  public static List<FileStatus> listStatusRecursive(FileSystem fileSystem, Path path) throws FileNotFoundException,
-      IOException {
+  public static List<FileStatus> listStatusRecursive(FileSystem fileSystem, Path path) throws IOException {
     List<FileStatus> results = Lists.newArrayList();
     walk(results, fileSystem, path);
     return results;
@@ -69,8 +68,7 @@ public class HadoopUtils {
     }
   }
 
-  private static void walk(List<FileStatus> results, FileSystem fileSystem, Path path) throws FileNotFoundException,
-      IOException {
+  private static void walk(List<FileStatus> results, FileSystem fileSystem, Path path) throws IOException {
     for (FileStatus status : fileSystem.listStatus(path)) {
       if (!status.isDir()) {
         results.add(status);

--- a/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.List;
+import java.util.Map;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -23,6 +24,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
@@ -151,5 +153,52 @@ public class JobLauncherUtils {
         }
       }
     }
+  }
+
+  /**
+   * Cleanup staging data of a Gobblin task using a {@link ParallelRunner}
+   *
+   * @param state workunit state
+   * @param closer a closer that registers the given map of ParallelRunners. The caller is responsible
+   * for closing the closer after the cleaning is done.
+   * @param parallelRunners a map from FileSystem URI to ParallelRunner.
+   * @throws IOException
+   */
+  public static void cleanStagingData(State state, Logger logger, Closer closer,
+      Map<String, ParallelRunner> parallelRunners) throws IOException {
+    int numBranches = state.getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY, 1);
+
+    int parallelRunnerThreads =
+        state.getPropAsInt(ParallelRunner.PARALLEL_RUNNER_THREADS_KEY, ParallelRunner.DEFAULT_PARALLEL_RUNNER_THREADS);
+
+    for (int branchId = 0; branchId < numBranches; branchId++) {
+      String writerFsUri = state.getProp(
+          ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, numBranches, branchId),
+          ConfigurationKeys.LOCAL_FS_URI);
+      FileSystem fs = FileSystem.get(URI.create(writerFsUri), new Configuration());
+
+      ParallelRunner parallelRunner = getParallelRunner(fs, closer, parallelRunnerThreads, parallelRunners);
+
+      Path stagingPath = WriterUtils.getWriterStagingDir(state, numBranches, branchId);
+      if (fs.exists(stagingPath)) {
+        logger.info("Cleaning up staging directory " + stagingPath.toUri().getPath());
+        parallelRunner.deletePath(stagingPath, true);
+      }
+
+      Path outputPath = WriterUtils.getWriterOutputDir(state, numBranches, branchId);
+      if (fs.exists(outputPath)) {
+        logger.info("Cleaning up output directory " + outputPath.toUri().getPath());
+        parallelRunner.deletePath(outputPath, true);
+      }
+    }
+  }
+
+  private static ParallelRunner getParallelRunner(FileSystem fs, Closer closer, int parallelRunnerThreads,
+      Map<String, ParallelRunner> parallelRunners) {
+    String uri = fs.getUri().toString();
+    if (!parallelRunners.containsKey(uri)) {
+      parallelRunners.put(uri, closer.register(new ParallelRunner(parallelRunnerThreads, fs)));
+    }
+    return parallelRunners.get(uri);
   }
 }


### PR DESCRIPTION
Parallelize the following: (1) moving file from task output dir to final output dir; (2) cleaning task output dir and task staging dir.

1. Renamed `ParallelStateSerDeRunner` to `ParallelRunner`, and add two methods: `deletePath()` and `renamePath()`.
2. Moved `ParallelRunner` from `gobblin-runtime` to `gobblin-utility`, since `gobblin.util.JobLauncherUtils` depends on it, but `gobblin-utility` cannot depend on `gobblin-runtime`.
3. `ParallelRunnerTest` has to stay in `gobblin-runtime`, since it depends on `gobblin.runtime.TaskState`.