### PR TITLE
Enable tasks to publish data

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -204,7 +204,7 @@ public class ConfigurationKeys {
   public static final String WRITER_STAGING_DIR = WRITER_PREFIX + ".staging.dir";
   public static final String WRITER_OUTPUT_DIR = WRITER_PREFIX + ".output.dir";
   // WRITER_FINAL_OUTPUT_PATH is used for internal purposes only to pass the absolute writer path to the publisher
-  public static final String WRITER_FINAL_OUTPUT_PATH = WRITER_PREFIX + ".final.output.path";
+  public static final String WRITER_FINAL_OUTPUT_FILE_PATHS = WRITER_PREFIX + ".final.output.file.paths";
   public static final String WRITER_BUILDER_CLASS = WRITER_PREFIX + ".builder.class";
   public static final String DEFAULT_WRITER_BUILDER_CLASS = "gobblin.writer.AvroDataWriterBuilder";
   public static final String WRITER_FILE_NAME = WRITER_PREFIX + ".file.name";
@@ -286,6 +286,8 @@ public class ConfigurationKeys {
   // This property is used to specify the owner group of the data publisher final output directory
   public static final String DATA_PUBLISHER_FINAL_DIR_GROUP = DATA_PUBLISHER_PREFIX + ".final.dir.group";
   public static final String DATA_PUBLISHER_PERMISSIONS = DATA_PUBLISHER_PREFIX + ".permissions";
+  public static final String PUBLISH_DATA_AT_JOB_LEVEL = "publish.data.at.job.level";
+  public static final boolean DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL = true;
 
   /**
    * Configuration properties used by the extractor.

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -365,6 +365,15 @@ public class State implements Writable {
   }
 
   /**
+   * Remove a property if it exists.
+   *
+   * @param key property key
+   */
+  public void removeProp(String key) {
+    this.properties.remove(key);
+  }
+
+  /**
    * @deprecated Use {@link #getProp(String)}
    */
   @Deprecated

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsTimePartitionedWriter.java
@@ -109,9 +109,9 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
   private final DateTimeFormatter timestampToPathFormatter;
 
   /**
-   * Maps a {@link Path} to the the {@link DataWriter} that is writing data to the Path.
+   * Maps a {@link Path} to the {@link DataWriter} that is writing data to the Path.
    */
-  protected final Map<Path, DataWriter<GenericRecord>> pathToWriterMap = Maps.newHashMap();
+  protected final Map<Path, FsDataWriter<GenericRecord>> pathToWriterMap = Maps.newHashMap();
 
   // Variables needed to build DataWriters
   private final Destination destination;
@@ -203,7 +203,7 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
 
       LOG.info("Creating a new DataWriter for path: " + writerOutputPath);
 
-      DataWriter<GenericRecord> avroHdfsDataWriter = createAvroHdfsDataWriterForPath(writerOutputPath);
+      FsDataWriter<GenericRecord> avroHdfsDataWriter = createAvroHdfsDataWriterForPath(writerOutputPath);
 
       this.pathToWriterMap.put(writerOutputPath, avroHdfsDataWriter);
     }
@@ -216,7 +216,7 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
   @Override
   public void commit() throws IOException {
     boolean commitFailed = false;
-    for (Entry<Path, DataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
+    for (Entry<Path, FsDataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
       try {
         entry.getValue().commit();
       } catch (IOException e) {
@@ -233,7 +233,7 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
   @Override
   public void cleanup() throws IOException {
     boolean cleanupFailed = false;
-    for (Entry<Path, DataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
+    for (Entry<Path, FsDataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
       try {
         entry.getValue().cleanup();
       } catch (IOException e) {
@@ -261,7 +261,7 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
     long bytesWritten = 0;
     boolean getBytesWritten = false;
 
-    for (Entry<Path, DataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
+    for (Entry<Path, FsDataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
       try {
         bytesWritten += entry.getValue().bytesWritten();
       } catch (IOException e) {
@@ -290,8 +290,12 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
 
     // Close all writers
     boolean closeFailed = false;
-    for (Entry<Path, DataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
+    for (Entry<Path, FsDataWriter<GenericRecord>> entry : this.pathToWriterMap.entrySet()) {
       try {
+
+        // Add output path to property writer.final.output.file.paths
+        this.properties.appendToListProp(ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS,
+            entry.getValue().getOutputFilePath());
         entry.getValue().close();
       } catch (IOException e) {
         closeFailed = true;
@@ -312,7 +316,7 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
    * @return a new {@link DataWriter} configured to write to the specified path.
    * @throws IOException if there is an problem creating the new {@link DataWriter}.
    */
-  private DataWriter<GenericRecord> createAvroHdfsDataWriterForPath(Path path) throws IOException {
+  private FsDataWriter<GenericRecord> createAvroHdfsDataWriterForPath(Path path) throws IOException {
 
     // Create a copy of the properties object
     State state = new State();
@@ -323,9 +327,9 @@ public class AvroHdfsTimePartitionedWriter implements DataWriter<GenericRecord> 
     // Set the output path that the DataWriter will write to
     state.setProp(getWriterFilePath(), path.toString());
 
-    return new AvroDataWriterBuilder().writeTo(Destination.of(this.destination.getType(), state))
-        .writeInFormat(this.writerOutputFormat).withWriterId(this.writerId).withSchema(this.schema)
-        .forBranch(this.branch).build();
+    return (FsDataWriter<GenericRecord>) new AvroDataWriterBuilder()
+        .writeTo(Destination.of(this.destination.getType(), state)).writeInFormat(this.writerOutputFormat)
+        .withWriterId(this.writerId).withSchema(this.schema).forBranch(this.branch).build();
   }
 
   /**

--- a/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
@@ -98,7 +98,7 @@ public class SimpleDataWriterTest {
     Assert.assertEquals(writer.recordsWritten(), 3);
     Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length);
 
-    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    String pathKey = ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS;
     Assert.assertTrue(properties.contains(pathKey));
     File outputFile = new File(properties.getProp(pathKey));
     InputStream is = new FileInputStream(outputFile);
@@ -141,7 +141,7 @@ public class SimpleDataWriterTest {
     Assert.assertEquals(writer.recordsWritten(), 3);
     Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length + (Long.SIZE / 8 * 3));
 
-    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    String pathKey = ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS;
     Assert.assertTrue(properties.contains(pathKey));
     File outputFile = new File(properties.getProp(pathKey));
     DataInputStream dis = new DataInputStream(new FileInputStream(outputFile));
@@ -181,7 +181,7 @@ public class SimpleDataWriterTest {
     Assert.assertEquals(writer.recordsWritten(), 3);
     Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length + 3); // 3 bytes for newline character
 
-    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    String pathKey = ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS;
     Assert.assertTrue(properties.contains(pathKey));
     File outputFile = new File(properties.getProp(pathKey));
     InputStream is = new FileInputStream(outputFile);
@@ -224,7 +224,7 @@ public class SimpleDataWriterTest {
     Assert.assertEquals(writer.recordsWritten(), 3);
     Assert.assertEquals(writer.bytesWritten(), rec1.length + rec2.length + rec3.length + (Long.SIZE / 8 * 3) + 3);
 
-    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    String pathKey = ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS;
     Assert.assertTrue(properties.contains(pathKey));
     File outputFile = new File(properties.getProp(pathKey));
     DataInputStream dis = new DataInputStream(new FileInputStream(outputFile));
@@ -265,7 +265,7 @@ public class SimpleDataWriterTest {
     Assert.assertEquals(writer.recordsWritten(), 3);
     Assert.assertEquals(writer.bytesWritten(), totalBytes);
 
-    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    String pathKey = ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS;
     Assert.assertTrue(properties.contains(pathKey));
     File outputFile = new File(properties.getProp(pathKey));
     BufferedReader br = new BufferedReader(new FileReader(outputFile));
@@ -313,7 +313,7 @@ public class SimpleDataWriterTest {
     Assert.assertEquals(writer.recordsWritten(), 1);
     Assert.assertEquals(writer.bytesWritten(), randomBytesWrite.length + 1);
 
-    String pathKey = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_PATH, 0);
+    String pathKey = ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS;
     Assert.assertTrue(properties.contains(pathKey));
     File writeFile = new File(properties.getProp(pathKey));
     int c, i = 0;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -456,7 +456,6 @@ public class Fork implements Closeable, Runnable, FinalState {
    */
   private void commitData() throws IOException {
     if (this.writer.isPresent()) {
-      this.logger.info(String.format("Committing data of fork %d of task %s", this.index, this.taskId));
       // Not to catch the exception this may throw so it gets propagated
       this.writer.get().commit();
     }

--- a/gobblin-runtime/src/test/java/gobblin/test/TestDataPublisher.java
+++ b/gobblin-runtime/src/test/java/gobblin/test/TestDataPublisher.java
@@ -35,24 +35,32 @@ public class TestDataPublisher extends DataPublisher {
   }
 
   @Override
-  public void initialize()
-      throws IOException {
+  public void initialize() throws IOException {
     // Do nothing
   }
 
   @Override
-  public void close()
-      throws IOException {
+  public void close() throws IOException {
     // Do nothing
   }
 
   @Override
-  public void publishData(Collection<? extends WorkUnitState> tasks)
-      throws IOException {
+  public void publishData(Collection<? extends WorkUnitState> tasks) throws IOException {
+    // Do nothing
   }
 
   @Override
-  public void publishMetadata(Collection<? extends WorkUnitState> tasks)
-      throws IOException {
+  public void publishMetadata(Collection<? extends WorkUnitState> tasks) throws IOException {
+    // Do nothing
+  }
+
+  @Override
+  public void publishData(WorkUnitState state) throws IOException {
+    // Do nothing
+  }
+
+  @Override
+  public void publishMetadata(WorkUnitState state) throws IOException {
+    // Do nothing
   }
 }


### PR DESCRIPTION
Summary:

- Data are published by tasks if `job.commit.policy=partial` and `publish.data.in.tasks=true`.
- Added method `DataPublisher.publish(WorkUnitState)` to publish data for a single task.
- Added a flag in `BaseDataPublisher.publishData()` to control whether to publish the data for a single task. When publishing for a single task, it checks the files against `writer.final.output.path` in the `WorkUnitState` to make sure it doesn't publish data written by other tasks.
- In `AvroHdfsTimePartitionedWriter.close()`, it adds all files created by this writer to `writer.final.output.path`.
- `AvroHdfsTimePartitionedWithRecordCountsWriter.close()` will rewrite `writer.final.output.path` upon renaming output file names to include row counts. It also gets the file names from `FsDataWriter` instead of constructing it itself, which is more consistent.
- `Task` publishes data in the `finally` block since it needs to wait till `closer.close()` is called which closes all the forks and data writers.