### PR TITLE
Choose a random rest server port in JobExecutionInfoServerTest

### DIFF
--- a/gobblin-rest-service/gobblin-rest-server/src/test/java/gobblin/rest/JobExecutionInfoServerTest.java
+++ b/gobblin-rest-service/gobblin-rest-server/src/test/java/gobblin/rest/JobExecutionInfoServerTest.java
@@ -81,7 +81,7 @@ public class JobExecutionInfoServerTest {
     Injector injector = Guice.createInjector(new MetaStoreModule(properties));
     this.jobHistoryStore = injector.getInstance(JobHistoryStore.class);
 
-    this.client = new JobExecutionInfoClient(String.format("%s:%s/", "http://localhost", randomPort));
+    this.client = new JobExecutionInfoClient(String.format("http://%s:%s/", "localhost", randomPort));
     this.server = new JobExecutionInfoServer(properties);
     this.server.startUp();
 


### PR DESCRIPTION
The local rest server is set up on port 8080 in JobExecutionInfoServerTest.
With a random port selection one can reduce the possibility of getting a BindException (Address already in use).