### PR TITLE
Changed start_time & end_time from TIMESTAMP to DATETIME

### DIFF
--- a/gobblin-metastore/src/main/resources/gobblin_job_history_store.sql
+++ b/gobblin-metastore/src/main/resources/gobblin_job_history_store.sql
@@ -14,8 +14,8 @@
 CREATE TABLE IF NOT EXISTS gobblin_job_executions (
 	job_name VARCHAR(128) NOT NULL,
 	job_id VARCHAR(128) NOT NULL,
-	start_time TIMESTAMP,
-	end_time TIMESTAMP,
+	start_time DATETIME,
+	end_time DATETIME,
 	duration BIGINT(21),
 	state ENUM('PENDING', 'RUNNING', 'SUCCESSFUL', 'COMMITTED', 'FAILED', 'CANCELLED'),
 	launched_tasks INT,
@@ -32,8 +32,8 @@ CREATE TABLE IF NOT EXISTS gobblin_job_executions (
 CREATE TABLE IF NOT EXISTS gobblin_task_executions (
 	task_id VARCHAR(128) NOT NULL,
 	job_id VARCHAR(128) NOT NULL,
-	start_time TIMESTAMP,
-	end_time TIMESTAMP,
+	start_time DATETIME,
+	end_time DATETIME,
 	duration BIGINT(21),
 	state ENUM('PENDING', 'RUNNING', 'SUCCESSFUL', 'COMMITTED', 'FAILED', 'CANCELLED'),
 	failure_exception TEXT,


### PR DESCRIPTION
To work around this error:
Data truncation: Incorrect datetime value: '1970-01-01 00:00:00' for column 'end_time'.

According to http://dev.mysql.com/doc/refman/5.6/en/datetime.html, The TIMESTAMP data type is used for values that contain both date and time parts. TIMESTAMP has a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07' UTC.

So when DatabaseJobHistoryStore declares DEFAULT_TIMESTAMP = "1970-01-01 00:00:00", it bombs.

Does LinkedIn have an internal version of MySQL with a different TIMESTAMP range?