### PR TITLE
Enable compaction to handle late data arrivals

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -460,6 +460,10 @@ public class ConfigurationKeys {
   public static final String COMPACTION_FILE_SYSTEM_URI = COMPACTION_PREFIX + "file.system.uri";
   public static final String COMPACTION_MR_JOB_TIMEOUT_MINUTES = COMPACTION_PREFIX + "mr.job.timeout.minutes";
   public static final int DEFAULT_COMPACTION_MR_JOB_TIMEOUT_MINUTES = Integer.MAX_VALUE;
+  public static final String COMPACTION_RECOMPACT_FOR_LATE_DATA = COMPACTION_PREFIX + "recompact.for.late.data";
+  public static final boolean DEFAULT_COMPACTION_RECOMPACT_FOR_LATE_DATA = false;
+  public static final String COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK = COMPACTION_PREFIX + "job.late.data.movement.task";
+  public static final String COMPACTION_JOB_LATE_DATA_FILES = COMPACTION_PREFIX + "job.late.data.files";
   public static final String COMPACTION_COMPLETE_FILE_NAME = "_COMPACTION_COMPLETE";
   public static final String COMPACTION_ENABLE_SUCCESS_FILE = "mapreduce.fileoutputcommitter.marksuccessfuljobs";
   public static final String COMPACTION_OVERWRITE_OUTPUT_DIR = COMPACTION_PREFIX + "overwrite.output.dir";

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
@@ -13,22 +13,26 @@
 package gobblin.compaction.mapreduce;
 
 import java.io.IOException;
-import java.util.List;
 import java.util.concurrent.Callable;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.filecache.DistributedCache;
+import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.LocalFileSystem;
+import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.io.Closer;
 import com.google.common.primitives.Ints;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -43,6 +47,11 @@ import gobblin.util.HadoopUtils;
  * The properties that control the number of reducers are compaction.target.output.file.size and
  * compaction.max.num.reducers. The number of reducers will be the smaller of
  * [total input size] / [compaction.target.output.file.size] + 1 and [compaction.max.num.reducers].
+ *
+ * If {@value ConfigurationKeys#COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK} is set to true, does not
+ * launch an MR job. Instead, just copies the files present in
+ * {@value ConfigurationKeys#COMPACTION_JOB_LATE_DATA_FILES} to a 'late' subdirectory within
+ * the output directory.
  *
  * @author ziliu
  */
@@ -77,17 +86,34 @@ public abstract class MRCompactorJobRunner implements Callable<Void> {
 
   @Override
   public Void call() throws IOException, ClassNotFoundException, InterruptedException {
-    if (this.fs.exists(this.outputPath) && !canOverwriteOutputDir()) {
-      LOG.warn(String.format("Output path %s exists. Will not compact %s.", this.outputPath, this.inputPath));
-      return null;
-    }
     Configuration conf = HadoopUtils.getConfFromState(this.jobProps);
-    addJars(conf);
-    Job job = Job.getInstance(conf);
-    this.configureJob(job);
-    this.submit(job);
-    this.moveTmpPathToOutputPath();
+    DateTime jobStartTime = new DateTime(DateTimeZone.forID(this.jobProps.getProp(
+        ConfigurationKeys.COMPACTION_TIMEZONE, ConfigurationKeys.DEFAULT_COMPACTION_TIMEZONE)));
+    if (this.jobProps.getPropAsBoolean(ConfigurationKeys.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, false)) {
+      this.copyLateDataFiles(new Path(this.outputPath, "late"), conf);
+    } else {
+      if (this.fs.exists(this.outputPath) && !canOverwriteOutputDir()) {
+        LOG.warn(String.format("Output path %s exists. Will not compact %s.", this.outputPath, this.inputPath));
+        return null;
+      }
+      addJars(conf);
+      Job job = Job.getInstance(conf);
+      this.configureJob(job);
+      this.submit(job);
+      this.moveTmpPathToOutputPath();
+    }
+    this.markOutputDirAsCompleted(jobStartTime);
     return null;
+  }
+
+  private void copyLateDataFiles(Path outputDirectory, Configuration conf) throws IOException {
+    for (String filePath : this.jobProps.getPropAsList(ConfigurationKeys.COMPACTION_JOB_LATE_DATA_FILES)) {
+      Path outPath = new Path(outputDirectory,
+          StringUtils.removeStart(StringUtils.removeStart(filePath, this.inputPath.toString()), "/"));
+      if (!FileUtil.copy(this.fs, new Path(filePath), this.fs, outPath, false, conf)) {
+        LOG.warn(String.format("Failed to copy %s to %s.", filePath, outPath));
+      }
+    }
   }
 
   private boolean canOverwriteOutputDir() {
@@ -190,6 +216,19 @@ public abstract class MRCompactorJobRunner implements Callable<Void> {
     }
   }
 
+  private void markOutputDirAsCompleted(DateTime jobStartTime) throws IOException {
+    Path completionFilePath = new Path(this.outputPath, ConfigurationKeys.COMPACTION_COMPLETE_FILE_NAME);
+    Closer closer = Closer.create();
+    try {
+      FSDataOutputStream completionFileStream = closer.register(this.fs.create(completionFilePath));
+      completionFileStream.writeLong(jobStartTime.getMillis());
+    } catch (Throwable e) {
+      throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+  }
+
   private void moveTmpPathToOutputPath() throws IOException {
     LOG.info(String.format("Moving %s to %s", this.tmpPath, this.outputPath));
     this.fs.delete(this.outputPath, true);
@@ -197,7 +236,5 @@ public abstract class MRCompactorJobRunner implements Callable<Void> {
     if (!this.fs.rename(this.tmpPath, this.outputPath)) {
       throw new IOException(String.format("Unable to move %s to %s", this.tmpPath, this.outputPath));
     }
-    Path completionFilePath = new Path(this.outputPath, ConfigurationKeys.COMPACTION_COMPLETE_FILE_NAME);
-    this.fs.createNewFile(completionFilePath);
   }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
@@ -12,13 +12,11 @@
 
 package gobblin.compaction.mapreduce;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
-
 import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTime;
@@ -31,7 +29,13 @@ import org.joda.time.format.PeriodFormatterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.HadoopUtils;
 
 
 /**
@@ -42,7 +46,7 @@ import com.google.common.collect.Lists;
  * being YYYY/MM/dd, which means an MR job will be launched for each qualified folder that matches
  * [this.inputPath]&#47;*&#47;*&#47;*.
  *
- * To control which folders to process, use properties compaction.timebased.max.time.ago and
+ * To control which folders to process, use properties compaction.timebased.min.time.ago and
  * compaction.timebased.max.time.ago. The format is ?m?d?h, e.g., 3m or 2d10h.
  *
  * @author ziliu
@@ -89,8 +93,17 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
       }
       Path jobOutputDir = new Path(this.topicOutputDir, folderTime.toString(this.timeFormatter));
       Path jobTmpDir = new Path(this.topicTmpDir, folderTime.toString(this.timeFormatter));
-      if (shouldProcessFolder(status.getPath(), jobOutputDir, folderTime)) {
-        allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir));
+      if (folderWithinAllowedPeriod(status.getPath(), folderTime)) {
+        if (!folderAlreadyCompacted(jobOutputDir)) {
+          allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir));
+        } else {
+          List<Path> newDataFiles = getNewDataInFolder(status.getPath(), jobOutputDir);
+          if (newDataFiles.isEmpty()) {
+            LOG.info(String.format("Folder %s already compacted. Skipping", jobOutputDir));
+          } else {
+            allJobProps.add(createJobPropsForLateData(status.getPath(), jobOutputDir, jobTmpDir, newDataFiles));
+          }
+        }
       }
     }
 
@@ -114,10 +127,10 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
   }
 
   /**
-   * A folder should be processed if (1) input folder time is between compaction.timebased.max.time.ago and
-   * compaction.timebased.max.time.ago, (2) output folder is not already compacted.
+   * Return true iff input folder time is between compaction.timebased.min.time.ago and
+   * compaction.timebased.max.time.ago.
    */
-  private boolean shouldProcessFolder(Path inputFolder, Path outputFolder, DateTime folderTime) {
+  private boolean folderWithinAllowedPeriod(Path inputFolder, DateTime folderTime) {
     DateTime currentTime = new DateTime(this.timeZone);
     PeriodFormatter periodFormatter = getPeriodFormatter();
     DateTime earliestAllowedFolderTime = getEarliestAllowedFolderTime(currentTime, periodFormatter);
@@ -131,11 +144,29 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
       LOG.info(String.format("Folder time for %s is %s, later than the latest allowed folder time, %s. Skipping",
           inputFolder, folderTime, latestAllowedFolderTime));
       return false;
-    } else if (folderAlreadyCompacted(outputFolder)) {
-      LOG.info(String.format("Folder %s already compacted. Skipping", outputFolder));
-      return false;
+    } else {
+      return true;
     }
-    return true;
+  }
+
+  /**
+   * Return job properties for a job to handle the appearance of data within jobInputDir which is
+   * more recent than the time of the last compaction.
+   */
+  private State createJobPropsForLateData(Path jobInputDir, Path jobOutputDir, Path jobTmpDir,
+      List<Path> newDataFiles) throws IOException {
+    if (this.state.getPropAsBoolean(ConfigurationKeys.COMPACTION_RECOMPACT_FOR_LATE_DATA,
+        ConfigurationKeys.DEFAULT_COMPACTION_RECOMPACT_FOR_LATE_DATA)) {
+      LOG.info(String.format("Recompacting folder at %s.", jobOutputDir));
+      return createJobProps(jobInputDir, jobOutputDir, jobTmpDir);
+    } else {
+      LOG.info(String.format("Moving %d new data files from %s to %s",
+          newDataFiles.size(), jobInputDir, new Path(jobOutputDir, "late")));
+      State jobProps = createJobProps(jobInputDir, jobOutputDir, jobTmpDir);
+      jobProps.setProp(ConfigurationKeys.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, true);
+      jobProps.setProp(ConfigurationKeys.COMPACTION_JOB_LATE_DATA_FILES, Joiner.on(",").join(newDataFiles));
+      return jobProps;
+    }
   }
 
   private PeriodFormatter getPeriodFormatter() {
@@ -165,6 +196,39 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
       LOG.error("Failed to verify the existence of file " + filePath, e);
       return false;
     }
+  }
+
+  /**
+   * Check if inputFolder contains any files which have modification times which are more
+   * recent than the last compaction time as stored within outputFolder; return any files
+   * which do. An empty list will be returned if all files are older than the last compaction time.
+   */
+  private List<Path> getNewDataInFolder(Path inputFolder, Path outputFolder) throws IOException {
+    List<Path> newFiles = Lists.newArrayList();
+
+    Path filePath = new Path(outputFolder, ConfigurationKeys.COMPACTION_COMPLETE_FILE_NAME);
+    Closer closer = Closer.create();
+    try {
+      FSDataInputStream completionFileStream = closer.register(this.fs.open(filePath));
+      DateTime lastCompactionTime = new DateTime(completionFileStream.readLong(), this.timeZone);
+      for (FileStatus fstat : HadoopUtils.listStatusRecursive(this.fs, inputFolder)) {
+        DateTime fileModificationTime = new DateTime(fstat.getModificationTime(), this.timeZone);
+        if (fileModificationTime.isAfter(lastCompactionTime)) {
+          newFiles.add(fstat.getPath());
+        }
+      }
+      if (!newFiles.isEmpty()) {
+        LOG.info(String.format("Found %d new files within folder %s which are more recent than the previous "
+            + "compaction start time of %s.", newFiles.size(), inputFolder, lastCompactionTime));
+      }
+    } catch (IOException e) {
+      LOG.error("Failed to check for new data within folder: " + inputFolder, e);
+    } catch (Throwable e) {
+      throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+    return newFiles;
   }
 
 }


### PR DESCRIPTION
Enable compaction to be able to handle the case where new data appears in a previously compacted directory. Configurable to either copy new files over to a subdirectory of the compaction output directory or redo compaction.