### PR TITLE
Added HadoopFileInputSource and HadoopFileInputExtractor

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -68,6 +68,7 @@ ext.externalDependency = [
   "hadoopClientCommon": "org.apache.hadoop:hadoop-mapreduce-client-common:"+hadoopVersion,
   "hadoopHdfs": "org.apache.hadoop:hadoop-hdfs:"+hadoopVersion,
   "hadoopAuth": "org.apache.hadoop:hadoop-auth:"+hadoopVersion,
+  "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:"+hadoopVersion,
   "hiveService": "org.apache.hive:hive-service:"+hiveVersion,
   "hiveJdbc": "org.apache.hive:hive-jdbc:"+hiveVersion,
   "hiveMetastore": "org.apache.hive:hive-metastore:"+hiveVersion,
@@ -159,6 +160,7 @@ subprojects {
       if (project.hasProperty('useHadoop2')) {
         compile externalDependency.hadoopCommon
         compile externalDependency.hadoopClientCore
+        compile externalDependency.hadoopAnnotations
         if (project.name.equals('gobblin-runtime') || project.name.equals('gobblin-test')) {
           compile externalDependency.hadoopClientCommon
         }

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -41,8 +41,11 @@ dependencies {
 
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2
+    compile externalDependency.hadoopClientCore
+    compile externalDependency.hadoopAnnotations
   } else {
     compile externalDependency.avroMapredH1
+    compile externalDependency.hadoop
   }
 
   testCompile externalDependency.testng

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -41,11 +41,8 @@ dependencies {
 
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2
-    compile externalDependency.hadoopClientCore
-    compile externalDependency.hadoopAnnotations
   } else {
     compile externalDependency.avroMapredH1
-    compile externalDependency.hadoop
   }
 
   testCompile externalDependency.testng

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputExtractor.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapreduce.RecordReader;
+
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.extractor.Extractor;
+
+
+/**
+ * An implementation of {@link Extractor} that uses a Hadoop {@link RecordReader} to read records
+ * from a {@link org.apache.hadoop.mapreduce.lib.input.FileSplit}.
+ *
+ * <p>
+ *   This class can read either keys of type {@link #<K>} or values of type {@link #<V>} using the
+ *   given {@link RecordReader}, depending on the value of the second argument of the constructor
+ *   {@link #HadoopFileInputExtractor(RecordReader, boolean)}. It will read keys if the argument
+ *   is {@code true}, otherwise it will read values. Normally, this is specified using the property
+ *   {@link HadoopFileInputSource#FILE_INPUT_READ_KEYS_KEY}, which is {@code false} by default.
+ * </p>
+ *
+ * <p>
+ *   This class provides a default implementation of {@link #readRecord(Object)} that simply casts
+ *   the keys or values read by the {@link RecordReader} into type {@link #<D>}. It is required
+ *   that type {@link #<K>} or {@link #<V>} can be safely casted to type {@link #<D>}.
+ * </p>
+ *
+ * <p>
+ *   The Hadoop {@link RecordReader} is passed into this class, which is responsible for closing
+ *   it by calling {@link RecordReader#close()} in {@link #close()}.
+ * </p>
+ *
+ * <p>
+ *   A concrete implementation of this class should at least implement the {@link #getSchema()}
+ *   method.
+ * </p>
+ *
+ * @param <S> output schema type
+ * @param <D> output data record type that MUST be compatible with either {@link #<K>} or {@link #<V>}
+ * @param <K> key type expected by the {@link RecordReader}
+ * @param <V> value type expected by the {@link RecordReader}
+ *
+ * @author ynli
+ */
+public abstract class HadoopFileInputExtractor<S, D, K, V> implements Extractor<S, D> {
+
+  private final RecordReader<K, V> recordReader;
+  private final boolean readKeys;
+
+  public HadoopFileInputExtractor(RecordReader<K, V> recordReader, boolean readKeys) {
+    this.recordReader = recordReader;
+    this.readKeys = readKeys;
+  }
+
+  /**
+   * {@inheritDoc}.
+   *
+   * This method will throw a {@link ClassCastException} if type {@link #<D>} is not compatible
+   * with type {@link #<K>} if keys are supposed to be read, or if it is not compatible with type
+   * {@link #<V>} if values are supposed to be read.
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public D readRecord(@Deprecated D reuse) throws DataRecordException, IOException {
+    try {
+      if (this.recordReader.nextKeyValue()) {
+        return this.readKeys ? (D) this.recordReader.getCurrentKey() : (D) this.recordReader.getCurrentValue();
+      }
+    } catch (InterruptedException ie) {
+      throw new IOException(ie);
+    }
+
+    return null;
+  }
+
+  @Override
+  public long getExpectedRecordCount() {
+    return -1l;
+  }
+
+  @Override
+  public long getHighWatermark() {
+    return -1l;
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.recordReader.close();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
@@ -12,10 +12,6 @@
 
 package gobblin.source.extractor.hadoop;
 
-import java.io.ByteArrayInputStream;
-import java.io.ByteArrayOutputStream;
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -33,8 +29,6 @@ import org.apache.hadoop.util.ReflectionUtils;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import com.google.common.io.BaseEncoding;
-import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.SourceState;
@@ -44,6 +38,7 @@ import gobblin.source.Source;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.HadoopUtils;
 
 
 /**
@@ -111,7 +106,7 @@ public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> 
         FileSplit fileSplit = (FileSplit) inputSplit;
         Extract extract = state.createExtract(tableType, tableNamespace, tableName);
         WorkUnit workUnit = state.createWorkUnit(extract);
-        workUnit.setProp(FILE_SPLIT_BYTES_STRING_KEY, serializeFileSplit(fileSplit));
+        workUnit.setProp(FILE_SPLIT_BYTES_STRING_KEY, HadoopUtils.serializeToString(fileSplit));
         workUnit.setProp(FILE_SPLIT_PATH_KEY, fileSplit.getPath().toString());
         workUnits.add(workUnit);
       }
@@ -132,7 +127,7 @@ public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> 
     FileInputFormat<K, V> fileInputFormat = getFileInputFormat(workUnitState, configuration);
 
     String fileSplitBytesStr = workUnitState.getProp(FILE_SPLIT_BYTES_STRING_KEY);
-    FileSplit fileSplit = deserializeFileSplit(fileSplitBytesStr);
+    FileSplit fileSplit = (FileSplit) HadoopUtils.deserializeFromString(FileSplit.class, fileSplitBytesStr);
     TaskAttemptContext taskAttemptContext =
         getTaskAttemptContext(configuration, DummyTaskAttemptIDFactory.newTaskAttemptID());
     try {
@@ -187,36 +182,6 @@ public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> 
   protected abstract HadoopFileInputExtractor<S, D, K, V> getExtractor(WorkUnitState workUnitState,
       RecordReader<K, V> recordReader, FileSplit fileSplit, boolean readKeys);
 
-  private String serializeFileSplit(FileSplit fileSplit) throws IOException {
-    Closer closer = Closer.create();
-    try {
-      ByteArrayOutputStream byteArrayOutputStream = closer.register(new ByteArrayOutputStream());
-      DataOutputStream dataOutputStream = closer.register(new DataOutputStream(byteArrayOutputStream));
-      fileSplit.write(dataOutputStream);
-      return BaseEncoding.base64().encode(byteArrayOutputStream.toByteArray());
-    } catch (Throwable t) {
-      throw closer.rethrow(t);
-    } finally {
-      closer.close();
-    }
-  }
-
-  private FileSplit deserializeFileSplit(String fileSplitBytesStr) throws IOException  {
-    Closer closer = Closer.create();
-    try {
-      byte[] fileSplitBytes = BaseEncoding.base64().decode(fileSplitBytesStr);
-      ByteArrayInputStream byteArrayInputStream = closer.register(new ByteArrayInputStream(fileSplitBytes));
-      DataInputStream dataInputStream = closer.register(new DataInputStream(byteArrayInputStream));
-      FileSplit fileSplit = ReflectionUtils.newInstance(FileSplit.class, new Configuration());
-      fileSplit.readFields(dataInputStream);
-      return fileSplit;
-    } catch (Throwable t) {
-      throw closer.rethrow(t);
-    } finally {
-      closer.close();
-    }
-  }
-
   @SuppressWarnings("unchecked")
   private TaskAttemptContext getTaskAttemptContext(Configuration configuration, TaskAttemptID taskAttemptID) {
     Class<?> taskAttemptContextClass;
@@ -245,6 +210,14 @@ public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> 
     }
   }
 
+  /**
+   * A factory class for creating new dummy {@link TaskAttemptID}s.
+   *
+   * <p>
+   *   This class extends {@link TaskAttemptID} so it has access to some protected string constants
+   *   in {@link TaskAttemptID}.
+   * </p>
+   */
   private static class DummyTaskAttemptIDFactory extends TaskAttemptID {
 
     /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
@@ -73,13 +73,14 @@ import gobblin.source.workunit.WorkUnit;
  */
 public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> {
 
-  public static final String FILE_INPUT_FORMAT_CLASS_KEY = "file.input.format.class";
-  public static final String FILE_SPLITS_DESIRED_KEY = "file.splits.desired";
+  private static final String HADOOP_SOURCE_KEY_PREFIX = "source.hadoop.";
+  public static final String FILE_INPUT_FORMAT_CLASS_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.input.format.class";
+  public static final String FILE_SPLITS_DESIRED_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.splits.desired";
   public static final int DEFAULT_FILE_SPLITS_DESIRED = 1;
-  public static final String FILE_INPUT_PATHS_KEY = "file.input.paths";
-  public static final String FILE_INPUT_READ_KEYS_KEY = "file.input.read.keys";
+  public static final String FILE_INPUT_PATHS_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.input.paths";
+  public static final String FILE_INPUT_READ_KEYS_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.read.keys";
   public static final boolean DEFAULT_FILE_INPUT_READ_KEYS = false;
-  static final String FILE_SPLIT_BYTES_STRING_KEY = "file.split.bytes.string";
+  static final String FILE_SPLIT_BYTES_STRING_KEY = HADOOP_SOURCE_KEY_PREFIX + "file.split.bytes.string";
 
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
@@ -202,7 +202,7 @@ public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> 
     try {
       byte[] fileSplitBytes = BaseEncoding.base64().decode(fileSplitBytesStr);
       ByteArrayInputStream byteArrayInputStream = closer.register(new ByteArrayInputStream(fileSplitBytes));
-      DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+      DataInputStream dataInputStream = closer.register(new DataInputStream(byteArrayInputStream));
       FileSplit fileSplit = ReflectionUtils.newInstance(FileSplit.class, new Configuration());
       fileSplit.readFields(dataInputStream);
       return fileSplit;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFileInputSource.java
@@ -1,0 +1,256 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.Source;
+import gobblin.source.extractor.Extractor;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An implementation of {@link Source} that uses a Hadoop {@link FileInputFormat} to get a {@link FileSplit}
+ * per {@link Extractor} return by {@link #getExtractor(WorkUnitState)} and a {@link RecordReader} to read
+ * the {@link FileSplit}.
+ *
+ * <p>
+ *   This class can read either keys of type {@link #<K>} or values of type {@link #<V>} supported by the
+ *   given {@link FileInputFormat}, through the property {@link #FILE_INPUT_READ_KEYS_KEY}. It will read keys
+ *   if the property is set to {@code true}, otherwise it will read values. By default, it will read values
+ *   through the given {@link FileInputFormat}.
+ * </p>
+ *
+ * <p>
+ *   A concrete implementation of this class should implement {@link #getFileInputFormat(State, Configuration)}
+ *   and {@link #getExtractor(RecordReader, boolean)}, which returns a {@link HadoopFileInputExtractor}
+ *   that needs an concrete implementation.
+ * </p>
+ *
+ * @param <S> output schema type
+ * @param <D> output data record type
+ * @param <K> key type expected by the {@link FileInputFormat}
+ * @param <V> value type expected by the {@link FileInputFormat}
+ *
+ * @author ynli
+ */
+public abstract class HadoopFileInputSource<S, D, K, V> implements Source<S, D> {
+
+  public static final String FILE_INPUT_FORMAT_CLASS_KEY = "file.input.format.class";
+  public static final String FILE_SPLITS_DESIRED_KEY = "file.splits.desired";
+  public static final int DEFAULT_FILE_SPLITS_DESIRED = 1;
+  public static final String FILE_INPUT_PATHS_KEY = "file.input.paths";
+  public static final String FILE_INPUT_READ_KEYS_KEY = "file.input.read.keys";
+  public static final boolean DEFAULT_FILE_INPUT_READ_KEYS = false;
+  static final String FILE_SPLIT_BYTES_STRING_KEY = "file.split.bytes.string";
+
+  @Override
+  public List<WorkUnit> getWorkunits(SourceState state) {
+    try {
+      Job job = Job.getInstance(new Configuration());
+
+      if (state.contains(FILE_INPUT_PATHS_KEY)) {
+        for (String inputPath : state.getPropAsList(FILE_INPUT_PATHS_KEY)) {
+          FileInputFormat.addInputPath(job, new Path(inputPath));
+        }
+      }
+
+      FileInputFormat<K, V> fileInputFormat = getFileInputFormat(state, job.getConfiguration());
+      List<InputSplit> fileSplits = fileInputFormat.getSplits(job);
+      if (fileSplits == null || fileSplits.isEmpty()) {
+        return ImmutableList.of();
+      }
+
+      Extract.TableType tableType =
+          Extract.TableType.valueOf(state.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY).toUpperCase());
+      String tableNamespace = state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY);
+      String tableName = state.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY);
+
+      List<WorkUnit> workUnits = Lists.newArrayListWithCapacity(fileSplits.size());
+      for (InputSplit inputSplit : fileSplits) {
+        // Create one WorkUnit per InputSplit
+        FileSplit fileSplit = (FileSplit) inputSplit;
+        Extract extract = state.createExtract(tableType, tableNamespace, tableName);
+        WorkUnit workUnit = state.createWorkUnit(extract);
+        workUnit.setProp(FILE_SPLIT_BYTES_STRING_KEY, serializeFileSplit(fileSplit));
+        workUnits.add(workUnit);
+      }
+
+      return workUnits;
+    } catch (IOException ioe) {
+      throw new RuntimeException("Failed to get workunits", ioe);
+    }
+  }
+
+  @Override
+  public Extractor<S, D> getExtractor(WorkUnitState workUnitState) throws IOException {
+    if (!workUnitState.contains(FILE_SPLIT_BYTES_STRING_KEY)) {
+      throw new IOException("No serialized FileSplit found in WorkUnitState " + workUnitState.getId());
+    }
+
+    Configuration configuration = new Configuration();
+    FileInputFormat<K, V> fileInputFormat = getFileInputFormat(workUnitState, configuration);
+
+    String fileSplitBytesStr = workUnitState.getProp(FILE_SPLIT_BYTES_STRING_KEY);
+    FileSplit fileSplit = deserializeFileSplit(fileSplitBytesStr);
+    TaskAttemptContext taskAttemptContext =
+        getTaskAttemptContext(configuration, DummyTaskAttemptIDFactory.newTaskAttemptID());
+    try {
+      RecordReader<K, V> recordReader = fileInputFormat.createRecordReader(fileSplit, taskAttemptContext);
+      recordReader.initialize(fileSplit, taskAttemptContext);
+      boolean readKeys = workUnitState.getPropAsBoolean(FILE_INPUT_READ_KEYS_KEY,
+          DEFAULT_FILE_INPUT_READ_KEYS);
+      return getExtractor(recordReader, readKeys);
+    } catch (InterruptedException ie) {
+      throw new IOException(ie);
+    }
+  }
+
+  @Override
+  public void shutdown(SourceState state) {
+
+  }
+
+  /**
+   * Get a {@link FileInputFormat} instance used to get {@link FileSplit}s and a {@link RecordReader}
+   * for every {@link FileSplit}.
+   *
+   * <p>
+   *   This default implementation simply creates a new instance of a {@link FileInputFormat} class
+   *   specified using the configuration property {@link #FILE_INPUT_FORMAT_CLASS_KEY}.
+   * </p>
+   *
+   * @param state a {@link State} object carrying configuration properties
+   * @param configuration a Hadoop {@link Configuration} object carrying Hadoop configurations
+   * @return a {@link FileInputFormat} instance
+   */
+  @SuppressWarnings("unchecked")
+  protected FileInputFormat<K, V> getFileInputFormat(State state, Configuration configuration) {
+    Preconditions.checkArgument(state.contains(FILE_INPUT_FORMAT_CLASS_KEY));
+    try {
+      return (FileInputFormat<K, V>) ReflectionUtils.newInstance(
+          Class.forName(state.getProp(FILE_INPUT_FORMAT_CLASS_KEY)), configuration);
+    } catch (ClassNotFoundException cnfe) {
+      throw new RuntimeException(cnfe);
+    }
+  }
+
+  /**
+   * Get a {@link HadoopFileInputExtractor} instance.
+   *
+   * @param recordReader a Hadoop {@link RecordReader} object used to read input records
+   * @param readKeys whether the {@link OldApiHadoopFileInputExtractor} should read keys of type {@link #<K>};
+   *                 by default values of type {@link #>V>} are read.
+   * @return a {@link HadoopFileInputExtractor} instance
+   */
+  protected abstract HadoopFileInputExtractor<S, D, K, V> getExtractor(RecordReader<K, V> recordReader,
+      boolean readKeys);
+
+  private String serializeFileSplit(FileSplit fileSplit) throws IOException {
+    Closer closer = Closer.create();
+    try {
+      ByteArrayOutputStream byteArrayOutputStream = closer.register(new ByteArrayOutputStream());
+      DataOutputStream dataOutputStream = closer.register(new DataOutputStream(byteArrayOutputStream));
+      fileSplit.write(dataOutputStream);
+      return BaseEncoding.base64().encode(byteArrayOutputStream.toByteArray());
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  private FileSplit deserializeFileSplit(String fileSplitBytesStr) throws IOException  {
+    Closer closer = Closer.create();
+    try {
+      byte[] fileSplitBytes = BaseEncoding.base64().decode(fileSplitBytesStr);
+      ByteArrayInputStream byteArrayInputStream = closer.register(new ByteArrayInputStream(fileSplitBytes));
+      DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+      FileSplit fileSplit = ReflectionUtils.newInstance(FileSplit.class, new Configuration());
+      fileSplit.readFields(dataInputStream);
+      return fileSplit;
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  private TaskAttemptContext getTaskAttemptContext(Configuration configuration, TaskAttemptID taskAttemptID) {
+    Class<?> taskAttemptContextClass;
+
+    // This is a method learned from Spark (See "org.apache.spark.mapreduce.SparkHadoopMapReduceUtil").
+    // The order of attempts below is important since "org.apache.hadoop.mapreduce.TaskAttemptContext"
+    // turns into an interface in Hadoop 2.x from a concrete class in Hadoop 1.x. If the order gets
+    // reversed, a NoSuchMethodException will be thrown.
+    try {
+      // For Hadoop 2.x
+      taskAttemptContextClass = Class.forName("org.apache.hadoop.mapreduce.task.TaskAttemptContextImpl");
+    } catch (ClassNotFoundException cnfe) {
+      try {
+        // For Hadoop 1.x
+        taskAttemptContextClass = Class.forName("org.apache.hadoop.mapreduce.TaskAttemptContext");
+      } catch (ClassNotFoundException cnfe1) {
+        throw new RuntimeException(cnfe1);
+      }
+    }
+
+    try {
+      return (TaskAttemptContext) taskAttemptContextClass.getDeclaredConstructor(
+          Configuration.class, TaskAttemptID.class).newInstance(configuration, taskAttemptID);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class DummyTaskAttemptIDFactory extends TaskAttemptID {
+
+    /**
+     * Create a new {@link TaskAttemptID} instance.
+     *
+     * @return a new {@link TaskAttemptID} instance
+     */
+    public static TaskAttemptID newTaskAttemptID() {
+      return TaskAttemptID.forName(ATTEMPT + SEPARATOR + Long.toString(System.currentTimeMillis()) +
+          SEPARATOR + 0 + SEPARATOR + 'm' + SEPARATOR + 0 + SEPARATOR + 0);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopTextInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopTextInputSource.java
@@ -15,11 +15,14 @@ package gobblin.source.extractor.hadoop;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.RecordReader;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
 
 
 /**
@@ -27,7 +30,7 @@ import gobblin.configuration.State;
  *
  * <p>
  *   A concrete implementation of this class should at least implement the
- *   {@link #getExtractor(org.apache.hadoop.mapreduce.RecordReader, boolean)} method.
+ *   {@link #getExtractor(WorkUnitState, RecordReader, FileSplit, boolean)} method.
  * </p>
  *
  * @param <S> output schema type

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopTextInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopTextInputSource.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
+import org.apache.hadoop.mapreduce.lib.input.TextInputFormat;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import gobblin.configuration.State;
+
+
+/**
+ * An extension to {@link HadoopFileInputSource} that uses a {@link TextInputFormat}.
+ *
+ * <p>
+ *   A concrete implementation of this class should at least implement the
+ *   {@link #getExtractor(org.apache.hadoop.mapreduce.RecordReader, boolean)} method.
+ * </p>
+ *
+ * @param <S> output schema type
+ *
+ * @author ynli
+ */
+public abstract class HadoopTextInputSource<S> extends HadoopFileInputSource<S, Text, LongWritable, Text> {
+
+  @Override
+  protected FileInputFormat<LongWritable, Text> getFileInputFormat(State state, Configuration configuration) {
+    return ReflectionUtils.newInstance(TextInputFormat.class, configuration);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputExtractor.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.IOException;
+
+import org.apache.hadoop.mapred.RecordReader;
+
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.extractor.Extractor;
+
+
+/**
+ * An implementation of {@link Extractor} that uses a Hadoop {@link RecordReader} to read records
+ * from a {@link org.apache.hadoop.mapred.FileSplit}.
+ *
+ * <p>
+ *   This class is equivalent to {@link HadoopFileInputExtractor} in terms of functionality except that
+ *   it uses the old Hadoop API.
+ * </p>
+ *
+ * <p>
+ *   This class can read either keys of type {@link #<K>} or values of type {@link #<V>} using the
+ *   given {@link RecordReader}, depending on the value of the second argument of the constructor
+ *   {@link #OldApiHadoopFileInputExtractor(RecordReader, boolean)}. It will read keys if the argument
+ *   is {@code true}, otherwise it will read values. Normally, this is specified using the property
+ *   {@link HadoopFileInputSource#FILE_INPUT_READ_KEYS_KEY}, which is {@code false} by default.
+ * </p>
+ *
+ * <p>
+ *   This class provides a default implementation of {@link #readRecord(Object)} that simply casts
+ *   the keys or values read by the {@link RecordReader} into type {@link #<D>}. It is required
+ *   that type {@link #<K>} or {@link #<V>} can be safely casted to type {@link #<D>}.
+ * </p>
+ *
+ * <p>
+ *   The Hadoop {@link RecordReader} is passed into this class, which is responsible for closing
+ *   it by calling {@link RecordReader#close()} in {@link #close()}.
+ * </p>
+ *
+ * <p>
+ *   A concrete implementation of this class should at least implement the {@link #getSchema()}
+ *   method.
+ * </p>
+ *
+ * @param <S> output schema type
+ * @param <D> output data record type that MUST be compatible with either {@link #<K>} or {@link #<V>}
+ * @param <K> key type expected by the {@link RecordReader}
+ * @param <V> value type expected by the {@link RecordReader}
+ *
+ * @author ynli
+ */
+public abstract class OldApiHadoopFileInputExtractor<S, D, K, V> implements Extractor<S, D> {
+
+  private final RecordReader<K, V> recordReader;
+  private final boolean readKeys;
+
+  public OldApiHadoopFileInputExtractor(RecordReader<K, V> recordReader, boolean readKeys) {
+    this.recordReader = recordReader;
+    this.readKeys = readKeys;
+  }
+
+  /**
+   * {@inheritDoc}.
+   *
+   * This method will throw a {@link ClassCastException} if type {@link #<D>} is not compatible
+   * with type {@link #<K>} if keys are supposed to be read, or if it is not compatible with type
+   * {@link #<V>} if values are supposed to be read.
+   */
+  @Override
+  @SuppressWarnings("unchecked")
+  public D readRecord(@Deprecated D reuse) throws DataRecordException, IOException {
+    K key = this.recordReader.createKey();
+    V value = this.recordReader.createValue();
+    if (this.recordReader.next(key, value)) {
+      return this.readKeys ? (D) key : (D) value;
+    }
+    return null;
+  }
+
+  @Override
+  public long getExpectedRecordCount() {
+    return -1l;
+  }
+
+  @Override
+  public long getHighWatermark() {
+    return -1l;
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.recordReader.close();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSource.java
@@ -1,0 +1,212 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
+import org.apache.hadoop.mapred.InputSplit;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
+import org.apache.hadoop.mapred.Reporter;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.Source;
+import gobblin.source.extractor.Extractor;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An implementation of {@link Source} that uses a Hadoop {@link FileInputFormat} to get a {@link FileSplit}
+ * per {@link Extractor} return by {@link #getExtractor(WorkUnitState)} and a {@link RecordReader} to read
+ * the {@link FileSplit}.
+ *
+ * <p>
+ *   This class is equivalent to {@link HadoopFileInputSource} in terms of functionality except that it uses
+ *   the old Hadoop API.
+ * </p>
+ *
+ * <p>
+ *   This class can read either keys of type {@link #<K>} or values of type {@link #<V>} supported by the
+ *   given {@link FileInputFormat}, configurable by {@link HadoopFileInputSource#FILE_INPUT_READ_KEYS_KEY}.
+ *   It will read keys if the property is set to {@code true}, otherwise it will read values. By default,
+ *   it will read values through the given {@link FileInputFormat}.
+ * </p>
+ *
+ * <p>
+ *   A concrete implementation of this class should implement {@link #getFileInputFormat(State, JobConf)}
+ *   and {@link #getExtractor(RecordReader, boolean)}, which returns a {@link OldApiHadoopFileInputExtractor}
+ *   that needs an concrete implementation.
+ * </p>
+ *
+ * @param <S> output schema type
+ * @param <D> output data record type
+ * @param <K> key type expected by the {@link FileInputFormat}
+ * @param <V> value type expected by the {@link FileInputFormat}
+ *
+ * @author ynli
+ */
+public abstract class OldApiHadoopFileInputSource<S, D, K, V> implements Source<S, D> {
+
+
+  @Override
+  public List<WorkUnit> getWorkunits(SourceState state) {
+    JobConf jobConf = new JobConf(new Configuration());
+    for (String key : state.getPropertyNames()) {
+      jobConf.set(key, state.getProp(key));
+    }
+
+    if (state.contains(HadoopFileInputSource.FILE_INPUT_PATHS_KEY)) {
+      for (String inputPath : state.getPropAsList(HadoopFileInputSource.FILE_INPUT_PATHS_KEY)) {
+        FileInputFormat.addInputPath(jobConf, new Path(inputPath));
+      }
+    }
+
+    try {
+      FileInputFormat<K, V> fileInputFormat = getFileInputFormat(state, jobConf);
+      InputSplit[] fileSplits = fileInputFormat.getSplits(jobConf, state.getPropAsInt(
+          HadoopFileInputSource.FILE_SPLITS_DESIRED_KEY, HadoopFileInputSource.DEFAULT_FILE_SPLITS_DESIRED));
+      if (fileSplits == null || fileSplits.length == 0) {
+        return ImmutableList.of();
+      }
+
+      Extract.TableType tableType =
+          Extract.TableType.valueOf(state.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY).toUpperCase());
+      String tableNamespace = state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY);
+      String tableName = state.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY);
+
+      List<WorkUnit> workUnits = Lists.newArrayListWithCapacity(fileSplits.length);
+      for (InputSplit inputSplit : fileSplits) {
+        // Create one WorkUnit per InputSplit
+        FileSplit fileSplit = (FileSplit) inputSplit;
+        Extract extract = state.createExtract(tableType, tableNamespace, tableName);
+        WorkUnit workUnit = state.createWorkUnit(extract);
+        workUnit.setProp(HadoopFileInputSource.FILE_SPLIT_BYTES_STRING_KEY, serializeFileSplit(fileSplit));
+        workUnits.add(workUnit);
+      }
+
+      return workUnits;
+    } catch (IOException ioe) {
+      throw new RuntimeException("Failed to get workunits", ioe);
+    }
+  }
+
+  @Override
+  public Extractor<S, D> getExtractor(WorkUnitState workUnitState) throws IOException {
+    if (!workUnitState.contains(HadoopFileInputSource.FILE_SPLIT_BYTES_STRING_KEY)) {
+      throw new IOException("No serialized FileSplit found in WorkUnitState " + workUnitState.getId());
+    }
+
+    JobConf jobConf = new JobConf(new Configuration());
+    for (String key : workUnitState.getPropertyNames()) {
+      jobConf.set(key, workUnitState.getProp(key));
+    }
+
+    String fileSplitBytesStr = workUnitState.getProp(HadoopFileInputSource.FILE_SPLIT_BYTES_STRING_KEY);
+    FileSplit fileSplit = deserializeFileSplit(fileSplitBytesStr);
+    FileInputFormat<K, V> fileInputFormat = getFileInputFormat(workUnitState, jobConf);
+    RecordReader<K, V> recordReader = fileInputFormat.getRecordReader(fileSplit, jobConf, Reporter.NULL);
+    boolean readKeys = workUnitState.getPropAsBoolean(
+        HadoopFileInputSource.FILE_INPUT_READ_KEYS_KEY, HadoopFileInputSource.DEFAULT_FILE_INPUT_READ_KEYS);
+    return getExtractor(recordReader, readKeys);
+  }
+
+  @Override
+  public void shutdown(SourceState state) {
+
+  }
+
+  /**
+   * Get a {@link FileInputFormat} instance used to get {@link FileSplit}s and a {@link RecordReader}
+   * for every {@link FileSplit}.
+   *
+   * <p>
+   *   This default implementation simply creates a new instance of a {@link FileInputFormat} class
+   *   specified using the configuration property {@link HadoopFileInputSource#FILE_INPUT_FORMAT_CLASS_KEY}.
+   * </p>
+   *
+   * @param state a {@link State} object carrying configuration properties
+   * @param jobConf a Hadoop {@link JobConf} object carrying Hadoop configurations
+   * @return a {@link FileInputFormat} instance
+   */
+  @SuppressWarnings("unchecked")
+  protected FileInputFormat<K, V> getFileInputFormat(State state, JobConf jobConf) {
+    Preconditions.checkArgument(state.contains(HadoopFileInputSource.FILE_INPUT_FORMAT_CLASS_KEY));
+    try {
+      return (FileInputFormat<K, V>) ReflectionUtils.newInstance(
+          Class.forName(state.getProp(HadoopFileInputSource.FILE_INPUT_FORMAT_CLASS_KEY)), new Configuration());
+    } catch (ClassNotFoundException cnfe) {
+      throw new RuntimeException(cnfe);
+    }
+  }
+
+  /**
+   * Get a {@link OldApiHadoopFileInputExtractor} instance.
+   *
+   * @param recordReader a Hadoop {@link RecordReader} object used to read input records
+   * @param readKeys whether the {@link OldApiHadoopFileInputExtractor} should read keys of type {@link #<K>};
+   *                 by default values of type {@link #>V>} are read.
+   * @return a {@link OldApiHadoopFileInputExtractor} instance
+   */
+  protected abstract OldApiHadoopFileInputExtractor<S, D, K, V> getExtractor(RecordReader<K, V> recordReader,
+      boolean readKeys);
+
+  private String serializeFileSplit(FileSplit fileSplit) throws IOException {
+    Closer closer = Closer.create();
+    try {
+      ByteArrayOutputStream byteArrayOutputStream = closer.register(new ByteArrayOutputStream());
+      DataOutputStream dataOutputStream = closer.register(new DataOutputStream(byteArrayOutputStream));
+      fileSplit.write(dataOutputStream);
+      return BaseEncoding.base64().encode(byteArrayOutputStream.toByteArray());
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  private FileSplit deserializeFileSplit(String fileSplitBytesStr) throws IOException  {
+    Closer closer = Closer.create();
+    try {
+      byte[] fileSplitBytes = BaseEncoding.base64().decode(fileSplitBytesStr);
+      ByteArrayInputStream byteArrayInputStream = closer.register(new ByteArrayInputStream(fileSplitBytes));
+      DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+      FileSplit fileSplit = ReflectionUtils.newInstance(FileSplit.class, new Configuration());
+      fileSplit.readFields(dataInputStream);
+      return fileSplit;
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSource.java
@@ -199,7 +199,7 @@ public abstract class OldApiHadoopFileInputSource<S, D, K, V> implements Source<
     try {
       byte[] fileSplitBytes = BaseEncoding.base64().decode(fileSplitBytesStr);
       ByteArrayInputStream byteArrayInputStream = closer.register(new ByteArrayInputStream(fileSplitBytes));
-      DataInputStream dataInputStream = new DataInputStream(byteArrayInputStream);
+      DataInputStream dataInputStream = closer.register(new DataInputStream(byteArrayInputStream));
       FileSplit fileSplit = ReflectionUtils.newInstance(FileSplit.class, new Configuration());
       fileSplit.readFields(dataInputStream);
       return fileSplit;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopTextInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopTextInputSource.java
@@ -15,11 +15,14 @@ package gobblin.source.extractor.hadoop;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.RecordReader;
 import org.apache.hadoop.mapred.TextInputFormat;
 import org.apache.hadoop.util.ReflectionUtils;
 
 import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
 
 
 /**
@@ -27,7 +30,7 @@ import gobblin.configuration.State;
  *
  * <p>
  *   A concrete implementation of this class should at least implement the
- *   {@link #getExtractor(org.apache.hadoop.mapred.RecordReader, boolean)} method.
+ *   {@link #getExtractor(WorkUnitState, RecordReader, FileSplit, boolean)} method.
  * </p>
  *
  * @param <S> output schema type

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopTextInputSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiHadoopTextInputSource.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FileInputFormat;
+import org.apache.hadoop.mapred.JobConf;
+import org.apache.hadoop.mapred.TextInputFormat;
+import org.apache.hadoop.util.ReflectionUtils;
+
+import gobblin.configuration.State;
+
+
+/**
+ * An extension to {@link OldApiHadoopFileInputSource} that uses a {@link TextInputFormat}.
+ *
+ * <p>
+ *   A concrete implementation of this class should at least implement the
+ *   {@link #getExtractor(org.apache.hadoop.mapred.RecordReader, boolean)} method.
+ * </p>
+ *
+ * @param <S> output schema type
+ *
+ * @author ynli
+ */
+public abstract class OldApiHadoopTextInputSource<S> extends OldApiHadoopFileInputSource<S, Text, LongWritable, Text> {
+
+  @Override
+  protected FileInputFormat<LongWritable, Text> getFileInputFormat(State state, JobConf jobConf) {
+    TextInputFormat textInputFormat = ReflectionUtils.newInstance(TextInputFormat.class, jobConf);
+    textInputFormat.configure(jobConf);
+    return textInputFormat;
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/HadoopFileInputSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/HadoopFileInputSourceTest.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.io.Closer;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * Unit tests for {@link HadoopFileInputSource}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.source.extractor.hadoop"})
+public class HadoopFileInputSourceTest extends OldApiHadoopFileInputSourceTest {
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    super.setUp();
+  }
+
+  @Test
+  public void testGetWorkUnitsAndExtractor() throws IOException, DataRecordException {
+    HadoopFileInputSource<String, Text, LongWritable, Text> fileInputSource = new TestHadoopFileInputSource();
+
+    List<WorkUnit> workUnitList = fileInputSource.getWorkunits(this.sourceState);
+    Assert.assertEquals(workUnitList.size(), 1);
+
+    WorkUnitState workUnitState = new WorkUnitState(workUnitList.get(0));
+
+    Closer closer = Closer.create();
+    try {
+      HadoopFileInputExtractor<String, Text, LongWritable, Text> extractor =
+          (HadoopFileInputExtractor<String, Text, LongWritable, Text>) fileInputSource.getExtractor(
+              workUnitState);
+      Text text = extractor.readRecord(null);
+      Assert.assertEquals(text.toString(), TEXT);
+      Assert.assertNull(extractor.readRecord(null));
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    super.tearDown();
+  }
+
+  private static class TestHadoopFileInputSource extends HadoopTextInputSource<String> {
+
+    @Override
+    protected HadoopFileInputExtractor<String, Text, LongWritable, Text> getExtractor(
+        RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
+      return new TestHadoopFileInputExtractor(recordReader, readKeys);
+    }
+  }
+
+  private static class TestHadoopFileInputExtractor
+      extends HadoopFileInputExtractor<String, Text, LongWritable, Text> {
+
+    public TestHadoopFileInputExtractor(RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
+      super(recordReader, readKeys);
+    }
+
+    @Override
+    public String getSchema() {
+      return "";
+    }
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/HadoopFileInputSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/HadoopFileInputSourceTest.java
@@ -18,6 +18,7 @@ import java.util.List;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
 import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.lib.input.FileSplit;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -75,8 +76,8 @@ public class HadoopFileInputSourceTest extends OldApiHadoopFileInputSourceTest {
   private static class TestHadoopFileInputSource extends HadoopTextInputSource<String> {
 
     @Override
-    protected HadoopFileInputExtractor<String, Text, LongWritable, Text> getExtractor(
-        RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
+    protected HadoopFileInputExtractor<String, Text, LongWritable, Text> getExtractor(WorkUnitState workUnitState,
+        RecordReader<LongWritable, Text> recordReader, FileSplit fileSplit, boolean readKeys) {
       return new TestHadoopFileInputExtractor(recordReader, readKeys);
     }
   }

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSourceTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.RecordReader;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.io.Closer;
+import com.google.common.io.Files;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * Unit tests for {@link OldApiHadoopFileInputSource}.
+ *
+ * @author ynli
+ */
+@Test(groups = {"gobblin.source.extractor.hadoop"})
+public class OldApiHadoopFileInputSourceTest {
+
+  protected static final String TEXT = "This is a test text file";
+
+  protected SourceState sourceState;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    File textFile = new File(OldApiHadoopFileInputSourceTest.class.getSimpleName(), "test.txt");
+    File dir = textFile.getParentFile();
+    if (!dir.exists() && !dir.mkdir()) {
+      throw new IOException("Failed to create directory: " + dir);
+    }
+    if (!textFile.createNewFile()) {
+      throw new IOException("Failed to create text file: " + textFile);
+    }
+
+    Files.write(TEXT, textFile, ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
+
+    this.sourceState = new SourceState();
+    this.sourceState.setProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY, Extract.TableType.SNAPSHOT_ONLY.toString());
+    this.sourceState.setProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, "test");
+    this.sourceState.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "test");
+    this.sourceState.setProp(OldApiHadoopFileInputSource.FILE_INPUT_PATHS_KEY, textFile.getAbsolutePath());
+  }
+
+  @Test
+  public void testGetWorkUnitsAndExtractor() throws IOException, DataRecordException {
+    OldApiHadoopFileInputSource<String, Text, LongWritable, Text> fileInputSource = new TestHadoopFileInputSource();
+
+    List<WorkUnit> workUnitList = fileInputSource.getWorkunits(this.sourceState);
+    Assert.assertEquals(workUnitList.size(), 1);
+
+    WorkUnitState workUnitState = new WorkUnitState(workUnitList.get(0));
+
+    Closer closer = Closer.create();
+    try {
+      OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> extractor =
+          (OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text>) fileInputSource.getExtractor(workUnitState);
+      Text text = extractor.readRecord(null);
+      Assert.assertEquals(text.toString(), TEXT);
+      Assert.assertNull(extractor.readRecord(null));
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    File dir = new File(OldApiHadoopFileInputSourceTest.class.getSimpleName());
+    FileUtils.deleteDirectory(dir);
+  }
+
+  private static class TestHadoopFileInputSource extends OldApiHadoopTextInputSource<String> {
+
+    @Override
+    protected OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> getExtractor(
+        RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
+      return new TestHadoopFileInputExtractor(recordReader, readKeys);
+    }
+  }
+
+  private static class TestHadoopFileInputExtractor extends OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> {
+
+    public TestHadoopFileInputExtractor(RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
+      super(recordReader, readKeys);
+    }
+
+    @Override
+    public String getSchema() {
+      return "";
+    }
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSourceTest.java
@@ -65,7 +65,7 @@ public class OldApiHadoopFileInputSourceTest {
     this.sourceState.setProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY, Extract.TableType.SNAPSHOT_ONLY.toString());
     this.sourceState.setProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, "test");
     this.sourceState.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "test");
-    this.sourceState.setProp(OldApiHadoopFileInputSource.FILE_INPUT_PATHS_KEY, textFile.getAbsolutePath());
+    this.sourceState.setProp(HadoopFileInputSource.FILE_INPUT_PATHS_KEY, textFile.getAbsolutePath());
   }
 
   @Test
@@ -80,7 +80,8 @@ public class OldApiHadoopFileInputSourceTest {
     Closer closer = Closer.create();
     try {
       OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> extractor =
-          (OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text>) fileInputSource.getExtractor(workUnitState);
+          (OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text>) fileInputSource.getExtractor(
+              workUnitState);
       Text text = extractor.readRecord(null);
       Assert.assertEquals(text.toString(), TEXT);
       Assert.assertNull(extractor.readRecord(null));
@@ -106,7 +107,8 @@ public class OldApiHadoopFileInputSourceTest {
     }
   }
 
-  private static class TestHadoopFileInputExtractor extends OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> {
+  private static class TestHadoopFileInputExtractor
+      extends OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> {
 
     public TestHadoopFileInputExtractor(RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
       super(recordReader, readKeys);

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/OldApiHadoopFileInputSourceTest.java
@@ -19,6 +19,7 @@ import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.io.LongWritable;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.FileSplit;
 import org.apache.hadoop.mapred.RecordReader;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -102,7 +103,8 @@ public class OldApiHadoopFileInputSourceTest {
 
     @Override
     protected OldApiHadoopFileInputExtractor<String, Text, LongWritable, Text> getExtractor(
-        RecordReader<LongWritable, Text> recordReader, boolean readKeys) {
+        WorkUnitState workUnitState, RecordReader<LongWritable, Text> recordReader,
+        FileSplit fileSplit, boolean readKeys) {
       return new TestHadoopFileInputExtractor(recordReader, readKeys);
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -566,7 +566,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
           this.map(context.getCurrentKey(), context.getCurrentValue(), context);
         }
         // Actually run the list of WorkUnits
-        runWorkUnits(this.workUnits, context);
+        runWorkUnits(this.workUnits);
       } finally {
         this.cleanup(context);
       }
@@ -617,7 +617,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
      * Run the given list of {@link WorkUnit}s sequentially. If any work unit/task fails,
      * an {@link java.io.IOException} is thrown so the mapper is failed and retried.
      */
-    private void runWorkUnits(List<WorkUnit> workUnits, Context context) throws IOException, InterruptedException {
+    private void runWorkUnits(List<WorkUnit> workUnits) throws IOException, InterruptedException {
       if (workUnits.isEmpty()) {
         LOG.warn("No work units to run");
         return;

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -12,9 +12,10 @@
 
 package gobblin.util;
 
-import gobblin.configuration.State;
-
-import java.io.FileNotFoundException;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 
@@ -22,11 +23,21 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.util.ReflectionUtils;
 
 import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.State;
 
 
+/**
+ * A utility class for working with Hadoop.
+ */
 public class HadoopUtils {
+
   public static Configuration newConfiguration() {
     Configuration conf = new Configuration();
 
@@ -52,8 +63,8 @@ public class HadoopUtils {
 
   /**
    * A wrapper around this.fs.delete which throws IOException if this.fs.delete returns False.
-   * @param f Path to be deleted
-   * @param recursive
+   * @param f path to be deleted
+   * @param recursive whether to do delete sub-directories under the given path (if any) recursively
    * @throws IOException if the deletion fails
    */
   public static void deletePath(FileSystem fs, Path f, boolean recursive) throws IOException {
@@ -84,5 +95,65 @@ public class HadoopUtils {
       conf.set(propName, state.getProp(propName));
     }
     return conf;
+  }
+
+  /**
+   * Serialize a {@link Writable} object into a string.
+   *
+   * @param writable the {@link Writable} object to be serialized
+   * @return a string serialized from the {@link Writable} object
+   * @throws IOException if there's something wrong with the serialization
+   */
+  public static String serializeToString(Writable writable) throws IOException {
+    Closer closer = Closer.create();
+    try {
+      ByteArrayOutputStream byteArrayOutputStream = closer.register(new ByteArrayOutputStream());
+      DataOutputStream dataOutputStream = closer.register(new DataOutputStream(byteArrayOutputStream));
+      writable.write(dataOutputStream);
+      return BaseEncoding.base64().encode(byteArrayOutputStream.toByteArray());
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  /**
+   * Deserialize a {@link Writable} object from a string.
+   *
+   * @param writableClass the {@link Writable} implementation class
+   * @param serializedWritableStr the string containing a serialized {@link Writable} object
+   * @return a {@link Writable} deserialized from the string
+   * @throws IOException if there's something wrong with the deserialization
+   */
+  public static Writable deserializeFromString(Class<? extends Writable> writableClass, String serializedWritableStr)
+      throws IOException {
+    return deserializeFromString(writableClass, serializedWritableStr, new Configuration());
+  }
+
+  /**
+   * Deserialize a {@link Writable} object from a string.
+   *
+   * @param writableClass the {@link Writable} implementation class
+   * @param serializedWritableStr the string containing a serialized {@link Writable} object
+   * @param configuration a {@link Configuration} object containing Hadoop configuration properties
+   * @return a {@link Writable} deserialized from the string
+   * @throws IOException if there's something wrong with the deserialization
+   */
+  public static Writable deserializeFromString(Class<? extends Writable> writableClass, String serializedWritableStr,
+      Configuration configuration) throws IOException {
+    Closer closer = Closer.create();
+    try {
+      byte[] writableBytes = BaseEncoding.base64().decode(serializedWritableStr);
+      ByteArrayInputStream byteArrayInputStream = closer.register(new ByteArrayInputStream(writableBytes));
+      DataInputStream dataInputStream = closer.register(new DataInputStream(byteArrayInputStream));
+      Writable writable = ReflectionUtils.newInstance(writableClass, configuration);
+      writable.readFields(dataInputStream);
+      return writable;
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/ParallelRunnerTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ParallelRunnerTest.java
@@ -13,7 +13,7 @@
 package gobblin.util;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Queue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -25,7 +25,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
 import com.google.common.io.Closer;
 import com.google.gson.Gson;
 import com.google.gson.JsonElement;
@@ -34,7 +34,6 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.source.extractor.Watermark;
 import gobblin.source.extractor.WatermarkSerializerHelper;
 import gobblin.source.workunit.WorkUnit;
-import gobblin.util.ParallelRunner;
 
 
 /**
@@ -132,7 +131,7 @@ public class ParallelRunnerTest {
 
   @Test(dependsOnMethods = "testSerializeToSequenceFile")
   public void testDeserializeFromSequenceFile() throws IOException {
-    List<WorkUnitState> workUnitStates = Lists.newArrayList();
+    Queue<WorkUnitState> workUnitStates = Queues.newConcurrentLinkedQueue();
 
     Closer closer = Closer.create();
     try {


### PR DESCRIPTION
1. `HadoopFileInputSource` and `HadoopFileInputExtractor` for new Hadoop APIs. Also added a `HadoopTextInputSource` mostly for example and testing.
2. `OldApiHadoopFileInputSource` and `OldApiHadoopFileInputExtractor` for old Hadoop APIs. Also added a `OldApiHadoopTextInputSource` mostly for example and testing.
3. Fixed a concurrency bug in `ParallelRunnerTest`.
 
Signed-off-by: Yinan Li <liyinan926@gmail.com>