### PR TITLE
Made the previous SourceState available in the current run

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ImmutableWorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ImmutableWorkUnitState.java
@@ -10,46 +10,45 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.source.workunit;
+package gobblin.configuration;
 
 import java.io.DataInput;
 import java.io.IOException;
 import java.util.Properties;
 
-import gobblin.configuration.State;
+import gobblin.source.extractor.Watermark;
 
 
 /**
- * An immutable version of {@link WorkUnit}.
+ * An immutable version of {@link WorkUnitState}.
  *
  * @author ynli
  */
-public class ImmutableWorkUnit extends WorkUnit {
+public class ImmutableWorkUnitState extends WorkUnitState {
 
-  public ImmutableWorkUnit(WorkUnit workUnit) {
-    super(workUnit.getExtract());
-    super.addAll(workUnit);
+  public ImmutableWorkUnitState(WorkUnitState workUnitState) {
+    super(workUnitState.getWorkunit());
+    super.addAll(workUnitState);
+  }
+
+  @Override
+  public void setWorkingState(WorkingState state) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setActualHighWatermark(Watermark watermark) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Deprecated
+  @Override
+  public void setHighWaterMark(long value) {
+    throw new UnsupportedOperationException();
   }
 
   @Override
   public void setProp(String key, Object value) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Deprecated
-  @Override
-  public void setHighWaterMark(long highWaterMark) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Deprecated
-  @Override
-  public void setLowWaterMark(long lowWaterMark) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public void addAll(Properties properties) {
     throw new UnsupportedOperationException();
   }
 
@@ -59,17 +58,27 @@ public class ImmutableWorkUnit extends WorkUnit {
   }
 
   @Override
+  public void addAll(Properties properties) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void setId(String id) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public synchronized void appendToListProp(String key, String value) {
+  public void readFields(DataInput in) throws IOException {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public void readFields(DataInput in) throws IOException {
+  public void backoffActualHighWatermark() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public synchronized void appendToListProp(String key, String value) {
     throw new UnsupportedOperationException();
   }
 }

--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -73,7 +73,9 @@ public class SourceState extends State {
   public SourceState(State properties, List<WorkUnitState> previousWorkUnitStates) {
     addAll(properties);
     this.previousSourceState = EMPTY_SOURCE_STATE;
-    this.previousWorkUnitStates.addAll(previousWorkUnitStates);
+    for (WorkUnitState workUnitState : previousWorkUnitStates) {
+      this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));
+    }
   }
 
   /**
@@ -86,7 +88,9 @@ public class SourceState extends State {
   public SourceState(State properties, SourceState previousSourceState, List<WorkUnitState> previousWorkUnitStates) {
     addAll(properties);
     this.previousSourceState = previousSourceState;
-    this.previousWorkUnitStates.addAll(previousWorkUnitStates);
+    for (WorkUnitState workUnitState : previousWorkUnitStates) {
+      this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));
+    }
   }
 
   /**
@@ -156,9 +160,9 @@ public class SourceState extends State {
   public void readFields(DataInput in) throws IOException {
     int size = in.readInt();
     for (int i = 0; i < size; i++) {
-      WorkUnitState state = new WorkUnitState();
-      state.readFields(in);
-      this.previousWorkUnitStates.add(state);
+      WorkUnitState workUnitState = new WorkUnitState();
+      workUnitState.readFields(in);
+      this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));
     }
     super.readFields(in);
   }
@@ -168,10 +172,6 @@ public class SourceState extends State {
    * internal state of a {@link SourceState}.
    */
   private static class ImmutableSourceState extends SourceState {
-
-    public ImmutableSourceState() {
-
-    }
 
     public ImmutableSourceState(SourceState sourceState) {
       super(sourceState, sourceState.previousSourceState, sourceState.previousWorkUnitStates);

--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -17,6 +17,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Properties;
 import java.util.Set;
 
 import org.joda.time.DateTime;
@@ -47,26 +48,54 @@ import gobblin.source.workunit.Extract;
  */
 public class SourceState extends State {
 
-  private final List<WorkUnitState> previousTaskStates = Lists.newArrayList();
+  private static final SourceState EMPTY_SOURCE_STATE = new SourceState();
+
   private static final Set<Extract> extractSet = Sets.newConcurrentHashSet();
   private static final DateTimeFormatter DTF =
       DateTimeFormat.forPattern("yyyyMMddHHmmss").withLocale(Locale.US).withZone(DateTimeZone.UTC);
+
+  private final SourceState previousSourceState;
+  private final List<WorkUnitState> previousWorkUnitStates = Lists.newArrayList();
 
   /**
    * Default constructor.
    */
   public SourceState() {
+    this.previousSourceState = EMPTY_SOURCE_STATE;
   }
 
   /**
    * Constructor.
    *
    * @param properties job configuration properties
-   * @param previousTaskStates list of previous task states
+   * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
    */
-  public SourceState(State properties, List<WorkUnitState> previousTaskStates) {
+  public SourceState(State properties, List<WorkUnitState> previousWorkUnitStates) {
     addAll(properties);
-    this.previousTaskStates.addAll(previousTaskStates);
+    this.previousSourceState = EMPTY_SOURCE_STATE;
+    this.previousWorkUnitStates.addAll(previousWorkUnitStates);
+  }
+
+  /**
+   * Constructor.
+   *
+   * @param properties job configuration properties
+   * @param previousSourceState {@link SourceState} of the previous job run
+   * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
+   */
+  public SourceState(State properties, SourceState previousSourceState, List<WorkUnitState> previousWorkUnitStates) {
+    addAll(properties);
+    this.previousSourceState = previousSourceState;
+    this.previousWorkUnitStates.addAll(previousWorkUnitStates);
+  }
+
+  /**
+   * Get the {@link SourceState} of the previous job run.
+   *
+   * @return {@link SourceState} of the previous job run
+   */
+  public SourceState getPreviousSourceState() {
+    return new ImmutableSourceState(this.previousSourceState);
   }
 
   /**
@@ -75,7 +104,7 @@ public class SourceState extends State {
    * @return (possibly empty) list of {@link WorkUnitState}s from the previous job run
    */
   public List<WorkUnitState> getPreviousWorkUnitStates() {
-    return ImmutableList.<WorkUnitState>builder().addAll(this.previousTaskStates).build();
+    return ImmutableList.<WorkUnitState>builder().addAll(this.previousWorkUnitStates).build();
   }
 
   /**
@@ -115,24 +144,67 @@ public class SourceState extends State {
   }
 
   @Override
-  public void write(DataOutput out)
-      throws IOException {
-    out.writeInt(this.previousTaskStates.size());
-    for (WorkUnitState state : this.previousTaskStates) {
+  public void write(DataOutput out) throws IOException {
+    out.writeInt(this.previousWorkUnitStates.size());
+    for (WorkUnitState state : this.previousWorkUnitStates) {
       state.write(out);
     }
     super.write(out);
   }
 
   @Override
-  public void readFields(DataInput in)
-      throws IOException {
+  public void readFields(DataInput in) throws IOException {
     int size = in.readInt();
     for (int i = 0; i < size; i++) {
       WorkUnitState state = new WorkUnitState();
       state.readFields(in);
-      this.previousTaskStates.add(state);
+      this.previousWorkUnitStates.add(state);
     }
     super.readFields(in);
+  }
+
+  /**
+   * An immutable version of {@link SourceState} that disables all methods that may change the
+   * internal state of a {@link SourceState}.
+   */
+  private static class ImmutableSourceState extends SourceState {
+
+    public ImmutableSourceState() {
+
+    }
+
+    public ImmutableSourceState(SourceState sourceState) {
+      super(sourceState, sourceState.previousSourceState, sourceState.previousWorkUnitStates);
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setId(String id) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setProp(String key, Object value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public synchronized void appendToListProp(String key, String value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAll(State otherState) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAll(Properties properties) {
+      throw new UnsupportedOperationException();
+    }
   }
 }

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -355,6 +355,17 @@ public class State implements Writable {
   }
 
   @Override
+  public boolean equals(Object object) {
+    if (!(object instanceof State)) {
+      return false;
+    }
+
+    State other = (State) object;
+    return ((this.id == null && other.id == null) || (this.id != null && this.id.equals(other.id))) &&
+        this.properties.equals(other.getProperties());
+  }
+
+  @Override
   public int hashCode() {
     final int prime = 31;
     int result = 1;

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -46,8 +46,6 @@ public class WorkUnitState extends State {
 
   private static final String FINAL_CONSTRUCT_STATE_PREFIX = "construct.final.state.";
 
-  private Watermark actualHighWatermark;
-
   private static final JsonParser JSON_PARSER = new JsonParser();
 
   /**
@@ -144,8 +142,6 @@ public class WorkUnitState extends State {
    * a method such as getCurrentHighWatermark() should be added.
    */
   public void setActualHighWatermark(Watermark watermark) {
-    this.actualHighWatermark = watermark;
-
     /**
      * TODO
      *
@@ -153,7 +149,7 @@ public class WorkUnitState extends State {
      * internally in via a configuration key. Once a state-store migration can be done, the {@link Watermark} can be
      * stored as Binary JSON.
      */
-    setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, this.actualHighWatermark.toJson().toString());
+    setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, watermark.toJson().toString());
   }
 
   /**
@@ -258,6 +254,17 @@ public class WorkUnitState extends State {
       throws IOException {
     this.workunit.write(out);
     super.write(out);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (!(object instanceof WorkUnitState)) {
+      return false;
+    }
+
+    WorkUnitState other = (WorkUnitState) object;
+    return ((this.workunit == null && other.workunit == null) ||
+        (this.workunit != null && this.workunit.equals(other.workunit))) && super.equals(other);
   }
 
   @Override

--- a/gobblin-api/src/main/java/gobblin/source/workunit/ImmutableExtract.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/ImmutableExtract.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.workunit;
+
+import java.io.DataInput;
+import java.io.IOException;
+import java.util.Properties;
+
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+
+
+/**
+ * An immutable version of {@link Extract}.
+ *
+ * @author ynli
+ */
+public class ImmutableExtract extends Extract {
+
+  public ImmutableExtract(SourceState state, TableType type, String namespace, String table) {
+    super(state, type, namespace, table);
+  }
+
+  public ImmutableExtract(Extract extract) {
+    super(extract);
+  }
+
+  @Override
+  public void setFullTrue(long extractFullRunTime) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setPrimaryKeys(String... primaryKeyFieldName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setDeltaFields(String... deltaFieldName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setId(String id) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setProp(String key, Object value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public synchronized void appendToListProp(String key, String value) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addAll(Properties properties) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addAll(State otherState) {
+    super.addAll(otherState);
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void setExtractId(String extractId) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addPrimaryKey(String... primaryKeyFieldName) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public void addDeltaField(String... deltaFieldName) {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -116,7 +116,7 @@ public class WorkUnit extends State {
    * @return the {@link Extract} associated with this {@link WorkUnit}
    */
   public Extract getExtract() {
-    return this.extract;
+    return new ImmutableExtract(this.extract);
   }
 
   /**

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -92,6 +92,15 @@ public class WorkUnit extends State {
   }
 
   /**
+   * Constructor.
+   *
+   * @param extract a {@link Extract} object
+   */
+  public WorkUnit(Extract extract) {
+    this.extract = extract;
+  }
+
+  /**
    * Copy constructor.
    *
    * @param other the other {@link WorkUnit} instance
@@ -186,6 +195,17 @@ public class WorkUnit extends State {
       throws IOException {
     super.write(out);
     this.extract.write(out);
+  }
+
+  @Override
+  public boolean equals(Object object) {
+    if (!(object instanceof WorkUnit)) {
+      return false;
+    }
+
+    WorkUnit other = (WorkUnit) object;
+    return ((this.extract == null && other.extract == null) ||
+        (this.extract != null && this.extract.equals(other.extract))) && super.equals(other);
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/AbstractSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/AbstractSource.java
@@ -27,8 +27,7 @@ import gobblin.source.workunit.WorkUnit;
 
 
 /**
- * A base implementation of {@link gobblin.source.Source}
- * that provides default behavior.
+ * A base implementation of {@link gobblin.source.Source} that provides default behavior.
  *
  * @author ynli
  */

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/AbstractSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/AbstractSourceTest.java
@@ -28,18 +28,19 @@ import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.WorkUnitState.WorkingState;
 import gobblin.source.extractor.Extractor;
+import gobblin.source.workunit.WorkUnit;
 
 
 @Test(groups = { "gobblin.source.extractor.extract" })
 public class AbstractSourceTest {
 
-  private TestSource testSource;
+  private TestSource<String, String> testSource;
   private List<WorkUnitState> previousWorkUnitStates;
   private List<WorkUnitState> expectedPreviousWorkUnitStates;
 
   @BeforeClass
   public void setUpBeforeClass() {
-    this.testSource = new TestSource();
+    this.testSource = new TestSource<String, String>();
 
     WorkUnitState committedWorkUnitState = new WorkUnitState();
     committedWorkUnitState.setWorkingState(WorkingState.COMMITTED);
@@ -132,7 +133,7 @@ public class AbstractSourceTest {
    * Test the always-retry policy, with WORK_UNIT_RETRY_ENABLED_KEY enabled.
    */
   @Test
-  public void testGetPreviousWorkUnitStatesEabledRetry() {
+  public void testGetPreviousWorkUnitStatesEnabledRetry() {
     SourceState sourceState = new SourceState(new State(), this.previousWorkUnitStates);
     sourceState.setProp(ConfigurationKeys.WORK_UNIT_RETRY_ENABLED_KEY, Boolean.TRUE);
 
@@ -142,7 +143,7 @@ public class AbstractSourceTest {
   }
 
   /**
-   * Test under always-retry policy, the overrite_configs_in_statestore enabled.
+   * Test under always-retry policy, the overwrite_configs_in_statestore enabled.
    * The previous workUnitState should be reset with the config in the current source.
    */
   @Test
@@ -157,8 +158,6 @@ public class AbstractSourceTest {
 
     List<WorkUnitState> returnedWorkUnitStates = this.testSource.getPreviousWorkUnitStatesForRetry(sourceState);
 
-    Assert.assertEquals(returnedWorkUnitStates, this.expectedPreviousWorkUnitStates);
-
     for (WorkUnitState workUnitState : returnedWorkUnitStates) {
       Assert.assertEquals(workUnitState.getProp("a"), "1");
       Assert.assertEquals(workUnitState.getProp("b"), "2");
@@ -166,7 +165,7 @@ public class AbstractSourceTest {
   }
 
   /**
-   * Test under always-retry policy, the overrite_configs_in_statestore disabled (default).
+   * Test under always-retry policy, the overwrite_configs_in_statestore disabled (default).
    * The previous workUnitState would not be reset with the config in the current source.
    */
   @Test
@@ -189,15 +188,15 @@ public class AbstractSourceTest {
   }
 
   // Class for test AbstractSource
-  public class TestSource extends AbstractSource {
+  public class TestSource<S, D> extends AbstractSource<S, D> {
 
     @Override
-    public List getWorkunits(SourceState state) {
+    public List<WorkUnit> getWorkunits(SourceState state) {
       return null;
     }
 
     @Override
-    public Extractor getExtractor(WorkUnitState state) throws IOException {
+    public Extractor<S, D> getExtractor(WorkUnitState state) throws IOException {
       return null;
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -89,8 +89,7 @@ public class JobContext {
     State jobPropsState = new State();
     jobPropsState.addAll(jobProps);
     JobState previousJobState = getPreviousJobState(this.jobName);
-    this.jobState = new JobState(jobPropsState, previousJobState.getTaskStatesAsWorkUnitStates(),
-        this.jobName, this.jobId);
+    this.jobState = new JobState(jobPropsState, previousJobState, this.jobName, this.jobId);
     // Remember the number of consecutive failures of this job in the past
     this.jobState.setProp(ConfigurationKeys.JOB_FAILURES_KEY,
         previousJobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -83,8 +83,8 @@ public class JobState extends SourceState {
     this.setId(jobId);
   }
 
-  public JobState(State properties, List<WorkUnitState> previousTaskStates, String jobName, String jobId) {
-    super(properties, previousTaskStates);
+  public JobState(State properties, JobState previousJobState, String jobName, String jobId) {
+    super(properties, previousJobState, previousJobState.getTaskStatesAsWorkUnitStates());
     this.jobName = jobName;
     this.jobId = jobId;
     this.setId(jobId);


### PR DESCRIPTION
Currently only the previous `WorkUnitState`s are available in the current job run through `SourceState.getPreviousWorkUnitStates`. The list of previous `WorkUnitStates` are from the previous `SourceState` (`JobState` more precisely). The previous `SourceState` itself, however, is not available for the `Source` to use. This PR fixed this so the previous `SourceState` is also available through `SourceState.getPreviousSourceState`.

Signed-off-by: Yinan Li <liyinan926@gmail.com>