### PR TITLE
Add compaction avro dedup key option

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -448,8 +448,7 @@ public class ConfigurationKeys {
   public static final String COMPACTION_MAPRED_MIN_SPLIT_SIZE = COMPACTION_PREFIX + "mapred.min.split.size";
   public static final long DEFAULT_COMPACTION_MAPRED_MIN_SPLIT_SIZE = 268435456;
   public static final String COMPACTION_AVRO_KEY_SCHEMA_LOC = COMPACTION_PREFIX + "avro.key.schema.loc";
-  public static final String COMPACTION_USE_ALL_ATTRIBUTES = COMPACTION_PREFIX + "use.all.attributes";
-  public static final boolean DEFAULT_COMPACTION_USE_ALL_ATTRIBUTES = false;
+  public static final String COMPACTION_DEDUP_KEY = COMPACTION_PREFIX + "dedup.key";
   public static final String COMPACTION_JOB_RUNNER_CLASS = COMPACTION_PREFIX + "job.runner.class";
   public static final String DEFAULT_COMPACTION_JOB_RUNNER_CLASS =
       "gobblin.compaction.mapreduce.avro.MRCompactorAvroKeyDedupJobRunner";

--- a/gobblin-compaction/test/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunnerTest.java
+++ b/gobblin-compaction/test/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunnerTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.mapreduce.avro;
+
+import java.io.File;
+import java.io.IOException;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.mapreduce.Job;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.AvroUtils;
+
+
+@Test(groups = { "gobblin.compaction" })
+public class MRCompactorAvroKeyDedupJobRunnerTest {
+
+  private MRCompactorAvroKeyDedupJobRunner runner;
+  private Job job;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    State state = new State();
+    state.setProp(ConfigurationKeys.COMPACTION_TOPIC, "TestTopic");
+    state.setProp(ConfigurationKeys.COMPACTION_JOB_INPUT_DIR, "TestInputDir");
+    state.setProp(ConfigurationKeys.COMPACTION_JOB_DEST_DIR, "TestDestDir");
+    state.setProp(ConfigurationKeys.COMPACTION_JOB_TMP_DIR, "TestTmpDir");
+    state.setProp(ConfigurationKeys.COMPACTION_DEDUP_KEY, "key");
+    this.runner = new MRCompactorAvroKeyDedupJobRunner(state, FileSystem.get(new Configuration()));
+    this.job = Job.getInstance();
+  }
+
+  @Test
+  public void testGetKeySchemaWithPrimaryKey() throws IOException {
+    Schema topicSchema =
+        new Schema.Parser().parse(new File("gobblin-test/resource/dedup-schema/dedup-schema-with-pkey.avsc"));
+    Schema actualKeySchema = this.runner.getKeySchema(this.job, topicSchema);
+    Schema expectedKeySchema =
+        new Schema.Parser().parse(new File("gobblin-test/resource/dedup-schema/dedup-schema.avsc"));
+    Assert.assertEquals(actualKeySchema, expectedKeySchema);
+  }
+
+  @Test
+  public void testGetKeySchemaWithoutPrimaryKey() throws IOException {
+    Schema topicSchema =
+        new Schema.Parser().parse(new File("gobblin-test/resource/dedup-schema/dedup-schema-without-pkey.avsc"));
+    Schema actualKeySchema = this.runner.getKeySchema(this.job, topicSchema);
+    Assert.assertEquals(actualKeySchema, AvroUtils.removeUncomparableFields(topicSchema).get());
+  }
+}

--- a/gobblin-test/resource/dedup-schema/dedup-schema-with-pkey.avsc
+++ b/gobblin-test/resource/dedup-schema/dedup-schema-with-pkey.avsc
@@ -1,0 +1,180 @@
+{
+  "type" : "record",
+  "name" : "GobblinCompactionTestEvent",
+  "namespace" : "gobblin.compaction.test.events",
+  "fields" : [ {
+    "name" : "header",
+    "type" : {
+      "type" : "record",
+      "name" : "EventHeader",
+      "fields" : [ {
+        "name" : "memberId",
+        "type" : "int",
+        "doc" : "The member id of the user initiating the action. PrimaryKey"
+      }, {
+        "name" : "viewerUrn",
+        "type" : [ "null", "string" ],
+        "doc" : "Urn of the user initiating the action",
+        "default" : null
+      }, {
+        "name" : "time",
+        "type" : [ "null", "long" ],
+        "doc" : "The time of the event"
+      }, {
+        "name" : "server",
+        "type" : "string",
+        "doc" : "The name of the server"
+      }, {
+        "name" : "service",
+        "type" : "string",
+        "doc" : "The name of the service"
+      }, {
+        "name" : "environment",
+        "type" : [ "string", "null" ],
+        "doc" : "The environment the service is running in",
+        "default" : ""
+      }, {
+        "name" : "guid",
+        "type" : {
+          "type" : "fixed",
+          "name" : "Guid",
+          "size" : 16
+        },
+        "doc" : "A unique identifier for the message"
+      }, {
+        "name" : "treeId",
+        "type" : [ "null", {
+          "type" : "fixed",
+          "name" : "fixed_16",
+          "size" : 16
+        } ],
+        "doc" : "Service call tree uuid",
+        "default" : null
+      }, {
+        "name" : "requestId",
+        "type" : [ "null", "int" ],
+        "doc" : "Service call request id",
+        "default" : null
+      }, {
+        "name" : "impersonatorId",
+        "type" : [ "null", "string" ],
+        "doc" : "this is the ID of the CS Agent or Application acting on the users behalf",
+        "default" : null
+      } ]
+    }
+  }, {
+    "name" : "requestHeader",
+    "type" : {
+      "type" : "record",
+      "name" : "UserRequestHeader",
+      "fields" : [ {
+        "name" : "browserId",
+        "type" : [ "string", "null" ],
+        "doc" : "The contents of the user's bcookie."
+      }, {
+        "name" : "sessionId",
+        "type" : [ "string", "null" ],
+        "doc" : "The tomcat jsessionid."
+      }, {
+        "name" : "ip",
+        "type" : [ "string", "null" ],
+        "doc" : "The user's IPv4 address in string representation. For IPv6 users, this field is null. PrimaryKey"
+      }, {
+        "name" : "pageKey",
+        "type" : [ "string", "null" ],
+        "doc" : "The page key of the page being viewed."
+      }, {
+        "name" : "path",
+        "type" : [ "string", "null" ],
+        "doc" : "The path of the http request"
+      }, {
+        "name" : "locale",
+        "type" : [ "string", "null" ],
+        "doc" : "The locale the user's browser sent to the server, as specified by the Accept-Language HTTP request header."
+      }, {
+        "name" : "interfaceLocale",
+        "type" : [ "null", "string" ],
+        "doc" : "The user's interface locale, which is not necessarily the same as the browser provided locale.  If this is a logged in user then it will be the last interface locale persisted in the DB.  For more information see: https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/International+Engineering+FAQ",
+        "default" : null
+      }, {
+        "name" : "trackingCode",
+        "type" : [ "null", "string" ],
+        "doc" : "A key for the LinkedIn page that referred this view",
+        "default" : null
+      }, {
+        "name" : "referer",
+        "type" : [ "string", "null" ],
+        "doc" : "The referer URL (sic) of the request."
+      }, {
+        "name" : "userAgent",
+        "type" : [ "string", "null" ],
+        "doc" : "The user agent on the request."
+      }, {
+        "name" : "ipAsBytes",
+        "type" : [ "null", {
+          "type" : "fixed",
+          "name" : "IPAddress",
+          "size" : 16
+        } ],
+        "doc" : "A 16-byte array representing the IPv6 address. If the client uses IPv4, this field is the IPv4-mapped IPv6 address",
+        "default" : null
+      } ]
+    }
+  }, {
+    "name" : "mobileHeader",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "MobileHeader",
+      "fields" : [ {
+        "name" : "osName",
+        "type" : [ "null", "string" ],
+        "doc" : "The name of the operating system.",
+        "default" : null
+      }, {
+        "name" : "osVersion",
+        "type" : [ "null", "string" ],
+        "doc" : "The version of the operating system.",
+        "default" : null
+      }, {
+        "name" : "deviceModel",
+        "type" : [ "null", "string" ],
+        "doc" : "The model of the device.",
+        "default" : null
+      }, {
+        "name" : "appVersion",
+        "type" : [ "null", "string" ],
+        "doc" : "The application version.",
+        "default" : null
+      } ]
+    } ],
+    "doc" : "Optional mobile header to track mobile usage.",
+    "default" : null
+  }, {
+    "name" : "pageType",
+    "type" : {
+      "type" : "enum",
+      "name" : "PageType",
+      "symbols" : [ "full", "ajax", "iframe", "redirect", "api", "form", "router", "error" ]
+    },
+    "doc" : "A flag which specifies what type of page this is."
+  }, {
+    "name" : "errorMessageKey",
+    "type" : [ "string", "null" ],
+    "doc" : "A unique identifier for the error message shown."
+  }, {
+    "name" : "trackingCode",
+    "type" : [ "string", "null" ],
+    "doc" : "A key for the linkedin page that referred this view"
+  }, {
+    "name" : "trackingInfo",
+    "type" : {
+      "type" : "map",
+      "values" : "string"
+    },
+    "doc" : "Misc fields supplied by the page"
+  }, {
+    "name" : "totalTime",
+    "type" : "int",
+    "doc" : "The total server-side time required to render the page in ms"
+  } ]
+}

--- a/gobblin-test/resource/dedup-schema/dedup-schema-without-pkey.avsc
+++ b/gobblin-test/resource/dedup-schema/dedup-schema-without-pkey.avsc
@@ -1,0 +1,180 @@
+{
+  "type" : "record",
+  "name" : "GobblinCompactionTestEvent",
+  "namespace" : "gobblin.compaction.test.events",
+  "fields" : [ {
+    "name" : "header",
+    "type" : {
+      "type" : "record",
+      "name" : "EventHeader",
+      "fields" : [ {
+        "name" : "memberId",
+        "type" : "int",
+        "doc" : "The member id of the user initiating the action."
+      }, {
+        "name" : "viewerUrn",
+        "type" : [ "null", "string" ],
+        "doc" : "Urn of the user initiating the action",
+        "default" : null
+      }, {
+        "name" : "time",
+        "type" : [ "null", "long" ],
+        "doc" : "The time of the event"
+      }, {
+        "name" : "server",
+        "type" : "string",
+        "doc" : "The name of the server"
+      }, {
+        "name" : "service",
+        "type" : "string",
+        "doc" : "The name of the service"
+      }, {
+        "name" : "environment",
+        "type" : [ "string", "null" ],
+        "doc" : "The environment the service is running in",
+        "default" : ""
+      }, {
+        "name" : "guid",
+        "type" : {
+          "type" : "fixed",
+          "name" : "Guid",
+          "size" : 16
+        },
+        "doc" : "A unique identifier for the message"
+      }, {
+        "name" : "treeId",
+        "type" : [ "null", {
+          "type" : "fixed",
+          "name" : "fixed_16",
+          "size" : 16
+        } ],
+        "doc" : "Service call tree uuid",
+        "default" : null
+      }, {
+        "name" : "requestId",
+        "type" : [ "null", "int" ],
+        "doc" : "Service call request id",
+        "default" : null
+      }, {
+        "name" : "impersonatorId",
+        "type" : [ "null", "string" ],
+        "doc" : "this is the ID of the CS Agent or Application acting on the users behalf",
+        "default" : null
+      } ]
+    }
+  }, {
+    "name" : "requestHeader",
+    "type" : {
+      "type" : "record",
+      "name" : "UserRequestHeader",
+      "fields" : [ {
+        "name" : "browserId",
+        "type" : [ "string", "null" ],
+        "doc" : "The contents of the user's bcookie."
+      }, {
+        "name" : "sessionId",
+        "type" : [ "string", "null" ],
+        "doc" : "The tomcat jsessionid."
+      }, {
+        "name" : "ip",
+        "type" : [ "string", "null" ],
+        "doc" : "The user's IPv4 address in string representation. For IPv6 users, this field is null."
+      }, {
+        "name" : "pageKey",
+        "type" : [ "string", "null" ],
+        "doc" : "The page key of the page being viewed."
+      }, {
+        "name" : "path",
+        "type" : [ "string", "null" ],
+        "doc" : "The path of the http request"
+      }, {
+        "name" : "locale",
+        "type" : [ "string", "null" ],
+        "doc" : "The locale the user's browser sent to the server, as specified by the Accept-Language HTTP request header."
+      }, {
+        "name" : "interfaceLocale",
+        "type" : [ "null", "string" ],
+        "doc" : "The user's interface locale, which is not necessarily the same as the browser provided locale.  If this is a logged in user then it will be the last interface locale persisted in the DB.  For more information see: https://iwww.corp.linkedin.com/wiki/cf/display/ENGS/International+Engineering+FAQ",
+        "default" : null
+      }, {
+        "name" : "trackingCode",
+        "type" : [ "null", "string" ],
+        "doc" : "A key for the LinkedIn page that referred this view",
+        "default" : null
+      }, {
+        "name" : "referer",
+        "type" : [ "string", "null" ],
+        "doc" : "The referer URL (sic) of the request."
+      }, {
+        "name" : "userAgent",
+        "type" : [ "string", "null" ],
+        "doc" : "The user agent on the request."
+      }, {
+        "name" : "ipAsBytes",
+        "type" : [ "null", {
+          "type" : "fixed",
+          "name" : "IPAddress",
+          "size" : 16
+        } ],
+        "doc" : "A 16-byte array representing the IPv6 address. If the client uses IPv4, this field is the IPv4-mapped IPv6 address",
+        "default" : null
+      } ]
+    }
+  }, {
+    "name" : "mobileHeader",
+    "type" : [ "null", {
+      "type" : "record",
+      "name" : "MobileHeader",
+      "fields" : [ {
+        "name" : "osName",
+        "type" : [ "null", "string" ],
+        "doc" : "The name of the operating system.",
+        "default" : null
+      }, {
+        "name" : "osVersion",
+        "type" : [ "null", "string" ],
+        "doc" : "The version of the operating system.",
+        "default" : null
+      }, {
+        "name" : "deviceModel",
+        "type" : [ "null", "string" ],
+        "doc" : "The model of the device.",
+        "default" : null
+      }, {
+        "name" : "appVersion",
+        "type" : [ "null", "string" ],
+        "doc" : "The application version.",
+        "default" : null
+      } ]
+    } ],
+    "doc" : "Optional mobile header to track mobile usage.",
+    "default" : null
+  }, {
+    "name" : "pageType",
+    "type" : {
+      "type" : "enum",
+      "name" : "PageType",
+      "symbols" : [ "full", "ajax", "iframe", "redirect", "api", "form", "router", "error" ]
+    },
+    "doc" : "A flag which specifies what type of page this is."
+  }, {
+    "name" : "errorMessageKey",
+    "type" : [ "string", "null" ],
+    "doc" : "A unique identifier for the error message shown."
+  }, {
+    "name" : "trackingCode",
+    "type" : [ "string", "null" ],
+    "doc" : "A key for the linkedin page that referred this view"
+  }, {
+    "name" : "trackingInfo",
+    "type" : {
+      "type" : "map",
+      "values" : "string"
+    },
+    "doc" : "Misc fields supplied by the page"
+  }, {
+    "name" : "totalTime",
+    "type" : "int",
+    "doc" : "The total server-side time required to render the page in ms"
+  } ]
+}

--- a/gobblin-test/resource/dedup-schema/dedup-schema.avsc
+++ b/gobblin-test/resource/dedup-schema/dedup-schema.avsc
@@ -1,0 +1,40 @@
+{
+   "type":"record",
+   "name":"GobblinCompactionTestEvent",
+   "namespace":"GobblinCompactionTestEvent",
+   "fields":[
+      {
+         "name":"header",
+         "type":{
+            "type":"record",
+            "name":"EventHeader",
+            "namespace":"EventHeader",
+            "fields":[
+               {
+                  "name":"memberId",
+                  "type":"int",
+                  "doc":"The member id of the user initiating the action. PrimaryKey"
+               }
+            ]
+         }
+      },
+      {
+         "name":"requestHeader",
+         "type":{
+            "type":"record",
+            "name":"UserRequestHeader",
+            "namespace":"UserRequestHeader",
+            "fields":[
+               {
+                  "name":"ip",
+                  "type":[
+                     "string",
+                     "null"
+                  ],
+                  "doc":"The user's IPv4 address in string representation. For IPv6 users, this field is null. PrimaryKey"
+               }
+            ]
+         }
+      }
+   ]
+}

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -357,7 +357,7 @@ public class AvroUtils {
   private static Optional<Schema> removeUncomparableFieldsFromRecord(Schema record) {
     Preconditions.checkArgument(record.getType() == Schema.Type.RECORD);
 
-    List<Field> fields = new ArrayList<Schema.Field>();
+    List<Field> fields = Lists.newArrayList();
     for (Field field : record.getFields()) {
       Optional<Schema> newFieldSchema = removeUncomparableFields(field.schema());
       if (newFieldSchema.isPresent()) {


### PR DESCRIPTION
Previously there were two options for deduping: (1) set `compaction.use.all.attributes=true` and use all fields in the topic schema; (2) specify a custom dedup schema via `avro.key.schema.loc`.

Now adding a 3rd option suggested by @shirshanka : use all fields in the topic schema annotated by "primarykey". If there's no such fields, all fields will be used.