### PR TITLE
ETL-2989: Add file level retention for fork operator

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
@@ -38,20 +38,19 @@ public class DatasetCleaner {
   public DatasetCleaner(FileSystem fs, Properties props) throws IOException {
 
     Preconditions.checkArgument(props.containsKey(DATASET_PROFILE_CLASS_KEY));
-
     try {
       Class<?> datasetFinderClass = Class.forName(props.getProperty(DATASET_PROFILE_CLASS_KEY));
-      this.datasetFinder = (DatasetFinder) datasetFinderClass.
-          getConstructor(FileSystem.class, Properties.class).newInstance(fs, props);
-    } catch(ClassNotFoundException exception) {
+      this.datasetFinder =
+          (DatasetFinder) datasetFinderClass.getConstructor(FileSystem.class, Properties.class).newInstance(fs, props);
+    } catch (ClassNotFoundException exception) {
       throw new IOException(exception);
-    } catch(NoSuchMethodException exception) {
+    } catch (NoSuchMethodException exception) {
       throw new IOException(exception);
-    } catch(InstantiationException exception) {
+    } catch (InstantiationException exception) {
       throw new IOException(exception);
-    } catch(IllegalAccessException exception) {
+    } catch (IllegalAccessException exception) {
       throw new IOException(exception);
-    } catch(InvocationTargetException exception) {
+    } catch (InvocationTargetException exception) {
       throw new IOException(exception);
     }
   }
@@ -63,7 +62,7 @@ public class DatasetCleaner {
   public void clean() throws IOException {
     List<Dataset> dataSets = this.datasetFinder.findDatasets();
 
-    for (Dataset dataset: dataSets) {
+    for (Dataset dataset : dataSets) {
       dataset.clean();
     }
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ProxyableDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ProxyableDatasetProfile.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.profile;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.retention.dataset.ConfigurableDataset;
+import gobblin.data.management.retention.dataset.Dataset;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.util.ProxiedFileSystemCache;
+
+
+/**
+ * A wrapper of {@link gobblin.data.management.retention.profile.ConfigurableGlobDatasetFinder} that looks for
+ * {@link gobblin.data.management.retention.dataset.Dataset}s with {@link org.apache.hadoop.fs.FileSystem}s 
+ * proxied as the owner of each dataset.
+ */
+public class ProxyableDatasetProfile extends ConfigurableGlobDatasetFinder {
+
+  public ProxyableDatasetProfile(FileSystem fs, Properties props) throws IOException {
+    super(fs, props);
+  }
+
+  @Override
+  public Dataset datasetAtPath(Path path) throws IOException {
+    return new ConfigurableDataset<DatasetVersion>(this.getFsForDataset(path), this.props, path);
+  }
+
+  public FileSystem getFsForDataset(Path path) throws IOException {
+    Preconditions.checkArgument(this.props.containsKey(ConfigurationKeys.SUPER_USER_NAME_TO_PROXY_AS_OTHERS));
+    Preconditions.checkArgument(this.props.containsKey(ConfigurationKeys.SUPER_USER_KEY_TAB_LOCATION));
+
+    try {
+      return ProxiedFileSystemCache.getProxiedFileSystemUsingKeytab(this.fs.getFileStatus(path).getOwner(),
+          this.props.getProperty(ConfigurationKeys.SUPER_USER_NAME_TO_PROXY_AS_OTHERS),
+          new Path(this.props.getProperty(ConfigurationKeys.SUPER_USER_KEY_TAB_LOCATION)), this.fs.getUri(),
+          this.fs.getConf());
+    } catch (ExecutionException e) {
+      throw new IOException("Cannot get proxied filesystem at Path: " + path);
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/DatasetVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/DatasetVersion.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.retention.version;
 
 import java.util.Set;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/StringDatasetVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/StringDatasetVersion.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.retention.version;
 
 import java.util.Set;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/TimestampedDatasetVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/TimestampedDatasetVersion.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.retention.version;
 
 import java.util.Set;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/FileLevelTimestampVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/FileLevelTimestampVersionFinder.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.version.finder;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+import gobblin.data.management.retention.dataset.Dataset;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+import gobblin.util.FileListUtils;
+
+
+/**
+ * {@link gobblin.data.management.retention.version.finder.VersionFinder} that uses the file level modifiedTimestamp 
+ * under the datasetRoot path to find {@link gobblin.data.management.retention.version.DatasetVersion}s, and represents
+ * each version as {@link gobblin.data.management.retention.version.TimestampedDatasetVersion} using the file level path 
+ * and modifiedTimestamp.
+ */
+public class FileLevelTimestampVersionFinder implements VersionFinder<TimestampedDatasetVersion> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(FileLevelTimestampVersionFinder.class);
+  private final FileSystem fs;
+
+  public FileLevelTimestampVersionFinder(FileSystem fs, Properties props) {
+    this.fs = fs;
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return TimestampedDatasetVersion.class;
+  }
+
+  @Override
+  public Collection<TimestampedDatasetVersion> findDatasetVersions(Dataset dataset) {
+    try {
+      List<TimestampedDatasetVersion> timestampedVersions = Lists.newArrayList();
+      for (FileStatus fileStatus : FileListUtils.listFilesRecursively(this.fs, dataset.datasetRoot())) {
+        timestampedVersions.add(new TimestampedDatasetVersion(new DateTime(fileStatus.getModificationTime()),
+            fileStatus.getPath()));
+      }
+      return timestampedVersions;
+    } catch (IOException e) {
+      LOGGER.warn("Failed to get ModifiedTimStamp for candidate dataset version at " + dataset.datasetRoot()
+          + ". Ignoring.");
+      return null;
+    }
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/util/PathUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/util/PathUtils.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.data.management.util;
 
 import org.apache.hadoop.fs.Path;

--- a/gobblin-utility/src/main/java/gobblin/util/FileListUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/FileListUtils.java
@@ -1,0 +1,81 @@
+package gobblin.util;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Lists;
+
+
+/**
+ * Utility class for listing files on a {@link FileSystem}.
+ *
+ * @see {@link FileSystem}
+ */
+public class FileListUtils {
+  private static final Logger LOG = LoggerFactory.getLogger(FileListUtils.class);
+
+  public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path) throws FileNotFoundException,
+      IOException {
+    return listFilesRecursively(fs, path, new PathFilter() {
+      @Override
+      public boolean accept(Path path) {
+        return true;
+      }
+    });
+  }
+
+  /**
+   * Helper method to list out all files under a specified path. The specified {@link PathFilter} is treated as a file
+   * filter, that is it is only applied to file {@link Path}s.
+   */
+  public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path, PathFilter fileFilter)
+      throws FileNotFoundException, IOException {
+    return listFilesRecursivelyHelper(fs, Lists.<FileStatus> newArrayList(), fs.getFileStatus(path), fileFilter);
+  }
+
+  private static List<FileStatus> listFilesRecursivelyHelper(FileSystem fs, List<FileStatus> files,
+      FileStatus fileStatus, PathFilter fileFilter) throws FileNotFoundException, IOException {
+    if (fileStatus.isDir()) {
+      for (FileStatus status : fs.listStatus(fileStatus.getPath())) {
+        listFilesRecursivelyHelper(fs, files, status, fileFilter);
+      }
+    } else if (fileFilter.accept(fileStatus.getPath())) {
+      files.add(fileStatus);
+    }
+    return files;
+  }
+
+  /**
+   * Helper method to list out all paths under a specified path. If the {@link org.apache.hadoop.fs.FileSystem} is
+   * unable to list the contents of a relevant directory, will log an error and skip.
+   */
+  public static List<FileStatus> listPathsRecursively(FileSystem fs, Path path, PathFilter fileFilter)
+      throws IOException {
+    return listPathsRecursivelyHelper(fs, Lists.<FileStatus> newArrayList(), fs.getFileStatus(path), fileFilter);
+  }
+
+  private static List<FileStatus> listPathsRecursivelyHelper(FileSystem fs, List<FileStatus> files,
+      FileStatus fileStatus, PathFilter fileFilter) {
+    if (fileFilter.accept(fileStatus.getPath())) {
+      files.add(fileStatus);
+    }
+    if (fileStatus.isDir()) {
+      try {
+        for (FileStatus status : fs.listStatus(fileStatus.getPath())) {
+          listPathsRecursivelyHelper(fs, files, status, fileFilter);
+        }
+      } catch (IOException ioe) {
+        LOG.error("Could not list contents of path " + fileStatus.getPath());
+      }
+    }
+    return files;
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/FileListUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/FileListUtilsTest.java
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Set;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Sets;
+
+
+/**
+ * Unit tests for the job configuration file monitor in {@link gobblin.util.FileListUtils}.
+ */
+@Test(groups = { "gobblin.util" })
+public class FileListUtilsTest {
+
+  private static final String FILE_UTILS_TEST_DIR = "gobblin-utility/src/test/resources/";
+  private static final String TEST_FILE_NAME1 = "test1";
+  private static final String TEST_FILE_NAME2 = "test2";
+
+  @Test
+  public void testListFilesRecursively() throws IOException {
+    FileSystem localFs = FileSystem.getLocal(new Configuration());
+    Path baseDir = new Path(FILE_UTILS_TEST_DIR, "fileListTestDir1");
+    try {
+      if (localFs.exists(baseDir)) {
+        localFs.delete(baseDir, true);
+      }
+      localFs.mkdirs(baseDir);
+      localFs.create(new Path(baseDir, TEST_FILE_NAME1));
+      Path subDir = new Path(baseDir, "subDir");
+      localFs.mkdirs(subDir);
+      localFs.create(new Path(subDir, TEST_FILE_NAME2));
+      List<FileStatus> testFiles = FileListUtils.listFilesRecursively(localFs, baseDir);
+
+      Assert.assertEquals(2, testFiles.size());
+
+      Set<String> fileNames = Sets.newHashSet();
+      for (FileStatus testFileStatus : testFiles) {
+        fileNames.add(testFileStatus.getPath().getName());
+      }
+      Assert.assertTrue(fileNames.contains(TEST_FILE_NAME1) && fileNames.contains(TEST_FILE_NAME2));
+    } finally {
+      localFs.delete(baseDir, true);
+    }
+  }
+
+  @Test
+  public void testListPathsRecursively() throws IOException {
+    FileSystem localFs = FileSystem.getLocal(new Configuration());
+    Path baseDir = new Path(FILE_UTILS_TEST_DIR, "fileListTestDir2");
+    try {
+      if (localFs.exists(baseDir)) {
+        localFs.delete(baseDir, true);
+      }
+      localFs.mkdirs(baseDir);
+      localFs.create(new Path(baseDir, TEST_FILE_NAME1));
+      Path subDir = new Path(baseDir, "subDir");
+      localFs.mkdirs(subDir);
+      localFs.create(new Path(subDir, TEST_FILE_NAME2));
+      List<FileStatus> testFiles = FileListUtils.listPathsRecursively(localFs, baseDir, new PathFilter() {
+        @Override
+        public boolean accept(Path path) {
+          return true;
+        }
+      });
+      Assert.assertEquals(4, testFiles.size());
+
+      Set<String> fileNames = Sets.newHashSet();
+      for (FileStatus testFileStatus : testFiles) {
+        fileNames.add(testFileStatus.getPath().getName());
+      }
+
+      Set<String> expectedFileNames = Sets.newHashSet();
+      expectedFileNames.add(baseDir.getName());
+      expectedFileNames.add(subDir.getName());
+      expectedFileNames.add(TEST_FILE_NAME1);
+      expectedFileNames.add(TEST_FILE_NAME2);
+
+      Assert.assertEquals(fileNames, expectedFileNames);
+    } finally {
+      localFs.delete(baseDir, true);
+    }
+  }
+}


### PR DESCRIPTION
1. Added ProxyableFileLevelDatasetProfile for finding file level datasets with proxy enabled.
2. Added SingleTimestampVersionFinder, which uses TimestampedDatasetVersion to find single versions.
3. Added FileListUtils, which is moved from internal idpc repo.

