### PR TITLE
Make some change regarding file permission

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -216,6 +216,7 @@ public class ConfigurationKeys {
   public static final String WRITER_FILE_REPLICATION_FACTOR = WRITER_PREFIX + ".file.replication.factor";
   public static final String WRITER_FILE_BLOCK_SIZE = WRITER_PREFIX + ".file.block.size";
   public static final String WRITER_FILE_PERMISSIONS = WRITER_PREFIX + ".file.permissions";
+  public static final String WRITER_DIR_PERMISSIONS = WRITER_PREFIX + ".dir.permissions";
   public static final String WRITER_BUFFER_SIZE = WRITER_PREFIX + ".buffer.size";
   public static final String WRITER_PRESERVE_FILE_NAME = WRITER_PREFIX + ".preserve.file.name";
   public static final String WRITER_DEFLATE_LEVEL = WRITER_PREFIX + ".deflate.level";
@@ -279,6 +280,7 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_FINAL_NAME = DATA_PUBLISHER_PREFIX + ".final.name";
   // This property is used to specify the owner group of the data publisher final output directory
   public static final String DATA_PUBLISHER_FINAL_DIR_GROUP = DATA_PUBLISHER_PREFIX + ".final.dir.group";
+  public static final String DATA_PUBLISHER_PERMISSIONS = DATA_PUBLISHER_PREFIX + ".permissions";
 
   /**
    * Configuration properties used by the extractor.
@@ -555,4 +557,5 @@ public class ConfigurationKeys {
    */
   public static final Charset DEFAULT_CHARSET_ENCODING = Charsets.UTF_8;
   public static final String TEST_HARNESS_LAUNCHER_IMPL = "gobblin.testharness.launcher.impl";
+  public static final int PERMISSION_PARSING_RADIX = 8;
 }

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -289,6 +289,17 @@ public class State implements Writable {
   }
 
   /**
+   * Get the value of a property as a short.
+   *
+   * @param key property key
+   * @param radix radix used to parse the value
+   * @return short value associated with the key
+   */
+  public short getPropAsShortWithRadix(String key, int radix) {
+    return Short.parseShort(getProperty(key), radix);
+  }
+
+  /**
    * Get the value of a property as an short, using the given default value if the property is not set.
    *
    * @param key property key
@@ -297,6 +308,18 @@ public class State implements Writable {
    */
   public short getPropAsShort(String key, short def) {
     return Short.parseShort(getProperty(key, String.valueOf(def)));
+  }
+
+  /**
+   * Get the value of a property as an short, using the given default value if the property is not set.
+   *
+   * @param key property key
+   * @param def default value
+   * @param radix radix used to parse the value
+   * @return short value associated with the key or the default value if the property is not set
+   */
+  public short getPropAsShortWithRadix(String key, short def, int radix) {
+    return contains(key) ? Short.parseShort(getProperty(key), radix) : def;
   }
 
   /**
@@ -405,8 +428,8 @@ public class State implements Writable {
     }
 
     State other = (State) object;
-    return ((this.id == null && other.id == null) || (this.id != null && this.id.equals(other.id))) &&
-        this.properties.equals(other.properties);
+    return ((this.id == null && other.id == null) || (this.id != null && this.id.equals(other.id)))
+        && this.properties.equals(other.properties);
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -24,6 +24,7 @@ import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.util.HadoopUtils;
 import gobblin.util.ParallelRunner;
+import gobblin.util.WriterUtils;
 
 
 /**
@@ -59,9 +60,8 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
           filePathStr.substring(filePathStr.indexOf(writerOutput.toString()) + writerOutput.toString().length() + 1);
       Path outputPath = new Path(publisherOutput, pathSuffix);
 
-      if (!this.fileSystemByBranches.get(branchId).exists(outputPath.getParent())) {
-        this.fileSystemByBranches.get(branchId).mkdirs(outputPath.getParent());
-      }
+      WriterUtils.mkdirsWithRecursivePermission(this.fileSystemByBranches.get(branchId), outputPath.getParent(),
+          this.permissions.get(branchId));
 
       LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));
       parallelRunner.renamePath(status.getPath(), outputPath, Optional.<String>absent());

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -54,7 +54,8 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
   protected final int bufferSize;
   protected final short replicationFactor;
   protected final long blockSize;
-  protected final FsPermission permission;
+  protected final FsPermission filePermission;
+  protected final FsPermission dirPermission;
   protected final Optional<String> group;
   protected final OutputStream stagingFileOutputStream;
   protected final Closer closer = Closer.create();
@@ -74,8 +75,8 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
         ConfigurationKeys.DEFAULT_SHOULD_FS_PROXY_AS_USER)) {
       // Initialize file system as a proxy user.
       try {
-        this.fs = new ProxiedFileSystemWrapper()
-            .getProxiedFileSystem(properties, ProxiedFileSystemWrapper.AuthType.TOKEN,
+        this.fs =
+            new ProxiedFileSystemWrapper().getProxiedFileSystem(properties, ProxiedFileSystemWrapper.AuthType.TOKEN,
                 properties.getProp(ConfigurationKeys.FS_PROXY_AS_USER_TOKEN_FILE), uri);
       } catch (InterruptedException e) {
         throw new IOException(e);
@@ -90,9 +91,9 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
     // Initialize staging/output directory
     this.stagingFile = new Path(WriterUtils.getWriterStagingDir(properties, numBranches, branchId), fileName);
     this.outputFile = new Path(WriterUtils.getWriterOutputDir(properties, numBranches, branchId), fileName);
-    this.properties
-        .setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, branchId),
-            this.outputFile.toString());
+    this.properties.setProp(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, branchId),
+        this.outputFile.toString());
 
     // Deleting the staging file if it already exists, which can happen if the
     // task failed and the staging file didn't get cleaned up for some reason.
@@ -102,34 +103,36 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
       HadoopUtils.deletePath(this.fs, this.stagingFile, false);
     }
 
-    // Create the parent directory of the output file if it does not exist
-    if (!this.fs.exists(this.outputFile.getParent())) {
-      this.fs.mkdirs(this.outputFile.getParent());
-    }
-
     this.bufferSize = Integer.parseInt(properties.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUFFER_SIZE, numBranches, branchId),
         ConfigurationKeys.DEFAULT_BUFFER_SIZE));
 
     this.replicationFactor = properties.getPropAsShort(ForkOperatorUtils
-            .getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR, numBranches, branchId),
+        .getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_REPLICATION_FACTOR, numBranches, branchId),
         this.fs.getDefaultReplication(this.outputFile));
 
     this.blockSize = properties.getPropAsLong(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_BLOCK_SIZE, numBranches, branchId),
         this.fs.getDefaultBlockSize(this.outputFile));
 
-    this.permission = new FsPermission(properties.getPropAsShort(
+    this.filePermission = new FsPermission(properties.getPropAsShortWithRadix(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PERMISSIONS, numBranches, branchId),
-        FsPermission.getDefault().toShort()));
+        FsPermission.getDefault().toShort(), ConfigurationKeys.PERMISSION_PARSING_RADIX));
 
-    this.stagingFileOutputStream = this.closer.register(this.fs.create(this.stagingFile, this.permission, true,
+    this.dirPermission = new FsPermission(properties.getPropAsShortWithRadix(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DIR_PERMISSIONS, numBranches, branchId),
+        FsPermission.getDefault().toShort(), ConfigurationKeys.PERMISSION_PARSING_RADIX));
+
+    this.stagingFileOutputStream = this.closer.register(this.fs.create(this.stagingFile, this.filePermission, true,
         this.bufferSize, this.replicationFactor, this.blockSize, null));
 
     this.group = Optional.fromNullable(properties.getProp(ConfigurationKeys.WRITER_GROUP_NAME));
     if (this.group.isPresent()) {
       HadoopUtils.setGroup(this.fs, this.stagingFile, this.group.get());
     }
+
+    // Create the parent directory of the output file if it does not exist
+    WriterUtils.mkdirsWithRecursivePermission(this.fs, this.outputFile.getParent(), this.dirPermission);
   }
 
   /**
@@ -190,7 +193,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
     state.setProp("RecordsWritten", recordsWritten());
     try {
       state.setProp("BytesWritten", bytesWritten());
-    } catch(Exception exception) {
+    } catch (Exception exception) {
       // If Writer fails to return bytesWritten, it might not be implemented, or implemented incorrectly.
       // Omit property instead of failing.
     }


### PR DESCRIPTION
1. In `FsDataWriter`, when getting the writer output file permission from the state, `Short.parseShort` should be based on radix 8, not 10.
1. Originally `FsDataWriter` calls `this.fs.mkdirs`, which does not use `this.permission`, but uses default permission. Although there's another version of `FileSystem.mkdirs()` that takes a `FsPermission` object, it does not set permissions recursively. So I added a util method `mkdirsWithRecursivePermission()`.
1. In `BaseDataPublisher` add a `List<FsPermission>` field to correctly set publisher output file/folder permissions.