### PR TITLE
Added config for non-deduping compaction

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -460,9 +460,12 @@ public class ConfigurationKeys {
   public static final int DEFAULT_COMPACTION_MR_JOB_TIMEOUT_MINUTES = Integer.MAX_VALUE;
   public static final String COMPACTION_RECOMPACT_FOR_LATE_DATA = COMPACTION_PREFIX + "recompact.for.late.data";
   public static final boolean DEFAULT_COMPACTION_RECOMPACT_FOR_LATE_DATA = false;
+  public static final String COMPACTION_DEDUPLICATE = COMPACTION_PREFIX + "deduplicate";
+  public static final boolean DEFAULT_COMPACTION_DEDUPLICATE = true;
   public static final String COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK = COMPACTION_PREFIX + "job.late.data.movement.task";
   public static final String COMPACTION_JOB_LATE_DATA_FILES = COMPACTION_PREFIX + "job.late.data.files";
   public static final String COMPACTION_COMPLETE_FILE_NAME = "_COMPACTION_COMPLETE";
+  public static final String COMPACTION_LATE_FILES_DIRECTORY = "late";
   public static final String COMPACTION_ENABLE_SUCCESS_FILE = "mapreduce.fileoutputcommitter.marksuccessfuljobs";
   public static final String COMPACTION_OVERWRITE_OUTPUT_DIR = COMPACTION_PREFIX + "overwrite.output.dir";
   public static final boolean DEFAULT_COMPACTION_OVERWRITE_OUTPUT_DIR = false;

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
@@ -266,11 +266,13 @@ public class MRCompactor implements Compactor {
   MRCompactorJobPropCreator getJobPropCreator(String topic, Path topicInputDir, Path topicOutputDir, Path topicTmpDir) {
     String builderClassName = this.state.getProp(ConfigurationKeys.COMPACTION_JOBPROPS_CREATOR_CLASS,
         ConfigurationKeys.DEFAULT_COMPACTION_JOBPROPS_CREATOR_CLASS) + "$Builder";
+    boolean deduplicate = this.state.getPropAsBoolean(ConfigurationKeys.COMPACTION_DEDUPLICATE,
+        ConfigurationKeys.DEFAULT_COMPACTION_DEDUPLICATE);
 
     try {
       return ((MRCompactorJobPropCreator.Builder<?>) Class.forName(builderClassName).newInstance()).withTopic(topic)
           .withTopicInputDir(topicInputDir).withTopicOutputDir(topicOutputDir).withTopicTmpDir(topicTmpDir)
-          .withFileSystem(this.fs).withState(this.state).build();
+          .withFileSystem(this.fs).withDeduplicate(deduplicate).withState(this.state).build();
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
@@ -95,7 +95,7 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
       Path jobTmpDir = new Path(this.topicTmpDir, folderTime.toString(this.timeFormatter));
       if (folderWithinAllowedPeriod(status.getPath(), folderTime)) {
         if (!folderAlreadyCompacted(jobOutputDir)) {
-          allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir));
+          allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate));
         } else {
           List<Path> newDataFiles = getNewDataInFolder(status.getPath(), jobOutputDir);
           if (newDataFiles.isEmpty()) {
@@ -158,11 +158,11 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
     if (this.state.getPropAsBoolean(ConfigurationKeys.COMPACTION_RECOMPACT_FOR_LATE_DATA,
         ConfigurationKeys.DEFAULT_COMPACTION_RECOMPACT_FOR_LATE_DATA)) {
       LOG.info(String.format("Recompacting folder at %s.", jobOutputDir));
-      return createJobProps(jobInputDir, jobOutputDir, jobTmpDir);
+      return createJobProps(jobInputDir, jobOutputDir, jobTmpDir, this.deduplicate);
     } else {
-      LOG.info(String.format("Moving %d new data files from %s to %s",
-          newDataFiles.size(), jobInputDir, new Path(jobOutputDir, "late")));
-      State jobProps = createJobProps(jobInputDir, jobOutputDir, jobTmpDir);
+      LOG.info(String.format("Moving %d new data files from %s to %s", newDataFiles.size(), jobInputDir,
+          new Path(jobOutputDir, ConfigurationKeys.COMPACTION_LATE_FILES_DIRECTORY)));
+      State jobProps = createJobProps(jobInputDir, jobOutputDir, jobTmpDir, this.deduplicate);
       jobProps.setProp(ConfigurationKeys.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, true);
       jobProps.setProp(ConfigurationKeys.COMPACTION_JOB_LATE_DATA_FILES, Joiner.on(",").join(newDataFiles));
       return jobProps;

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
@@ -15,13 +15,13 @@ package gobblin.compaction.mapreduce.avro;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaCompatibility;
-import org.apache.avro.Schema.Field;
 import org.apache.avro.SchemaCompatibility.SchemaCompatibilityType;
 import org.apache.avro.mapred.AvroKey;
 import org.apache.avro.mapred.AvroValue;
@@ -36,8 +36,6 @@ import org.apache.hadoop.mapreduce.lib.input.FileInputFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 
 import gobblin.compaction.mapreduce.MRCompactorJobRunner;
@@ -210,6 +208,11 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
   @Override
   protected void setOutputValueClass(Job job) {
     job.setOutputValueClass(NullWritable.class);
+  }
+
+  @Override
+  protected Collection<String> getApplicableFileExtensions() {
+    return Lists.newArrayList(AVRO);
   }
 
   /**


### PR DESCRIPTION
Added a config to have the ability to do compaction which is non-deduplicating, just copying files to the destination rather than going through all records and deduping.

Tested on Azkaban.