### PR TITLE
Add locks to ParallelRunner

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -68,7 +68,7 @@ public class HadoopUtils {
    * @throws IOException if the deletion fails
    */
   public static void deletePath(FileSystem fs, Path f, boolean recursive) throws IOException {
-    if (!fs.delete(f, recursive)) {
+    if (fs.exists(f) && !fs.delete(f, recursive)) {
       throw new IOException("Failed to delete: " + f);
     }
   }


### PR DESCRIPTION
Reason: https://github.com/linkedin/gobblin/issues/313
An alternative approach is to modify `AbstractJobLauncher` to avoid submitting the same directory for cleaning more than once. I'd prefer the lock approach since it is cleaner and makes it easier for future classes that use `ParallelRunner`.