### PR TITLE
Use MR jobs for non-deduping compaction

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -442,8 +442,7 @@ public class ConfigurationKeys {
   public static final String COMPACTION_TIMEBASED_MIN_TIME_AGO = COMPACTION_PREFIX + "timebased.min.time.ago";
   public static final String DEFAULT_COMPACTION_TIMEBASED_MIN_TIME_AGO = "1d";
   public static final String COMPACTION_TOPIC = COMPACTION_PREFIX + "topic";
-  public static final String COMPACTION_OUTPUT_PERMISSION = COMPACTION_PREFIX + "output.permission";
-  public static final int DEFAULT_COMPACTION_OUTPUT_PERMISSION = 0755;
+  public static final String COMPACTION_OUTPUT_DIR_PERMISSION = COMPACTION_PREFIX + "output.dir.permission";
   public static final String COMPACTION_TARGET_OUTPUT_FILE_SIZE = COMPACTION_PREFIX + "target.output.file.size";
   public static final long DEFAULT_COMPACTION_TARGET_OUTPUT_FILE_SIZE = 268435456;
   public static final String COMPACTION_MAX_NUM_REDUCERS = COMPACTION_PREFIX + "max.num.reducers";

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyMapper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyMapper.java
@@ -24,6 +24,8 @@ import org.apache.avro.mapreduce.AvroJob;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.mapreduce.Mapper;
 
+import gobblin.compaction.mapreduce.avro.AvroKeyDedupReducer.EVENT_COUNTER;
+
 
 /**
  * Mapper class for compaction MR job for Avro data.
@@ -36,6 +38,10 @@ import org.apache.hadoop.mapreduce.Mapper;
  * @author ziliu
  */
 public class AvroKeyMapper extends Mapper<AvroKey<GenericRecord>, NullWritable, AvroKey<GenericRecord>, Object> {
+
+  public enum EVENT_COUNTER {
+    RECORD_COUNT
+  }
 
   private AvroKey<GenericRecord> outKey;
   private AvroValue<GenericRecord> outValue;
@@ -59,6 +65,7 @@ public class AvroKeyMapper extends Mapper<AvroKey<GenericRecord>, NullWritable, 
       outValue.datum(key.datum());
       context.write(outKey, outValue);
     }
+    context.getCounter(EVENT_COUNTER.RECORD_COUNT).increment(1);
   }
 
   /**

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
@@ -90,9 +90,8 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
 
   private void configureSchema(Job job) throws IOException {
     Schema newestSchema = getNewestSchemaFromSource(job);
-    Schema keySchema = getKeySchema(job, newestSchema);
     AvroJob.setInputKeySchema(job, newestSchema);
-    AvroJob.setMapOutputKeySchema(job, keySchema);
+    AvroJob.setMapOutputKeySchema(job, this.deduplicate ? getKeySchema(job, newestSchema) : newestSchema);
     AvroJob.setMapOutputValueSchema(job, newestSchema);
     AvroJob.setOutputKeySchema(job, newestSchema);
   }

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -175,7 +175,8 @@ public class HadoopUtils {
    * Given a {@link FsPermission} objects, set a key, value pair in the given {@link State} for the writer to
    * use when creating files. This method should be used in conjunction with {@link #deserializeWriterFilePermissions(State, int, int)}.
    */
-  public static void serializeWriterFilePermissions(State state, int numBranches, int branchId, FsPermission fsPermissions) {
+  public static void serializeWriterFilePermissions(State state, int numBranches, int branchId,
+      FsPermission fsPermissions) {
     serializeFsPermissions(state,
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PERMISSIONS, numBranches, branchId),
         fsPermissions);
@@ -185,7 +186,8 @@ public class HadoopUtils {
    * Given a {@link FsPermission} objects, set a key, value pair in the given {@link State} for the writer to
    * use when creating files. This method should be used in conjunction with {@link #deserializeWriterDirPermissions(State, int, int)}.
    */
-  public static void serializeWriterDirPermissions(State state, int numBranches, int branchId, FsPermission fsPermissions) {
+  public static void serializeWriterDirPermissions(State state, int numBranches, int branchId,
+      FsPermission fsPermissions) {
     serializeFsPermissions(state,
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DIR_PERMISSIONS, numBranches, branchId),
         fsPermissions);
@@ -202,7 +204,8 @@ public class HadoopUtils {
    * Given a {@link String} in octal notation, set a key, value pair in the given {@link State} for the writer to
    * use when creating files. This method should be used in conjunction with {@link #deserializeWriterFilePermissions(State, int, int)}.
    */
-  public static void setWriterFileOctalPermissions(State state, int numBranches, int branchId, String octalPermissions) {
+  public static void setWriterFileOctalPermissions(State state, int numBranches, int branchId,
+      String octalPermissions) {
     state.setProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_PERMISSIONS, numBranches, branchId),
         octalPermissions);
@@ -234,5 +237,20 @@ public class HadoopUtils {
     return new FsPermission(state.getPropAsShortWithRadix(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DIR_PERMISSIONS, numBranches, branchId),
         FsPermission.getDefault().toShort(), ConfigurationKeys.PERMISSION_PARSING_RADIX));
+  }
+
+  /**
+   * Get {@link FsPermission} from a {@link State} object.
+   *
+   * @param props A {@link State} containing properties.
+   * @param propName The property name for the permission. If not contained in the given state,
+   * defaultPermission will be used.
+   * @param defaultPermission default permission if propName is not contained in props.
+   * @return An {@link FsPermission} object.
+   */
+  public static FsPermission deserializeFsPermission(State props, String propName, FsPermission defaultPermission) {
+    short mode = props.getPropAsShortWithRadix(propName, defaultPermission.toShort(),
+        ConfigurationKeys.PERMISSION_PARSING_RADIX);
+    return new FsPermission(mode);
   }
 }


### PR DESCRIPTION
Previously if `deduplicate=false`, it uses the Azkaban job to copy the data from hourly folder to daily folder, which is too slow for large number of topics and data volumes.

Now using a map-only job similar as camus-sweeper.

Also add a counter in `AvroKepMapper` to get row count for map-only jobs.