### PR TITLE
Adding additional logging in case an ExecutorService cannot shutdown all its threads

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
@@ -69,7 +69,7 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
   protected void shutDown()
       throws Exception {
     this.logger.info("Stopping the task state tracker");
-    ExecutorsUtils.shutdownExecutorService(this.taskMetricsUpdaterExecutor);
+    ExecutorsUtils.shutdownExecutorService(this.taskMetricsUpdaterExecutor, Optional.of(this.logger));
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -134,12 +134,12 @@ public class TaskExecutor extends AbstractIdleService {
       throws Exception {
     LOG.info("Stopping the task executor");
     try {
-      ExecutorsUtils.shutdownExecutorService(this.taskExecutor);
+      ExecutorsUtils.shutdownExecutorService(this.taskExecutor, Optional.of(LOG));
     } finally {
       try {
-        ExecutorsUtils.shutdownExecutorService(this.taskRetryExecutor);
+        ExecutorsUtils.shutdownExecutorService(this.taskRetryExecutor, Optional.of(LOG));
       } finally {
-        ExecutorsUtils.shutdownExecutorService(this.forkExecutor);
+        ExecutorsUtils.shutdownExecutorService(this.forkExecutor, Optional.of(LOG));
       }
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/WorkUnitManager.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/WorkUnitManager.java
@@ -79,7 +79,7 @@ public class WorkUnitManager extends AbstractIdleService {
       throws Exception {
     LOG.info("Stopping the work unit manager");
     this.workUnitHandler.stop();
-    ExecutorsUtils.shutdownExecutorService(this.executorService);
+    ExecutorsUtils.shutdownExecutorService(this.executorService, Optional.of(LOG));
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalTaskStateTracker.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 import com.google.common.util.concurrent.AbstractIdleService;
 
@@ -83,7 +84,7 @@ public class LocalTaskStateTracker extends AbstractIdleService implements TaskSt
   @Override
   protected void shutDown() throws Exception {
     LOG.info("Stopping the local task state tracker");
-    ExecutorsUtils.shutdownExecutorService(this.reporterExecutor);
+    ExecutorsUtils.shutdownExecutorService(this.reporterExecutor, Optional.of(LOG));
   }
 
   @Override

--- a/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
@@ -270,7 +270,7 @@ public class ParallelRunner implements Closeable {
     } catch (ExecutionException ee) {
       throw new IOException(ee);
     } finally {
-      ExecutorsUtils.shutdownExecutorService(this.executor);
+      ExecutorsUtils.shutdownExecutorService(this.executor, Optional.of(LOGGER));
     }
   }
 }


### PR DESCRIPTION
@liyinan926 can you take a look.

We're adding this because there was a recent Gobblin map task that hung for over 40 hours. ETL-3550 has more info, but long story short, the theory is that not all threads got shut down properly, causing the JVM to hang.

This PR should better help us debug this issue if it occurs again.