### PR TITLE
Add another option to KafkaReportingFormats

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -511,6 +511,8 @@ public class ConfigurationKeys {
   public static final String METRICS_CUSTOM_BUILDERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.custom.builders";
   public static final String METRICS_REPORT_INTERVAL_KEY = METRICS_CONFIGURATIONS_PREFIX + "report.interval";
   public static final String DEFAULT_METRICS_REPORT_INTERVAL = Long.toString(TimeUnit.SECONDS.toMillis(30));
+  public static final String METRICS_KAFKA_REPORTER_BUILDER_CLASS =
+      METRICS_CONFIGURATIONS_PREFIX + "reporting.reporter.builder.class";
 
   /**
    * Rest server configuration properties.

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
@@ -40,7 +40,7 @@ public class KafkaReporter extends MetricReportReporter {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaReporter.class);
 
   protected final AvroSerializer<MetricReport> serializer;
-  private final KafkaPusher kafkaPusher;
+  protected final KafkaPusher kafkaPusher;
 
   protected KafkaReporter(Builder<?> builder) throws IOException {
     super(builder);


### PR DESCRIPTION
Add another option `CLASS` for `KafkaReportingFormats` so that I can pass in a custom reporter instead of using `KafkaAvroReporter`