### PR TITLE
Refactor Writer and Publisher, and add a Util class for publishing Kafka audit counts

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -444,28 +444,30 @@ public class ConfigurationKeys {
   public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(true);
   public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
   public static final String DEFAULT_METRICS_FILE_SUFFIX = "";
-  public static final String METRICS_REPORTING_FILE_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX
-      + "reporting.file.enabled";
+  public static final String METRICS_REPORTING_FILE_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
   public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_JMX_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX
-      + "reporting.jmx.enabled";
+  public static final String METRICS_REPORTING_JMX_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
   public static final String DEFAULT_METRICS_REPORTING_JMX_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY = METRICS_CONFIGURATIONS_PREFIX
-      + "reporting.kafka.enabled";
+  public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_ENABLED = Boolean.toString(false);
   public static final String METRICS_REPORTING_KAFKA_FORMAT = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.format";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_FORMAT = "json";
-  public static final String METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY = METRICS_CONFIGURATIONS_PREFIX
-      + "reporting.kafka.avro.use.schema.registry";
+  public static final String METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.avro.use.schema.registry";
   public static final String DEFAULT_METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY = Boolean.toString(false);
   public static final String METRICS_KAFKA_BROKERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.brokers";
   // Topic used for both event and metric reporting.
   // Can be overriden by METRICS_KAFKA_TOPIC_METRICS and METRICS_KAFKA_TOPIC_EVENTS.
   public static final String METRICS_KAFKA_TOPIC = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic";
   // Topic used only for metric reporting.
-  public static final String METRICS_KAFKA_TOPIC_METRICS = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic.metrics";
+  public static final String METRICS_KAFKA_TOPIC_METRICS =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic.metrics";
   // Topic used only for event reporting.
-  public static final String METRICS_KAFKA_TOPIC_EVENTS = METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic.events";
+  public static final String METRICS_KAFKA_TOPIC_EVENTS =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic.events";
   public static final String METRICS_CUSTOM_BUILDERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.custom.builders";
   public static final String METRICS_REPORT_INTERVAL_KEY = METRICS_CONFIGURATIONS_PREFIX + "report.interval";
   public static final String DEFAULT_METRICS_REPORT_INTERVAL = Long.toString(TimeUnit.SECONDS.toMillis(30));
@@ -477,6 +479,11 @@ public class ConfigurationKeys {
   public static final String DEFAULT_REST_SERVER_HOST = "localhost";
   public static final String REST_SERVER_PORT_KEY = "rest.server.port";
   public static final String DEFAULT_REST_SERVER_PORT = "8080";
+
+  /**
+   * Kafka job configurations.
+   */
+  public static final String KAFKA_BROKERS = "kafka.brokers";
 
   /**
    * MySQL job history store configuration properties.

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaWrapper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaWrapper.java
@@ -12,6 +12,7 @@
 
 package gobblin.source.extractor.extract.kafka;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.util.DatasetFilterUtils;
 
@@ -62,7 +63,6 @@ public class KafkaWrapper implements Closeable {
 
   private static final String USE_NEW_KAFKA_API = "use.new.kafka.api";
   private static final boolean DEFAULT_USE_NEW_KAFKA_API = false;
-  private static final String KAFKA_BROKERS = "kafka.brokers";
 
   private final List<String> brokers;
   private final KafkaAPI kafkaAPI;
@@ -107,12 +107,13 @@ public class KafkaWrapper implements Closeable {
    * use.new.kafka.api=true.
    */
   public static KafkaWrapper create(State state) {
-    Preconditions.checkNotNull(state.getProp(KAFKA_BROKERS), "Need to specify at least one Kafka broker.");
+    Preconditions.checkNotNull(state.getProp(ConfigurationKeys.KAFKA_BROKERS),
+        "Need to specify at least one Kafka broker.");
     KafkaWrapper.Builder builder = new KafkaWrapper.Builder();
     if (state.getPropAsBoolean(USE_NEW_KAFKA_API, DEFAULT_USE_NEW_KAFKA_API)) {
       builder = builder.withNewKafkaAPI();
     }
-    return builder.withBrokers(state.getPropAsList(KAFKA_BROKERS)).build();
+    return builder.withBrokers(state.getPropAsList(ConfigurationKeys.KAFKA_BROKERS)).build();
   }
 
   public List<String> getBrokers() {

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
@@ -153,13 +153,11 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
 
   @Override
   public void write(GenericRecord record) throws IOException {
-    long recordTimestamp = getRecordTimestamp(record);
-    write(record, recordTimestamp);
+    write(record, getRecordTimestamp(record));
   }
 
   protected long getRecordTimestamp(GenericRecord record) {
-    Optional<Object> writerPartitionColumnValue = getWriterPartitionColumnValue(record);
-    return getRecordTimestamp(writerPartitionColumnValue);
+    return getRecordTimestamp(getWriterPartitionColumnValue(record));
   }
 
   /**

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroSchemaRegistry.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroSchemaRegistry.java
@@ -36,6 +36,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.Maps;
 
+
 /**
  * A schema registry class that provides two services: get the latest schema of a topic, and register a schema.
  *
@@ -71,18 +72,17 @@ public class KafkaAvroSchemaRegistry {
    * "kafka.schema.registry.cache.expire.after.write.min" (default = 10).
    */
   public KafkaAvroSchemaRegistry(Properties properties) {
-    Preconditions.checkArgument(properties.containsKey(KAFKA_SCHEMA_REGISTRY_URL), "Schema registry URL not provided.");
+    Preconditions.checkArgument(properties.containsKey(KAFKA_SCHEMA_REGISTRY_URL),
+        String.format("Property %s not provided.", KAFKA_SCHEMA_REGISTRY_URL));
 
     this.url = properties.getProperty(KAFKA_SCHEMA_REGISTRY_URL);
-    int maxCacheSize =
-        Integer.parseInt(
-            properties.getProperty(KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE, DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE));
-    int expireAfterWriteMin = Integer.parseInt(properties
-        .getProperty(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
+    int maxCacheSize = Integer.parseInt(
+        properties.getProperty(KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE, DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE));
+    int expireAfterWriteMin =
+        Integer.parseInt(properties.getProperty(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
             DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN));
-    this.cachedSchemasById =
-        CacheBuilder.newBuilder().maximumSize(maxCacheSize).expireAfterWrite(expireAfterWriteMin, TimeUnit.MINUTES)
-            .build(new KafkaSchemaCacheLoader());
+    this.cachedSchemasById = CacheBuilder.newBuilder().maximumSize(maxCacheSize)
+        .expireAfterWrite(expireAfterWriteMin, TimeUnit.MINUTES).build(new KafkaSchemaCacheLoader());
     this.httpClient = new HttpClient(new MultiThreadedHttpConnectionManager());
   }
 
@@ -255,8 +255,8 @@ public class KafkaAvroSchemaRegistry {
       }
 
       if (statusCode != HttpStatus.SC_OK) {
-        throw new SchemaNotFoundException(String.format("Schema with ID = %s cannot be retrieved, statusCode = %d", id,
-            statusCode));
+        throw new SchemaNotFoundException(
+            String.format("Schema with ID = %s cannot be retrieved, statusCode = %d", id, statusCode));
       }
 
       Schema schema;
@@ -267,8 +267,8 @@ public class KafkaAvroSchemaRegistry {
           throw new SchemaNotFoundException(String.format("Schema with ID = %s cannot be parsed", id), e);
         }
       } else {
-        throw new SchemaNotFoundException(String.format(
-            "Schema with ID = %s cannot be parsed: schema should start with '{'", id));
+        throw new SchemaNotFoundException(
+            String.format("Schema with ID = %s cannot be parsed: schema should start with '{'", id));
       }
 
       return schema;

--- a/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
+import java.nio.charset.Charset;
+
+import com.google.common.base.Charsets;
+import com.google.common.io.Closer;
+
+
+/**
+ * A utility class for serializing and deserializing Objects to/from Strings.
+ *
+ * @author ziliu
+ */
+public class SerializationUtils {
+
+  private static final Charset CHARSET = Charsets.ISO_8859_1;
+
+  /**
+   * Serialize an object into a String. The object is first serialized into a byte array,
+   * which is converted into a String using charset ISO_8859_1.
+   *
+   * @param obj A {@link Serializable} object
+   * @return A String representing the input object
+   */
+  public static <T extends Serializable> String serialize(T obj) throws IOException {
+    Closer closer = Closer.create();
+    try {
+      ByteArrayOutputStream bos = closer.register(new ByteArrayOutputStream());
+      ObjectOutputStream oos = closer.register(new ObjectOutputStream(bos));
+      oos.writeObject(obj);
+      oos.flush();
+      return bos.toString(CHARSET.name());
+    } catch (Throwable e) {
+      throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+  }
+
+  /**
+   * Deserialize a String obtained via {@link #serialize(Serializable)} into an object.
+   *
+   * @param serialized The serialized String
+   * @param clazz The class the deserialized object should be cast to.
+   * @return The deserialized object
+   */
+  public static <T extends Serializable> T deserialize(String serialized, Class<T> clazz) throws IOException {
+    Closer closer = Closer.create();
+    try {
+      ByteArrayInputStream bis = closer.register(new ByteArrayInputStream(serialized.getBytes(CHARSET)));
+      ObjectInputStream ois = new ObjectInputStream(bis);
+      return clazz.cast(ois.readObject());
+    } catch (Throwable e) {
+      throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+  }
+}


### PR DESCRIPTION
- Break `BaseDataPublisher.publishData()` and `AvroHdfsTimePartitionedWriter.write()` into smaller methods, so that they can be reused by subclasses.
- Added a class `SerializationUtils` which serializes and deserializes an object to/from Strings using charset ISO_8859_1. This is used to transfer Kafka audit count objects from Writers to Publishers as a config property.
- Added a method in `AvroUtils` for converting `GenericRecord` into byte array.
- Some other small changes.