### PR TITLE
Fixed a potential NPE in WorkUnit.getLowWatermark()

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -160,7 +160,11 @@ public class WorkUnitState extends State {
    * Backoff the actual high watermark to the low watermark returned by {@link WorkUnit#getLowWatermark()}.
    */
   public void backoffActualHighWatermark() {
-    setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, this.workunit.getLowWatermark().toString());
+    JsonElement lowWatermark = this.workunit.getLowWatermark();
+    if (lowWatermark == null) {
+      return;
+    }
+    setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, lowWatermark.toString());
   }
 
   /**

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -113,9 +113,13 @@ public class WorkUnit extends State {
   /**
    * Get the low {@link Watermark} as a {@link JsonElement}.
    *
-   * @return a {@link JsonElement} representing the low {@link Watermark}.
+   * @return a {@link JsonElement} representing the low {@link Watermark} or
+   *         {@code null} if the low {@link Watermark} is not set.
    */
   public JsonElement getLowWatermark() {
+    if (!contains(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY)) {
+      return null;
+    }
     return JSON_PARSER.parse(getProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY)).getAsJsonObject()
         .get(WatermarkInterval.LOW_WATERMARK_TO_JSON_KEY);
   }

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -17,7 +17,6 @@ import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
-import org.apache.avro.file.DataFileConstants;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -167,10 +166,12 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   /**
    * Create a new {@link DataFileWriter} for writing Avro records.
    *
-   * @param avroFile Avro file to write to
-   * @param bufferSize Buffer size
-   * @param codecType Compression codec type
-   * @param deflateLevel Deflate level
+   * @param avroFile the Avro file to write to
+   * @param bufferSize the Avro data writer buffer size
+   * @param codecFactory a {@link CodecFactory} object for building the compression codec
+   * @param replication the replication factor
+   * @param blockSize the block size
+   * @param permissions a {@link FsPermission} object defining the Avro file permission
    * @throws IOException if there is something wrong creating a new {@link DataFileWriter}
    */
   private DataFileWriter<GenericRecord> createDatumWriter(Path avroFile, int bufferSize, CodecFactory codecFactory,

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -164,7 +164,11 @@ public class MRJobLauncher extends AbstractJobLauncher {
         this.job.killJob();
       }
     } finally {
-      super.close();
+      try {
+        cleanUpWorkingDirectory();
+      } finally {
+        super.close();
+      }
     }
   }
 
@@ -235,7 +239,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   @Override
   protected void executeCancellation() {
     try {
-      if (!this.job.isComplete()) {
+      if (this.hadoopJobSubmitted && !this.job.isComplete()) {
         LOG.info("Killing the Hadoop MR job for job " + this.jobContext.getJobId());
         this.job.killJob();
       }


### PR DESCRIPTION
`WorkUnit.getLowWatermark()` assumes that the key `watermark.interval.value` is set, which seems only happening in the Kafka adapter. If this key is not set, `getLowWatermark` will throw an NPE if it is called, which is called in `WorkUnitState.backoffActualHighWatermark`.

Signed-off-by: Yinan Li <liyinan926@gmail.com>