### PR TITLE
Adding option to submit additional metadata when stopping a timer event

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/event/TimingEvent.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/event/TimingEvent.java
@@ -12,6 +12,10 @@
 
 package gobblin.metrics.event;
 
+import java.util.Map;
+
+import com.google.common.collect.Maps;
+
 /**
  * Event to time actions in the program. Automatically reports start time, end time, and duration from the time
  * the {@link gobblin.metrics.event.TimingEvent} was created to the time {@link #stop} is called.
@@ -36,16 +40,33 @@ public class TimingEvent {
   }
 
   /**
-   * Stop the timer and submit the event. If timer was already stopped before, this is a no-op.
+   * Stop the timer and submit the event. If the timer was already stopped before, this is a no-op.
    */
   public void stop() {
-    if(this.stopped) {
+    stop(Maps.<String, String> newHashMap());
+  }
+
+  /**
+   * Stop the timer and submit the event, along with the additional metadata specified. If the timer was already stopped
+   * before, this is a no-op.
+   *
+   * @param additionalMetadata a {@link Map} of additional metadata that should be submitted along with this event
+   */
+  public void stop(Map<String, String> additionalMetadata) {
+    if (this.stopped) {
       return;
     }
     this.stopped = true;
     long endTime = System.currentTimeMillis();
     long duration = endTime - this.startTime;
-    this.submitter.submit(this.name, EventSubmitter.EVENT_TYPE, TIMING_EVENT, START_TIME, Long.toString(this.startTime),
-        END_TIME, Long.toString(endTime), DURATION, Long.toString(duration));
+
+    Map<String, String> finalMetadata = Maps.newHashMap();
+    finalMetadata.putAll(additionalMetadata);
+    finalMetadata.put(EventSubmitter.EVENT_TYPE, TIMING_EVENT);
+    finalMetadata.put(START_TIME, Long.toString(this.startTime));
+    finalMetadata.put(END_TIME, Long.toString(endTime));
+    finalMetadata.put(DURATION, Long.toString(duration));
+
+    this.submitter.submit(this.name, finalMetadata);
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.NLineInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -53,6 +54,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Queues;
 import com.google.common.io.Closer;
@@ -208,7 +210,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
       TimingEvent mrJobRunTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.MR_JOB_RUN);
       LOG.info(String.format("Waiting for Hadoop MR job %s to complete", this.job.getJobID()));
       this.job.waitForCompletion(true);
-      mrJobRunTimer.stop();
+      mrJobRunTimer.stop(ImmutableMap.of("hadoopMRJobId", this.job.getJobID().toString()));
 
       if (this.cancellationRequested) {
         // Wait for the cancellation execution if it has been requested


### PR DESCRIPTION
Modified `TimingEvent` and added a new method `stop(Map<String, String> additionalMetadata)` which specifies extra metadata that can be submitted along with the `TimingEvent`. The advantage being that a user may want to emit additional metadata specific to that timing event. I decided to add `additionalMetadata` to the `stop()` method instead of the constructor, because the metadata may not be known until the timing event has completed.

Updated `MRJobLauncher` to record the hadoop job id when it submits a timing event for the length of the MR job.

@ibuenros and @liyinan926 could you review?