### PR TITLE
Fix default timestamp insertion to JobHistoryStore

### DIFF
--- a/gobblin-metastore/src/main/java/gobblin/metastore/DatabaseJobHistoryStore.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/DatabaseJobHistoryStore.java
@@ -22,8 +22,11 @@ import java.text.DateFormat;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.AbstractMap;
+import java.util.Calendar;
 import java.util.List;
 import java.util.Map;
+import java.util.TimeZone;
+
 import javax.sql.DataSource;
 
 import org.slf4j.Logger;
@@ -151,7 +154,7 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
   private static final String TASK_PROPERTY_QUERY_STATEMENT_TEMPLATE =
       "SELECT property_key, property_value FROM gobblin_task_properties WHERE task_id=?";
 
-  private static final String DEFAULT_TIMESTAMP = "1970-01-01 00:00:00";
+  private static final Timestamp DEFAULT_TIMESTAMP = new Timestamp(1000L);
 
   private final DataSource dataSource;
 
@@ -324,9 +327,9 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
     insertStatement.setString(++index, info.getJobName());
     insertStatement.setString(++index, info.getJobId());
     insertStatement.setTimestamp(++index,
-        info.hasStartTime() ? new Timestamp(info.getStartTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasStartTime() ? new Timestamp(info.getStartTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     insertStatement.setTimestamp(++index,
-        info.hasEndTime() ? new Timestamp(info.getEndTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasEndTime() ? new Timestamp(info.getEndTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     insertStatement.setLong(++index, info.hasDuration() ? info.getDuration() : -1);
     insertStatement.setString(++index, info.hasState() ? info.getState().name() : null);
     insertStatement.setInt(++index, info.hasLaunchedTasks() ? info.getLaunchedTasks() : -1);
@@ -343,9 +346,9 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
     PreparedStatement updateStatement = connection.prepareStatement(JOB_EXECUTION_UPDATE_STATEMENT_TEMPLATE);
     int index = 0;
     updateStatement.setTimestamp(++index,
-        info.hasStartTime() ? new Timestamp(info.getStartTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasStartTime() ? new Timestamp(info.getStartTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     updateStatement.setTimestamp(++index,
-        info.hasEndTime() ? new Timestamp(info.getEndTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasEndTime() ? new Timestamp(info.getEndTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     updateStatement.setLong(++index, info.hasDuration() ? info.getDuration() : -1);
     updateStatement.setString(++index, info.hasState() ? info.getState().name() : null);
     updateStatement.setInt(++index, info.hasLaunchedTasks() ? info.getLaunchedTasks() : -1);
@@ -375,9 +378,9 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
     insertStatement.setString(++index, info.getTaskId());
     insertStatement.setString(++index, info.getJobId());
     insertStatement.setTimestamp(++index,
-        info.hasStartTime() ? new Timestamp(info.getStartTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasStartTime() ? new Timestamp(info.getStartTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     insertStatement.setTimestamp(++index,
-        info.hasEndTime() ? new Timestamp(info.getEndTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasEndTime() ? new Timestamp(info.getEndTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     insertStatement.setLong(++index, info.hasDuration() ? info.getDuration() : -1);
     insertStatement.setString(++index, info.hasState() ? info.getState().name() : null);
     insertStatement.setString(++index, info.hasFailureException() ? info.getFailureException() : null);
@@ -398,9 +401,9 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
     PreparedStatement updateStatement = connection.prepareStatement(TASK_EXECUTION_UPDATE_STATEMENT_TEMPLATE);
     int index = 0;
     updateStatement.setTimestamp(++index,
-        info.hasStartTime() ? new Timestamp(info.getStartTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasStartTime() ? new Timestamp(info.getStartTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     updateStatement.setTimestamp(++index,
-        info.hasEndTime() ? new Timestamp(info.getEndTime()) : Timestamp.valueOf(DEFAULT_TIMESTAMP));
+        info.hasEndTime() ? new Timestamp(info.getEndTime()) : DEFAULT_TIMESTAMP, getCalendarUTCInstance());
     updateStatement.setLong(++index, info.hasDuration() ? info.getDuration() : -1);
     updateStatement.setString(++index, info.hasState() ? info.getState().name() : null);
     updateStatement.setString(++index, info.hasFailureException() ? info.getFailureException() : null);
@@ -780,5 +783,9 @@ public class DatabaseJobHistoryStore implements JobHistoryStore {
     }
 
     return sb.toString();
+  }
+  
+  private static Calendar getCalendarUTCInstance() {
+    return Calendar.getInstance(TimeZone.getTimeZone("UTC"));
   }
 }


### PR DESCRIPTION
When a job execution info is inserted into the jobhistory store, first a default timestamp is inserted into the end_time column of the tables. As the job finishes this timestamp is updated to the actual one.
However, the default timestamp is defined as **1970-01-01 00:00:00** which results in the following exception:
```
Failed to write job execution information to the job history store: java.io.IOException: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Incorrect datetime value: '1970-01-01 00:00:00' for column 'end_time' at row 1
java.io.IOException: com.mysql.jdbc.MysqlDataTruncation: Data truncation: Incorrect datetime value: '1970-01-01 00:00:00' for column 'end_time' at row 1
	at gobblin.metastore.DatabaseJobHistoryStore.put(DatabaseJobHistoryStore.java:245)
```
According to http://dev.mysql.com/doc/refman/5.1/en/datetime.html the min value of the timestamp should be **1970-01-01 00:00:01**.
In MySQL 5 and above, TIMESTAMP values are converted from the current timezone to UTC for storage, and converted back from UTC to the current time zone for retrieval.
We need to ensure to insert '1970-01-01 00:00:01' with UTC timzone, othewise the minimum value might violate the MySQL timstamp constraint if we are using a different timezone.
E.g: 1970-01-01 00:00:01 inserted with UTC+4:30 hours would result in 1969-12-31 19:30:01 in UTC.
