### PR TITLE
Fixing bug in WorkUnitState.getExtract()

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -233,7 +233,6 @@ public class WorkUnitState extends State {
    */
   public Extract getExtract() {
     Extract curExtract = new Extract(workunit.getExtract());
-    curExtract.addAll(this);
     return curExtract;
   }
 


### PR DESCRIPTION
Hey @liyinan926 I noticed that the `getExtract()` method in `WorkUnitState` adds all the props for the current `WorkUnitState` to its `Extract` before returning it. Is this behavior necessary / expected?

It's causing some issues on the IDPC side because now each `Extract` is no longer unique. Properties such as `qualitychecker.rows.written` are showing up in each `Extract` which is a little weird. This only became an issue recently because the `equals()` method of `Extract` has recently been changed so that is does a comparison for all the `Extract`s props.