### PR TITLE
Adding new data-management policies, updating proxying code, creating PublisherUtils

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -11,12 +11,16 @@
 apply plugin: 'java'
 
 dependencies {
+  compile project(":gobblin-api")
+  compile project(":gobblin-utility")
+
   compile externalDependency.guava
   compile externalDependency.slf4j
   compile externalDependency.log4j
   compile externalDependency.jodaTime
   compile externalDependency.findBugs
   compile externalDependency.azkaban
+  compile externalDependency.lombok
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
@@ -1,3 +1,15 @@
+/*
+* Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
 package gobblin.data.management.retention;
 
 import java.io.IOException;
@@ -5,11 +17,9 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Properties;
 
-import org.apache.hadoop.fs.FileSystem;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.google.common.base.Preconditions;
+
+import org.apache.hadoop.fs.FileSystem;
 
 import gobblin.data.management.retention.dataset.Dataset;
 import gobblin.data.management.retention.dataset.finder.DatasetFinder;
@@ -20,8 +30,6 @@ import gobblin.data.management.retention.dataset.finder.DatasetFinder;
  */
 public class DatasetCleaner {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(DatasetCleaner.class);
-
   public static final String CONFIGURATION_KEY_PREFIX = "gobblin.retention.";
   public static final String DATASET_PROFILE_CLASS_KEY = CONFIGURATION_KEY_PREFIX + "dataset.profile.class";
 
@@ -31,7 +39,7 @@ public class DatasetCleaner {
 
     Preconditions.checkArgument(props.containsKey(DATASET_PROFILE_CLASS_KEY));
 
-    try{
+    try {
       Class<?> datasetFinderClass = Class.forName(props.getProperty(DATASET_PROFILE_CLASS_KEY));
       this.datasetFinder = (DatasetFinder) datasetFinderClass.
           getConstructor(FileSystem.class, Properties.class).newInstance(fs, props);
@@ -55,10 +63,8 @@ public class DatasetCleaner {
   public void clean() throws IOException {
     List<Dataset> dataSets = this.datasetFinder.findDatasets();
 
-    for(Dataset dataset: dataSets) {
+    for (Dataset dataset: dataSets) {
       dataset.clean();
     }
-
   }
-
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/DeleteAllRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/DeleteAllRetentionPolicy.java
@@ -1,0 +1,34 @@
+/*
+* Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package gobblin.data.management.retention.policy;
+
+import java.util.Collection;
+import java.util.List;
+
+import gobblin.data.management.retention.version.DatasetVersion;
+
+/**
+ * Implementation of {@link RetentionPolicy} that marks all {@link DatasetVersion}s as deletable.
+ */
+public class DeleteAllRetentionPolicy implements RetentionPolicy<DatasetVersion> {
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return DatasetVersion.class;
+  }
+
+  @Override
+  public Collection<DatasetVersion> listDeletableVersions(List<DatasetVersion> allVersions) {
+    return allVersions;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/PredicateRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/PredicateRetentionPolicy.java
@@ -1,0 +1,57 @@
+/*
+* Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package gobblin.data.management.retention.policy;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import gobblin.data.management.retention.version.DatasetVersion;
+
+
+/**
+ * Implementation of {@link RetentionPolicy} that marks a {@link DatasetVersion} for deletion if it does not pass a
+ * specified {@link Predicate}. The {@link Predicate} class is determined by the key
+ * {@link #RETENTION_POLICY_PREDICATE_CLASS}.
+ */
+public class PredicateRetentionPolicy implements RetentionPolicy<DatasetVersion> {
+
+  private final Predicate<DatasetVersion> predicate;
+
+  private static final String RETENTION_POLICY_PREDICATE_CLASS = "gobblin.retention.retention.policy.predicate.class";
+
+  @SuppressWarnings("unchecked")
+  public PredicateRetentionPolicy(Properties props) throws InstantiationException, IllegalAccessException,
+      ClassNotFoundException, IllegalArgumentException, SecurityException, InvocationTargetException,
+      NoSuchMethodException {
+    this.predicate =
+        (Predicate<DatasetVersion>) Class.forName(props.getProperty(RETENTION_POLICY_PREDICATE_CLASS))
+            .getConstructor(Properties.class).newInstance(props);
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return DatasetVersion.class;
+  }
+
+  @Override
+  public Collection<DatasetVersion> listDeletableVersions(List<DatasetVersion> allVersions) {
+    return Lists.newArrayList(Iterables.filter(allVersions, Predicates.not(this.predicate)));
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/RetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/RetentionPolicy.java
@@ -1,3 +1,15 @@
+/*
+* Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
 package gobblin.data.management.retention.policy;
 
 import java.util.Collection;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/TimeBasedRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/TimeBasedRetentionPolicy.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.retention.policy;
 
 import java.util.Collection;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DatasetVersionFinder.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.retention.version.finder;
 
 import java.io.IOException;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.retention.version.finder;
 
 import java.util.Properties;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/SingleVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/SingleVersionFinder.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.version.finder;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Properties;
+
+import com.google.common.collect.Lists;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import gobblin.data.management.retention.dataset.Dataset;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.StringDatasetVersion;
+
+/**
+ * Implementation of {@link VersionFinder} that uses a {@link StringDatasetVersion} and simply creates a single
+ * {@link StringDatasetVersion} for the given {@link Dataset}.
+ */
+public class SingleVersionFinder implements VersionFinder<StringDatasetVersion> {
+
+  public SingleVersionFinder(FileSystem fs, Properties props) {
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return StringDatasetVersion.class;
+  }
+
+  @Override
+  public Collection<StringDatasetVersion> findDatasetVersions(Dataset dataset) throws IOException {
+    return Lists.newArrayList(new StringDatasetVersion(dataset.datasetRoot().getName(), dataset.datasetRoot()));
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/util/PathUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/util/PathUtils.java
@@ -14,4 +14,12 @@ public class PathUtils {
     return new Path(pathPrefix.toUri().relativize(fullPath.toUri()));
   }
 
+  /**
+   * Removes the Scheme and Authority from a Path.
+   *
+   * @see {@link Path}, {@link URI}
+   */
+  public static Path getPathWithoutSchemeAndAuthority(Path path) {
+    return new Path(null, null, path.toUri().getPath());
+  }
 }

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -13,7 +13,7 @@ apply plugin: 'java'
 dependencies {
   compile project(":gobblin-api")
 
-compile externalDependency.commonsCli
+  compile externalDependency.commonsCli
   compile externalDependency.commonsConfiguration
   compile externalDependency.commonsEmail
   compile externalDependency.commonsIo
@@ -24,6 +24,7 @@ compile externalDependency.commonsCli
   compile externalDependency.jodaTime
   compile externalDependency.jacksonCore
   compile externalDependency.jasypt
+  compile externalDependency.lombok
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2
     runtime externalDependency.hadoopCommon

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemCache.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemCache.java
@@ -1,0 +1,94 @@
+/*
+* Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package gobblin.util;
+
+import java.net.URI;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.base.Preconditions;
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import lombok.NonNull;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.security.token.Token;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+
+
+/**
+ * A cache for storing a mapping between Hadoop users and user {@link FileSystem} objects.
+ *
+ * <p>
+ *  This classes uses Guava's {@link Cache} for storing the user to {@link FileSystem} mapping, and creates the
+ *  {@link FileSystem}s using the {@link ProxiedFileSystemUtils} class.
+ * </p>
+ *
+ * @see {@link Cache}, {@link ProxiedFileSystemUtils}
+ */
+public class ProxiedFileSystemCache {
+
+  private static final int DEFAULT_MAX_CACHE_SIZE = 1000;
+
+  private static final Cache<String, FileSystem> USER_NAME_TO_FILESYSTEM_CACHE = CacheBuilder.newBuilder()
+      .maximumSize(DEFAULT_MAX_CACHE_SIZE).build();
+
+  /**
+   * Cached version of {@link ProxiedFileSystemUtils#getProxiedFileSystemUsingKeytab(String, String, Path, URI, Configuration)}.
+   */
+  public static FileSystem getProxiedFileSystemUsingKeytab(@NonNull final String userNameToProxyAs,
+      final String superUserName, final Path superUserKeytabLocation, final URI fsURI, final Configuration conf)
+      throws ExecutionException {
+
+    return USER_NAME_TO_FILESYSTEM_CACHE.get(userNameToProxyAs, new Callable<FileSystem>() {
+      @Override
+      public FileSystem call() throws Exception {
+        return ProxiedFileSystemUtils.getProxiedFileSystemUsingKeytab(userNameToProxyAs, superUserName,
+            superUserKeytabLocation, fsURI, conf);
+      }
+    });
+  }
+
+  /**
+   * Cached version of {@link ProxiedFileSystemUtils#getProxiedFileSystemUsingKeytab(State, URI, Configuration)}.
+   */
+  public static FileSystem getProxiedFileSystemUsingKeytab(State state, URI fsURI, Configuration conf)
+      throws ExecutionException {
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.FS_PROXY_AS_USER_NAME));
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.SUPER_USER_NAME_TO_PROXY_AS_OTHERS));
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.SUPER_USER_KEY_TAB_LOCATION));
+
+    return getProxiedFileSystemUsingKeytab(state.getProp(ConfigurationKeys.FS_PROXY_AS_USER_NAME),
+        state.getProp(ConfigurationKeys.SUPER_USER_NAME_TO_PROXY_AS_OTHERS),
+        new Path(state.getProp(ConfigurationKeys.SUPER_USER_KEY_TAB_LOCATION)), fsURI, conf);
+  }
+
+  /**
+   * Cached version of {@link ProxiedFileSystemUtils#getProxiedFileSystemUsingToken(String, Token, URI, Configuration)}.
+   */
+  public static FileSystem getProxiedFileSystemUsingToken(@NonNull final String userNameToProxyAs,
+      final Token<?> userNameToken, final URI fsURI, final Configuration conf) throws ExecutionException {
+
+    return USER_NAME_TO_FILESYSTEM_CACHE.get(userNameToProxyAs, new Callable<FileSystem>() {
+      @Override
+      public FileSystem call() throws Exception {
+        return ProxiedFileSystemUtils.getProxiedFileSystemUsingToken(userNameToProxyAs, userNameToken, fsURI, conf);
+      }
+    });
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemUtils.java
@@ -1,0 +1,204 @@
+/*
+* Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package gobblin.util;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.security.PrivilegedExceptionAction;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.io.Closer;
+
+import lombok.AllArgsConstructor;
+import lombok.NonNull;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+
+
+/**
+ * Utility class for creating {@link FileSystem} objects while proxied as another user. This class requires access to a
+ * user with secure impersonation priveleges. The {@link FileSystem} objects returned will have full permissions to
+ * access any operations on behalf of the specified user.
+ *
+ * @see <a href="http://hadoop.apache.org/docs/r1.2.1/Secure_Impersonation.html">Secure Impersonation</a>,
+ * <a href="https://hadoop.apache.org/docs/r1.2.1/api/org/apache/hadoop/security/UserGroupInformation.html">UserGroupInformation</a>
+ *
+ * TODO figure out the proper generic type for the {@link Token} objects.
+ */
+@Slf4j
+public class ProxiedFileSystemUtils {
+
+  /**
+   * Creates a {@link FileSystem} that can perform any operations allowed by the specified userNameToProxyAs. This
+   * method first logs in as the specified super user. If Hadoop security is enabled, then logging in entails
+   * authenticating via Kerberos. So logging in requires contacting the Kerberos infrastructure. A proxy user is then
+   * created on behalf of the logged in user, and a {@link FileSystem} object is created using the proxy user's UGI.
+   *
+   * @param userNameToProxyAs The name of the user the super user should proxy as
+   * @param superUserName The name of the super user with secure impersonation priveleges
+   * @param superUserKeytabLocation The location of the keytab file for the super user
+   * @param fsURI The {@link URI} for the {@link FileSystem} that should be created
+   * @param conf The {@link Configuration} for the {@link FileSystem} that should be created
+   *
+   * @return a {@link FileSystem} that can execute commands on behalf of the specified userNameToProxyAs
+   */
+  public static FileSystem getProxiedFileSystemUsingKeytab(String userNameToProxyAs, String superUserName,
+      Path superUserKeytabLocation, URI fsURI, Configuration conf) throws IOException, InterruptedException,
+      URISyntaxException {
+
+    return loginAndProxyAsUser(userNameToProxyAs, superUserName, superUserKeytabLocation).doAs(
+        new ProxiedFileSystem(fsURI, conf));
+  }
+
+  /**
+   * Create a {@link FileSystem} that can perform any operations allowed the by the specified userNameToProxyAs. This
+   * method uses the {@link #getProxiedFileSystemUsingKeytab(String, String, Path, URI, Configuration)} object to perform
+   * all its work. A specific set of configuration keys are required to be set in the given {@link State} object:
+   *
+   * <ul>
+   *  <li>{@link ConfigurationKeys#FS_PROXY_AS_USER_NAME} specifies the user name to proxy as</li>
+   *  <li>{@link ConfigurationKeys#SUPER_USER_NAME_TO_PROXY_AS_OTHERS} specifies the name of the user with secure
+   *  impersonation priveleges</li>
+   *  <li>{@link ConfigurationKeys#SUPER_USER_KEY_TAB_LOCATION} specifies the location of the super user's keytab file</li>
+   * <ul>
+   *
+   * @param state The {@link State} object that contains all the necessary key, value pairs for
+   * {@link #getProxiedFileSystemUsingKeytab(String, String, Path, URI, Configuration)}
+   * @param fsURI The {@link URI} for the {@link FileSystem} that should be created
+   * @param conf The {@link Configuration} for the {@link FileSystem} that should be created
+   *
+   * @return a {@link FileSystem} that can execute commands on behalf of the specified userNameToProxyAs
+   */
+  public static FileSystem getProxiedFileSystemUsingKeytab(State state, URI fsURI, Configuration conf)
+      throws IOException, InterruptedException, URISyntaxException {
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.FS_PROXY_AS_USER_NAME));
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.SUPER_USER_NAME_TO_PROXY_AS_OTHERS));
+    Preconditions.checkArgument(state.contains(ConfigurationKeys.SUPER_USER_KEY_TAB_LOCATION));
+
+    return getProxiedFileSystemUsingKeytab(state.getProp(ConfigurationKeys.FS_PROXY_AS_USER_NAME),
+        state.getProp(ConfigurationKeys.SUPER_USER_NAME_TO_PROXY_AS_OTHERS),
+        new Path(state.getProp(ConfigurationKeys.SUPER_USER_KEY_TAB_LOCATION)), fsURI, conf);
+  }
+
+  /**
+   * Create a {@link FileSystem} that can perform any operations allowed the by the specified userNameToProxyAs. The
+   * method first proxies as userNameToProxyAs, and then adds the specified {@link Token} to the given
+   * {@link UserGroupInformation} object. It then uses the {@link UserGroupInformation#doAs(PrivilegedExceptionAction)}
+   * method to create a {@link FileSystem}.
+   *
+   * @param userNameToProxyAs The name of the user the super user should proxy as
+   * @param userNameToken The {@link Token} to add to the proxied user's {@link UserGroupInformation}.
+   * @param fsURI The {@link URI} for the {@link FileSystem} that should be created
+   * @param conf The {@link Configuration} for the {@link FileSystem} that should be created
+   *
+   * @return a {@link FileSystem} that can execute commands on behalf of the specified userNameToProxyAs
+   */
+  public static FileSystem getProxiedFileSystemUsingToken(@NonNull String userNameToProxyAs,
+      @NonNull Token<?> userNameToken, URI fsURI, Configuration conf) throws IOException, InterruptedException {
+    UserGroupInformation ugi =
+        UserGroupInformation.createProxyUser(userNameToProxyAs, UserGroupInformation.getLoginUser());
+    ugi.addToken(userNameToken);
+    return ugi.doAs(new ProxiedFileSystem(fsURI, conf));
+  }
+
+  /**
+   * Returns true if superUserName can proxy as userNameToProxyAs using the specified superUserKeytabLocation, false
+   * otherwise.
+   */
+  public static boolean canProxyAs(String userNameToProxyAs, String superUserName, Path superUserKeytabLocation) {
+    try {
+      loginAndProxyAsUser(userNameToProxyAs, superUserName, superUserKeytabLocation);
+    } catch (IOException e) {
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Retrives a {@link Token} from a given sequence file for a specified user. The sequence file should contain a list
+   * of key, value pairs where each key corresponds to a user and each value corresponds to a {@link Token} for that
+   * user.
+   *
+   * @param userNameKey The name of the user to retrieve a {@link Token} for
+   * @param tokenFilePath The path to the sequence file containing the {@link Token}s
+   *
+   * @return A {@link Token} for the given user name
+   */
+  public static Optional<Token<?>> getTokenFromSeqFile(String userNameKey, Path tokenFilePath) throws IOException {
+    log.info("Reading tokens from sequence file " + tokenFilePath);
+
+    Closer closer = Closer.create();
+    try {
+      FileSystem localFs = FileSystem.getLocal(new Configuration());
+      SequenceFile.Reader tokenReader =
+          closer.register(new SequenceFile.Reader(localFs, tokenFilePath, localFs.getConf()));
+      Text key = new Text();
+      Token<?> value = new Token();
+      while (tokenReader.next(key, value)) {
+        log.debug("Found token for user: " + key);
+        if (key.toString().equals(userNameKey)) {
+          return Optional.<Token<?>> of(value);
+        }
+      }
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      try {
+        closer.close();
+      } catch (IOException e) {
+        log.warn("Unable to close sequence file reader for path: " + tokenFilePath);
+      }
+    }
+    log.warn("Did not find any tokens for user " + userNameKey);
+    return Optional.absent();
+  }
+
+  private static UserGroupInformation loginAndProxyAsUser(@NonNull String userNameToProxyAs,
+      @NonNull String superUserName, Path superUserKeytabLocation) throws IOException {
+
+    if (!UserGroupInformation.getLoginUser().getUserName().equals(superUserName)) {
+      Preconditions.checkNotNull(superUserKeytabLocation);
+      UserGroupInformation.loginUserFromKeytab(superUserName, superUserKeytabLocation.toString());
+    }
+    return UserGroupInformation.createProxyUser(userNameToProxyAs, UserGroupInformation.getLoginUser());
+  }
+
+  @AllArgsConstructor
+  private static class ProxiedFileSystem implements PrivilegedExceptionAction<FileSystem> {
+
+    @NonNull
+    private URI fsURI;
+
+    @NonNull
+    private Configuration conf;
+
+    @Override
+    public FileSystem run() throws IOException {
+
+      log.info("Creating a filesystem for user: " + UserGroupInformation.getCurrentUser());
+      return FileSystem.get(fsURI, conf);
+    }
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
@@ -39,6 +39,7 @@ import gobblin.configuration.State;
 /**
  * A wrapper class for generating a file system as a proxy user.
  */
+@Deprecated
 public class ProxiedFileSystemWrapper {
   private static final Logger LOG = LoggerFactory.getLogger(ProxiedFileSystemWrapper.class);
   private FileSystem proxiedFs;

--- a/gobblin-utility/src/main/java/gobblin/util/PublisherUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PublisherUtils.java
@@ -1,0 +1,60 @@
+package gobblin.util;
+
+import java.util.Collection;
+import java.util.Map;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Multimap;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.configuration.WorkUnitState.WorkingState;
+import gobblin.source.workunit.Extract;
+
+/**
+ * Utility class for {@link DataPublisher}.
+ */
+public class PublisherUtils {
+
+  /**
+   * Creates a {@link Multimap} that maps {@link Extract} to their corresponds {@link WorkUnitState}s.
+   *
+   * @see {@link Multimap}
+   */
+  public static Multimap<Extract, WorkUnitState> createExtractToWorkUnitStateMap(
+      Collection<? extends WorkUnitState> workUnitStates) {
+    Multimap<Extract, WorkUnitState> extractToWorkUnitStateMap = ArrayListMultimap.create();
+
+    for (WorkUnitState workUnitState : workUnitStates) {
+      extractToWorkUnitStateMap.put(workUnitState.getExtract(), workUnitState);
+    }
+    return extractToWorkUnitStateMap;
+  }
+
+  /**
+   * Given a {@link Multimap} of {@link Extract}s to {@link WorkUnitState}s, filter out any {@link Extract}s where all
+   * of the corresponding {@link WorkUnitState}s do not meet the given {@link Predicate}.
+   */
+  public static Multimap<Extract, WorkUnitState> getExtractsForPredicate(
+      Multimap<Extract, WorkUnitState> extractToWorkUnitStateMap, Predicate<WorkUnitState> predicate) {
+    Multimap<Extract, WorkUnitState> successfulExtracts = ArrayListMultimap.create();
+    for (Map.Entry<Extract, Collection<WorkUnitState>> entry : extractToWorkUnitStateMap.asMap().entrySet()) {
+      if (Iterables.all(entry.getValue(), predicate)) {
+        successfulExtracts.putAll(entry.getKey(), entry.getValue());
+      }
+    }
+    return successfulExtracts;
+  }
+
+  /**
+   * Implementation of {@link Predicate} that checks if a given {@link WorkUnitState} has a {@link WorkingState} equal
+   * to {@link WorkingState#SUCCESSFUL}.
+   */
+  public static class WorkUnitStateSuccess implements Predicate<WorkUnitState> {
+    @Override
+    public boolean apply(WorkUnitState workUnitState) {
+      return workUnitState.getWorkingState().equals(WorkingState.SUCCESSFUL);
+    }
+  }
+}


### PR DESCRIPTION
Changes:

* Creating a few new data-management policies
* Creating new classes `ProxiedFileSystemUtils` and `ProxiedFileSystemCache` in order to replace `ProxiedFileSystemWrapper`. The main reason I did this was the clean up some of the code and to make a cache around all proxied filesystem objects created
* Creating a new class called `PublisherUtils` to store utilities for the `DataPublisher`s