### PR TITLE
Downgrade Guava to version 15.0 to work with Hadoop 2.6.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,7 +59,7 @@ ext.externalDependency = [
   "commonsHttpClient": "commons-httpclient:commons-httpclient:3.1",
   "datanucleusCore": "org.datanucleus:datanucleus-core:4.1.2",
   "datanucleusRdbms": "org.datanucleus:datanucleus-rdbms:4.1.2",
-  "guava": "com.google.guava:guava:18.0",
+  "guava": "com.google.guava:guava:15.0",
   "gson": "com.google.code.gson:gson:2.3.1",
   "findBugs": "com.google.code.findbugs:jsr305:1.3.9",
   "hadoop": "org.apache.hadoop:hadoop-core:"+hadoopVersion,

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ ext.externalDependency = [
   "hadoopHdfs": "org.apache.hadoop:hadoop-hdfs:"+hadoopVersion,
   "hadoopAuth": "org.apache.hadoop:hadoop-auth:"+hadoopVersion,
   "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:"+hadoopVersion,
+  "hadoopAws": "org.apache.hadoop:hadoop-aws:"+hadoopVersion,
   "hiveService": "org.apache.hive:hive-service:"+hiveVersion,
   "hiveJdbc": "org.apache.hive:hive-jdbc:"+hiveVersion,
   "hiveMetastore": "org.apache.hive:hive-metastore:"+hiveVersion,

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -41,6 +41,7 @@ dependencies {
 
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2
+    testCompile externalDependency.hadoopAws
   } else {
     compile externalDependency.avroMapredH1
   }

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/AvroFsHelperTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/AvroFsHelperTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 
 public class AvroFsHelperTest {
 
-  @Test(groups = { "ignore" }, expectedExceptions = IllegalArgumentException.class)
+  @Test(expectedExceptions = IllegalArgumentException.class)
   public void testConnectFailsWithS3URLWithoutAWSCredentials() throws FileBasedHelperException {
     Configuration conf = new Configuration(); // plain conf, no S3 credentials
     SourceState sourceState = new SourceState();

--- a/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/AvroFsHelperTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/hadoop/AvroFsHelperTest.java
@@ -27,7 +27,7 @@ import org.testng.annotations.Test;
 
 public class AvroFsHelperTest {
 
-  @Test(expectedExceptions = IllegalArgumentException.class)
+  @Test(groups = { "ignore" }, expectedExceptions = IllegalArgumentException.class)
   public void testConnectFailsWithS3URLWithoutAWSCredentials() throws FileBasedHelperException {
     Configuration conf = new Configuration(); // plain conf, no S3 credentials
     SourceState sourceState = new SourceState();

--- a/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
@@ -252,11 +252,7 @@ public class ParallelRunner implements Closeable {
     } catch (ExecutionException ee) {
       throw new IOException(ee);
     } finally {
-      try {
-        ExecutorsUtils.shutdownExecutorService(this.executor);
-      } catch (InterruptedException ie) {
-        LOGGER.error("Failed to shutdown the executor service", ie);
-      }
+      ExecutorsUtils.shutdownExecutorService(this.executor);
     }
   }
 }


### PR DESCRIPTION
Due to the issue reported in HADOOP-10961, Hadoop 2.6.0 does not work with Guava version 16.0 or after because the deprecation of a constructor of Stopwatch. To make sure Gobblin supports Hadoop 2.6.0, we need to downgrade Guava to version 15.0.

Signed-off-by: Yinan Li <liyinan926@gmail.com>