### PR TITLE
Fixed the way addAll(State) is used in some State classes

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -70,7 +70,7 @@ public class SourceState extends State {
    * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
    */
   public SourceState(State properties, List<WorkUnitState> previousWorkUnitStates) {
-    addAll(properties);
+    super.addAll(properties);
     this.previousSourceState = Optional.absent();
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
       this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));
@@ -85,7 +85,7 @@ public class SourceState extends State {
    * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
    */
   public SourceState(State properties, SourceState previousSourceState, List<WorkUnitState> previousWorkUnitStates) {
-    addAll(properties);
+    super.addAll(properties);
     this.previousSourceState = Optional.of(previousSourceState);
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
       this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));

--- a/gobblin-api/src/main/java/gobblin/source/workunit/Extract.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/Extract.java
@@ -94,7 +94,7 @@ public class Extract extends State {
    * @param extract the other {@link Extract} instance
    */
   public Extract(Extract extract) {
-    addAll(extract);
+    super.addAll(extract);
   }
 
   @Override

--- a/gobblin-api/src/main/java/gobblin/source/workunit/ImmutableExtract.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/ImmutableExtract.java
@@ -72,7 +72,7 @@ public class ImmutableExtract extends Extract {
 
   @Override
   public void addAll(State otherState) {
-    super.addAll(otherState);
+    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -60,7 +60,7 @@ public class WorkUnit extends State {
   public WorkUnit(SourceState state, Extract extract) {
     // Values should only be null for deserialization
     if (state != null) {
-      this.addAll(state);
+      super.addAll(state);
     }
 
     if (extract != null) {
@@ -106,7 +106,7 @@ public class WorkUnit extends State {
    * @param other the other {@link WorkUnit} instance
    */
   public WorkUnit(WorkUnit other) {
-    addAll(other);
+    super.addAll(other);
     this.extract = other.getExtract();
   }
 


### PR DESCRIPTION
Currently, `addAll` is called to add all properties from one `State` object to another. This will cause a `UnsupportedOperationException` if the source `State` object is immutable because the `addAll` of the immutable `State` class will be called. Changed all such occurrences to `super.addAll`.
 
Signed-off-by: Yinan Li <liyinan926@gmail.com>