### PR TITLE
Persist state and commit data on a per-dataset basis

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -126,6 +126,7 @@ public class ConfigurationKeys {
   /**
    * Dataset-related configuration properties;
    */
+  // This property is used to specify the URN of a dataset a job or WorkUnit extracts data for
   public static final String DATASET_URN_KEY = "dataset.urn";
   public static final String DEFAULT_DATASET_URN = "";
 
@@ -278,7 +279,8 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".final.dir";
   public static final String DATA_PUBLISHER_REPLACE_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".replace.final.dir";
   public static final String DATA_PUBLISHER_FINAL_NAME = DATA_PUBLISHER_PREFIX + ".final.name";
-  public static final String DATA_PUBLISHER_GROUP_NAME = DATA_PUBLISHER_PREFIX + ".group.name";
+  // This property is used to specify the owner group of the data publisher final output directory
+  public static final String DATA_PUBLISHER_FINAL_DIR_GROUP = DATA_PUBLISHER_PREFIX + "final.dir.group";
 
   /**
    * Configuration properties used by the extractor.

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -124,6 +124,12 @@ public class ConfigurationKeys {
   public static final String JOB_STATE_FILE_PATH_KEY = "job.state.file.path";
 
   /**
+   * Dataset-related configuration properties;
+   */
+  public static final String DATASET_URN_KEY = "dataset.urn";
+  public static final String DEFAULT_DATASET_URN = "";
+
+  /**
    * Work unit related configuration properties.
    */
   public static final String WORK_UNIT_LOW_WATER_MARK_KEY = "workunit.low.water.mark";
@@ -264,6 +270,7 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".final.dir";
   public static final String DATA_PUBLISHER_REPLACE_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".replace.final.dir";
   public static final String DATA_PUBLISHER_FINAL_NAME = DATA_PUBLISHER_PREFIX + ".final.name";
+  public static final String DATA_PUBLISHER_GROUP_NAME = DATA_PUBLISHER_PREFIX + ".group.name";
 
   /**
    * Configuration properties used by the extractor.

--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -17,6 +17,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 
@@ -25,10 +26,11 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 
 import gobblin.source.workunit.WorkUnit;
@@ -53,14 +55,14 @@ public class SourceState extends State {
   private static final DateTimeFormatter DTF =
       DateTimeFormat.forPattern("yyyyMMddHHmmss").withLocale(Locale.US).withZone(DateTimeZone.UTC);
 
-  private final Optional<SourceState> previousSourceState;
+  private final Map<String, SourceState> previousDatasetStatesByUrns;
   private final List<WorkUnitState> previousWorkUnitStates = Lists.newArrayList();
 
   /**
    * Default constructor.
    */
   public SourceState() {
-    this.previousSourceState = Optional.absent();
+    this.previousDatasetStatesByUrns = ImmutableMap.of();
   }
 
   /**
@@ -71,7 +73,7 @@ public class SourceState extends State {
    */
   public SourceState(State properties, List<WorkUnitState> previousWorkUnitStates) {
     super.addAll(properties);
-    this.previousSourceState = Optional.absent();
+    this.previousDatasetStatesByUrns = ImmutableMap.of();
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
       this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));
     }
@@ -81,12 +83,13 @@ public class SourceState extends State {
    * Constructor.
    *
    * @param properties job configuration properties
-   * @param previousSourceState {@link SourceState} of the previous job run
+   * @param previousDatasetStatesByUrns {@link SourceState} of the previous job run
    * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
    */
-  public SourceState(State properties, SourceState previousSourceState, List<WorkUnitState> previousWorkUnitStates) {
+  public SourceState(State properties, Map<String, ? extends SourceState> previousDatasetStatesByUrns,
+      List<WorkUnitState> previousWorkUnitStates) {
     super.addAll(properties);
-    this.previousSourceState = Optional.of(previousSourceState);
+    this.previousDatasetStatesByUrns = ImmutableMap.copyOf(previousDatasetStatesByUrns);
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
       this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));
     }
@@ -95,10 +98,31 @@ public class SourceState extends State {
   /**
    * Get the {@link SourceState} of the previous job run.
    *
-   * @return {@link SourceState} of the previous job run
+   * <p>
+   *   This is a convenient method for existing jobs that do not use the new feature that allows output data to
+   *   be committed on a per-dataset basis. Use of this method assumes that the job deals with a single dataset,
+   *   which uses the default data URN defined by {@link ConfigurationKeys#DEFAULT_DATASET_URN}.
+   * </p>
+   *
+   * @return {@link SourceState} of the previous job run or {@code null} if no previous {@link SourceState} is found
    */
   public SourceState getPreviousSourceState() {
-    return new ImmutableSourceState(this.previousSourceState.or(new SourceState()));
+    return getPreviousDatasetState(ConfigurationKeys.DEFAULT_DATASET_URN);
+  }
+
+  /**
+   * Get the state (in the form of a {@link SourceState}) of a dataset identified by a dataset URN
+   * of the previous job run.
+   *
+   * @param datasetUrn the dataset URN
+   * @return the dataset state (in the form of a {@link SourceState}) of the previous job run
+   *         or {@code null} if no previous dataset state is found for the given dataset URN
+   */
+  public SourceState getPreviousDatasetState(String datasetUrn) {
+    if (!this.previousDatasetStatesByUrns.containsKey(datasetUrn)) {
+      return null;
+    }
+    return new ImmutableSourceState(this.previousDatasetStatesByUrns.get(datasetUrn));
   }
 
   /**
@@ -108,6 +132,32 @@ public class SourceState extends State {
    */
   public List<WorkUnitState> getPreviousWorkUnitStates() {
     return ImmutableList.<WorkUnitState> builder().addAll(this.previousWorkUnitStates).build();
+  }
+
+  /**
+   * Get a {@link Map} from dataset URNs (as being specified by {@link ConfigurationKeys#DATASET_URN_KEY}
+   * to the {@link List} of {@link WorkUnitState} with the dataset URNs.
+   *
+   * <p>
+   *   {@link WorkUnitState}s that do not have {@link ConfigurationKeys#DATASET_URN_KEY} set will be added
+   *   to the dataset state belonging to {@link ConfigurationKeys#DEFAULT_DATASET_URN}.
+   * </p>
+   *
+   * @return a {@link Map} from dataset URNs to the {@link List} of {@link WorkUnitState} with the dataset URNs
+   */
+  public Map<String, List<WorkUnitState>> getPreviousWorkUnitStatesByDatasetUrns() {
+    Map<String, List<WorkUnitState>> previousWorkUnitStatesByDatasetUrns = Maps.newHashMap();
+
+    for (WorkUnitState workUnitState : this.previousWorkUnitStates) {
+      String datasetUrn = workUnitState.getProp(ConfigurationKeys.DATASET_URN_KEY,
+          ConfigurationKeys.DEFAULT_DATASET_URN);
+      if (!previousWorkUnitStatesByDatasetUrns.containsKey(datasetUrn)) {
+        previousWorkUnitStatesByDatasetUrns.put(datasetUrn, Lists.<WorkUnitState>newArrayList());
+      }
+      previousWorkUnitStatesByDatasetUrns.get(datasetUrn).add(workUnitState);
+    }
+
+    return ImmutableMap.copyOf(previousWorkUnitStatesByDatasetUrns);
   }
 
   /**
@@ -122,7 +172,8 @@ public class SourceState extends State {
    * @param table name of the table this extract belongs to
    * @return a new unique {@link Extract} instance
    *
-   * @Deprecated Use {@link gobblin.source.extractor.extract.AbstractSource#createExtract(gobblin.source.workunit.Extract.TableType, String, String)}
+   * @Deprecated Use {@link gobblin.source.extractor.extract.AbstractSource#createExtract(
+   * gobblin.source.workunit.Extract.TableType, String, String)}
    */
   @Deprecated
   public synchronized Extract createExtract(Extract.TableType type, String namespace, String table) {
@@ -180,7 +231,7 @@ public class SourceState extends State {
     }
 
     SourceState other = (SourceState) object;
-    return super.equals(other) && this.previousSourceState.equals(other.previousSourceState)
+    return super.equals(other) && this.previousDatasetStatesByUrns.equals(other.previousDatasetStatesByUrns)
         && this.previousWorkUnitStates.equals(other.previousWorkUnitStates);
   }
 
@@ -188,7 +239,7 @@ public class SourceState extends State {
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + this.previousSourceState.hashCode();
+    result = prime * result + this.previousDatasetStatesByUrns.hashCode();
     result = prime * result + this.previousWorkUnitStates.hashCode();
     return result;
   }
@@ -200,7 +251,7 @@ public class SourceState extends State {
   private static class ImmutableSourceState extends SourceState {
 
     public ImmutableSourceState(SourceState sourceState) {
-      super(sourceState, sourceState.previousSourceState.or(new SourceState()), sourceState.previousWorkUnitStates);
+      super(sourceState, sourceState.previousDatasetStatesByUrns, sourceState.previousWorkUnitStates);
     }
 
     @Override

--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -69,9 +69,9 @@ public class SourceState extends State {
    * Constructor.
    *
    * @param properties job configuration properties
-   * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
+   * @param previousWorkUnitStates an {@link Iterable} of {@link WorkUnitState}s of the previous job run
    */
-  public SourceState(State properties, List<WorkUnitState> previousWorkUnitStates) {
+  public SourceState(State properties, Iterable<WorkUnitState> previousWorkUnitStates) {
     super.addAll(properties);
     this.previousDatasetStatesByUrns = ImmutableMap.of();
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
@@ -84,10 +84,10 @@ public class SourceState extends State {
    *
    * @param properties job configuration properties
    * @param previousDatasetStatesByUrns {@link SourceState} of the previous job run
-   * @param previousWorkUnitStates list of {@link WorkUnitState}s of the previous job run
+   * @param previousWorkUnitStates an {@link Iterable} of {@link WorkUnitState}s of the previous job run
    */
   public SourceState(State properties, Map<String, ? extends SourceState> previousDatasetStatesByUrns,
-      List<WorkUnitState> previousWorkUnitStates) {
+      Iterable<WorkUnitState> previousWorkUnitStates) {
     super.addAll(properties);
     this.previousDatasetStatesByUrns = ImmutableMap.copyOf(previousDatasetStatesByUrns);
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
@@ -126,27 +126,27 @@ public class SourceState extends State {
   }
 
   /**
-   * Get a (possibly empty) list of {@link WorkUnitState}s from the previous job run.
+   * Get {@link WorkUnitState}s from the previous job run.
    *
-   * @return (possibly empty) list of {@link WorkUnitState}s from the previous job run
+   * @return an {@link Iterable} of {@link WorkUnitState}s from the previous job run
    */
-  public List<WorkUnitState> getPreviousWorkUnitStates() {
+  public Iterable<WorkUnitState> getPreviousWorkUnitStates() {
     return ImmutableList.<WorkUnitState> builder().addAll(this.previousWorkUnitStates).build();
   }
 
   /**
    * Get a {@link Map} from dataset URNs (as being specified by {@link ConfigurationKeys#DATASET_URN_KEY}
-   * to the {@link List} of {@link WorkUnitState} with the dataset URNs.
+   * to the {@link WorkUnitState} with the dataset URNs.
    *
    * <p>
    *   {@link WorkUnitState}s that do not have {@link ConfigurationKeys#DATASET_URN_KEY} set will be added
    *   to the dataset state belonging to {@link ConfigurationKeys#DEFAULT_DATASET_URN}.
    * </p>
    *
-   * @return a {@link Map} from dataset URNs to the {@link List} of {@link WorkUnitState} with the dataset URNs
+   * @return a {@link Map} from dataset URNs to the {@link WorkUnitState} with the dataset URNs
    */
-  public Map<String, List<WorkUnitState>> getPreviousWorkUnitStatesByDatasetUrns() {
-    Map<String, List<WorkUnitState>> previousWorkUnitStatesByDatasetUrns = Maps.newHashMap();
+  public Map<String, Iterable<WorkUnitState>> getPreviousWorkUnitStatesByDatasetUrns() {
+    Map<String, Iterable<WorkUnitState>> previousWorkUnitStatesByDatasetUrns = Maps.newHashMap();
 
     for (WorkUnitState workUnitState : this.previousWorkUnitStates) {
       String datasetUrn = workUnitState.getProp(ConfigurationKeys.DATASET_URN_KEY,
@@ -154,7 +154,7 @@ public class SourceState extends State {
       if (!previousWorkUnitStatesByDatasetUrns.containsKey(datasetUrn)) {
         previousWorkUnitStatesByDatasetUrns.put(datasetUrn, Lists.<WorkUnitState>newArrayList());
       }
-      previousWorkUnitStatesByDatasetUrns.get(datasetUrn).add(workUnitState);
+      ((List<WorkUnitState>) previousWorkUnitStatesByDatasetUrns.get(datasetUrn)).add(workUnitState);
     }
 
     return ImmutableMap.copyOf(previousWorkUnitStatesByDatasetUrns);

--- a/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
@@ -51,8 +51,7 @@ public abstract class DataPublisher implements Closeable {
    * First publish the metadata via {@link DataPublisher#publishMetadata(Collection)}, and then publish the output data
    * via the {@link DataPublisher#publishData(Collection)} method.
    *
-   * @param states is a {@link Collection} of {@link WorkUnitState}s. Each {@link WorkUnitState} contains a
-   * {@link WorkUnit} that was scheduled to run, along with all the runtime information specific to the {@link WorkUnit}.
+   * @param states is a {@link Collection} of {@link WorkUnitState}s.
    * @throws IOException if there is a problem with publishing the metadata or the data.
    */
   public void publish(Collection<? extends WorkUnitState> states)

--- a/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
@@ -36,7 +36,6 @@ import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.util.ForkOperatorUtils;
-import gobblin.util.HadoopUtils;
 import gobblin.util.ParallelRunner;
 import gobblin.util.WriterUtils;
 

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -53,14 +53,14 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
   protected void addWriterOutputToExistingDir(Path writerOutput, Path publisherOutput, WorkUnitState workUnitState,
       int branchId, ParallelRunner parallelRunner) throws IOException {
 
-    for (FileStatus status : HadoopUtils.listStatusRecursive(this.fss.get(branchId), writerOutput)) {
+    for (FileStatus status : HadoopUtils.listStatusRecursive(this.fileSystemByBranches.get(branchId), writerOutput)) {
       String filePathStr = status.getPath().toString();
       String pathSuffix =
           filePathStr.substring(filePathStr.indexOf(writerOutput.toString()) + writerOutput.toString().length() + 1);
       Path outputPath = new Path(publisherOutput, pathSuffix);
 
-      if (!this.fss.get(branchId).exists(outputPath.getParent())) {
-        this.fss.get(branchId).mkdirs(outputPath.getParent());
+      if (!this.fileSystemByBranches.get(branchId).exists(outputPath.getParent())) {
+        this.fileSystemByBranches.get(branchId).mkdirs(outputPath.getParent());
       }
 
       LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -12,6 +12,7 @@
 
 package gobblin.publisher;
 
+import com.google.common.base.Optional;
 import java.io.IOException;
 
 import org.apache.hadoop.fs.FileStatus;
@@ -63,7 +64,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
       }
 
       LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));
-      parallelRunner.renamePath(status.getPath(), outputPath);
+      parallelRunner.renamePath(status.getPath(), outputPath, Optional.<String>absent());
     }
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/DatePartitionedDailyAvroSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/DatePartitionedDailyAvroSource.java
@@ -290,7 +290,7 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
    * Gets the LWM for this job runs. The new LWM is the HWM of the previous run + 1 day. If there was no previous
    * execution then it is set to the given lowWaterMark + 1 day.
    */
-  private long getLowWaterMark(List<WorkUnitState> previousStates, String lowWaterMark) {
+  private long getLowWaterMark(Iterable<WorkUnitState> previousStates, String lowWaterMark) {
 
     long lowWaterMarkValue = DAILY_FOLDER_FORMATTER.parseMillis(lowWaterMark);
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/AbstractSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/AbstractSource.java
@@ -15,6 +15,7 @@ package gobblin.source.extractor.extract;
 import java.util.List;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -57,7 +58,7 @@ public abstract class AbstractSource<S, D> implements Source<S, D> {
    * @return list of {@link WorkUnitState}s of previous {@link WorkUnit}s subject for retries
    */
   protected List<WorkUnitState> getPreviousWorkUnitStatesForRetry(SourceState state) {
-    if (state.getPreviousWorkUnitStates().isEmpty()) {
+    if (Iterables.isEmpty(state.getPreviousWorkUnitStates())) {
       return ImmutableList.of();
     }
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -12,11 +12,6 @@
 
 package gobblin.source.extractor.extract;
 
-import gobblin.source.extractor.JobCommitPolicy;
-import gobblin.source.extractor.partition.Partitioner;
-import gobblin.source.extractor.utils.Utils;
-import gobblin.source.extractor.watermark.WatermarkPredicate;
-import gobblin.source.extractor.watermark.WatermarkType;
 import java.util.Collections;
 import java.util.Date;
 import java.util.List;
@@ -30,10 +25,16 @@ import org.slf4j.MDC;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.SourceState;
 import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.WorkUnitState.WorkingState;
+import gobblin.source.extractor.JobCommitPolicy;
+import gobblin.source.extractor.partition.Partitioner;
+import gobblin.source.extractor.utils.Utils;
+import gobblin.source.extractor.watermark.WatermarkPredicate;
+import gobblin.source.extractor.watermark.WatermarkType;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.Extract.TableType;
 import gobblin.source.workunit.WorkUnit;
@@ -104,10 +105,10 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
    * @return latest water mark (high water mark)
    */
   private long getLatestWatermarkFromMetadata(SourceState state) {
-    LOG.debug("Get latest watermark from the previou run");
+    LOG.debug("Get latest watermark from the previous run");
     long latestWaterMark = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
 
-    List<WorkUnitState> previousWorkUnitStates = state.getPreviousWorkUnitStates();
+    List<WorkUnitState> previousWorkUnitStates = Lists.newArrayList(state.getPreviousWorkUnitStates());
     List<Long> previousWorkUnitStateHighWatermarks = Lists.newArrayList();
     List<Long> previousWorkUnitLowWatermarks = Lists.newArrayList();
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -89,7 +89,7 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
     }
 
     TableType tableType = TableType.valueOf(state.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY).toUpperCase());
-    List<WorkUnitState> previousWorkunits = state.getPreviousWorkUnitStates();
+    List<WorkUnitState> previousWorkunits = Lists.newArrayList(state.getPreviousWorkUnitStates());
     List<String> prevFsSnapshot = Lists.newArrayList();
 
     // Get list of files seen in the previous run

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -128,7 +128,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
 
     this.group = Optional.fromNullable(properties.getProp(ConfigurationKeys.WRITER_GROUP_NAME));
     if (this.group.isPresent()) {
-      this.fs.setOwner(this.stagingFile, this.fs.getFileStatus(this.stagingFile).getOwner(), this.group.get());
+      HadoopUtils.setGroup(this.fs, this.stagingFile, this.group.get());
     }
   }
 

--- a/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
@@ -52,11 +52,11 @@ import gobblin.configuration.State;
  */
 public class FsStateStore<T extends State> implements StateStore<T> {
 
-  private final Configuration conf;
-  private final FileSystem fs;
+  protected final Configuration conf;
+  protected final FileSystem fs;
 
   // Root directory for the task state store
-  private final String storeRootDir;
+  protected final String storeRootDir;
 
   // Class of the state objects to be put into the store
   private final Class<T> stateClass;

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -72,6 +72,9 @@ artifacts {
 test {
     useTestNG () {
       excludeGroups 'ignore'
+      if (project.hasProperty('useHadoop2')) {
+        excludeGroups 'Hadoop1Only'
+      }
     }
     workingDir rootProject.rootDir
     maxParallelForks = 1

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -251,7 +251,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       workUnitsPreparationTimer.stop();
 
       // Write job execution info to the job history store before the job starts to run
-      storeJobExecutionInfo();
+      this.jobContext.storeJobExecutionInfo();
 
       TimingEvent jobRunTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_RUN);
       // Start the job and wait for it to finish
@@ -286,7 +286,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       jobCleanupTimer.stop();
 
       // Write job execution info to the job history store upon job termination
-      storeJobExecutionInfo();
+      this.jobContext.storeJobExecutionInfo();
 
       launchJobTimer.stop();
 
@@ -438,19 +438,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         this.jobLockOptional.get().unlock();
       } catch (IOException ioe) {
         LOG.error(String.format("Failed to unlock for job %s: %s", this.jobContext.getJobId(), ioe), ioe);
-      }
-    }
-  }
-
-  /**
-   * Store job execution information into the job history store.
-   */
-  private void storeJobExecutionInfo() {
-    if (this.jobContext.getJobHistoryStoreOptional().isPresent()) {
-      try {
-        this.jobContext.getJobHistoryStoreOptional().get().put(this.jobContext.getJobState().toJobExecutionInfo());
-      } catch (IOException ioe) {
-        LOG.error("Failed to write job execution information to the job history store: " + ioe, ioe);
       }
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -13,7 +13,6 @@
 package gobblin.runtime;
 
 import java.io.IOException;
-import java.lang.reflect.Constructor;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -33,7 +32,6 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.GobblinMetricsRegistry;
@@ -41,10 +39,8 @@ import gobblin.metrics.MetricContext;
 import gobblin.metrics.event.EventNames;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.metrics.event.TimingEvent;
-import gobblin.publisher.DataPublisher;
 import gobblin.runtime.util.JobMetrics;
 import gobblin.runtime.util.TimingEventNames;
-import gobblin.source.extractor.JobCommitPolicy;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.ExecutorsUtils;
 import gobblin.util.JobLauncherUtils;
@@ -59,9 +55,6 @@ import gobblin.util.ParallelRunner;
 public abstract class AbstractJobLauncher implements JobLauncher {
 
   private static final Logger LOG = LoggerFactory.getLogger(AbstractJobLauncher.class);
-
-  protected static final String TASK_STATE_STORE_TABLE_SUFFIX = ".tst";
-  protected static final String JOB_STATE_STORE_TABLE_SUFFIX = ".jst";
 
   // Job configuration properties
   protected final Properties jobProps;
@@ -275,15 +268,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
 
       TimingEvent jobCommitTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_COMMIT);
 
-      setFinalJobState(jobState);
-      if (canCommit(this.jobContext.getJobCommitPolicy(), jobState)) {
-        try {
-          commitJob(jobState);
-        } finally {
-          persistJobState(jobState);
-        }
-      }
-
+      this.jobContext.setFinalJobState();
+      this.jobContext.commit();
       jobCommitTimer.stop();
     } catch (Throwable t) {
       jobState.setState(JobState.RunningState.FAILED);
@@ -459,97 +445,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         LOG.error("Failed to write job execution information to the job history store: " + ioe, ioe);
       }
     }
-  }
-
-  /**
-   * Set final {@link JobState} of the given job.
-   */
-  private void setFinalJobState(JobState jobState) {
-    jobState.setEndTime(System.currentTimeMillis());
-    jobState.setDuration(jobState.getEndTime() - jobState.getStartTime());
-
-    for (TaskState taskState : jobState.getTaskStates()) {
-      // Set fork.branches explicitly here so the rest job flow can pick it up
-      jobState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY,
-          taskState.getPropAsInt(ConfigurationKeys.FORK_BRANCHES_KEY, 1));
-
-      // Determine the final job state based on the task states and the job commit policy.
-      // If COMMIT_ON_FULL_SUCCESS is used, the job is considered failed if any task failed.
-      // On the other hand, if COMMIT_ON_PARTIAL_SUCCESS is used, the job is considered
-      // successful even if some tasks failed.
-      if (taskState.getWorkingState() != WorkUnitState.WorkingState.SUCCESSFUL
-          && this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS) {
-        jobState.setState(JobState.RunningState.FAILED);
-        break;
-      }
-    }
-
-    if (jobState.getState() == JobState.RunningState.SUCCESSFUL) {
-      // Reset the failure count if the job successfully completed
-      jobState.setProp(ConfigurationKeys.JOB_FAILURES_KEY, 0);
-    }
-
-    if (jobState.getState() == JobState.RunningState.FAILED) {
-      // Increment the failure count by 1 if the job failed
-      int failures = jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY, 0) + 1;
-      jobState.setProp(ConfigurationKeys.JOB_FAILURES_KEY, failures);
-    }
-  }
-
-  /**
-   * Check if it is OK to commit the output data of the job.
-   */
-  private boolean canCommit(JobCommitPolicy commitPolicy, JobState jobState) {
-    // Only commit job data if 1) COMMIT_ON_PARTIAL_SUCCESS is used,
-    // or 2) COMMIT_ON_FULL_SUCCESS is used and the job has succeeded.
-    return commitPolicy == JobCommitPolicy.COMMIT_ON_PARTIAL_SUCCESS
-        || (commitPolicy == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS
-            && jobState.getState() == JobState.RunningState.SUCCESSFUL);
-  }
-
-  /**
-   * Commit the job's output data.
-   */
-  @SuppressWarnings("unchecked")
-  private void commitJob(JobState jobState) throws Exception {
-    LOG.info(String.format("Publishing data of job %s with commit policy %s", this.jobContext.getJobId(),
-        this.jobContext.getJobCommitPolicy().name()));
-
-    Closer closer = Closer.create();
-    try {
-      Class<? extends DataPublisher> dataPublisherClass = (Class<? extends DataPublisher>) Class.forName(
-          jobState.getProp(ConfigurationKeys.DATA_PUBLISHER_TYPE, ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
-      Constructor<? extends DataPublisher> dataPublisherConstructor = dataPublisherClass.getConstructor(State.class);
-      DataPublisher publisher = closer.register(dataPublisherConstructor.newInstance(jobState));
-      publisher.initialize();
-      publisher.publish(jobState.getTaskStates());
-    } catch (Throwable t) {
-      throw closer.rethrow(t);
-    } finally {
-      closer.close();
-    }
-
-    // Set the job state to COMMITTED upon successful commit
-    jobState.setState(JobState.RunningState.COMMITTED);
-  }
-
-  /**
-   * Persist job state of a completed job.
-   */
-  private void persistJobState(JobState jobState) throws IOException {
-    for (TaskState taskState : jobState.getTaskStates()) {
-      // Backoff the actual high watermark to the low watermark for each task that has not been committed
-      if (taskState.getWorkingState() != WorkUnitState.WorkingState.COMMITTED) {
-        taskState.backoffActualHighWatermark();
-      }
-    }
-
-    String jobName = jobState.getJobName();
-    String jobId = jobState.getJobId();
-    LOG.info("Persisting job state of job " + jobId);
-    this.jobContext.getJobStateStore().put(jobName, jobId + JOB_STATE_STORE_TABLE_SUFFIX, jobState);
-    this.jobContext.getJobStateStore().createAlias(jobName, jobId + JOB_STATE_STORE_TABLE_SUFFIX,
-        "current" + JOB_STATE_STORE_TABLE_SUFFIX);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -117,8 +117,7 @@ public class Fork implements Closeable, Runnable, FinalState {
 
     this.converter = this.closer.register(new MultiConverter(this.taskContext.getConverters(this.index)));
     this.convertedSchema = Optional.fromNullable(this.converter.convertSchema(schema, this.taskState));
-    this.rowLevelPolicyChecker =
-        this.closer.register(this.taskContext.getRowLevelPolicyChecker(this.taskState, this.index));
+    this.rowLevelPolicyChecker = this.closer.register(this.taskContext.getRowLevelPolicyChecker(this.index));
     this.rowLevelPolicyCheckingResult = new RowLevelPolicyCheckResults();
 
     this.recordQueue = BoundedBlockingRecordQueue.newBuilder()

--- a/gobblin-runtime/src/main/java/gobblin/runtime/FsDatasetStateStore.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/FsDatasetStateStore.java
@@ -1,0 +1,226 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.apache.hadoop.io.SequenceFile;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.metastore.FsStateStore;
+
+
+/**
+ * A custom extension to {@link FsStateStore} for storing and reading {@link JobState.DatasetState}s.
+ *
+ * <p>
+ *   The purpose of having this class is to hide some implementation details that are unnecessarily
+ *   exposed if using the {@link FsStateStore} to store and serve job/dataset states between job runs.
+ * </p>
+ *
+ * <p>
+ *   In addition to persisting and reading {@link JobState.DatasetState}s. This class is also able to
+ *   read job state files of existing jobs that store serialized instances of {@link JobState} for
+ *   backward compatibility.
+ * </p>
+ *
+ * @author ynli
+ */
+public class FsDatasetStateStore extends FsStateStore<JobState.DatasetState> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FsDatasetStateStore.class);
+
+  static final String DATASET_STATE_STORE_TABLE_SUFFIX = ".jst";
+
+  static final String CURRENT_DATASET_STATE_FILE_SUFFIX = "current";
+
+  public FsDatasetStateStore(String fsUri, String storeRootDir) throws IOException {
+    super(fsUri, storeRootDir, JobState.DatasetState.class);
+  }
+
+  public FsDatasetStateStore(FileSystem fs, String storeRootDir) throws IOException {
+    super(fs, storeRootDir, JobState.DatasetState.class);
+  }
+
+  public FsDatasetStateStore(String storeUrl) throws IOException {
+    super(storeUrl, JobState.DatasetState.class);
+  }
+
+  @Override
+  public JobState.DatasetState get(String storeName, String tableName, String stateId) throws IOException {
+    Path tablePath = new Path(new Path(this.storeRootDir, storeName), tableName);
+    if (!this.fs.exists(tablePath)) {
+      return null;
+    }
+
+    Closer closer = Closer.create();
+    try {
+      SequenceFile.Reader reader = closer.register(new SequenceFile.Reader(this.fs, tablePath, this.conf));
+      // This is necessary for backward compatibility as existing jobs are using the JobState class
+      Writable writable = reader.getValueClass() == JobState.class ? new JobState() : new JobState.DatasetState();
+
+      try {
+        Text key = new Text();
+
+        while (reader.next(key, writable)) {
+          if (key.toString().equals(stateId)) {
+            if (writable instanceof JobState.DatasetState) {
+              return (JobState.DatasetState) writable;
+            } else {
+              return ((JobState) writable).newDatasetState(true);
+            }
+          }
+        }
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+
+    return null;
+  }
+
+  @Override
+  public List<JobState.DatasetState> getAll(String storeName, String tableName) throws IOException {
+    List<JobState.DatasetState> states = Lists.newArrayList();
+
+    Path tablePath = new Path(new Path(this.storeRootDir, storeName), tableName);
+    if (!this.fs.exists(tablePath)) {
+      return states;
+    }
+
+    Closer closer = Closer.create();
+    try {
+      SequenceFile.Reader reader = closer.register(new SequenceFile.Reader(this.fs, tablePath, this.conf));
+      // This is necessary for backward compatibility as existing jobs are using the JobState class
+      Writable writable = reader.getValueClass() == JobState.class ? new JobState() : new JobState.DatasetState();
+
+      try {
+        Text key = new Text();
+        while (reader.next(key, writable)) {
+          if (writable instanceof JobState.DatasetState) {
+            states.add((JobState.DatasetState) writable);
+            writable = new JobState.DatasetState();
+          } else {
+            states.add(((JobState) writable).newDatasetState(true));
+            writable = new JobState();
+          }
+        }
+      } catch (Exception e) {
+        throw new IOException(e);
+      }
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+
+    return states;
+  }
+
+  @Override
+  public List<JobState.DatasetState> getAll(String storeName) throws IOException {
+    return super.getAll(storeName);
+  }
+
+  /**
+   * Get a {@link Map} from dataset URNs to the latest {@link JobState.DatasetState}s.
+   *
+   * @param jobName the job name
+   * @return a {@link Map} from dataset URNs to the latest {@link JobState.DatasetState}s
+   * @throws IOException if there's something wrong reading the {@link JobState.DatasetState}s
+   */
+  public Map<String, JobState.DatasetState> getLatestDatasetStatesByUrns(String jobName) throws IOException {
+    Path stateStorePath = new Path(this.storeRootDir, jobName);
+    if (!this.fs.exists(stateStorePath)) {
+      return ImmutableMap.of();
+    }
+
+    FileStatus[] stateStoreFileStatuses = this.fs.listStatus(stateStorePath, new PathFilter() {
+      @Override
+      public boolean accept(Path path) {
+        return path.getName().endsWith(CURRENT_DATASET_STATE_FILE_SUFFIX + DATASET_STATE_STORE_TABLE_SUFFIX);
+      }
+    });
+
+    if (stateStoreFileStatuses == null || stateStoreFileStatuses.length == 0) {
+      return ImmutableMap.of();
+    }
+
+    Map<String, JobState.DatasetState> datasetStatesByUrns = Maps.newHashMap();
+    for (FileStatus stateStoreFileStatus : stateStoreFileStatuses) {
+      List<JobState.DatasetState> previousDatasetStates = getAll(jobName, stateStoreFileStatus.getPath().getName());
+      if (!previousDatasetStates.isEmpty()) {
+        // There should be a single dataset state on the list if the list is not empty
+        JobState.DatasetState previousDatasetState = previousDatasetStates.get(0);
+        datasetStatesByUrns.put(previousDatasetState.getProp(ConfigurationKeys.DATASET_URN_KEY,
+            ConfigurationKeys.DEFAULT_DATASET_URN), previousDatasetState);
+      }
+    }
+
+    // The dataset (job) state from the deprecated "current.jst" will be read even though
+    // the job has transitioned to the new dataset-based mechanism
+    if (datasetStatesByUrns.size() > 1) {
+      datasetStatesByUrns.remove(ConfigurationKeys.DEFAULT_DATASET_URN);
+    }
+
+    return datasetStatesByUrns;
+  }
+
+  public JobState.DatasetState getLatestDatasetState(String storeName, String datasetUrn) throws IOException {
+    String alias = Strings.isNullOrEmpty(datasetUrn) ?
+        CURRENT_DATASET_STATE_FILE_SUFFIX + DATASET_STATE_STORE_TABLE_SUFFIX
+        : datasetUrn + "-" + CURRENT_DATASET_STATE_FILE_SUFFIX + DATASET_STATE_STORE_TABLE_SUFFIX;
+    return get(storeName, alias, datasetUrn);
+  }
+
+  /**
+   * Persist a given {@link JobState.DatasetState}.
+   *
+   * @param datasetUrn the dataset URN
+   * @param datasetState the {@link JobState.DatasetState} to persist
+   * @throws IOException if there's something wrong persisting the {@link JobState.DatasetState}
+   */
+  public void persistDatasetState(String datasetUrn, JobState.DatasetState datasetState) throws IOException {
+    String jobName = datasetState.getJobName();
+    String jobId = datasetState.getJobId();
+
+    String tableName = Strings.isNullOrEmpty(datasetUrn) ? jobId + DATASET_STATE_STORE_TABLE_SUFFIX
+        : datasetUrn + "-" + jobId + DATASET_STATE_STORE_TABLE_SUFFIX;
+    String alias = Strings.isNullOrEmpty(datasetUrn) ?
+        CURRENT_DATASET_STATE_FILE_SUFFIX + DATASET_STATE_STORE_TABLE_SUFFIX
+        : datasetUrn + "-" + CURRENT_DATASET_STATE_FILE_SUFFIX + DATASET_STATE_STORE_TABLE_SUFFIX;
+    LOGGER.info("Persisting " + tableName + " to the job state store");
+    put(jobName, tableName, datasetState);
+    createAlias(jobName, tableName, alias);
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -169,12 +169,16 @@ public class JobContext {
   }
 
   /**
-   * Get an {@link Optional} of {@link JobHistoryStore}.
-   *
-   * @return an {@link Optional} of {@link JobHistoryStore}
+   * Store job execution information into the job history store.
    */
-  public Optional<JobHistoryStore> getJobHistoryStoreOptional() {
-    return this.jobHistoryStoreOptional;
+  void storeJobExecutionInfo() {
+    if (this.jobHistoryStoreOptional.isPresent()) {
+      try {
+        this.jobHistoryStoreOptional.get().put(this.jobState.toJobExecutionInfo());
+      } catch (IOException ioe) {
+        this.logger.error("Failed to write job execution information to the job history store: " + ioe, ioe);
+      }
+    }
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -512,6 +512,7 @@ public class JobState extends SourceState {
     DatasetState datasetState = new DatasetState(this.jobName, this.jobId);
     datasetState.addAll(this);
     datasetState.setState(this.state);
+    datasetState.setTasks(this.tasks);
     if (addTaskStates) {
       datasetState.addTaskStates(this.taskStates.values());
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -533,7 +533,6 @@ public class JobState extends SourceState {
   public static class DatasetState extends JobState {
 
     // For serialization/deserialization
-    @SuppressWarnings("unused")
     public DatasetState() {
       super();
     }
@@ -548,16 +547,6 @@ public class JobState extends SourceState {
 
     public String getDatasetUrn() {
       return getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN);
-    }
-
-    @Override
-    public void write(DataOutput out) throws IOException {
-      super.write(out);
-    }
-
-    @Override
-    public void readFields(DataInput in) throws IOException {
-      super.readFields(in);
     }
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -158,7 +158,7 @@ public class Task implements Runnable {
       }
 
       // Build the row-level quality checker
-      RowLevelPolicyChecker rowChecker = closer.register(this.taskContext.getRowLevelPolicyChecker(this.taskState));
+      RowLevelPolicyChecker rowChecker = closer.register(this.taskContext.getRowLevelPolicyChecker());
       RowLevelPolicyCheckResults rowResults = new RowLevelPolicyCheckResults();
 
       long recordsPulled = 0;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
@@ -86,7 +86,7 @@ public class TaskContext {
    */
   public Source getSource() {
     try {
-      return (Source) Class.forName(this.workUnit.getProp(ConfigurationKeys.SOURCE_CLASS_KEY)).newInstance();
+      return Source.class.cast(Class.forName(this.workUnit.getProp(ConfigurationKeys.SOURCE_CLASS_KEY)).newInstance());
     } catch (ClassNotFoundException cnfe) {
       throw new RuntimeException(cnfe);
     } catch (InstantiationException ie) {
@@ -191,7 +191,7 @@ public class TaskContext {
     for (String converterClass : Splitter.on(",").omitEmptyStrings().trimResults()
         .split(this.workUnit.getProp(converterClassKey))) {
       try {
-        Converter<?, ?, ?, ?> converter = (Converter<?, ?, ?, ?>) Class.forName(converterClass).newInstance();
+        Converter<?, ?, ?, ?> converter = Converter.class.cast(Class.forName(converterClass).newInstance());
         InstrumentedConverterDecorator instrumentedConverter = new InstrumentedConverterDecorator(converter);
         instrumentedConverter.init(converterTaskState);
         converters.add(instrumentedConverter);
@@ -215,9 +215,9 @@ public class TaskContext {
   @SuppressWarnings("unchecked")
   public ForkOperator getForkOperator() {
     try {
-      ForkOperator fork = (ForkOperator) Class.forName(this.workUnit
-          .getProp(ConfigurationKeys.FORK_OPERATOR_CLASS_KEY, ConfigurationKeys.DEFAULT_FORK_OPERATOR_CLASS))
-          .newInstance();
+      ForkOperator fork = ForkOperator.class.cast(
+          Class.forName(this.workUnit.getProp(ConfigurationKeys.FORK_OPERATOR_CLASS_KEY,
+              ConfigurationKeys.DEFAULT_FORK_OPERATOR_CLASS)).newInstance());
       return new InstrumentedForkOperatorDecorator(fork);
     } catch (ClassNotFoundException cnfe) {
       throw new RuntimeException(cnfe);
@@ -232,25 +232,23 @@ public class TaskContext {
    * Get a pre-fork {@link RowLevelPolicyChecker} for executing row-level
    * {@link gobblin.qualitychecker.row.RowLevelPolicy}.
    *
-   * @param taskState {@link TaskState} of a {@link Task}
    * @return a {@link RowLevelPolicyChecker}
    */
-  public RowLevelPolicyChecker getRowLevelPolicyChecker(TaskState taskState)
+  public RowLevelPolicyChecker getRowLevelPolicyChecker()
       throws Exception {
-    return getRowLevelPolicyChecker(taskState, -1);
+    return getRowLevelPolicyChecker(-1);
   }
 
   /**
    * Get a post-fork {@link RowLevelPolicyChecker} for executing row-level
    * {@link gobblin.qualitychecker.row.RowLevelPolicy} in the given branch.
    *
-   * @param taskState {@link TaskState} of a {@link Task}
    * @param index branch index
    * @return a {@link RowLevelPolicyChecker}
    */
-  public RowLevelPolicyChecker getRowLevelPolicyChecker(TaskState taskState, int index)
+  public RowLevelPolicyChecker getRowLevelPolicyChecker(int index)
       throws Exception {
-    return new RowLevelPolicyCheckerBuilderFactory().newPolicyCheckerBuilder(taskState, index).build();
+    return new RowLevelPolicyCheckerBuilderFactory().newPolicyCheckerBuilder(this.taskState, index).build();
   }
 
   /**
@@ -292,7 +290,7 @@ public class TaskContext {
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUILDER_CLASS, branches, index),
         ConfigurationKeys.DEFAULT_WRITER_BUILDER_CLASS);
     try {
-      return (DataWriterBuilder) Class.forName(dataWriterBuilderClassName).newInstance();
+      return DataWriterBuilder.class.cast(Class.forName(dataWriterBuilderClassName).newInstance());
     } catch (ClassNotFoundException cnfe) {
       throw new RuntimeException(cnfe);
     } catch (InstantiationException ie) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputCommitter.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/GobblinOutputCommitter.java
@@ -76,7 +76,7 @@ public class GobblinOutputCommitter extends OutputCommitter {
 
         // If the file ends with ".wu" de-serialize it into a WorkUnit
         if (status.getPath().getName().endsWith(".wu")) {
-          WorkUnit wu = new WorkUnit();
+          WorkUnit wu = WorkUnit.createEmpty();
           try {
             wu.readFields(workUnitFileCloser.register(new DataInputStream(fs.open(status.getPath()))));
           } finally {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/DatasetStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/DatasetStateStoreTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 
@@ -167,7 +168,7 @@ public class DatasetStateStoreTest {
             previousSourceState != null ? previousSourceState.getPropAsInt(CURRENT_RUN_KEY) + 1 : 1);
       sourceState.setProp(FOO, BAR);
 
-      if (sourceState.getPreviousWorkUnitStates().isEmpty()) {
+      if (Iterables.isEmpty(sourceState.getPreviousWorkUnitStates())) {
         return initializeWorkUnits();
       }
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/FsDatasetStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/FsDatasetStateStoreTest.java
@@ -1,0 +1,162 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.metastore.FsStateStore;
+import gobblin.metastore.StateStore;
+
+
+/**
+ * Unit tests for {@link FsDatasetStateStore}.
+ *
+ * @author ynli
+ */
+@Test(groups = { "gobblin.runtime" })
+public class FsDatasetStateStoreTest {
+
+  private static final String TEST_JOB_NAME = "TestJob";
+  private static final String TEST_JOB_ID = "TestJob1";
+  private static final String TEST_TASK_ID_PREFIX = "TestTask-";
+  private static final String TEST_DATASET_URN = "TestDataset";
+
+  private StateStore<JobState> fsJobStateStore;
+  private FsDatasetStateStore fsDatasetStateStore;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    this.fsJobStateStore = new FsStateStore<JobState>(ConfigurationKeys.LOCAL_FS_URI,
+        FsDatasetStateStoreTest.class.getSimpleName(), JobState.class);
+    this.fsDatasetStateStore = new FsDatasetStateStore(ConfigurationKeys.LOCAL_FS_URI,
+        FsDatasetStateStoreTest.class.getSimpleName());
+  }
+
+  @Test
+  public void testPersistJobState() throws IOException {
+    JobState jobState = new JobState(TEST_JOB_NAME, TEST_JOB_ID);
+    jobState.setId(TEST_JOB_ID);
+    jobState.setProp("foo", "bar");
+    jobState.setState(JobState.RunningState.COMMITTED);
+
+    for (int i = 0; i < 3; i++) {
+      TaskState taskState = new TaskState();
+      taskState.setJobId(TEST_JOB_ID);
+      taskState.setTaskId(TEST_TASK_ID_PREFIX + i);
+      taskState.setId(TEST_TASK_ID_PREFIX + i);
+      taskState.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
+      jobState.addTaskState(taskState);
+    }
+
+    this.fsJobStateStore.put(TEST_JOB_NAME,
+        FsDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX + FsDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX,
+        jobState);
+  }
+
+  @Test(dependsOnMethods = "testPersistJobState")
+  public void testGetJobState() throws IOException {
+    JobState jobState = this.fsDatasetStateStore.get(TEST_JOB_NAME,
+        FsDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX + FsDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX,
+        TEST_JOB_ID);
+
+    Assert.assertEquals(jobState.getJobName(), TEST_JOB_NAME);
+    Assert.assertEquals(jobState.getJobId(), TEST_JOB_ID);
+    Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
+    Assert.assertEquals(jobState.getProp("foo"), "bar");
+
+    Assert.assertEquals(jobState.getCompletedTasks(), 3);
+    for (int i = 0; i < jobState.getCompletedTasks(); i++) {
+      TaskState taskState = jobState.getTaskStates().get(i);
+      Assert.assertEquals(taskState.getJobId(), TEST_JOB_ID);
+      Assert.assertEquals(taskState.getTaskId(), TEST_TASK_ID_PREFIX + i);
+      Assert.assertEquals(taskState.getId(), TEST_TASK_ID_PREFIX + i);
+      Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
+    }
+  }
+
+  @Test(dependsOnMethods = "testGetJobState")
+  public void testPersistDatasetState() throws IOException {
+    JobState.DatasetState datasetState = new JobState.DatasetState(TEST_JOB_NAME, TEST_JOB_ID);
+
+    datasetState.setDatasetUrn(TEST_DATASET_URN);
+    datasetState.setProp("foo", "bar");
+    datasetState.setState(JobState.RunningState.COMMITTED);
+    datasetState.setId(TEST_DATASET_URN);
+
+    for (int i = 0; i < 3; i++) {
+      TaskState taskState = new TaskState();
+      taskState.setJobId(TEST_JOB_ID);
+      taskState.setTaskId(TEST_TASK_ID_PREFIX + i);
+      taskState.setId(TEST_TASK_ID_PREFIX + i);
+      taskState.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
+      datasetState.addTaskState(taskState);
+    }
+
+    this.fsDatasetStateStore.persistDatasetState(TEST_DATASET_URN, datasetState);
+  }
+
+  @Test(dependsOnMethods = "testPersistDatasetState")
+  public void testGetDatasetState() throws IOException {
+    JobState.DatasetState datasetState =
+        this.fsDatasetStateStore.getLatestDatasetState(TEST_JOB_NAME, TEST_DATASET_URN);
+
+    Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN);
+    Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
+    Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
+    Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
+    Assert.assertEquals(datasetState.getProp("foo"), "bar");
+
+    Assert.assertEquals(datasetState.getCompletedTasks(), 3);
+    for (int i = 0; i < datasetState.getCompletedTasks(); i++) {
+      TaskState taskState = datasetState.getTaskStates().get(i);
+      Assert.assertEquals(taskState.getJobId(), TEST_JOB_ID);
+      Assert.assertEquals(taskState.getTaskId(), TEST_TASK_ID_PREFIX + i);
+      Assert.assertEquals(taskState.getId(), TEST_TASK_ID_PREFIX + i);
+      Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
+    }
+  }
+
+  @Test(dependsOnMethods = "testGetDatasetState")
+  public void testGetPreviousDatasetStatesByUrns() throws IOException {
+    Map<String, JobState.DatasetState> datasetStatesByUrns =
+        this.fsDatasetStateStore.getLatestDatasetStatesByUrns(TEST_JOB_NAME);
+    Assert.assertEquals(datasetStatesByUrns.size(), 1);
+
+    JobState.DatasetState datasetState = datasetStatesByUrns.get(TEST_DATASET_URN);
+    Assert.assertEquals(datasetState.getDatasetUrn(), TEST_DATASET_URN);
+    Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
+    Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
+    Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
+    Assert.assertEquals(datasetState.getProp("foo"), "bar");
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    FileSystem fs = FileSystem.getLocal(new Configuration(false));
+    Path rootDir = new Path(FsDatasetStateStoreTest.class.getSimpleName());
+    if (fs.exists(rootDir)) {
+      fs.delete(rootDir, true);
+    }
+  }
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -57,12 +57,12 @@ public class JobLauncherTestHelper {
 
   public static final String SOURCE_FILE_LIST_KEY = "source.files";
 
-  private final StateStore<JobState> jobStateStore;
+  private final StateStore<JobState.DatasetState> datasetStateStore;
   private final Properties launcherProps;
 
-  public JobLauncherTestHelper(Properties launcherProps, StateStore<JobState> jobStateStore) {
+  public JobLauncherTestHelper(Properties launcherProps, StateStore<JobState.DatasetState> datasetStateStore) {
     this.launcherProps = launcherProps;
-    this.jobStateStore = jobStateStore;
+    this.datasetStateStore = datasetStateStore;
   }
 
   @SuppressWarnings("unchecked")
@@ -79,8 +79,8 @@ public class JobLauncherTestHelper {
       closer.close();
     }
 
-    List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
-    JobState jobState = jobStateList.get(0);
+    List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
+    JobState jobState = datasetStateList.get(0);
 
     Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
     Assert.assertEquals(jobState.getCompletedTasks(), 4);
@@ -105,8 +105,8 @@ public class JobLauncherTestHelper {
       closer.close();
     }
 
-    List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
-    JobState jobState = jobStateList.get(0);
+    List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
+    JobState jobState = datasetStateList.get(0);
 
     Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
     Assert.assertEquals(jobState.getCompletedTasks(), 4);
@@ -153,8 +153,8 @@ public class JobLauncherTestHelper {
       closer.close();
     }
 
-    List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
-    Assert.assertTrue(jobStateList.isEmpty());
+    List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
+    Assert.assertTrue(datasetStateList.isEmpty());
   }
 
   @SuppressWarnings("unchecked")
@@ -172,8 +172,8 @@ public class JobLauncherTestHelper {
       closer.close();
     }
 
-    List<JobState> jobStateList = this.jobStateStore.getAll(jobName, jobId + ".jst");
-    JobState jobState = jobStateList.get(0);
+    List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
+    JobState jobState = datasetStateList.get(0);
 
     Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
     Assert.assertEquals(jobState.getCompletedTasks(), 4);
@@ -210,8 +210,8 @@ public class JobLauncherTestHelper {
     }
 
     for (int i = 0; i < 4; i++) {
-      List<JobState> jobStateList = this.jobStateStore.getAll(jobName, "Dataset" + i + "-current.jst");
-      JobState jobState = jobStateList.get(0);
+      List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, "Dataset" + i + "-current.jst");
+      JobState jobState = datasetStateList.get(0);
 
       Assert.assertEquals(jobState.getProp(ConfigurationKeys.DATASET_URN_KEY), "Dataset" + i);
       Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
@@ -242,11 +242,11 @@ public class JobLauncherTestHelper {
     }
 
     // Task 0 should have failed
-    Assert.assertTrue(this.jobStateStore.getAll(jobName, "Dataset0-current.jst").isEmpty());
+    Assert.assertTrue(this.datasetStateStore.getAll(jobName, "Dataset0-current.jst").isEmpty());
 
     for (int i = 1; i < 4; i++) {
-      List<JobState> jobStateList = this.jobStateStore.getAll(jobName, "Dataset" + i + "-current.jst");
-      JobState jobState = jobStateList.get(0);
+      List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, "Dataset" + i + "-current.jst");
+      JobState jobState = datasetStateList.get(0);
 
       Assert.assertEquals(jobState.getProp(ConfigurationKeys.DATASET_URN_KEY), "Dataset" + i);
       Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
@@ -291,7 +291,7 @@ public class JobLauncherTestHelper {
   }
 
   public void deleteStateStore(String storeName) throws IOException {
-    this.jobStateStore.delete(storeName);
+    this.datasetStateStore.delete(storeName);
   }
 
   public static class MultiDatasetTestSource extends TestSource {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobStateTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobStateTest.java
@@ -136,7 +136,7 @@ public class JobStateTest {
 
     Set<String> sortedDatasetUrns = Sets.newTreeSet(jobState.getDatasetStatesByUrns().keySet());
     Assert.assertEquals(sortedDatasetUrns.size(), jobState.getCompletedTasks());
-    Map<String, JobState> datasetStatesByUrns = jobState.getDatasetStatesByUrns();
+    Map<String, JobState.DatasetState> datasetStatesByUrns = jobState.getDatasetStatesByUrns();
     int index = 0;
     for (String dataSetUrn : sortedDatasetUrns) {
       Assert.assertEquals(dataSetUrn, "TestDataset" + index);
@@ -173,14 +173,5 @@ public class JobStateTest {
 
     Collections.sort(taskStateIds);
     Assert.assertEquals(taskStateIds, Lists.newArrayList("TestTask-0", "TestTask-1", "TestTask-2"));
-  }
-
-  @Test (dependsOnMethods = {"testSetAndGet"})
-  public void testCopyOf() {
-    JobState copy = JobState.copyOf(this.jobState, false);
-    doAsserts(copy, false);
-
-    copy = JobState.copyOf(this.jobState, true);
-    doAsserts(copy, true);
   }
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -67,23 +67,42 @@ public class LocalJobLauncherTest {
 
   @Test
   public void testLaunchJob() throws Exception {
-    this.jobLauncherTestHelper.runTest(loadJobProps());
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
+        "-testLaunchJob");
+    try {
+      this.jobLauncherTestHelper.runTest(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test
   public void testLaunchJobWithPullLimit() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
+        "-testLaunchJobWithPullLimit");
     jobProps.setProperty(ConfigurationKeys.EXTRACT_LIMIT_ENABLED_KEY, Boolean.TRUE.toString());
     jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.COUNT_BASED.toString());
     jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY, "10");
-    this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
+    try {
+      this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test
   public void testLaunchJobWithMultiWorkUnit() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
+        "-testLaunchJobWithMultiWorkUnit");
     jobProps.setProperty("use.multiworkunit", Boolean.toString(true));
-    this.jobLauncherTestHelper.runTest(jobProps);
+    try {
+      this.jobLauncherTestHelper.runTest(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test(groups = { "ignore" })
@@ -94,6 +113,8 @@ public class LocalJobLauncherTest {
   @Test
   public void testLaunchJobWithFork() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
+        "-testLaunchJobWithFork");
     jobProps.setProperty(ConfigurationKeys.CONVERTER_CLASSES_KEY, "gobblin.test.TestConverter2");
     jobProps.setProperty(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
     jobProps
@@ -112,17 +133,51 @@ public class LocalJobLauncherTest {
     jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY + ".1", WriterOutputFormat.AVRO.name());
     jobProps.setProperty(ConfigurationKeys.WRITER_DESTINATION_TYPE_KEY + ".0", Destination.DestinationType.HDFS.name());
     jobProps.setProperty(ConfigurationKeys.WRITER_DESTINATION_TYPE_KEY + ".1", Destination.DestinationType.HDFS.name());
-    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".0", "gobblin-test/basicTest/tmp/taskStaging");
-    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".1", "gobblin-test/basicTest/tmp/taskStaging");
-    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".0", "gobblin-test/basicTest/tmp/taskOutput");
-    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".1", "gobblin-test/basicTest/tmp/taskOutput");
-    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".0", "gobblin-test/jobOutput");
-    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".1", "gobblin-test/jobOutput");
-    this.jobLauncherTestHelper.runTestWithFork(jobProps);
+    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".0",
+        jobProps.getProperty(ConfigurationKeys.WRITER_STAGING_DIR));
+    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".1",
+        jobProps.getProperty(ConfigurationKeys.WRITER_STAGING_DIR));
+    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".0",
+        jobProps.getProperty(ConfigurationKeys.WRITER_OUTPUT_DIR));
+    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".1",
+        jobProps.getProperty(ConfigurationKeys.WRITER_OUTPUT_DIR));
+    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".0",
+        jobProps.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
+    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".1",
+        jobProps.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
+    try {
+      this.jobLauncherTestHelper.runTestWithFork(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
+  @Test
+  public void testLaunchJobWithMultipleDatasets() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithMultipleDatasets");
+    try {
+      this.jobLauncherTestHelper.runTestWithMultipleDatasets(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
+  @Test
+  public void testLaunchJobWithMultipleDatasetsAndFaultyExtractor() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithMultipleDatasetsAndFaultyExtractor");
+    try {
+      this.jobLauncherTestHelper.runTestWithMultipleDatasetsWithFaultyExtractor(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @AfterClass
-  public void tearDown() {
+  public void tearDown() throws IOException {
     try {
       DriverManager.getConnection("jdbc:derby:memory:gobblin1;shutdown=true");
     } catch (SQLException se) {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -56,12 +56,12 @@ public class LocalJobLauncherTest {
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY,
         "jdbc:derby:memory:gobblin1;create=true");
 
-    StateStore<JobState> jobStateStore = new FsStateStore<JobState>(
+    StateStore<JobState.DatasetState> datasetStateStore = new FsStateStore<JobState.DatasetState>(
         this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
         this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY),
-        JobState.class);
+        JobState.DatasetState.class);
 
-    this.jobLauncherTestHelper = new JobLauncherTestHelper(this.launcherProps, jobStateStore);
+    this.jobLauncherTestHelper = new JobLauncherTestHelper(this.launcherProps, datasetStateStore);
     this.jobLauncherTestHelper.prepareJobHistoryStoreDatabase(this.launcherProps);
   }
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobManagerTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobManagerTest.java
@@ -42,7 +42,7 @@ import gobblin.runtime.WorkUnitManager;
  * @author ynli
  */
 @Deprecated
-@Test(groups = {"gobblin.test"})
+@Test(groups = { "ignore" })
 public class LocalJobManagerTest {
 
   private static final String SOURCE_FILE_LIST_KEY = "source.files";
@@ -77,7 +77,8 @@ public class LocalJobManagerTest {
     Properties jobProps = new Properties();
     jobProps.load(new FileReader("gobblin-test/resource/job-conf/GobblinTest1.pull"));
     jobProps.putAll(this.properties);
-    jobProps.setProperty(SOURCE_FILE_LIST_KEY, "gobblin-test/resource/source/test.avro.2,gobblin-test/resource/source/test.avro.3");
+    jobProps.setProperty(SOURCE_FILE_LIST_KEY,
+        "gobblin-test/resource/source/test.avro.2,gobblin-test/resource/source/test.avro.3");
     jobProps.setProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "true");
 
     CountDownLatch latch = new CountDownLatch(1);
@@ -91,7 +92,8 @@ public class LocalJobManagerTest {
     Properties jobProps = new Properties();
     jobProps.load(new FileReader("gobblin-test/resource/job-conf/GobblinTest2.pull"));
     jobProps.putAll(this.properties);
-    jobProps.setProperty(SOURCE_FILE_LIST_KEY, "gobblin-test/resource/source/test.avro.2,gobblin-test/resource/source/test.avro.3");
+    jobProps.setProperty(SOURCE_FILE_LIST_KEY,
+        "gobblin-test/resource/source/test.avro.2,gobblin-test/resource/source/test.avro.3");
     jobProps.setProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "true");
 
     CountDownLatch latch = new CountDownLatch(1);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -73,34 +73,59 @@ public class MRJobLauncherTest extends BMNGRunner {
 
   @Test
   public void testLaunchJob() throws Exception {
-    this.jobLauncherTestHelper.runTest(loadJobProps());
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJob");
+    try {
+      this.jobLauncherTestHelper.runTest(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test
   public void testLaunchJobWithConcurrencyLimit() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithConcurrencyLimit");
     jobProps.setProperty(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, "2");
     this.jobLauncherTestHelper.runTest(jobProps);
     jobProps.setProperty(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, "3");
     this.jobLauncherTestHelper.runTest(jobProps);
     jobProps.setProperty(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY, "5");
-    this.jobLauncherTestHelper.runTest(jobProps);
+    try {
+      this.jobLauncherTestHelper.runTest(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test
   public void testLaunchJobWithPullLimit() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithPullLimit");
     jobProps.setProperty(ConfigurationKeys.EXTRACT_LIMIT_ENABLED_KEY, Boolean.TRUE.toString());
     jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.COUNT_BASED.toString());
     jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY, "10");
-    this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
+    try {
+      this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test
   public void testLaunchJobWithMultiWorkUnit() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithMultiWorkUnit");
     jobProps.setProperty("use.multiworkunit", Boolean.toString(true));
-    this.jobLauncherTestHelper.runTest(jobProps);
+    try {
+      this.jobLauncherTestHelper.runTest(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   @Test(groups = { "ignore" })
@@ -111,6 +136,8 @@ public class MRJobLauncherTest extends BMNGRunner {
   @Test
   public void testLaunchJobWithFork() throws Exception {
     Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithFork");
     jobProps.setProperty(ConfigurationKeys.CONVERTER_CLASSES_KEY, "gobblin.test.TestConverter2");
     jobProps.setProperty(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
     jobProps
@@ -129,13 +156,23 @@ public class MRJobLauncherTest extends BMNGRunner {
     jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY + ".1", WriterOutputFormat.AVRO.name());
     jobProps.setProperty(ConfigurationKeys.WRITER_DESTINATION_TYPE_KEY + ".0", Destination.DestinationType.HDFS.name());
     jobProps.setProperty(ConfigurationKeys.WRITER_DESTINATION_TYPE_KEY + ".1", Destination.DestinationType.HDFS.name());
-    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".0", "gobblin-test/basicTest/tmp/taskStaging");
-    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".1", "gobblin-test/basicTest/tmp/taskStaging");
-    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".0", "gobblin-test/basicTest/tmp/taskOutput");
-    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".1", "gobblin-test/basicTest/tmp/taskOutput");
-    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".0", "gobblin-test/jobOutput");
-    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".1", "gobblin-test/jobOutput");
-    this.jobLauncherTestHelper.runTestWithFork(jobProps);
+    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".0",
+        jobProps.getProperty(ConfigurationKeys.WRITER_STAGING_DIR));
+    jobProps.setProperty(ConfigurationKeys.WRITER_STAGING_DIR + ".1",
+        jobProps.getProperty(ConfigurationKeys.WRITER_STAGING_DIR));
+    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".0",
+        jobProps.getProperty(ConfigurationKeys.WRITER_OUTPUT_DIR));
+    jobProps.setProperty(ConfigurationKeys.WRITER_OUTPUT_DIR + ".1",
+        jobProps.getProperty(ConfigurationKeys.WRITER_OUTPUT_DIR));
+    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".0",
+        jobProps.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
+    jobProps.setProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".1",
+        jobProps.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
+    try {
+      this.jobLauncherTestHelper.runTestWithFork(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
   }
 
   /**
@@ -157,6 +194,8 @@ public class MRJobLauncherTest extends BMNGRunner {
       Assert.fail("Byteman is not configured properly, the runTest method should have throw an exception");
     } catch (Exception e) {
       // The job should throw an exception, ignore it
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(props.getProperty(ConfigurationKeys.JOB_NAME_KEY));
     }
 
     Assert.assertTrue(props.containsKey(ConfigurationKeys.WRITER_STAGING_DIR));
@@ -169,8 +208,39 @@ public class MRJobLauncherTest extends BMNGRunner {
     Assert.assertEquals(FileUtils.listFiles(outputDir, null, true).size(), 0);
   }
 
+  @Test
+  public void testLaunchJobWithMultipleDatasets() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithMultipleDatasets");
+    try {
+      this.jobLauncherTestHelper.runTestWithMultipleDatasets(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
+  /**
+   * Seems setting mapreduce.map.failures.maxpercent=100 does not prevent Hadoop2's LocalJobRunner from
+   * failing and aborting a job if any mapper task fails. Aborting the job causes its working directory
+   * to be deleted in {@link GobblinOutputCommitter}, which further fails this test since all the output
+   * {@link gobblin.runtime.TaskState}s are deleted. It works fine in Hadoop1 though by setting
+   * mapred.max.map.failures.percent=100. There may be a bug in Hadoop2's LocalJobRunner.
+   */
+  @Test(groups = { "Hadoop1Only" })
+  public void testLaunchJobWithMultipleDatasetsAndFaultyExtractor() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
+        "-testLaunchJobWithMultipleDatasetsAndFaultyExtractor");
+    try {
+      this.jobLauncherTestHelper.runTestWithMultipleDatasetsWithFaultyExtractor(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
   @AfterClass
-  public void tearDown() {
+  public void tearDown() throws IOException {
     try {
       DriverManager.getConnection("jdbc:derby:memory:gobblin2;shutdown=true");
     } catch (SQLException se) {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -62,12 +62,12 @@ public class MRJobLauncherTest extends BMNGRunner {
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY,
         "jdbc:derby:memory:gobblin2;create=true");
 
-    StateStore<JobState> jobStateStore = new FsStateStore<JobState>(
+    StateStore<JobState.DatasetState> datasetStateStore = new FsStateStore<JobState.DatasetState>(
         this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
         this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY),
-        JobState.class);
+        JobState.DatasetState.class);
 
-    this.jobLauncherTestHelper = new JobLauncherTestHelper(this.launcherProps, jobStateStore);
+    this.jobLauncherTestHelper = new JobLauncherTestHelper(this.launcherProps, datasetStateStore);
     this.jobLauncherTestHelper.prepareJobHistoryStoreDatabase(this.launcherProps);
   }
 

--- a/gobblin-runtime/src/test/java/gobblin/test/TestExtractor.java
+++ b/gobblin-runtime/src/test/java/gobblin/test/TestExtractor.java
@@ -82,7 +82,7 @@ public class TestExtractor implements Extractor<String, String> {
   }
 
   @Override
-  public String readRecord(@Deprecated String reuse) {
+  public String readRecord(@Deprecated String reuse) throws IOException {
     if (this.dataFileReader == null) {
       return null;
     }

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -19,6 +19,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -95,6 +96,18 @@ public class HadoopUtils {
       conf.set(propName, state.getProp(propName));
     }
     return conf;
+  }
+
+  /**
+   * Set the group associated with a given path.
+   *
+   * @param fs the {@link FileSystem} instance used to perform the file operation
+   * @param path the given path
+   * @param group the group associated with the path
+   * @throws IOException
+   */
+  public static void setGroup(FileSystem fs, Path path, String group) throws IOException {
+    fs.setOwner(path, fs.getFileStatus(path).getOwner(), group);
   }
 
   /**

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -19,7 +19,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.util.List;
 
-import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;

--- a/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
@@ -225,12 +225,16 @@ public class ParallelRunner implements Closeable {
    *
    * @param src path to be renamed
    * @param dst new path after rename
+   * @param group an optional group name for the destination path
    */
-  public void renamePath(final Path src, final Path dst) {
+  public void renamePath(final Path src, final Path dst, final Optional<String> group) {
     this.futures.add(this.executor.submit(new Callable<Void>() {
       @Override
       public Void call() throws Exception {
         HadoopUtils.renamePath(fs, src, dst);
+        if (group.isPresent()) {
+          HadoopUtils.setGroup(fs, dst, group.get());
+        }
         return null;
       }
     }));


### PR DESCRIPTION
1. A `WorkUnit` can be specified to belong to a dataset group by using a new config property `dataset.urn`.
2. Job/task state will be persisted on a per-dataset basis into different state store files, one per dataset. All `current` dataset state store files will be loaded in the next job run. 
3. Commit of data will be done on a per-dataset basis, allowing datasets to be committed independently.
4. For existing job that does not have a dataset concept or only deals with a single dataset, the logic of job/task state persistence and data commit remains the same.
 
Signed-off-by: Yinan Li <liyinan926@gmail.com>