### PR TITLE
Separate SourceState/JobState from workUnits

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -121,6 +121,7 @@ public class ConfigurationKeys {
   public static final String JOB_TRACKING_URL_KEY = "job.tracking.url";
   public static final String FORK_STATE_KEY = "fork.state";
   public static final String METRIC_CONTEXT_NAME_KEY = "metrics.context.name";
+  public static final String JOB_STATE_FILE_PATH_KEY = "job.state.file.path";
 
   /**
    * Work unit related configuration properties.

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -76,6 +76,50 @@ public class State implements Writable {
   }
 
   /**
+   * Add properties in a {@link State} instance that are not in the current instance.
+   *
+   * @param otherState a {@link State} instance
+   */
+  public void addAllIfNotExist(State otherState) {
+    addAllIfNotExist(otherState.properties);
+  }
+
+  /**
+   * Add properties in a {@link Properties} instance that are not in the current instance.
+   *
+   * @param properties a {@link Properties} instance
+   */
+  public void addAllIfNotExist(Properties properties) {
+    for (String key : properties.stringPropertyNames()) {
+      if (!this.properties.containsKey(key)) {
+        this.properties.setProperty(key, properties.getProperty(key));
+      }
+    }
+  }
+
+  /**
+   * Add properties in a {@link State} instance that are in the current instance.
+   *
+   * @param otherState a {@link State} instance
+   */
+  public void overrideWith(State otherState) {
+    overrideWith(otherState.properties);
+  }
+
+  /**
+   * Add properties in a {@link Properties} instance that are in the current instance.
+   *
+   * @param properties a {@link Properties} instance
+   */
+  public void overrideWith(Properties properties) {
+    for (String key : properties.stringPropertyNames()) {
+      if (this.properties.containsKey(key)) {
+        this.properties.setProperty(key, properties.getProperty(key));
+      }
+    }
+  }
+
+  /**
    * Set the id used for state persistence and logging.
    *
    * @param id id of this instance

--- a/gobblin-api/src/main/java/gobblin/source/workunit/Extract.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/Extract.java
@@ -62,7 +62,11 @@ public class Extract extends State {
    * @param namespace dot separated namespace path
    * @param type {@link TableType}
    * @param table table name
+   *
+   * @deprecated Extract does not use any property in {@link SourceState}.
+   * Use {@link #Extract(TableType, String, String)}
    */
+  @Deprecated
   public Extract(SourceState state, TableType type, String namespace, String table) {
     // Values should only be null for deserialization
     if (state != null && type != null && !Strings.isNullOrEmpty(namespace) && !Strings.isNullOrEmpty(table)) {
@@ -81,11 +85,22 @@ public class Extract extends State {
       }
 
       // Setting full drop date if not already specified, the value can still be overridden if required.
-      if (state.getPropAsBoolean(ConfigurationKeys.EXTRACT_IS_FULL_KEY) && !state
-          .contains(ConfigurationKeys.EXTRACT_FULL_RUN_TIME_KEY)) {
+      if (state.getPropAsBoolean(ConfigurationKeys.EXTRACT_IS_FULL_KEY)
+          && !state.contains(ConfigurationKeys.EXTRACT_FULL_RUN_TIME_KEY)) {
         super.setProp(ConfigurationKeys.EXTRACT_FULL_RUN_TIME_KEY, System.currentTimeMillis());
       }
     }
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param type {@link TableType}
+   * @param namespace dot separated namespace path
+   * @param table table name
+   */
+  public Extract(TableType type, String namespace, String table) {
+    this(new SourceState(), type, namespace, table);
   }
 
   /**
@@ -104,8 +119,8 @@ public class Extract extends State {
     }
 
     Extract other = (Extract) object;
-    return super.equals(other) && this.getNamespace().equals(other.getNamespace()) &&
-        this.getTable().equals(other.getTable()) && this.getExtractId().equals(other.getExtractId());
+    return super.equals(other) && this.getNamespace().equals(other.getNamespace())
+        && this.getTable().equals(other.getTable()) && this.getExtractId().equals(other.getExtractId());
   }
 
   @Override
@@ -119,9 +134,8 @@ public class Extract extends State {
    * @return writer output file path corresponding to this {@link Extract}
    */
   public String getOutputFilePath() {
-    return this.getNamespace().replaceAll("\\.", "/") + "/" +
-        this.getTable() + "/" + this.getExtractId() + "_" +
-        (this.getIsFull() ? "full" : "append");
+    return this.getNamespace().replaceAll("\\.", "/") + "/" + this.getTable() + "/" + this.getExtractId() + "_"
+        + (this.getIsFull() ? "full" : "append");
   }
 
   /**

--- a/gobblin-api/src/main/java/gobblin/source/workunit/ExtractFactory.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/ExtractFactory.java
@@ -1,0 +1,49 @@
+package gobblin.source.workunit;
+
+import java.util.Locale;
+import java.util.Set;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.Sets;
+
+import gobblin.source.workunit.Extract.TableType;
+
+
+public class ExtractFactory {
+  private final Set<Extract> createdInstances;
+  private final DateTimeFormatter dtf;
+
+  public ExtractFactory(String dateTimeFormat) {
+    this.createdInstances = Sets.newHashSet();
+    this.dtf = DateTimeFormat.forPattern(dateTimeFormat).withLocale(Locale.US).withZone(DateTimeZone.UTC);
+  }
+
+  /**
+   * Returns a unique {@link Extract} instance.
+   * Any two calls of this method from the same {@link ExtractFactory} instance guarantees to
+   * return {@link Extract}s with different IDs.
+   *
+   * @param type {@link TableType}
+   * @param namespace dot separated namespace path
+   * @param table table name
+   * @return a unique {@link Extract} instance
+   */
+  public synchronized Extract getUniqueExtract(TableType type, String namespace, String table) {
+    Extract newExtract = new Extract(type, namespace, table);
+    while (this.createdInstances.contains(newExtract)) {
+      if (Strings.isNullOrEmpty(newExtract.getExtractId())) {
+        newExtract.setExtractId(this.dtf.print(new DateTime()));
+      } else {
+        DateTime extractDateTime = this.dtf.parseDateTime(newExtract.getExtractId());
+        newExtract.setExtractId(this.dtf.print(extractDateTime.plusSeconds(1)));
+      }
+    }
+    this.createdInstances.add(newExtract);
+    return newExtract;
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -46,7 +46,10 @@ public class WorkUnit extends State {
 
   /**
    * Default constructor.
+   *
+   * @deprecated Use {@link #createEmpty()}
    */
+  @Deprecated
   public WorkUnit() {
     this(null, null);
   }
@@ -56,7 +59,11 @@ public class WorkUnit extends State {
    *
    * @param state a {@link SourceState} the properties of which will be copied into this {@link WorkUnit} instance
    * @param extract an {@link Extract}
+   *
+   * @deprecated Properties in {@link SourceState} should not be added to a {@link WorkUnit}. Having each 
+   * {@link WorkUnit} contain a copy of {@link SourceState} is a waste of memory. Use {@link #create(Extract)}.
    */
+  @Deprecated
   public WorkUnit(SourceState state, Extract extract) {
     // Values should only be null for deserialization
     if (state != null) {
@@ -76,7 +83,11 @@ public class WorkUnit extends State {
    * @param state a {@link gobblin.configuration.SourceState} the properties of which will be copied into this {@link WorkUnit} instance.
    * @param extract an {@link Extract}.
    * @param watermarkInterval a {@link WatermarkInterval} which defines the range of data this {@link WorkUnit} will process.
+   *
+   * @deprecated Properties in {@link SourceState} should not be added to a {@link WorkUnit}. Having each 
+   * {@link WorkUnit} contain a copy of {@link SourceState} is a waste of memory. Use {@link #create(Extract, WatermarkInterval)}.
    */
+  @Deprecated
   public WorkUnit(SourceState state, Extract extract, WatermarkInterval watermarkInterval) {
     this(state, extract);
 
@@ -104,10 +115,53 @@ public class WorkUnit extends State {
    * Copy constructor.
    *
    * @param other the other {@link WorkUnit} instance
+   *
+   * @deprecated Use {@link #copyOf(WorkUnit)}
    */
+  @Deprecated
   public WorkUnit(WorkUnit other) {
     super.addAll(other);
     this.extract = other.getExtract();
+  }
+
+  /**
+   * Facotry method.
+   *
+   * @return An empty {@link WorkUnit}.
+   */
+  public static WorkUnit createEmpty() {
+    return new WorkUnit();
+  }
+
+  /**
+   * Facotry method.
+   *
+   * @param extract {@link Extract}
+   * @return A {@link WorkUnit} with the given {@link Extract}
+   */
+  public static WorkUnit create(Extract extract) {
+    return new WorkUnit(null, extract);
+  }
+
+  /**
+   * Facotry method.
+   *
+   * @param extract {@link Extract}
+   * @param watermarkInterval {@link WatermarkInterval}
+   * @return A {@link WorkUnit} with the given {@link Extract} and {@link WatermarkInterval}
+   */
+  public static WorkUnit create(Extract extract, WatermarkInterval watermarkInterval) {
+    return new WorkUnit(null, extract, watermarkInterval);
+  }
+
+  /**
+   * Facotry method.
+   *
+   * @param workUnit a {@link WorkUnit} instance
+   * @return A copy of the given {@link WorkUnit} instance
+   */
+  public static WorkUnit copyOf(WorkUnit other) {
+    return new WorkUnit(other);
   }
 
   /**
@@ -188,15 +242,13 @@ public class WorkUnit extends State {
   }
 
   @Override
-  public void readFields(DataInput in)
-      throws IOException {
+  public void readFields(DataInput in) throws IOException {
     super.readFields(in);
     this.extract.readFields(in);
   }
 
   @Override
-  public void write(DataOutput out)
-      throws IOException {
+  public void write(DataOutput out) throws IOException {
     super.write(out);
     this.extract.write(out);
   }

--- a/gobblin-api/src/test/java/gobblin/source/workunit/ExtractFactoryTest.java
+++ b/gobblin-api/src/test/java/gobblin/source/workunit/ExtractFactoryTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.workunit;
+
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Sets;
+
+
+@Test(groups = { "gobblin.source.workunit" })
+public class ExtractFactoryTest {
+
+  /**
+   * Verify that each {@link Extract} created by an {@ExtractFactory} has a unique ID.
+   */
+  @Test
+  public void testGetUniqueExtract() {
+    ExtractFactory extractFactory = new ExtractFactory("yyyyMMddHHmmss");
+    Set<String> extractIDs = Sets.newHashSet();
+    int numOfExtracts = 100;
+    for (int i = 0; i < numOfExtracts; i++) {
+      extractIDs
+          .add(extractFactory.getUniqueExtract(Extract.TableType.APPEND_ONLY, "namespace", "table").getExtractId());
+    }
+    Assert.assertEquals(extractIDs.size(), numOfExtracts);
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/AbstractSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/AbstractSourceTest.java
@@ -148,6 +148,10 @@ public class AbstractSourceTest {
    */
   @Test
   public void testGetPreviousWorkUnitStatesWithConfigOverWrittenEnabled() {
+    for (WorkUnitState workUnitState : this.previousWorkUnitStates) {
+      workUnitState.setProp("a", "3");
+      workUnitState.setProp("b", "4");
+    }
     SourceState sourceState = new SourceState(new State(), this.previousWorkUnitStates);
     sourceState.setProp(ConfigurationKeys.WORK_UNIT_RETRY_POLICY_KEY, "always");
     sourceState.setProp(ConfigurationKeys.OVERWRITE_CONFIGS_IN_STATESTORE, Boolean.TRUE);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -153,8 +153,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       taskExecutor.submit(task);
     }
 
-    new EventSubmitter.Builder(JobMetrics.get(jobId).getMetricContext(), "gobblin.runtime").build().
-        submit(EventNames.TASKS_SUBMITTED, "tasksCount", Integer.toString(workUnits.size()));
+    new EventSubmitter.Builder(JobMetrics.get(jobId).getMetricContext(), "gobblin.runtime").build()
+        .submit(EventNames.TASKS_SUBMITTED, "tasksCount", Integer.toString(workUnits.size()));
 
     return tasks;
   }
@@ -208,14 +208,14 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public void launchJob(JobListener jobListener) throws JobException {
 
     if (this.jobContext.getJobMetricsOptional().isPresent()) {
       this.jobContext.getJobMetricsOptional().get().startMetricReporting(this.jobProps);
     }
 
-    TimingEvent launchJobTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.FULL_JOB_EXECUTION);
+    TimingEvent launchJobTimer =
+        this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.FULL_JOB_EXECUTION);
     String jobId = this.jobContext.getJobId();
     JobState jobState = this.jobContext.getJobState();
 
@@ -226,8 +226,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
             "Previous instance of job %s is still running, skipping this scheduled run", this.jobContext.getJobName()));
       }
 
-      TimingEvent workUnitsCreationTimer = this.eventSubmitter.getTimingEvent(
-          TimingEventNames.LauncherTimings.WORK_UNITS_CREATION);
+      TimingEvent workUnitsCreationTimer =
+          this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.WORK_UNITS_CREATION);
       // Generate work units of the job from the source
       Optional<List<WorkUnit>> workUnits = Optional.fromNullable(this.jobContext.getSource().getWorkunits(jobState));
       workUnitsCreationTimer.stop();
@@ -260,8 +260,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       // Write job execution info to the job history store before the job starts to run
       storeJobExecutionInfo();
 
-      TimingEvent jobRunTimer =
-          this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_RUN);
+      TimingEvent jobRunTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_RUN);
       // Start the job and wait for it to finish
       runWorkUnits(workUnits.get());
       jobRunTimer.stop();
@@ -274,8 +273,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         return;
       }
 
-      TimingEvent jobCommitTimer =
-          this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_COMMIT);
+      TimingEvent jobCommitTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_COMMIT);
 
       setFinalJobState(jobState);
       if (canCommit(this.jobContext.getJobCommitPolicy(), jobState)) {
@@ -297,8 +295,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       jobState.setEndTime(endTime);
       jobState.setDuration(endTime - jobState.getStartTime());
 
-      TimingEvent jobCleanupTimer =
-          this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_CLEANUP);
+      TimingEvent jobCleanupTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_CLEANUP);
       cleanupStagingData(jobState);
       jobCleanupTimer.stop();
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -63,8 +63,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   public LocalJobLauncher(Properties jobProps) throws Exception {
     super(jobProps);
 
-    TimingEvent jobLocalSetupTimer =
-        this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.JOB_LOCAL_SETUP);
+    TimingEvent jobLocalSetupTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.JOB_LOCAL_SETUP);
 
     this.taskExecutor = new TaskExecutor(jobProps);
     this.taskStateTracker = new LocalTaskStateTracker2(jobProps, this.taskExecutor);
@@ -107,8 +106,11 @@ public class LocalJobLauncher extends AbstractJobLauncher {
     String jobId = this.jobContext.getJobId();
     JobState jobState = this.jobContext.getJobState();
 
-    TimingEvent workUnitsRunTimer =
-        this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.WORK_UNITS_RUN);
+    for (WorkUnit workUnit : workUnitsToRun) {
+      workUnit.addAllIfNotExist(jobState);
+    }
+
+    TimingEvent workUnitsRunTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.WORK_UNITS_RUN);
 
     this.countDownLatch = new CountDownLatch(workUnitsToRun.size());
     List<Task> tasks = AbstractJobLauncher.submitWorkUnits(this.jobContext.getJobId(), workUnitsToRun,


### PR DESCRIPTION
Summary:
- Deprecated all constructors of `WorkUnit`, and added some factory methods, which do not add job states to workunits. 
The reason to use factory methods is to avoid having too many constructors for `WorkUnit`, some deprecated and some not deprecated.
- Deprecated the constructor of `Extract` that takes `SourceState`, added a new constructor without `SourceState`.
- In `MRJobLauncher.prepareHadoopJob()`, serialize `jobState` into a file. Then in `TaskRunner.setup()`, read `jobState` from the file and add it to each `workUnit`.
- In `LocalJobLauncher.runWorkUnits()`, add `jobState` to each `workUnit`.
- In `MRJobLauncher.runWorkUnits()`, combine `jobState` with each `workUnit` into a `fatWorkUnit`, since properties from both `jobState` and `workUnit` are needed in order to invoke `JobLauncherUtils.cleanStagingData()`.
- Modified `KafkaSource` to use the new paradigm.

Tested with Kafka adapter. Existing source implementations still work.