### PR TITLE
Add classname and line number to azkaban logs

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -220,7 +220,11 @@ public class ConfigurationKeys {
   public static final String WRITER_PRESERVE_FILE_NAME = WRITER_PREFIX + ".preserve.file.name";
   public static final String WRITER_DEFLATE_LEVEL = WRITER_PREFIX + ".deflate.level";
   public static final String WRITER_CODEC_TYPE = WRITER_PREFIX + ".codec.type";
+
+  // Deprecated. Use WRITER_PARTITION_COLUMNS
+  @Deprecated
   public static final String WRITER_PARTITION_COLUMN_NAME = WRITER_PREFIX + ".partition.column.name";
+  public static final String WRITER_PARTITION_COLUMNS = WRITER_PREFIX + ".partition.columns";
   public static final String WRITER_PARTITION_LEVEL = WRITER_PREFIX + ".partition.level";
   public static final String WRITER_PARTITION_PATTERN = WRITER_PREFIX + ".partition.pattern";
   public static final String WRITER_PARTITION_TIMEZONE = WRITER_PREFIX + ".partition.timezone";
@@ -549,6 +553,12 @@ public class ConfigurationKeys {
   public static final String FS_PROXY_AS_USER_TOKEN_FILE = "fs.proxy.as.user.token.file";
   public static final String SUPER_USER_NAME_TO_PROXY_AS_OTHERS = "super.user.name.to.proxy.as.others";
   public static final String SUPER_USER_KEY_TAB_LOCATION = "super.user.key.tab.location";
+
+  /**
+   * Azkaban properties.
+   */
+  public static final String AZKABAN_EXECUTION_TIME_RANGE = "azkaban.execution.time.range";
+  public static final String AZKABAN_EXECUTION_DAYS_LIST = "azkaban.execution.days.list";
 
   /**
    * Other configuration properties.

--- a/gobblin-azkaban/build.gradle
+++ b/gobblin-azkaban/build.gradle
@@ -18,11 +18,13 @@ dependencies {
   compile project(":gobblin-metastore")
   compile project(":gobblin-core")
   compile project(":gobblin-metrics")
+  compile project(":gobblin-utility")
 
   compile externalDependency.azkaban
   compile externalDependency.log4j
   compile externalDependency.guava
   compile externalDependency.commonsLang
+  compile externalDependency.jodaTime
 }
 
 configurations {

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
@@ -12,13 +12,16 @@
 
 package gobblin.azkaban;
 
+import java.util.Enumeration;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
+import org.apache.log4j.PatternLayout;
 
 import azkaban.jobExecutor.AbstractJob;
 
@@ -55,6 +58,7 @@ public class AzkabanJobLauncher extends AbstractJob {
   private static final String AZKABAN_LINK_JOBEXEC_URL = "azkaban.link.jobexec.url";
   private static final String HADOOP_TOKEN_FILE_LOCATION = "HADOOP_TOKEN_FILE_LOCATION";
   private static final String MAPREDUCE_JOB_CREDENTIALS_BINARY = "mapreduce.job.credentials.binary";
+  private static final String LOGGER_PATTERN_LAYOUT = "%c: %L - %m%n";
 
   private static final ImmutableMap<String, String> PROPERTIES_TO_TAGS_MAP =
       new ImmutableMap.Builder<String, String>()
@@ -71,6 +75,8 @@ public class AzkabanJobLauncher extends AbstractJob {
   public AzkabanJobLauncher(String jobId, Properties props)
       throws Exception {
     super(jobId, LOG);
+
+    updateLogger();
 
     Properties properties = new Properties();
     properties.putAll(props);
@@ -124,6 +130,22 @@ public class AzkabanJobLauncher extends AbstractJob {
       }
     }
     return tags;
+  }
+
+  /**
+   * Azkaban ignores the log4j config provided in the artifacts. This method includes class name and line number to azkaban logs
+   */
+  private void updateLogger() {
+
+    @SuppressWarnings("unchecked")
+    Enumeration<Appender> appenders = Logger.getRootLogger().getAllAppenders();
+
+    if (appenders != null) {
+      while (appenders.hasMoreElements()) {
+        appenders.nextElement().setLayout(new PatternLayout(LOGGER_PATTERN_LAYOUT));
+
+      }
+    }
   }
 
   @Override

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
@@ -22,9 +22,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.log4j.Appender;
 import org.apache.log4j.Logger;
 import org.apache.log4j.PatternLayout;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
 
 import azkaban.jobExecutor.AbstractJob;
 
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -37,6 +41,7 @@ import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobLauncherFactory;
 import gobblin.runtime.JobListener;
 import gobblin.runtime.util.JobMetrics;
+import gobblin.util.TimeRangeChecker;
 
 
 /**
@@ -71,50 +76,51 @@ public class AzkabanJobLauncher extends AbstractJob {
   private final Closer closer = Closer.create();
   private final JobLauncher jobLauncher;
   private final JobListener jobListener = new EmailNotificationJobListener();
+  private final Properties props;
 
   public AzkabanJobLauncher(String jobId, Properties props)
       throws Exception {
     super(jobId, LOG);
 
-    updateLogger();
+    this.props = new Properties();
+    this.props.putAll(props);
 
-    Properties properties = new Properties();
-    properties.putAll(props);
+
     Configuration conf = new Configuration();
 
     String fsUri = conf.get(HADOOP_FS_DEFAULT_NAME);
     if (!Strings.isNullOrEmpty(fsUri)) {
-      if (!properties.containsKey(ConfigurationKeys.FS_URI_KEY)) {
-        properties.setProperty(ConfigurationKeys.FS_URI_KEY, fsUri);
+      if (!this.props.containsKey(ConfigurationKeys.FS_URI_KEY)) {
+        this.props.setProperty(ConfigurationKeys.FS_URI_KEY, fsUri);
       }
-      if (!properties.containsKey(ConfigurationKeys.STATE_STORE_FS_URI_KEY)) {
-        properties.setProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, fsUri);
+      if (!this.props.containsKey(ConfigurationKeys.STATE_STORE_FS_URI_KEY)) {
+        this.props.setProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, fsUri);
       }
     }
 
     // Set the job tracking URL to point to the Azkaban job execution link URL
-    properties.setProperty(
+    this.props.setProperty(
         ConfigurationKeys.JOB_TRACKING_URL_KEY, Strings.nullToEmpty(conf.get(AZKABAN_LINK_JOBEXEC_URL)));
 
     // Necessary for compatibility with Azkaban's hadoopJava job type
     // http://azkaban.github.io/azkaban/docs/2.5/#hadoopjava-type
     if (System.getenv(HADOOP_TOKEN_FILE_LOCATION) != null) {
-      properties.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, System.getenv(HADOOP_TOKEN_FILE_LOCATION));
+      this.props.setProperty(MAPREDUCE_JOB_CREDENTIALS_BINARY, System.getenv(HADOOP_TOKEN_FILE_LOCATION));
     }
 
-    JobMetrics.addCustomTagsToProperties(properties, getAzkabanTags());
+    JobMetrics.addCustomTagsToProperties(this.props, getAzkabanTags());
 
     // If the job launcher type is not specified in the job configuration,
     // override the default to use the MAPREDUCE launcher.
-    if (!properties.containsKey(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY)) {
-      properties.setProperty(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY,
+    if (!this.props.containsKey(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY)) {
+      this.props.setProperty(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY,
           JobLauncherFactory.JobLauncherType.MAPREDUCE.toString());
     }
 
     // Create a JobLauncher instance depending on the configuration. The same properties object is
     // used for both system and job configuration properties because Azkaban puts configuration
     // properties in the .job file and in the .properties file into the same Properties object.
-    this.jobLauncher = this.closer.register(JobLauncherFactory.newJobLauncher(properties, properties));
+    this.jobLauncher = this.closer.register(JobLauncherFactory.newJobLauncher(this.props, this.props));
   }
 
   private List<Tag<?>> getAzkabanTags() {
@@ -152,7 +158,9 @@ public class AzkabanJobLauncher extends AbstractJob {
   public void run()
       throws Exception {
     try {
-      this.jobLauncher.launchJob(this.jobListener);
+      if (isCurrentTimeInRange()) {
+        this.jobLauncher.launchJob(this.jobListener);
+      }
     } finally {
       this.closer.close();
     }
@@ -166,5 +174,32 @@ public class AzkabanJobLauncher extends AbstractJob {
     } finally {
       this.closer.close();
     }
+  }
+
+  /**
+   * Uses the properties {@link ConfigurationKeys#AZKABAN_EXECUTION_DAYS_LIST},
+   * {@link ConfigurationKeys#AZKABAN_EXECUTION_TIME_RANGE}, and
+   * {@link TimeRangeChecker#isTimeInRange(List, String, String, DateTime)} to determine if the current job should
+   * continue its execution based on the extra scheduled parameters defined in the config.
+   *
+   * @return true if this job should be launched, false otherwise.
+   */
+  private boolean isCurrentTimeInRange() {
+    Splitter splitter = Splitter.on(",").omitEmptyStrings().trimResults();
+
+    if (this.props.contains(ConfigurationKeys.AZKABAN_EXECUTION_DAYS_LIST)
+        && this.props.contains(ConfigurationKeys.AZKABAN_EXECUTION_TIME_RANGE)) {
+
+      List<String> executionTimeRange =
+          splitter.splitToList(this.props.getProperty(ConfigurationKeys.AZKABAN_EXECUTION_TIME_RANGE));
+      List<String> executionDays =
+          splitter.splitToList(this.props.getProperty(ConfigurationKeys.AZKABAN_EXECUTION_DAYS_LIST));
+      Preconditions.checkArgument(executionTimeRange.size() == 2, "The property "
+          + ConfigurationKeys.AZKABAN_EXECUTION_DAYS_LIST + " should be a comma separated list of two entries");
+
+      return TimeRangeChecker.isTimeInRange(executionDays, executionTimeRange.get(0), executionTimeRange.get(1),
+          new DateTime(DateTimeZone.forID("America/Los_Angeles")));
+    }
+    return true;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -122,9 +122,14 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
     this.stagingFileOutputStream = this.closer.register(this.fs.create(this.stagingFile, this.filePermission, true,
         this.bufferSize, this.replicationFactor, this.blockSize, null));
 
-    this.group = Optional.fromNullable(properties.getProp(ConfigurationKeys.WRITER_GROUP_NAME));
+    this.group =
+        Optional.fromNullable(properties.getProp(ForkOperatorUtils.getPropertyNameForBranch(
+            ConfigurationKeys.WRITER_GROUP_NAME, numBranches, branchId)));
+
     if (this.group.isPresent()) {
       HadoopUtils.setGroup(this.fs, this.stagingFile, this.group.get());
+    } else {
+      LOG.warn("No group found for " + this.stagingFile);
     }
 
     // Create the parent directory of the output file if it does not exist

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -115,13 +115,9 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_BLOCK_SIZE, numBranches, branchId),
         this.fs.getDefaultBlockSize(this.outputFile));
 
-    this.filePermission = new FsPermission(properties.getPropAsShortWithRadix(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PERMISSIONS, numBranches, branchId),
-        FsPermission.getDefault().toShort(), ConfigurationKeys.PERMISSION_PARSING_RADIX));
+    this.filePermission = HadoopUtils.deserializeWriterFilePermissions(properties, numBranches, branchId);
 
-    this.dirPermission = new FsPermission(properties.getPropAsShortWithRadix(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DIR_PERMISSIONS, numBranches, branchId),
-        FsPermission.getDefault().toShort(), ConfigurationKeys.PERMISSION_PARSING_RADIX));
+    this.dirPermission = HadoopUtils.deserializeWriterDirPermissions(properties, numBranches, branchId);
 
     this.stagingFileOutputStream = this.closer.register(this.fs.create(this.stagingFile, this.filePermission, true,
         this.bufferSize, this.replicationFactor, this.blockSize, null));

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/ModificationTimeDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/ModificationTimeDataset.java
@@ -1,0 +1,55 @@
+package gobblin.data.management.retention.dataset;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gobblin.data.management.retention.policy.RetentionPolicy;
+import gobblin.data.management.retention.policy.TimeBasedRetentionPolicy;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+import gobblin.data.management.retention.version.finder.ModDateTimeDatasetVersionFinder;
+import gobblin.data.management.retention.version.finder.VersionFinder;
+
+
+/**
+ * {@link DatasetBase} for a modification time based dataset.
+ *
+ * Uses a {@link ModDateTimeDatasetVersionFinder} and a {@link TimeBasedRetentionPolicy}.
+ */
+public class ModificationTimeDataset extends DatasetBase<TimestampedDatasetVersion> {
+
+  private final VersionFinder<TimestampedDatasetVersion> versionFinder;
+  private final RetentionPolicy<TimestampedDatasetVersion> retentionPolicy;
+  private final Path datasetRoot;
+
+  public ModificationTimeDataset(FileSystem fs, Properties props, Path datasetRoot) throws IOException {
+    this(fs, props, datasetRoot, LoggerFactory.getLogger(ModificationTimeDataset.class));
+  }
+
+  public ModificationTimeDataset(FileSystem fs, Properties props, Path datasetRoot, Logger log) throws IOException {
+    super(fs, props, log);
+    this.versionFinder = new ModDateTimeDatasetVersionFinder(fs, props);
+    this.retentionPolicy = new TimeBasedRetentionPolicy(props);
+    this.datasetRoot = datasetRoot;
+  }
+
+  @Override
+  public Path datasetRoot() {
+    return this.datasetRoot;
+  }
+
+  @Override
+  public VersionFinder<? extends TimestampedDatasetVersion> getVersionFinder() {
+    return this.versionFinder;
+  }
+
+  @Override
+  public RetentionPolicy<TimestampedDatasetVersion> getRetentionPolicy() {
+    return this.retentionPolicy;
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ModificationTimeDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ModificationTimeDatasetProfile.java
@@ -1,0 +1,28 @@
+package gobblin.data.management.retention.profile;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import gobblin.data.management.retention.dataset.Dataset;
+import gobblin.data.management.retention.dataset.ModificationTimeDataset;
+
+
+/**
+ * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for {@link ModificationTimeDataset}s.
+ *
+ * Modification time datasets will be cleaned by the modification timestamps of the datasets that match
+ * 'gobblin.retention.dataset.pattern'.
+ */
+public class ModificationTimeDatasetProfile extends ConfigurableGlobDatasetFinder {
+  public ModificationTimeDatasetProfile(FileSystem fs, Properties props) throws IOException {
+    super(fs, props);
+  }
+
+  @Override
+  public Dataset datasetAtPath(Path path) throws IOException {
+    return new ModificationTimeDataset(this.fs, this.props, path);
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
@@ -27,8 +27,9 @@ import gobblin.data.management.retention.version.TimestampedDatasetVersion;
 
 
 /**
- * {@link gobblin.data.management.retention.version.finder.DatasetVersionFinder} for timestamped datasets. Uses a datetime pattern
- * to find dataset versions and parse the {@link org.joda.time.DateTime} representing the version.
+ * {@link gobblin.data.management.retention.version.finder.DatasetVersionFinder} for datasets based on path timestamps.
+ * Uses a datetime pattern to find dataset versions from the dataset path
+ * and parse the {@link org.joda.time.DateTime} representing the version.
  */
 public class DateTimeDatasetVersionFinder extends DatasetVersionFinder<TimestampedDatasetVersion> {
 
@@ -66,10 +67,11 @@ public class DateTimeDatasetVersionFinder extends DatasetVersionFinder<Timestamp
   @Override
   public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, Path fullPath) {
     try {
-      return new TimestampedDatasetVersion(this.formatter.parseDateTime(pathRelativeToDatasetRoot.toString()), fullPath);
-    } catch(IllegalArgumentException exception) {
-      LOGGER.warn("Candidate dataset version at " + pathRelativeToDatasetRoot
-          + " does not match expected pattern. Ignoring.");
+      return new TimestampedDatasetVersion(this.formatter.parseDateTime(pathRelativeToDatasetRoot.toString()),
+          fullPath);
+    } catch (IllegalArgumentException exception) {
+      LOGGER.warn(
+          "Candidate dataset version at " + pathRelativeToDatasetRoot + " does not match expected pattern. Ignoring.");
       return null;
     }
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/ModDateTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/ModDateTimeDatasetVersionFinder.java
@@ -1,0 +1,40 @@
+package gobblin.data.management.retention.version.finder;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.joda.time.DateTime;
+
+import com.google.common.collect.Lists;
+
+import gobblin.data.management.retention.dataset.Dataset;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+
+
+/**
+ * {@link VersionFinder} for datasets based on modification timestamps.
+ */
+public class ModDateTimeDatasetVersionFinder implements VersionFinder<TimestampedDatasetVersion> {
+
+  private final FileSystem fs;
+
+  public ModDateTimeDatasetVersionFinder(FileSystem fs, Properties props) {
+    this.fs = fs;
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return TimestampedDatasetVersion.class;
+  }
+
+  @Override
+  public Collection<TimestampedDatasetVersion> findDatasetVersions(Dataset dataset) throws IOException {
+    FileStatus status = this.fs.getFileStatus(dataset.datasetRoot());
+    return Lists
+        .newArrayList(new TimestampedDatasetVersion(new DateTime(status.getModificationTime()), dataset.datasetRoot()));
+  }
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
@@ -40,7 +40,7 @@ public class KafkaReporter extends MetricReportReporter {
   private static final Logger LOGGER = LoggerFactory.getLogger(KafkaReporter.class);
 
   protected final AvroSerializer<MetricReport> serializer;
-  private final KafkaPusher kafkaPusher;
+  protected final KafkaPusher kafkaPusher;
 
   protected KafkaReporter(Builder<?> builder) throws IOException {
     super(builder);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -275,7 +275,6 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       jobState.setState(JobState.RunningState.FAILED);
       String errMsg = "Failed to launch and run job " + jobId;
       LOG.error(errMsg + ": " + t, t);
-      throw new JobException(errMsg, t);
     } finally {
       long endTime = System.currentTimeMillis();
       jobState.setEndTime(endTime);
@@ -320,7 +319,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
    * Subclasses can override this method to do whatever processing on the {@link TaskState}s,
    * e.g., aggregate task-level metrics into job-level metrics.
    */
-  protected void postProcessTaskStates(List<TaskState> taskStates) {
+  protected void postProcessTaskStates(@SuppressWarnings("unused") List<TaskState> taskStates) {
     // Do nothing
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -145,7 +145,6 @@ public class LocalJobLauncher extends AbstractJobLauncher {
       jobState.addTaskState(task.getTaskState());
       if (task.getTaskState().getWorkingState() == WorkUnitState.WorkingState.FAILED) {
         this.eventSubmitter.submit(gobblin.metrics.event.EventNames.TASK_FAILED, "taskId", task.getTaskId());
-        jobState.setState(JobState.RunningState.FAILED);
       }
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -219,8 +219,6 @@ public class MRJobLauncher extends AbstractJobLauncher {
         }
       }
 
-      jobState.setState(this.job.isSuccessful() ? JobState.RunningState.SUCCESSFUL : JobState.RunningState.FAILED);
-
       // Collect the output task states and add them to the job state
       List<TaskState> outputTaskStates = collectOutputTaskStates(new Path(jobOutputPath, jobState.getJobId()));
       if (outputTaskStates.size() < jobState.getTaskCount()) {

--- a/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobLauncherUtils.java
@@ -212,7 +212,7 @@ public class JobLauncherUtils {
 
   private static ParallelRunner getParallelRunner(FileSystem fs, Closer closer, int parallelRunnerThreads,
       Map<String, ParallelRunner> parallelRunners) {
-    String uriAndHomeDir = fs.getUri().toString() + fs.getHomeDirectory();
+    String uriAndHomeDir = new Path(new Path(fs.getUri()), fs.getHomeDirectory()).toString();
     if (!parallelRunners.containsKey(uriAndHomeDir)) {
       parallelRunners.put(uriAndHomeDir, closer.register(new ParallelRunner(parallelRunnerThreads, fs)));
     }

--- a/gobblin-utility/src/main/java/gobblin/util/TimeRangeChecker.java
+++ b/gobblin-utility/src/main/java/gobblin/util/TimeRangeChecker.java
@@ -1,0 +1,100 @@
+// Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.
+
+package gobblin.util;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+
+import lombok.AllArgsConstructor;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeConstants;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+/**
+ * Utility class to check if a given time is in a pre-defined range. Particularly useful for Job-Schedulers such as
+ * Azkaban that don't provide a day level scheduling granularity.
+ */
+public class TimeRangeChecker {
+
+  private static final DateTimeZone DATE_TIME_ZONE = DateTimeZone.forID("America/Los_Angeles");
+  private static final String HOUR_MINUTE_FORMAT = "HH-mm";
+  private static final DateTimeFormatter HOUR_MINUTE_FORMATTER = DateTimeFormat.forPattern("HH-mm");
+  private static final Map<Integer, String> DAYS_OF_WEEK = new ImmutableMap.Builder<Integer, String>()
+                                                               .put(DateTimeConstants.MONDAY, "MONDAY")
+                                                               .put(DateTimeConstants.TUESDAY, "TUESDAY")
+                                                               .put(DateTimeConstants.WEDNESDAY, "WEDNESDAY")
+                                                               .put(DateTimeConstants.THURSDAY, "THURSDAY")
+                                                               .put(DateTimeConstants.FRIDAY, "FRIDAY")
+                                                               .put(DateTimeConstants.SATURDAY, "SATURDAY")
+                                                               .put(DateTimeConstants.SUNDAY, "SUNDAY").build();
+
+  /**
+   * Checks if a specified time is on a day that is specified the a given {@link List} of acceptable days, and that the
+   * hours + minutes of the specified time fall into a range defined by startTimeStr and endTimeStr.
+   *
+   * @param days is a {@link List} of days, if the specified {@link DateTime} does not have a day that falls is in this
+   * {@link List} then this method will return false.
+   * @param startTimeStr defines the start range that the currentTime can fall into. This {@link String} should be of
+   * the pattern defined by {@link #HOUR_MINUTE_FORMAT}.
+   * @param endTimeStr defines the start range that the currentTime can fall into. This {@link String} should be of
+   * the pattern defined by {@link #HOUR_MINUTE_FORMAT}.
+   * @param currentTime is a {@link DateTime} for which this method will check if it is in the given {@link List} of
+   * days and falls into the time range defined by startTimeStr and endTimeStr.
+   *
+   * @return true if the given time is in the defined range, false otherwise.
+   */
+  public static boolean isTimeInRange(List<String> days, String startTimeStr, String endTimeStr, DateTime currentTime) {
+
+    if (!Iterables.any(days, new AreDaysEqual(DAYS_OF_WEEK.get(currentTime.getDayOfWeek())))) {
+      return false;
+    }
+
+    DateTime startTime = null;
+    DateTime endTime = null;
+
+    try {
+      startTime = HOUR_MINUTE_FORMATTER.withZone(DATE_TIME_ZONE).parseDateTime(startTimeStr);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("startTimeStr format is invalid, must be of format " + HOUR_MINUTE_FORMAT, e);
+    }
+
+    try {
+      endTime = HOUR_MINUTE_FORMATTER.withZone(DATE_TIME_ZONE).parseDateTime(endTimeStr);
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("endTimeStr format is invalid, must be of format " + HOUR_MINUTE_FORMAT, e);
+    }
+
+    startTime = startTime.withDate(currentTime.getYear(), currentTime.getMonthOfYear(), currentTime.getDayOfMonth());
+    endTime = endTime.withDate(currentTime.getYear(), currentTime.getMonthOfYear(), currentTime.getDayOfMonth());
+
+    Interval interval = new Interval(startTime.getMillis(), endTime.getMillis(), DATE_TIME_ZONE);
+    return interval.contains(currentTime.getMillis());
+  }
+
+  @AllArgsConstructor
+  private static class AreDaysEqual implements Predicate<String> {
+
+    private String day;
+
+    @Override
+    public boolean apply(String day) {
+      return this.day.equalsIgnoreCase(day);
+    }
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/HadoopUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/HadoopUtilsTest.java
@@ -1,0 +1,34 @@
+package gobblin.util;
+
+import org.apache.hadoop.fs.permission.FsPermission;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.State;
+
+
+@Test(groups = { "gobblin.util" })
+public class HadoopUtilsTest {
+
+  @Test
+  public void fsShortSerializationTest() {
+    State state = new State();
+    short mode = 420;
+    FsPermission perms = new FsPermission(mode);
+
+    HadoopUtils.serializeWriterFilePermissions(state, 0, 0, perms);
+    FsPermission deserializedPerms = HadoopUtils.deserializeWriterFilePermissions(state, 0, 0);
+    Assert.assertEquals(mode, deserializedPerms.toShort());
+  }
+
+  @Test
+  public void fsOctalSerializationTest() {
+    State state = new State();
+    String mode = "0755";
+
+    HadoopUtils.setWriterFileOctalPermissions(state, 0, 0, mode);
+    FsPermission deserializedPerms = HadoopUtils.deserializeWriterFilePermissions(state, 0, 0);
+    Assert.assertEquals(Integer.parseInt(mode, 8), deserializedPerms.toShort());
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/TimeRangeCheckerTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/TimeRangeCheckerTest.java
@@ -1,0 +1,52 @@
+// Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.
+
+package gobblin.util;
+
+import com.google.common.collect.Lists;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test(groups = {"gobblin.util"})
+public class TimeRangeCheckerTest {
+
+  @Test
+  public void testTimeRangeChecker() {
+    // January 1st, 2015 (a Thursday)
+    DateTime dateTime = new DateTime(2015, 1, 1, 0, 0, 0, DateTimeZone.forID("America/Los_Angeles"));
+
+    // Positive Tests
+
+    // Base hour
+    Assert.assertTrue(TimeRangeChecker.isTimeInRange(Lists.newArrayList("THURSDAY"), "00-00", "06-00", dateTime));
+
+    // Valid minute
+    Assert.assertTrue(TimeRangeChecker.isTimeInRange(Lists.newArrayList("THURSDAY"), "00-00", "00-01", dateTime));
+
+    // Multiple days
+    Assert.assertTrue(TimeRangeChecker.isTimeInRange(Lists.newArrayList("MONDAY", "THURSDAY"), "00-00", "06-00", dateTime));
+
+    // Negative Tests
+
+    // Invalid day
+    Assert.assertFalse(TimeRangeChecker.isTimeInRange(Lists.newArrayList("MONDAY"), "00-00", "06-00", dateTime));
+
+    // Invalid minute
+    Assert.assertFalse(TimeRangeChecker.isTimeInRange(Lists.newArrayList("THURSDAY"), "00-01", "06-00", dateTime));
+
+    // Invalid hour
+    Assert.assertFalse(TimeRangeChecker.isTimeInRange(Lists.newArrayList("THURSDAY"), "01-00", "06-00", dateTime));
+  }
+}


### PR DESCRIPTION
@liyinan926 and @chavdar can you guys take a looks this?
- I spoke to the Azkaban team today as to why the azkaban logs do not have class names and log messages even though we have it in our log4j conifg files. It turns out the azkaban hard codes the pattern to just project name and message. In fact it seems like azkaban ignores all the log4j properties we set.
- This change is to add the class name and line number to all the appenders in the root logger.