### PR TITLE
Fixed gobblin-mapreduce.sh and allowed use of proxy in WikipediaExtractor

### DIFF
--- a/bin/gobblin-mapreduce.sh
+++ b/bin/gobblin-mapreduce.sh
@@ -100,8 +100,8 @@ set_user_jars "$JARS"
 # Jars Gobblin runtime depends on
 LIBJARS=$USER_JARS$separator$FWDIR_LIB/gobblin-metastore.jar,$FWDIR_LIB/gobblin-metrics.jar,\
 $FWDIR_LIB/gobblin-core.jar,$FWDIR_LIB/gobblin-api.jar,$FWDIR_LIB/gobblin-utility.jar,\
-$FWDIR_LIB/guava-15.0.jar,$FWDIR_LIB/avro-1.7.6.jar,$FWDIR_LIB/avro-mapred-1.7.6.jar,\
-$FWDIR_LIB/metrics-core-3.1.0.jar,$FWDIR_LIB/gson-2.2.4.jar,$FWDIR_LIB/joda-time-1.6.jar,$FWDIR_LIB/data-1.15.9.jar
+$FWDIR_LIB/guava-18.0.jar,$FWDIR_LIB/avro-1.7.7.jar,$FWDIR_LIB/metrics-core-3.1.0.jar,\
+$FWDIR_LIB/gson-2.3.1.jar,$FWDIR_LIB/joda-time-2.8.1.jar,$FWDIR_LIB/data-1.15.9.jar
 
 # Add libraries to the Hadoop classpath
 GOBBLIN_DEP_JARS=`echo "$USER_JARS" | tr ',' ':' `

--- a/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
+++ b/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
@@ -12,11 +12,12 @@
 
 package gobblin.example.wikipedia;
 
-import gobblin.configuration.ConfigurationKeys;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
+import java.net.InetSocketAddress;
+import java.net.Proxy;
 import java.net.URL;
 import java.util.Iterator;
 import java.util.LinkedList;
@@ -32,6 +33,7 @@ import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
@@ -67,6 +69,7 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
 
   private static final Gson GSON = new Gson();
 
+  private final WorkUnit workUnit;
   private final WikiResponseReader reader;
   private final int revisionsCnt;
   private final String rootUrl;
@@ -92,8 +95,7 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
         while (!requestedTitles.isEmpty()) {
           String currentTitle = requestedTitles.poll();
           try {
-            recordsOfCurrentTitle =
-                retrievePageRevisions(currentTitle);
+            recordsOfCurrentTitle = retrievePageRevisions(workUnit, currentTitle);
           } catch (IOException e) {
             LOG.error("IOException while retrieving revisions for title '" + currentTitle + "'");
           }
@@ -120,34 +122,33 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
   }
 
   public WikipediaExtractor(WorkUnitState workUnitState) throws IOException {
-    WorkUnit workUnit = workUnitState.getWorkunit();
-    rootUrl = workUnit.getProp(WIKIPEDIA_API_ROOTURL);
-    schema = workUnit.getProp(WIKIPEDIA_AVRO_SCHEMA);
-    requestedTitles = new LinkedList<String>(SPLITTER.splitToList(workUnit.getProp(SOURCE_PAGE_TITLES)));
-    revisionsCnt = Integer.parseInt(workUnit.getProp(SOURCE_REVISIONS_CNT));
-    numRequestedTitles = requestedTitles.size();
+    this.workUnit = workUnitState.getWorkunit();
+    this.rootUrl = this.workUnit.getProp(WIKIPEDIA_API_ROOTURL);
+    this.schema = this.workUnit.getProp(WIKIPEDIA_AVRO_SCHEMA);
+    this.requestedTitles = new LinkedList<String>(SPLITTER.splitToList(this.workUnit.getProp(SOURCE_PAGE_TITLES)));
+    this.revisionsCnt = Integer.parseInt(this.workUnit.getProp(SOURCE_REVISIONS_CNT));
+    this.numRequestedTitles = this.requestedTitles.size();
 
-    if (requestedTitles.isEmpty()) {
-      recordsOfCurrentTitle = new LinkedList<JsonElement>();
+    if (this.requestedTitles.isEmpty()) {
+      this.recordsOfCurrentTitle = new LinkedList<JsonElement>();
     } else {
-      String firstTitle = requestedTitles.poll();
-      recordsOfCurrentTitle = retrievePageRevisions(firstTitle);
+      String firstTitle = this.requestedTitles.poll();
+      this.recordsOfCurrentTitle = retrievePageRevisions(this.workUnit, firstTitle);
     }
 
     this.reader = new WikiResponseReader();
   }
 
-  private Queue<JsonElement> retrievePageRevisions(String pageTitle) throws IOException {
+  private Queue<JsonElement> retrievePageRevisions(WorkUnit workUnit, String pageTitle) throws IOException {
     Queue<JsonElement> retrievedRevisions = new LinkedList<JsonElement>();
 
     Closer closer = Closer.create();
     HttpURLConnection conn = null;
     StringBuilder sb = new StringBuilder();
-    String urlStr = rootUrl + "&titles=" + pageTitle
-        + "&rvlimit=" + revisionsCnt;
+    String urlStr = this.rootUrl + "&titles=" + pageTitle + "&rvlimit=" + this.revisionsCnt;
     try {
-      URL url = new URL(urlStr);
-      conn = (HttpURLConnection) url.openConnection();
+      conn = getHttpConnection(workUnit, urlStr);
+      conn.connect();
       BufferedReader br = closer.register(
           new BufferedReader(new InputStreamReader(conn.getInputStream(), ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
       String line;
@@ -208,11 +209,26 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
       if (pageIdObj.has(JSON_MEMBER_TITLE)) {
         revObj.add(JSON_MEMBER_TITLE, pageIdObj.get(JSON_MEMBER_TITLE));
       }
-      retrievedRevisions.add((JsonElement) revObj);
+      retrievedRevisions.add(revObj);
     }
 
     LOG.info(retrievedRevisions.size() + " record(s) retrieved for title " + pageTitle);
     return retrievedRevisions;
+  }
+
+  private HttpURLConnection getHttpConnection(WorkUnit workUnit, String urlStr) throws IOException {
+    URL url = new URL(urlStr);
+    Proxy proxy = Proxy.NO_PROXY;
+    if (workUnit.contains(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL) &&
+        workUnit.contains(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT)) {
+      LOG.info("Use proxy host: " + workUnit.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL));
+      LOG.info("Use proxy port: " + workUnit.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT));
+      InetSocketAddress proxyAddress =
+          new InetSocketAddress(workUnit.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL),
+              Integer.parseInt(workUnit.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT)));
+      proxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
+    }
+    return (HttpURLConnection) url.openConnection(proxy);
   }
 
   @Override
@@ -222,7 +238,7 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
 
   @Override
   public String getSchema() {
-    return schema;
+    return this.schema;
   }
 
   @Override
@@ -238,7 +254,7 @@ public class WikipediaExtractor implements Extractor<String, JsonElement>{
 
   @Override
   public long getExpectedRecordCount() {
-    return numRequestedTitles * this.revisionsCnt;
+    return this.numRequestedTitles * this.revisionsCnt;
   }
 
   @Override


### PR DESCRIPTION
1. Fixed version numbers of some dependent jars in `bin/gobblin-mapreduce.sh`.
2. Added support for using proxy in `WikipediaExtractor`.

Signed-off-by: Yinan Li <liyinan926@gmail.com>