### PR TITLE
Use a specific version of hadoop-aws

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ ext.externalDependency = [
   "hadoopHdfs": "org.apache.hadoop:hadoop-hdfs:"+hadoopVersion,
   "hadoopAuth": "org.apache.hadoop:hadoop-auth:"+hadoopVersion,
   "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:"+hadoopVersion,
-  "hadoopAws": "org.apache.hadoop:hadoop-aws:"+hadoopVersion,
+  "hadoopAws": "org.apache.hadoop:hadoop-aws:2.6.0",
   "hiveService": "org.apache.hive:hive-service:"+hiveVersion,
   "hiveJdbc": "org.apache.hive:hive-jdbc:"+hiveVersion,
   "hiveMetastore": "org.apache.hive:hive-metastore:"+hiveVersion,


### PR DESCRIPTION
Seems the earliest version of hadoop-aws is 2.6.0, so it's not possible to use hadoopVersion for it.

Signed-off-by: Yinan Li <liyinan926@gmail.com>