### PR TITLE
Fix a couple of FindBugs warnings

### DIFF
--- a/gobblin-runtime/src/test/java/gobblin/runtime/util/ClustersNamesTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/util/ClustersNamesTest.java
@@ -15,7 +15,7 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 /** Unit tests for {@link ClustersNames}. This test relies on the ClustersNames.properties file */
-public class TestClustersNames {
+public class ClustersNamesTest {
 
   @Test
   public void testClustersNames() {

--- a/gobblin-utility/src/main/java/gobblin/util/SchedulerUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SchedulerUtils.java
@@ -12,6 +12,8 @@
 
 package gobblin.util;
 
+import gobblin.configuration.ConfigurationKeys;
+
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
@@ -36,8 +38,6 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
-
-import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -242,7 +242,7 @@ public class SchedulerUtils {
     return ImmutableSet.copyOf(Iterables.transform(jobConfigFileExtensionsIterable, new Function<String, String>() {
       @Override
       public String apply(String input) {
-        return input.toLowerCase();
+        return null != input ? input.toLowerCase() : "";
       }
     }));
   }


### PR DESCRIPTION
* Add proper closing of input streams to ClustersNames constructor to fix a FindBugs warning
* Rename TestClustersNames to ClustersNamesTest to be consistent with other tests.
* Fix a FindBugs warning in Scheduler utils which complains that "input" parameter might be null.

@pcadabam can you please review?