### PR TITLE
Defining Sla Event metadata

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -427,6 +427,7 @@ public class ConfigurationKeys {
   public static final String COMPACTION_DEST_SUBDIR = COMPACTION_PREFIX + "dest.subdir";
   public static final String DEFAULT_COMPACTION_DEST_SUBDIR = "daily";
   public static final String COMPACTION_JOB_DEST_DIR = COMPACTION_PREFIX + "job.dest.dir";
+  public static final String COMPACTION_JOB_DEST_PARTITION = COMPACTION_PREFIX + "job.dest.partition";
   public static final String COMPACTION_TMP_DIR = COMPACTION_PREFIX + "tmp.dir";
   public static final String DEFAULT_COMPACTION_TMP_DIR = "/tmp";
   public static final String COMPACTION_JOB_TMP_DIR = COMPACTION_PREFIX + "job.tmp.dir";
@@ -477,6 +478,7 @@ public class ConfigurationKeys {
   public static final String COMPACTION_OVERWRITE_OUTPUT_DIR = COMPACTION_PREFIX + "overwrite.output.dir";
   public static final boolean DEFAULT_COMPACTION_OVERWRITE_OUTPUT_DIR = false;
   public static final String COMPACTION_JARS = COMPACTION_PREFIX + "jars";
+  public static final String COMPACTION_TRACKING_EVENTS_NAMESPACE = COMPACTION_PREFIX + "tracking.events";
 
   /**
    * Common metrics configuration properties.

--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -14,6 +14,8 @@ apply plugin: 'eclipse'
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-utility")
+  compile project(":gobblin-metrics")
+  compile project(":gobblin-core")
   compile externalDependency.avro
   compile externalDependency.commonsLang
   compile externalDependency.hiveExec

--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
@@ -1,0 +1,97 @@
+package gobblin.compaction.event;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.Counters;
+import org.apache.hadoop.mapreduce.Job;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gobblin.compaction.mapreduce.avro.AvroKeyDedupReducer;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.metrics.event.sla.SlaEventKeys;
+
+/**
+ * Helper class to populate sla event metadata in state.
+ */
+public class CompactionSlaEventHelper {
+
+  private static final Logger LOG = LoggerFactory.getLogger(CompactionSlaEventHelper.class);
+
+  public static void populateState(State state , Job job, FileSystem fs) {
+    setDatasetUrn(state);
+    setPartition(state);
+    setDedupeStatus(state);
+    setPreviousPublishTime(state, fs);
+    setRecordCount(state, job);
+    setUpstreamTimeStamp(state, fs);
+  }
+
+  private static void setDatasetUrn(State state) {
+    state.setProp(SlaEventKeys.DATASET_URN_KEY, new Path(state.getProp(ConfigurationKeys.COMPACTION_DEST_DIR),
+        state.getProp(ConfigurationKeys.COMPACTION_TOPIC)).toString());
+  }
+
+  private static void setPartition(State state) {
+    state.setProp(SlaEventKeys.PARTITION_KEY, state.getProp(ConfigurationKeys.COMPACTION_JOB_DEST_PARTITION));
+  }
+
+  private static void setUpstreamTimeStamp(State state, FileSystem fs) {
+
+    String inputDirectory = state.getProp(ConfigurationKeys.COMPACTION_JOB_INPUT_DIR);
+    try {
+      FileStatus fileStatus = fs.getFileStatus(new Path(inputDirectory));
+      state.setProp(SlaEventKeys.UPSTREAM_TS_IN_MILLI_SECS_KEY, Long.toString(fileStatus.getModificationTime()));
+    } catch (IOException e) {
+      LOG.debug("Failed to get upstream time.", e);
+    }
+  }
+
+  private static void setPreviousPublishTime(State state, FileSystem fs) {
+
+    Path compactionCompletePath =
+        new Path(state.getProp(ConfigurationKeys.COMPACTION_JOB_DEST_DIR),
+            ConfigurationKeys.COMPACTION_COMPLETE_FILE_NAME);
+
+    try {
+      FileStatus fileStatus = fs.getFileStatus(compactionCompletePath);
+      state.setProp(SlaEventKeys.PREVIOUS_PUBLISH_TS_IN_MILLI_SECS_KEY, Long.toString(fileStatus.getModificationTime()));
+    } catch (IOException e) {
+      LOG.debug("Failed to get previous publish time.", e);
+    }
+  }
+
+  private static void setDedupeStatus(State state) {
+    if (state.getPropAsBoolean(ConfigurationKeys.COMPACTION_DEDUPLICATE,
+        ConfigurationKeys.DEFAULT_COMPACTION_DEDUPLICATE)) {
+      state.setProp(SlaEventKeys.DEDUPE_STATUS_KEY, DedupeStatus.DEDUPED);
+
+    } else {
+      state.setProp(SlaEventKeys.DEDUPE_STATUS_KEY, DedupeStatus.NOT_DEDUPED);
+    }
+  }
+
+  private static void setRecordCount(State state, Job job) {
+
+    Counters counters = null;
+    try {
+      counters = job.getCounters();
+    } catch (IOException e) {
+      LOG.debug("Failed to get job counters. Record count will not be set. ", e);
+      return;
+    }
+
+    if (counters != null) {
+      Counter recordCounter = counters.findCounter(AvroKeyDedupReducer.EVENT_COUNTER.RECORD_COUNT);
+      if (recordCounter != null) {
+        state.setProp(SlaEventKeys.RECORD_COUNT_KEY, Long.toString(recordCounter.getValue()));
+      }
+    }
+  }
+
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/DedupeStatus.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/DedupeStatus.java
@@ -1,0 +1,6 @@
+package gobblin.compaction.event;
+
+public enum DedupeStatus {
+  DEDUPED,
+  NOT_DEDUPED
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobPropCreator.java
@@ -134,4 +134,13 @@ public class MRCompactorJobPropCreator {
     return jobProps;
   }
 
+  /**
+   * Create MR job properties for a specific input folder ,output folder and partition
+   */
+  protected State createJobProps(Path jobInputDir, Path jobOutputDir, Path jobTmpDir, boolean deduplicate, String partition)
+      throws IOException {
+    State jobProps = createJobProps(jobInputDir, jobOutputDir, jobTmpDir, deduplicate);
+    jobProps.setProp(ConfigurationKeys.COMPACTION_JOB_DEST_PARTITION, partition);
+    return jobProps;
+  }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
@@ -95,7 +95,8 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
       Path jobTmpDir = new Path(this.topicTmpDir, folderTime.toString(this.timeFormatter));
       if (folderWithinAllowedPeriod(status.getPath(), folderTime)) {
         if (!folderAlreadyCompacted(jobOutputDir)) {
-          allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate));
+          allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate,
+              folderTime.toString(this.timeFormatter)));
         } else {
           List<Path> newDataFiles = getNewDataInFolder(status.getPath(), jobOutputDir);
           if (newDataFiles.isEmpty()) {

--- a/gobblin-metrics/build.gradle
+++ b/gobblin-metrics/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   compile externalDependency.metricsCore
   compile externalDependency.metricsGraphite
   compile externalDependency.slf4j
+  compile externalDependency.lombok
   compile(externalDependency.kafka){
     exclude group: "com.sun.jmx", module: "jmxri"
     exclude group: "com.sun.jdmk", module: "jmxtools"
@@ -44,6 +45,7 @@ dependencies {
   compile externalDependency.findBugs
   compile externalDependency.commonsHttpClient
   compile externalDependency.commonsCodec
+  compile externalDependency.commonsLang
 
   testCompile externalDependency.testng
   testCompile externalDependency.mockito

--- a/gobblin-metrics/src/main/java/gobblin/metrics/event/sla/SlaEventKeys.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/event/sla/SlaEventKeys.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.metrics.event.sla;
+
+public class SlaEventKeys {
+
+  static final String EVENT_GOBBLIN_STATE_PREFIX = "event.sla.";
+  public static final String DATASET_URN_KEY = EVENT_GOBBLIN_STATE_PREFIX + "datasetUrn";
+  public static final String PARTITION_KEY = EVENT_GOBBLIN_STATE_PREFIX + "partition";
+  public static final String ORIGIN_TS_IN_MILLI_SECS_KEY = EVENT_GOBBLIN_STATE_PREFIX + "originTimestamp";
+  public static final String UPSTREAM_TS_IN_MILLI_SECS_KEY = EVENT_GOBBLIN_STATE_PREFIX + "upstreamTimestamp";
+
+  public static final String COMPLETENESS_PERCENTAGE_KEY = EVENT_GOBBLIN_STATE_PREFIX + "completenessPercentage";
+  public static final String DEDUPE_STATUS_KEY = EVENT_GOBBLIN_STATE_PREFIX + "dedupeStatus";
+  public static final String RECORD_COUNT_KEY = EVENT_GOBBLIN_STATE_PREFIX + "recordCount";
+  public static final String PREVIOUS_PUBLISH_TS_IN_MILLI_SECS_KEY = EVENT_GOBBLIN_STATE_PREFIX + "previousPublishTs";
+
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/event/sla/SlaEventSubmitter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/event/sla/SlaEventSubmitter.java
@@ -1,0 +1,129 @@
+package gobblin.metrics.event.sla;
+
+import java.util.Map;
+import java.util.Properties;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Singular;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang.StringUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.base.Strings;
+import com.google.common.collect.Maps;
+
+import gobblin.metrics.event.EventSubmitter;
+
+/**
+ * A wrapper around the {@link EventSubmitter} which can submit SLA Events.
+ */
+@Builder
+@Slf4j
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SlaEventSubmitter {
+
+  private EventSubmitter eventSubmitter;
+  private String eventName;
+  private String datasetUrn;
+  private String partition;
+  private String originTimestamp;
+  private String upstreamTimestamp;
+  private String recordCount;
+  private String previousPublishTimestamp;
+  private String dedupeStatus;
+  private String completenessPercentage;
+  @Singular("additionalMetadata") private Map<String, String> additionalMetadata;
+
+  /**
+   * Construct an {@link SlaEventSubmitter} by extracting Sla event metadata from the properties. See
+   * {@link SlaEventKeys} for keys to set in properties
+   *
+   * <p>
+   * Use {@link SlaEventSubmitter#builder()} to build an {@link SlaEventSubmitter} directly with event metadata.
+   * </p>
+   *
+   * @param submitter used to submit the event
+   * @param name of the event
+   * @param props reference that contains event metadata
+   */
+  public SlaEventSubmitter(EventSubmitter submitter, String name , Properties props) {
+
+    this.eventName = name;
+    this.eventSubmitter = submitter;
+    this.datasetUrn = props.getProperty(SlaEventKeys.DATASET_URN_KEY);
+    this.partition = props.getProperty(SlaEventKeys.PARTITION_KEY);
+    this.originTimestamp = props.getProperty(SlaEventKeys.ORIGIN_TS_IN_MILLI_SECS_KEY);
+    this.upstreamTimestamp = props.getProperty(SlaEventKeys.UPSTREAM_TS_IN_MILLI_SECS_KEY);
+    this.completenessPercentage = props.getProperty(SlaEventKeys.COMPLETENESS_PERCENTAGE_KEY);
+    this.recordCount = props.getProperty(SlaEventKeys.RECORD_COUNT_KEY);
+    this.previousPublishTimestamp = props.getProperty(SlaEventKeys.PREVIOUS_PUBLISH_TS_IN_MILLI_SECS_KEY);
+    this.dedupeStatus = props.getProperty(SlaEventKeys.DEDUPE_STATUS_KEY);
+
+  }
+
+  /**
+   * Submit the sla event by calling {@link SlaEventSubmitter#EventSubmitter#submit()}. If
+   * {@link SlaEventSubmitter#eventName}, {@link SlaEventSubmitter#eventSubmitter}, {@link SlaEventSubmitter#datasetUrn}
+   * , {@link SlaEventSubmitter#partition} are not available the method is a no-op.
+   */
+  public void submit() {
+    try {
+
+      Preconditions.checkNotNull(eventSubmitter, "EventSubmitter needs to be set");
+      Preconditions.checkArgument(NOT_NULL_OR_EMPTY_PREDICATE.apply(eventName), "Eventname is required");
+      Preconditions.checkArgument(NOT_NULL_OR_EMPTY_PREDICATE.apply(datasetUrn), "DatasetUrn is required");
+      Preconditions.checkArgument(NOT_NULL_OR_EMPTY_PREDICATE.apply(partition), "Partition is required");
+
+      eventSubmitter.submit(eventName, buildEventMap());
+
+    } catch (IllegalArgumentException e) {
+      log.info("Required arguments to submit an SLA event is not available. No Sla event will be submitted", e.toString());
+    }
+  }
+
+  /**
+   * Builds an EventMetadata {@link Map} from the {@link #SlaEventSubmitter}. The method filters out metadata by
+   * applying {@link #NOT_NULL_OR_EMPTY_PREDICATE}
+   *
+   */
+  private Map<String, String> buildEventMap() {
+
+    Map<String, String> eventMetadataMap = Maps.newHashMap();
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.DATASET_URN_KEY), datasetUrn);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.PARTITION_KEY), partition);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.ORIGIN_TS_IN_MILLI_SECS_KEY), originTimestamp);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.UPSTREAM_TS_IN_MILLI_SECS_KEY), upstreamTimestamp);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.COMPLETENESS_PERCENTAGE_KEY), completenessPercentage);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.RECORD_COUNT_KEY), recordCount);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.PREVIOUS_PUBLISH_TS_IN_MILLI_SECS_KEY), previousPublishTimestamp);
+    eventMetadataMap.put(withoutPropertiesPrefix(SlaEventKeys.DEDUPE_STATUS_KEY), dedupeStatus);
+
+    if (additionalMetadata != null) {
+      eventMetadataMap.putAll(additionalMetadata);
+    }
+    return Maps.newHashMap(Maps.filterValues(eventMetadataMap, NOT_NULL_OR_EMPTY_PREDICATE));
+  }
+
+  /**
+   * {@link SlaEventKeys} have a prefix of {@link SlaEventKeys#EVENT_GOBBLIN_STATE_PREFIX} to keep properties organized
+   * in state. This method removes the prefix before submitting an Sla event.
+   */
+  private String withoutPropertiesPrefix(String key) {
+    return StringUtils.removeStart(key, SlaEventKeys.EVENT_GOBBLIN_STATE_PREFIX);
+  }
+
+  /**
+   * Predicate that returns false if a string is null or empty. Calls {@link Strings#isNullOrEmpty(String)} internally.
+   */
+  private static final Predicate<String> NOT_NULL_OR_EMPTY_PREDICATE = new Predicate<String>() {
+
+    @Override
+    public boolean apply(String input) {
+      return !Strings.isNullOrEmpty(input);
+    }
+  };
+}


### PR DESCRIPTION
@ibuenros @chavdar  can you take a look at this?

Overview
- The change defines metadata required in an SLA event. An SLA event must have datasetUrn, partition, originTs and upstreamTs
- An SLA event can also have additional optional metadata like completenessPercentage, recordCount etc. See SlaEventKeys.java. Optional metadata is not applicable to all ETL flows.
- Any ETL flow can extend the abstract class SlaEvent and implement the getters for datasetUrn, partition, originTs, upstreamTs. The SlaEvent class does not expose the key names for any metadata. This promises a fixed schema for an SlaEvent.
- Next, we want to define and Arvo schema for the sla event. This change will still emit a GobblinTrackingEvent.

Compaction changes
- Enabled metrics/events for MRCompactor job
- emit an SLA event when daily compaction is completed. See CompactionSlaEvent.java