### PR TITLE
several fixes and optimizations for compaction

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -430,6 +430,7 @@ public class ConfigurationKeys {
   public static final String COMPACTION_ENABLE_SUCCESS_FILE = "mapreduce.fileoutputcommitter.marksuccessfuljobs";
   public static final String COMPACTION_OVERWRITE_OUTPUT_DIR = COMPACTION_PREFIX + "overwrite.output.dir";
   public static final boolean DEFAULT_COMPACTION_OVERWRITE_OUTPUT_DIR = false;
+  public static final String COMPACTION_JARS = COMPACTION_PREFIX + "jars";
 
   /**
    * Common metrics configuration properties.

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
@@ -91,9 +91,7 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
     Schema keySchema = null;
     if (useAllAttributesForCompaction()) {
       LOG.info("Using all attributes in the schema (except Map fields) for compaction");
-      System.out.println("Original schema: " + newestSchema);
-      keySchema = removeUncomparableFields(newestSchema).get();
-      System.out.println("Key schema: " + keySchema);
+      keySchema = AvroUtils.removeUncomparableFields(newestSchema).get();
     } else if (keySchemaFileSpecified()) {
       Path keySchemaFile = getKeySchemaFile();
       LOG.info("Using attributes specified in schema file " + keySchemaFile + " for compaction");
@@ -102,17 +100,17 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
       } catch (IOException e) {
         LOG.error("Failed to parse avro schema from " + keySchemaFile
             + ", using all attributes in the schema (except Map fields) for compaction");
-        keySchema = removeUncomparableFields(newestSchema).get();
+        keySchema = AvroUtils.removeUncomparableFields(newestSchema).get();
       }
       if (!isKeySchemaValid(keySchema, newestSchema)) {
         LOG.warn(String.format("Key schema %s is not compatible with record schema %s.", keySchema, newestSchema)
             + "Using all attributes in the schema (except Map fields) for compaction");
-        keySchema = removeUncomparableFields(newestSchema).get();
+        keySchema = AvroUtils.removeUncomparableFields(newestSchema).get();
       }
     } else {
       LOG.info("Property " + ConfigurationKeys.COMPACTION_AVRO_KEY_SCHEMA_LOC
           + " not provided. Using all attributes in the schema (except Map fields) for compaction");
-      keySchema = removeUncomparableFields(newestSchema).get();
+      keySchema = AvroUtils.removeUncomparableFields(newestSchema).get();
     }
 
     return keySchema;
@@ -165,62 +163,6 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
   private boolean useAllAttributesForCompaction() {
     return this.jobProps.getPropAsBoolean(ConfigurationKeys.COMPACTION_USE_ALL_ATTRIBUTES,
         ConfigurationKeys.DEFAULT_COMPACTION_USE_ALL_ATTRIBUTES);
-  }
-
-  /**
-   * Remove map, array, enum fields, as well as union fields that contain map, array or enum,
-   * from an Avro schema.
-   */
-  private static Optional<Schema> removeUncomparableFields(Schema schema) {
-    switch (schema.getType()) {
-      case RECORD:
-        return removeUncomparableFieldsFromRecord(schema);
-      case UNION:
-        return removeUncomparableFieldsFromUnion(schema);
-      case MAP:
-        return Optional.absent();
-      case ARRAY:
-        return Optional.absent();
-      case ENUM:
-        return Optional.absent();
-      default:
-        return Optional.of(schema);
-    }
-  }
-
-  private static Optional<Schema> removeUncomparableFieldsFromRecord(Schema record) {
-    Preconditions.checkArgument(record.getType() == Schema.Type.RECORD);
-
-    List<Field> fields = new ArrayList<Schema.Field>();
-    for (Field field : record.getFields()) {
-      Optional<Schema> newFieldSchema = removeUncomparableFields(field.schema());
-      if (newFieldSchema.isPresent()) {
-        fields.add(new Field(field.name(), newFieldSchema.get(), field.doc(), field.defaultValue()));
-      }
-    }
-
-    Schema newSchema = Schema.createRecord(record.getName(), record.getDoc(), record.getName(), false);
-    newSchema.setFields(fields);
-    return Optional.of(newSchema);
-  }
-
-  private static Optional<Schema> removeUncomparableFieldsFromUnion(Schema union) {
-    Preconditions.checkArgument(union.getType() == Schema.Type.UNION);
-
-    List<Schema> newUnion = Lists.newArrayList();
-    for (Schema unionType : union.getTypes()) {
-      Optional<Schema> newType = removeUncomparableFields(unionType);
-      if (newType.isPresent()) {
-        newUnion.add(newType.get());
-      }
-    }
-
-    // Discard the union field if one or more types are removed from the union.
-    if (newUnion.size() != union.getTypes().size()) {
-      return Optional.absent();
-    } else {
-      return Optional.of(Schema.createUnion(newUnion));
-    }
   }
 
   private boolean keySchemaFileSpecified() {


### PR DESCRIPTION
1. Added code to add dependency jars to distributed cache.
2. In Mapper class, created method `populateRecord` to replace `AvroUtils.convertRecordSchema`, which is more efficient, since `AvroUtils.convertRecordSchema` needs to serialize the record to byte array and then deserialize it.
3. For Avro key schema, created method `removeUncomparableFields` to replace `getAllFieldsExceptMap`, since we not only need to remove MAP fields, but also need to remove ARRAY and ENUM fields, as well as UNIONS that contain one of those types. Also, `getAllFieldsExceptMap` was not recursive, which is now fixed.

The reason to remove those fields in Avro key schema is that a schema that contains these fields cannot be used as the dedup key.