### PR TITLE
KafkaSource sets actual high watermark in workunits

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -341,10 +341,18 @@ public class State implements Writable {
     return Boolean.parseBoolean(getProperty(key, String.valueOf(def)));
   }
 
+  /**
+   * @deprecated Use {@link #getProp(String)}
+   */
+  @Deprecated
   protected String getProperty(String key) {
     return this.properties.getProperty(key);
   }
 
+  /**
+   * @deprecated Use {@link #getProp(String, String)}
+   */
+  @Deprecated
   protected String getProperty(String key, String def) {
     return this.properties.getProperty(key, def);
   }
@@ -405,8 +413,8 @@ public class State implements Writable {
     }
 
     State other = (State) object;
-    return ((this.id == null && other.id == null) || (this.id != null && this.id.equals(other.id))) &&
-        this.properties.equals(other.properties);
+    return ((this.id == null && other.id == null) || (this.id != null && this.id.equals(other.id)))
+        && this.properties.equals(other.properties);
   }
 
   @Override

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -58,7 +58,12 @@ public class WorkUnitState extends State {
    * </p>
    */
   public enum WorkingState {
-    PENDING, RUNNING, SUCCESSFUL, COMMITTED, FAILED, CANCELLED
+    PENDING,
+    RUNNING,
+    SUCCESSFUL,
+    COMMITTED,
+    FAILED,
+    CANCELLED
   }
 
   private WorkUnit workunit;
@@ -195,6 +200,16 @@ public class WorkUnitState extends State {
   }
 
   @Override
+  public String getProp(String key) {
+    return getProperty(key);
+  }
+
+  @Override
+  public String getProp(String key, String def) {
+    return getProperty(key, def);
+  }
+
+  @Override
   protected String getProperty(String key) {
     String propStr = super.getProperty(key);
     if (propStr != null) {
@@ -246,15 +261,13 @@ public class WorkUnitState extends State {
   }
 
   @Override
-  public void readFields(DataInput in)
-      throws IOException {
+  public void readFields(DataInput in) throws IOException {
     this.workunit.readFields(in);
     super.readFields(in);
   }
 
   @Override
-  public void write(DataOutput out)
-      throws IOException {
+  public void write(DataOutput out) throws IOException {
     this.workunit.write(out);
     super.write(out);
   }
@@ -266,8 +279,8 @@ public class WorkUnitState extends State {
     }
 
     WorkUnitState other = (WorkUnitState) object;
-    return ((this.workunit == null && other.workunit == null) ||
-        (this.workunit != null && this.workunit.equals(other.workunit))) && super.equals(other);
+    return ((this.workunit == null && other.workunit == null)
+        || (this.workunit != null && this.workunit.equals(other.workunit))) && super.equals(other);
   }
 
   @Override
@@ -296,8 +309,8 @@ public class WorkUnitState extends State {
    *                                                               object.
    */
   public void addFinalConstructState(String infix, State finalConstructState) {
-    for(String property : finalConstructState.getPropertyNames()) {
-      if(Strings.isNullOrEmpty(infix)) {
+    for (String property : finalConstructState.getPropertyNames()) {
+      if (Strings.isNullOrEmpty(infix)) {
         setProp(FINAL_CONSTRUCT_STATE_PREFIX + property, finalConstructState.getProp(property));
       } else {
         setProp(FINAL_CONSTRUCT_STATE_PREFIX + infix + "." + property, finalConstructState.getProp(property));
@@ -326,8 +339,8 @@ public class WorkUnitState extends State {
    */
   public State getFinalConstructStates() {
     State constructState = new State();
-    for(String property : getPropertyNames()) {
-      if(property.startsWith(FINAL_CONSTRUCT_STATE_PREFIX)) {
+    for (String property : getPropertyNames()) {
+      if (property.startsWith(FINAL_CONSTRUCT_STATE_PREFIX)) {
         constructState.setProp(property.substring(FINAL_CONSTRUCT_STATE_PREFIX.length()), getProp(property));
       }
     }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -242,6 +242,7 @@ public abstract class KafkaSource<S, D> extends EventBasedSource<S, D> {
     Preconditions.checkArgument(!partitions.isEmpty(), "There must be at least one partition in the multiWorkUnit");
     Extract extract = this.createExtract(DEFAULT_TABLE_TYPE, DEFAULT_NAMESPACE_NAME, partitions.get(0).getTopicName());
     WorkUnit workUnit = WorkUnit.create(extract, interval);
+    workUnit.setActualHighWatermark(interval.getLowWatermark());
     populateMultiPartitionWorkUnit(partitions, workUnit);
     workUnit.setProp(ESTIMATED_DATA_SIZE, multiWorkUnit.getProp(ESTIMATED_DATA_SIZE));
     LOG.info(String.format("Created workunit for partitions %s", partitions));


### PR DESCRIPTION
ETL-3352. High watermark was originally set into `WorkUnitState` by `KafkaExtractor`. However, if `KafkaExtractor` fails before the high watermark is set, and its `WorkUnitState` is still committed (which may happen if job.commit.policy is set to partial), the next run may lose checkpoint.

Now `KafkaSource` sets actual high watermark into `WorkUnit`s.

Also, not sure why `State` has both `getProp` and `getProperty`. Deprecated `getProperty`.