### PR TITLE
Fixing FindBugs warnings

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -12,9 +12,6 @@
 
 package gobblin.source.extractor.utils;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.source.extractor.watermark.WatermarkType;
-
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -38,6 +35,9 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.source.extractor.watermark.WatermarkType;
 
 
 public class Utils {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -12,6 +12,9 @@
 
 package gobblin.source.extractor.utils;
 
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.source.extractor.watermark.WatermarkType;
+
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.Arrays;
@@ -35,9 +38,6 @@ import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.source.extractor.watermark.WatermarkType;
 
 
 public class Utils {
@@ -245,11 +245,11 @@ public class Utils {
     DateTimeFormatter dtFormatter = DateTimeFormat.forPattern(CURRENT_DATE_FORMAT).withZone(time.getZone());
     if (value.toUpperCase().startsWith(CURRENT_DAY)) {
       return Long
-          .valueOf(dtFormatter.print(time.minusDays(Integer.parseInt(value.substring(CURRENT_DAY.length() + 1)))));
+          .parseLong(dtFormatter.print(time.minusDays(Integer.parseInt(value.substring(CURRENT_DAY.length() + 1)))));
     }
     if (value.toUpperCase().startsWith(CURRENT_HOUR)) {
       return Long
-          .valueOf(dtFormatter.print(time.minusHours(Integer.parseInt(value.substring(CURRENT_HOUR.length() + 1)))));
+          .parseLong(dtFormatter.print(time.minusHours(Integer.parseInt(value.substring(CURRENT_HOUR.length() + 1)))));
     }
     return Long.parseLong(value);
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -12,19 +12,6 @@
 
 package gobblin.runtime;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.io.Closer;
-
 import gobblin.Constructs;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
@@ -37,6 +24,20 @@ import gobblin.instrumented.extractor.InstrumentedExtractorDecorator;
 import gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
 import gobblin.qualitychecker.row.RowLevelPolicyChecker;
 import gobblin.runtime.util.RuntimeConstructs;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
 
 
 /**
@@ -82,7 +83,7 @@ public class Task implements Runnable {
   private final List<Optional<Fork>> forks = Lists.newArrayList();
 
   // Number of task retries
-  private volatile int retryCount = 0;
+  private AtomicInteger retryCount = new AtomicInteger();
 
   /**
    * Instantiate a new {@link Task}.
@@ -92,7 +93,6 @@ public class Task implements Runnable {
    * @param taskExecutor a {@link TaskExecutor} for executing the {@link Task} and its {@link Fork}s
    * @param countDownLatch an optional {@link java.util.concurrent.CountDownLatch} used to signal the task completion
    */
-  @SuppressWarnings("unchecked")
   public Task(TaskContext context, TaskStateTracker taskStateTracker, TaskExecutor taskExecutor,
       Optional<CountDownLatch> countDownLatch) {
     this.taskContext = context;
@@ -313,7 +313,7 @@ public class Task implements Runnable {
    * Increment the retry count of this task.
    */
   public void incrementRetryCount() {
-    this.retryCount++;
+    this.retryCount.incrementAndGet();
   }
 
   /**
@@ -322,7 +322,7 @@ public class Task implements Runnable {
    * @return number of times this task has been retried
    */
   public int getRetryCount() {
-    return this.retryCount;
+    return this.retryCount.get();
   }
 
   /**
@@ -332,7 +332,7 @@ public class Task implements Runnable {
     if (this.countDownLatch.isPresent()) {
       this.countDownLatch.get().countDown();
     }
-    this.taskState.setProp(ConfigurationKeys.TASK_RETRIES_KEY, this.retryCount);
+    this.taskState.setProp(ConfigurationKeys.TASK_RETRIES_KEY, this.retryCount.get());
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -12,19 +12,6 @@
 
 package gobblin.runtime;
 
-import gobblin.Constructs;
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.WorkUnitState;
-import gobblin.converter.Converter;
-import gobblin.fork.CopyNotSupportedException;
-import gobblin.fork.Copyable;
-import gobblin.fork.ForkOperator;
-import gobblin.instrumented.extractor.InstrumentedExtractorBase;
-import gobblin.instrumented.extractor.InstrumentedExtractorDecorator;
-import gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
-import gobblin.qualitychecker.row.RowLevelPolicyChecker;
-import gobblin.runtime.util.RuntimeConstructs;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
@@ -38,6 +25,19 @@ import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
+
+import gobblin.Constructs;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.fork.CopyNotSupportedException;
+import gobblin.fork.Copyable;
+import gobblin.fork.ForkOperator;
+import gobblin.instrumented.extractor.InstrumentedExtractorBase;
+import gobblin.instrumented.extractor.InstrumentedExtractorDecorator;
+import gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
+import gobblin.qualitychecker.row.RowLevelPolicyChecker;
+import gobblin.runtime.util.RuntimeConstructs;
 
 
 /**
@@ -83,7 +83,7 @@ public class Task implements Runnable {
   private final List<Optional<Fork>> forks = Lists.newArrayList();
 
   // Number of task retries
-  private AtomicInteger retryCount = new AtomicInteger();
+  private final AtomicInteger retryCount = new AtomicInteger();
 
   /**
    * Instantiate a new {@link Task}.

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java
@@ -16,6 +16,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
+import java.io.Reader;
 import java.lang.reflect.Constructor;
 import java.net.URI;
 import java.util.Arrays;
@@ -61,6 +62,7 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
+import com.google.common.io.Closer;
 import com.google.common.util.concurrent.AbstractIdleService;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -68,7 +70,6 @@ import gobblin.configuration.SourceState;
 import gobblin.configuration.WorkUnitState;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
-import gobblin.metrics.GobblinMetrics;
 import gobblin.publisher.DataPublisher;
 import gobblin.runtime.EmailNotificationJobListener;
 import gobblin.runtime.JobException;
@@ -472,7 +473,7 @@ public class LocalJobManager extends AbstractIdleService {
           Long ts1 = Long.parseLong(taskId1.substring(taskId1.lastIndexOf('_') + 1));
           Long ts2 = Long.parseLong(taskId2.substring(taskId2.lastIndexOf('_') + 1));
 
-          return -ts1.compareTo(ts2);
+          return -Integer.signum(ts1.compareTo(ts2));
         }
       });
 
@@ -582,12 +583,23 @@ public class LocalJobManager extends AbstractIdleService {
         }
       }
 
-      private void loadJobConfig(Properties jobProps, File file) {
+      private void loadJobConfig(Properties jobProps, File file)  {
+        Closer closer = Closer.create();
         try {
-          jobProps.load(new InputStreamReader(new FileInputStream(file), ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+          Reader propsReader =
+              closer.register(new InputStreamReader(new FileInputStream(file),
+                                                    ConfigurationKeys.DEFAULT_CHARSET_ENCODING));
+          jobProps.load(propsReader);
           jobProps.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY, file.getAbsolutePath());
         } catch (Exception e) {
           LOG.error("Failed to load job configuration from file " + file.getAbsolutePath(), e);
+        }
+        finally {
+          try {
+            closer.close();
+          } catch (IOException e) {
+            LOG.error("unable to close properties file:" + e, e);
+          }
         }
       }
     };

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -12,6 +12,9 @@
 
 package gobblin.util;
 
+import static org.apache.avro.SchemaCompatibility.checkReaderWriterCompatibility;
+import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE;
+
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -52,9 +55,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 import com.google.common.primitives.Longs;
-
-import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.COMPATIBLE;
-import static org.apache.avro.SchemaCompatibility.checkReaderWriterCompatibility;
 
 
 /**
@@ -405,6 +405,10 @@ public class AvroUtils {
     List<Field> fields = schema.getFields();
     Iterable<Field> fieldsNew = Iterables.transform(fields, new Function<Field, Field>() {
       @Override public Schema.Field apply(Field input) {
+        //this should never happen but the API has marked input as Nullable
+        if (null == input) {
+          return null;
+        }
         Field field = new Field(input.name(), input.schema(), input.doc(), input.defaultValue(), input.order());
         return field;
       }


### PR DESCRIPTION
Issues fixed:
* gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java doing unnecessary boxing/unboxing of long
* gobblin-runtime/src/main/java/gobblin/runtime/Task.java using ++ on a volatile
* gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java - negating an integer in compare() (may cause integer overflow)
* gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobManager.java not closing a stream
* gobblin-utility/src/main/java/gobblin/util/AvroUtils.java - making FB shut up that input can be null

@liyinan926 @ibuenros can you have a look?