### PR TITLE
make some changes for kafka adapter job-level metrics

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -236,6 +236,8 @@ public class ConfigurationKeys {
    */
   public static final String WRITER_RECORDS_WRITTEN = WRITER_PREFIX + ".records.written";
   public static final String WRITER_BYTES_WRITTEN = WRITER_PREFIX + ".bytes.written";
+  public static final String WRITER_EARLIEST_TIMESTAMP = WRITER_PREFIX + ".earliest.timestamp";
+  public static final String WRITER_AVERAGE_TIMESTAMP = WRITER_PREFIX + ".average.timestamp";
 
   /**
    * Configuration properties used by the quality checker.
@@ -316,6 +318,13 @@ public class ConfigurationKeys {
   public static final String SOURCE_FILEBASED_FS_SNAPSHOT = "source.filebased.fs.snapshot";
   public static final String SOURCE_FILEBASED_FS_URI = "source.filebased.fs.uri";
   public static final String SOURCE_FILEBASED_PRESERVE_FILE_NAME = "source.filebased.preserve.file.name";
+
+  /**
+   * Configuration properties used internally by the KafkaExtractor.
+   */
+  public static final String ERROR_PARTITION_COUNT = "error.partition.count";
+  public static final String ERROR_MESSAGE_INVALID_SCHEMA_ID_COUNT = "error.message.invalid.schema.id.count";
+  public static final String ERROR_MESSAGE_UNDECODABLE_COUNT = "error.message.undecodable.count";
 
   /**
    * Configuration properties for source connection.

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -232,6 +232,12 @@ public class ConfigurationKeys {
   public static final String SIMPLE_WRITER_PREPEND_SIZE = "simple.writer.prepend.size";
 
   /**
+   * Writer configuration properties used internally.
+   */
+  public static final String WRITER_RECORDS_WRITTEN = WRITER_PREFIX + ".records.written";
+  public static final String WRITER_BYTES_WRITTEN = WRITER_PREFIX + ".bytes.written";
+
+  /**
    * Configuration properties used by the quality checker.
    */
   public static final String QUALITY_CHECKER_PREFIX = "qualitychecker";

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
@@ -75,6 +75,7 @@ import gobblin.util.WriterUtils;
  * on each {@link DataWriter}.
  */
 public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> {
+  private static final Logger LOG = LoggerFactory.getLogger(AvroHdfsTimePartitionedWriter.class);
 
   /**
    * This is the base file path that all data will be written to. By default, data will be written to
@@ -113,8 +114,6 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
   protected final State properties;
   protected final int numBranches;
   protected final int branch;
-
-  private static final Logger LOG = LoggerFactory.getLogger(AvroHdfsTimePartitionedWriter.class);
 
   public AvroHdfsTimePartitionedWriter(Destination destination, String writerId, Schema schema,
       WriterOutputFormat writerOutputFormat, int numBranches, int branch) {
@@ -261,6 +260,12 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
 
   @Override
   public void close() throws IOException {
+
+    // Add records written and bytes written to task state
+    this.properties.setProp(ConfigurationKeys.WRITER_RECORDS_WRITTEN, recordsWritten());
+    this.properties.setProp(ConfigurationKeys.WRITER_BYTES_WRITTEN, bytesWritten());
+
+    // Close all writers
     boolean closeFailed = false;
     for (Entry<Path, DataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
       try {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -279,12 +279,12 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       if (canCommit(this.jobContext.getJobCommitPolicy(), jobState)) {
         try {
           commitJob(jobState);
-          processTaskStates(jobState.getTaskStates());
         } finally {
           persistJobState(jobState);
         }
       }
 
+      postProcessTaskStates(jobState.getTaskStates());
       jobCommitTimer.stop();
     } catch (Throwable t) {
       jobState.setState(JobState.RunningState.FAILED);
@@ -325,10 +325,10 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   }
 
   /**
-   * Subclasses can override this method to do whatever processing on the taskStates,
+   * Subclasses can override this method to do whatever processing on the {@link TaskState}s,
    * e.g., aggregate task-level metrics into job-level metrics.
    */
-  protected void processTaskStates(List<TaskState> taskStates) {
+  protected void postProcessTaskStates(List<TaskState> taskStates) {
     // Do nothing
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -279,6 +279,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       if (canCommit(this.jobContext.getJobCommitPolicy(), jobState)) {
         try {
           commitJob(jobState);
+          processTaskStates(jobState.getTaskStates());
         } finally {
           persistJobState(jobState);
         }
@@ -321,6 +322,14 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     if (jobState.getState() == JobState.RunningState.FAILED) {
       throw new JobException(String.format("Job %s failed", jobId));
     }
+  }
+
+  /**
+   * Subclasses can override this method to do whatever processing on the taskStates,
+   * e.g., aggregate task-level metrics into job-level metrics.
+   */
+  protected void processTaskStates(List<TaskState> taskStates) {
+    // Do nothing
   }
 
   @Override


### PR DESCRIPTION
- `AvroHdfsTimePartitionedWriter` now writes recordsWritten and bytesWritten to task state, so that the job launcher can aggregate them into job-level metrics.
- Added a noop method in `AbstractJobLauncher` so that subclasses can override it.
- `JobLauncherFactory` now supports creating job launcher based on class name, so I'll be able to write a job launcher class for Kafka.