### PR TITLE
Fix overflow bug in FileBased partitioning

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -122,10 +122,9 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
         filesToPull.size() / numPartitions : filesToPull.size() / numPartitions + 1;
 
     int workUnitCount = 0;
-    int fileOffset = 0;
 
     // Distribute the files across the workunits
-    for (int i = 0; i < numPartitions; i++) {
+    for (int fileOffset = 0; fileOffset < filesToPull.size(); fileOffset += filesPerPartition) {
       SourceState partitionState = new SourceState();
       partitionState.addAll(state);
 
@@ -148,7 +147,6 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
       Extract extract = partitionState.createExtract(tableType, nameSpaceName, extractTableName);
       workUnits.add(partitionState.createWorkUnit(extract));
       workUnitCount++;
-      fileOffset += filesPerPartition;
     }
 
     log.info("Total number of work units for the current run: " + workUnitCount);


### PR DESCRIPTION
In certain edge case combinations of number of files and partitions, you can run into an issue where the `fileOffset` will exceed the number of `filesToPull` and still attempt to create partitions even though there are no files to add to the partitions. Switched the for loop to loop by `fileOffset` rather than the number of partitions.

Example issue state: 100 partitions, 180 files