### PR TITLE
ETL-3428: Fix for cleaning staging data using proxy file system

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -137,7 +137,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       workUnitState.setId(taskId);
       workUnitState.setProp(ConfigurationKeys.JOB_ID_KEY, jobId);
       workUnitState.setProp(ConfigurationKeys.TASK_ID_KEY, taskId);
-      LOG.info("WORKUNIT PREP: " + taskId + " owner: " + workUnitState.getProp(ConfigurationKeys.FS_PROXY_AS_USER_NAME));
 
       // Create a new task from the work unit and submit the task to run
       Task task = new Task(new TaskContext(workUnitState), stateTracker, taskExecutor, Optional.of(countDownLatch));
@@ -458,8 +457,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     try {
       for (TaskState taskState : jobState.getTaskStates()) {
         try {
-          LOG.info("current task id" + taskState.getTaskId() + " owner: "
-              + taskState.getProp(ConfigurationKeys.FS_PROXY_AS_USER_NAME));
           JobLauncherUtils.cleanStagingData(taskState, LOG, closer, parallelRunners);
         } catch (IOException e) {
           LOG.error(String.format("Failed to clean staging data for task %s: %s", taskState.getTaskId(), e), e);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -137,6 +137,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       workUnitState.setId(taskId);
       workUnitState.setProp(ConfigurationKeys.JOB_ID_KEY, jobId);
       workUnitState.setProp(ConfigurationKeys.TASK_ID_KEY, taskId);
+      LOG.info("WORKUNIT PREP: " + taskId + " owner: " + workUnitState.getProp(ConfigurationKeys.FS_PROXY_AS_USER_NAME));
 
       // Create a new task from the work unit and submit the task to run
       Task task = new Task(new TaskContext(workUnitState), stateTracker, taskExecutor, Optional.of(countDownLatch));
@@ -454,6 +455,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     try {
       for (TaskState taskState : jobState.getTaskStates()) {
         try {
+          LOG.info("current task id" + taskState.getTaskId() + " owner: "
+              + taskState.getProp(ConfigurationKeys.FS_PROXY_AS_USER_NAME));
           JobLauncherUtils.cleanStagingData(taskState, LOG, closer, parallelRunners);
         } catch (IOException e) {
           LOG.error(String.format("Failed to clean staging data for task %s: %s", taskState.getTaskId(), e), e);

--- a/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
@@ -166,10 +166,10 @@ public class JobLauncherUtils {
           state.getProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI,
               numBranches, branchId), ConfigurationKeys.LOCAL_FS_URI);
       FileSystem fs = getFsWithProxy(state, writerFsUri);
-
       ParallelRunner parallelRunner = getParallelRunner(fs, closer, parallelRunnerThreads, parallelRunners);
 
       Path stagingPath = WriterUtils.getWriterStagingDir(state, numBranches, branchId);
+
       if (fs.exists(stagingPath)) {
         logger.info("Cleaning up staging directory " + stagingPath.toUri().getPath());
         parallelRunner.deletePath(stagingPath, true);
@@ -212,10 +212,10 @@ public class JobLauncherUtils {
 
   private static ParallelRunner getParallelRunner(FileSystem fs, Closer closer, int parallelRunnerThreads,
       Map<String, ParallelRunner> parallelRunners) {
-    String uri = fs.getUri().toString();
-    if (!parallelRunners.containsKey(uri)) {
-      parallelRunners.put(uri, closer.register(new ParallelRunner(parallelRunnerThreads, fs)));
+    String uriAndHomeDir = fs.getUri().toString() + fs.getHomeDirectory();
+    if (!parallelRunners.containsKey(uriAndHomeDir)) {
+      parallelRunners.put(uriAndHomeDir, closer.register(new ParallelRunner(parallelRunnerThreads, fs)));
     }
-    return parallelRunners.get(uri);
+    return parallelRunners.get(uriAndHomeDir);
   }
 }


### PR DESCRIPTION
The parallel runner will use the same filesystem for the ones that have same fs uri. But in proxy filesystem, besides comparing fs uri, the user of that proxy file system should also be compared.
Add fs.getHomeDirectory() to getParallelRunner. 
Tested on Nertz.
@sahilTakiar Can you review it?