### PR TITLE
Kafka Adapter Performance Enhancement

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,7 @@ ext.externalDependency = [
   "commonsLang": "commons-lang:commons-lang:2.6",
   "commonsConfiguration": "commons-configuration:commons-configuration:1.10",
   "commonsIo": "commons-io:commons-io:2.4",
+  "commonsMath": "org.apache.commons:commons-math3:3.5",
   "commonsHttpClient": "commons-httpclient:commons-httpclient:3.1",
   "datanucleusCore": "org.datanucleus:datanucleus-core:4.1.2",
   "datanucleusRdbms": "org.datanucleus:datanucleus-rdbms:4.1.2",

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -209,10 +209,17 @@ public class WorkUnit extends State {
   }
 
   /**
+   * Set {@link WatermarkInterval} for a {@link WorkUnit}.
+   */
+  public void setWatermarkInterval(WatermarkInterval watermarkInterval) {
+    setProp(ConfigurationKeys.WATERMARK_INTERVAL_VALUE_KEY, watermarkInterval.toJson().toString());
+  }
+
+  /**
    * Set the high watermark of this {@link WorkUnit}.
    *
    * @param highWaterMark high watermark
-   * @deprecated watermarks should be set using the {@link #WorkUnit(SourceState, Extract, WatermarkInterval)} constructor.
+   * @deprecated use {@link #setWatermarkInterval(WatermarkInterval)}.
    */
   @Deprecated
   public void setHighWaterMark(long highWaterMark) {
@@ -234,7 +241,7 @@ public class WorkUnit extends State {
    * Set the low watermark of this {@link WorkUnit}.
    *
    * @param lowWaterMark low watermark
-   * @deprecated watermarks should be set using the {@link #WorkUnit(SourceState, Extract, WatermarkInterval)} constructor.
+   * @deprecated use {@link #setWatermarkInterval(WatermarkInterval)}.
    */
   @Deprecated
   public void setLowWaterMark(long lowWaterMark) {
@@ -260,8 +267,8 @@ public class WorkUnit extends State {
     }
 
     WorkUnit other = (WorkUnit) object;
-    return ((this.extract == null && other.extract == null) ||
-        (this.extract != null && this.extract.equals(other.extract))) && super.equals(other);
+    return ((this.extract == null && other.extract == null)
+        || (this.extract != null && this.extract.equals(other.extract))) && super.equals(other);
   }
 
   @Override

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -17,6 +17,7 @@ dependencies {
 
   compile externalDependency.commonsCodec
   compile externalDependency.commonsDbcp
+  compile externalDependency.commonsMath
   compile externalDependency.commonsHttpClient
   compile externalDependency.avro
   compile externalDependency.guava

--- a/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
@@ -29,7 +29,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -236,9 +235,11 @@ public class BaseDataPublisher extends DataPublisher {
 
   protected void addSingleTaskWriterOutputToExistingDir(Path writerOutputDir, Path publisherOutputDir,
       WorkUnitState workUnitState, int branchId, ParallelRunner parallelRunner) throws IOException {
-    Preconditions.checkArgument(workUnitState.contains(ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS),
-        "Missing property " + ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS
-            + ", which is needed for publishing data of a single task");
+    if (!workUnitState.contains(ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS)) {
+      LOG.warn("Missing property " + ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS
+          + ". This task may have pulled no data.");
+      return;
+    }
 
     Iterable<String> taskOutputFiles = workUnitState.getPropAsList(ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS);
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordSizeBasedWorkUnitSizeEstimator.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordSizeBasedWorkUnitSizeEstimator.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.Maps;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.extract.kafka.KafkaPartition;
+import gobblin.source.extractor.extract.kafka.KafkaUtils;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An implementation of {@link KafkaWorkUnitSizeEstimator} which uses the average record size of each partition to
+ * estimate the sizes of {@link WorkUnits}.
+ *
+ * Each partition pulled in the previous run should have an avg record size in its {@link WorkUnitState}. In the
+ * next run, for each partition the avg record size pulled in the previous run is considered the avg record size
+ * to be pulled in this run.
+ *
+ * If a partition was not pulled in the previous run, a default value of 1024 is used.
+ *
+ * @author ziliu
+ */
+public class KafkaAvgRecordSizeBasedWorkUnitSizeEstimator implements KafkaWorkUnitSizeEstimator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaAvgRecordSizeBasedWorkUnitSizeEstimator.class);
+
+  private static final long DEFAULT_AVG_RECORD_SIZE = 1024;
+
+  private final Map<KafkaPartition, Long> estAvgSizes = Maps.newHashMap();
+
+  KafkaAvgRecordSizeBasedWorkUnitSizeEstimator(SourceState state) {
+    readPreAvgRecordSizes(state);
+  }
+
+  @Override
+  public double calcEstimatedSize(WorkUnit workUnit) {
+    long avgSize = this.getEstAvgSizeForPartition(KafkaUtils.getPartition(workUnit));
+    long numOfRecords = workUnit.getPropAsLong(ConfigurationKeys.WORK_UNIT_HIGH_WATER_MARK_KEY)
+        - workUnit.getPropAsLong(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY);
+    return (double) avgSize * numOfRecords;
+  }
+
+  private long getEstAvgSizeForPartition(KafkaPartition partition) {
+    if (this.estAvgSizes.containsKey(partition)) {
+      LOG.info(String.format("Estimated avg record size for partition %s is %d", partition,
+          this.estAvgSizes.get(partition)));
+      return this.estAvgSizes.get(partition);
+    } else {
+      LOG.warn(String.format("Avg record size for partition %s not available, using default size %d", partition,
+          DEFAULT_AVG_RECORD_SIZE));
+      return DEFAULT_AVG_RECORD_SIZE;
+    }
+  }
+
+  private void readPreAvgRecordSizes(SourceState state) {
+    this.estAvgSizes.clear();
+    for (WorkUnitState workUnitState : state.getPreviousWorkUnitStates()) {
+      List<KafkaPartition> partitions = KafkaUtils.getPartitions(workUnitState);
+      for (KafkaPartition partition : partitions) {
+        if (KafkaUtils.containsPartitionAvgRecordSize(workUnitState, partition)) {
+          long previousAvgSize = KafkaUtils.getPartitionAvgRecordSize(workUnitState, partition);
+          this.estAvgSizes.put(partition, previousAvgSize);
+        }
+      }
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordTimeBasedWorkUnitSizeEstimator.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordTimeBasedWorkUnitSizeEstimator.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.math3.stat.descriptive.moment.GeometricMean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.extract.kafka.KafkaPartition;
+import gobblin.source.extractor.extract.kafka.KafkaUtils;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An implementation of {@link KafkaWorkUnitSizeEstimator} which uses the average time to pull a record in the
+ * previous run to estimate the sizes of {@link WorkUnits}.
+ *
+ * Each partition pulled in the previous run should have an avg time per record in its {@link WorkUnitState}. In the
+ * next run, the estimated avg time per record for each topic is the geometric mean of the avg time per record of all
+ * partitions. For example if a topic has two partitions whose avg time per record in the previous run are 2 and 8,
+ * the next run will use 4 as the estimated avg time per record. The reason to choose geometric mean over algebraic
+ * mean is because large numbers are likely outliers, e.g., a topic may have 5 partitions, and the avg time per record
+ * collected from the previous run could sometimes be [1.1, 1.2, 1.1, 1.3, 100].
+ *
+ * If a topic was not pulled in the previous run, its estimated avg time per record is the geometric mean of the
+ * estimated avg time per record of all topics that were pulled in the previous run. If no topic was pulled in the
+ * previous run, a default value of 1.0 is used.
+ *
+ * @author ziliu
+ */
+public class KafkaAvgRecordTimeBasedWorkUnitSizeEstimator implements KafkaWorkUnitSizeEstimator {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaAvgRecordTimeBasedWorkUnitSizeEstimator.class);
+
+  private static final GeometricMean GEOMETRIC_MEAN = new GeometricMean();
+  private static final double EPS = 0.01;
+
+  private final Map<String, Double> estAvgMillis = Maps.newHashMap();
+  private double avgEstAvgMillis = 0.0;
+
+  KafkaAvgRecordTimeBasedWorkUnitSizeEstimator(SourceState state) {
+    readPrevAvgRecordMillis(state);
+  }
+
+  @Override
+  public double calcEstimatedSize(WorkUnit workUnit) {
+    double avgMillis = this.getEstAvgMillisForTopic(KafkaUtils.getTopicName(workUnit));
+    long numOfRecords = workUnit.getPropAsLong(ConfigurationKeys.WORK_UNIT_HIGH_WATER_MARK_KEY)
+        - workUnit.getPropAsLong(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY);
+    return avgMillis * numOfRecords;
+  }
+
+  /**
+   * Calculate the geometric mean of a {@link List} of double numbers. Numbers smaller than {@link #EPS} will be
+   * treated as {@link #EPS}.
+   */
+  private static double geometricMean(List<Double> numbers) {
+    Preconditions.checkArgument(!numbers.isEmpty());
+
+    double[] numberArray = new double[numbers.size()];
+    for (int i = 0; i < numbers.size(); i++) {
+      numberArray[i] = Math.max(numbers.get(i), EPS);
+    }
+
+    return GEOMETRIC_MEAN.evaluate(numberArray, 0, numberArray.length);
+  }
+
+  private double getEstAvgMillisForTopic(String topic) {
+    if (this.estAvgMillis.containsKey(topic)) {
+      return this.estAvgMillis.get(topic);
+    } else {
+      return this.avgEstAvgMillis;
+    }
+  }
+
+  /**
+   * Get avg time to pull a record in the previous run for all topics, each of which is the geometric mean
+   * of the avg time to pull a record of all partitions of the topic.
+   *
+   * If a topic was not pulled in the previous run (e.g., it's a new topic), it will use the geometric mean
+   * of avg record time of topics that were pulled in the previous run.
+   *
+   * If no topic was pulled in the previous run, 1.0 will be used for all topics.
+   */
+  private void readPrevAvgRecordMillis(SourceState state) {
+    Map<String, List<Double>> prevAvgMillis = Maps.newHashMap();
+
+    for (WorkUnitState workUnitState : state.getPreviousWorkUnitStates()) {
+      List<KafkaPartition> partitions = KafkaUtils.getPartitions(workUnitState);
+      for (KafkaPartition partition : partitions) {
+        if (KafkaUtils.containsPartitionAvgRecordMillis(workUnitState, partition)) {
+          double prevAvgMillisForPartition = KafkaUtils.getPartitionAvgRecordMillis(workUnitState, partition);
+          if (prevAvgMillis.containsKey(partition.getTopicName())) {
+            prevAvgMillis.get(partition.getTopicName()).add(prevAvgMillisForPartition);
+          } else {
+            prevAvgMillis.put(partition.getTopicName(), Lists.newArrayList(prevAvgMillisForPartition));
+          }
+        }
+      }
+    }
+    this.estAvgMillis.clear();
+    if (prevAvgMillis.isEmpty()) {
+      this.avgEstAvgMillis = 1.0;
+    } else {
+      List<Double> allEstAvgMillis = Lists.newArrayList();
+      for (Map.Entry<String, List<Double>> entry : prevAvgMillis.entrySet()) {
+        String topic = entry.getKey();
+        List<Double> prevAvgMillisForPartitions = entry.getValue();
+
+        // If a topic has k partitions, and in the previous run, each partition recorded its avg time to pull
+        // a record, then use the geometric mean of these k numbers as the estimated avg time to pull
+        // a record in this run.
+        double estAvgMillisForTopic = geometricMean(prevAvgMillisForPartitions);
+        this.estAvgMillis.put(topic, estAvgMillisForTopic);
+        LOG.info(String.format("Estimated avg time to pull a record for topic %s is %f milliseconds", topic,
+            estAvgMillisForTopic));
+        allEstAvgMillis.add(estAvgMillisForTopic);
+      }
+
+      // If a topic was not pulled in the previous run, use this.avgEstAvgMillis as the estimated avg time
+      // to pull a record in this run, which is the geometric mean of all topics whose avg times to pull
+      // a record in the previous run are known.
+      this.avgEstAvgMillis = geometricMean(allEstAvgMillis);
+    }
+    LOG.info("For all topics not pulled in the previous run, estimated avg time to pull a record is "
+        + this.avgEstAvgMillis + " milliseconds");
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaBiLevelWorkUnitPacker.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaBiLevelWorkUnitPacker.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+import com.google.common.collect.Lists;
+
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.source.extractor.extract.AbstractSource;
+import gobblin.source.workunit.MultiWorkUnit;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An implementation of {@link KafkaWorkUnitPacker} with two levels of bin packing.
+ *
+ * In the first level, some {@link WorkUnit}s corresponding to partitions
+ * of the same topic are grouped together into a single {@link WorkUnit}. The number of grouped {@link WorkUnit}s
+ * is approximately {@link #WORKUNIT_PRE_GROUPING_SIZE_FACTOR} * number of {@link MultiWorkUnit}s. The value of
+ * {@link #WORKUNIT_PRE_GROUPING_SIZE_FACTOR} should generally be 3.0 or higher, since the worst-fit-decreasing
+ * algorithm (used by the second level) may not achieve a good balance if the number of items
+ * is less than 3 times the number of bins.
+ *
+ * In the second level, these grouped {@link WorkUnit}s are assembled into {@link MultiWorkunit}s
+ * using worst-fit-decreasing.
+ *
+ * Bi-level bin packing has two advantages: (1) reduce the number of small output files since it tends to pack
+ * partitions of the same topic together; (2) reduce the total number of workunits / tasks since multiple partitions
+ * of the same topic are assigned to the same task. A task has a non-trivial cost of initialization, tear down and
+ * task state persistence. However, bi-level bin packing has more mapper skew than single-level bin packing, because
+ * if we pack lots of partitions of the same topic to the same mapper, and we underestimate the avg time per record
+ * for this topic, then this mapper could be much slower than other mappers.
+ *
+ * @author ziliu
+ */
+public class KafkaBiLevelWorkUnitPacker extends KafkaWorkUnitPacker {
+
+  public static final String WORKUNIT_PRE_GROUPING_SIZE_FACTOR = "workunit.pre.grouping.size.factor";
+  public static final double DEFAULT_WORKUNIT_PRE_GROUPING_SIZE_FACTOR = 3.0;
+
+  protected KafkaBiLevelWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
+    super(source, state);
+  }
+
+  @Override
+  public List<WorkUnit> pack(Map<String, List<WorkUnit>> workUnitsByTopic, int numContainers) {
+    double totalEstDataSize = setWorkUnitEstSizes(workUnitsByTopic);
+    double avgGroupSize = totalEstDataSize / (double) numContainers / getPreGroupingSizeFactor(this.state);
+
+    List<MultiWorkUnit> mwuGroups = Lists.newArrayList();
+    for (List<WorkUnit> workUnitsForTopic : workUnitsByTopic.values()) {
+      double estimatedDataSizeForTopic = calcTotalEstSizeForTopic(workUnitsForTopic);
+      if (estimatedDataSizeForTopic < avgGroupSize) {
+
+        // If the total estimated size of a topic is smaller than group size, put all partitions of this
+        // topic in a single group.
+        MultiWorkUnit mwuGroup = new MultiWorkUnit();
+        addWorkUnitsToMultiWorkUnit(workUnitsForTopic, mwuGroup);
+        mwuGroups.add(mwuGroup);
+      } else {
+
+        // Use best-fit-decreasing to group workunits for a topic into multiple groups.
+        mwuGroups.addAll(bestFitDecreasingBinPacking(workUnitsForTopic, avgGroupSize));
+      }
+    }
+
+    List<WorkUnit> groups = squeezeMultiWorkUnits(mwuGroups, state);
+    return worstFitDecreasingBinPacking(groups, numContainers);
+  }
+
+  private static double calcTotalEstSizeForTopic(List<WorkUnit> workUnitsForTopic) {
+    double totalSize = 0;
+    for (WorkUnit w : workUnitsForTopic) {
+      totalSize += getWorkUnitEstSize(w);
+    }
+    return totalSize;
+  }
+
+  private double getPreGroupingSizeFactor(State state) {
+    return state.getPropAsDouble(WORKUNIT_PRE_GROUPING_SIZE_FACTOR, DEFAULT_WORKUNIT_PRE_GROUPING_SIZE_FACTOR);
+  }
+
+  /**
+   * Group {@link WorkUnit}s into groups. Each group is a {@link MultiWorkUnit}. Each group has a capacity of
+   * avgGroupSize. If there's a single {@link WorkUnit} whose size is larger than avgGroupSize, it forms a group itself.
+   */
+  private List<MultiWorkUnit> bestFitDecreasingBinPacking(List<WorkUnit> workUnits, double avgGroupSize) {
+
+    // Sort workunits by data size desc
+    Collections.sort(workUnits, LOAD_DESC_COMPARATOR);
+
+    PriorityQueue<MultiWorkUnit> pQueue = new PriorityQueue<MultiWorkUnit>(workUnits.size(), LOAD_DESC_COMPARATOR);
+    for (WorkUnit workUnit : workUnits) {
+      MultiWorkUnit bestGroup = findAndPopBestFitGroup(workUnit, pQueue, avgGroupSize);
+      if (bestGroup != null) {
+        addWorkUnitToMultiWorkUnit(workUnit, bestGroup);
+      } else {
+        bestGroup = new MultiWorkUnit();
+        addWorkUnitToMultiWorkUnit(workUnit, bestGroup);
+      }
+      pQueue.add(bestGroup);
+    }
+    return Lists.newArrayList(pQueue);
+  }
+
+  /**
+   * Find the best group using the best-fit-decreasing algorithm.
+   * The best group is the fullest group that has enough capacity for the new {@link WorkUnit}.
+   * If no existing group has enough capacity for the new {@link WorkUnit}, return null.
+   */
+  private MultiWorkUnit findAndPopBestFitGroup(WorkUnit workUnit, PriorityQueue<MultiWorkUnit> pQueue,
+      double avgGroupSize) {
+
+    List<MultiWorkUnit> fullWorkUnits = Lists.newArrayList();
+    MultiWorkUnit bestFit = null;
+
+    while (!pQueue.isEmpty()) {
+      MultiWorkUnit candidate = pQueue.poll();
+      if (getWorkUnitEstSize(candidate) + getWorkUnitEstSize(workUnit) <= avgGroupSize) {
+        bestFit = candidate;
+        break;
+      } else {
+        fullWorkUnits.add(candidate);
+      }
+    }
+
+    for (MultiWorkUnit fullWorkUnit : fullWorkUnits) {
+      pQueue.add(fullWorkUnit);
+    }
+
+    return bestFit;
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaSingleLevelWorkUnitPacker.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaSingleLevelWorkUnitPacker.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+import com.google.common.math.DoubleMath;
+
+import gobblin.configuration.SourceState;
+import gobblin.source.extractor.extract.AbstractSource;
+import gobblin.source.workunit.MultiWorkUnit;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An implementation of {@link KafkaWorkUnitPacker} with a single level of bin packing using worst-fit-decreasing.
+ *
+ * Note that for each skipped topic, an empty workunit is created for each partition to preserve its checkpoints.
+ * In single-level bin packing mode, it still assigns all partitions of a skipped topic to the same workunit / task,
+ * so that a single empty task will be created for this topic, instead of one empty task per partition.
+ *
+ * Please refer to the Javadoc of {@link KafkaBiLevelWorkUnitPacker} for a comparison between
+ * {@link KafkaSingleLevelWorkUnitPacker} and {@link KafkaBiLevelWorkUnitPacker}.
+ *
+ * @author ziliu
+ */
+public class KafkaSingleLevelWorkUnitPacker extends KafkaWorkUnitPacker {
+
+  protected KafkaSingleLevelWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
+    super(source, state);
+  }
+
+  @Override
+  public List<WorkUnit> pack(Map<String, List<WorkUnit>> workUnitsByTopic, int numContainers) {
+    setWorkUnitEstSizes(workUnitsByTopic);
+    List<WorkUnit> workUnits = Lists.newArrayList();
+    for (List<WorkUnit> workUnitsForTopic : workUnitsByTopic.values()) {
+
+      // For each topic, merge all empty workunits into a single workunit, so that a single
+      // empty task will be created instead of many.
+      MultiWorkUnit zeroSizeWorkUnit = new MultiWorkUnit();
+      for (WorkUnit workUnit : workUnitsForTopic) {
+        if (DoubleMath.fuzzyEquals(getWorkUnitEstSize(workUnit), 0.0, EPS)) {
+          addWorkUnitToMultiWorkUnit(workUnit, zeroSizeWorkUnit);
+        } else {
+          workUnit.setWatermarkInterval(getWatermarkIntervalFromWorkUnit(workUnit));
+          workUnits.add(workUnit);
+        }
+      }
+      if (!zeroSizeWorkUnit.getWorkUnits().isEmpty()) {
+        workUnits.add(squeezeMultiWorkUnit(zeroSizeWorkUnit, state));
+      }
+    }
+    return worstFitDecreasingBinPacking(workUnits, numContainers);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -1,0 +1,335 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Enums;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import com.google.common.collect.MinMaxPriorityQueue;
+import com.google.common.primitives.Doubles;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.metrics.GobblinMetrics;
+import gobblin.metrics.Tag;
+import gobblin.source.extractor.WatermarkInterval;
+import gobblin.source.extractor.extract.AbstractSource;
+import gobblin.source.extractor.extract.kafka.KafkaPartition;
+import gobblin.source.extractor.extract.kafka.KafkaSource;
+import gobblin.source.extractor.extract.kafka.KafkaUtils;
+import gobblin.source.extractor.extract.kafka.MultiLongWatermark;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.MultiWorkUnit;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An abstract class for packing Kafka {@link WorkUnits} into {@link MultiWorkUnits} based on the number of containers.
+ *
+ * @author ziliu
+ */
+public abstract class KafkaWorkUnitPacker {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaWorkUnitPacker.class);
+
+  public enum PackerType {
+    SINGLE_LEVEL,
+    BI_LEVEL
+  }
+
+  public enum SizeEstimatorType {
+    AVG_RECORD_TIME,
+    AVG_RECORD_SIZE
+  }
+
+  public static final String KAFKA_WORKUNIT_PACKER_TYPE = "kafka.workunit.packer.type";
+  private static final PackerType DEFAULT_PACKER_TYPE = PackerType.SINGLE_LEVEL;
+
+  public static final String KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE = "kafka.workunit.size.estimator.type";
+  private static final SizeEstimatorType DEFAULT_SIZE_ESTIMATOR_TYPE = SizeEstimatorType.AVG_RECORD_TIME;
+
+  protected static final double EPS = 0.01;
+
+  public static final String MIN_MULTIWORKUNIT_LOAD = "min.multiworkunit.load";
+  public static final String MAX_MULTIWORKUNIT_LOAD = "max.multiworkunit.load";
+  private static final String ESTIMATED_WORKUNIT_SIZE = "estimated.workunit.size";
+
+  protected final AbstractSource<?, ?> source;
+  protected final SourceState state;
+  protected final KafkaWorkUnitSizeEstimator sizeEstimator;
+
+  protected KafkaWorkUnitPacker(AbstractSource<?, ?> source, SourceState state) {
+    this.source = source;
+    this.state = state;
+    this.sizeEstimator = getWorkUnitSizeEstimator();
+  }
+
+  protected static final Comparator<WorkUnit> LOAD_ASC_COMPARATOR = new Comparator<WorkUnit>() {
+    @Override
+    public int compare(WorkUnit w1, WorkUnit w2) {
+      return Doubles.compare(getWorkUnitEstLoad(w1), getWorkUnitEstLoad(w2));
+    }
+  };
+
+  protected static final Comparator<WorkUnit> LOAD_DESC_COMPARATOR = new Comparator<WorkUnit>() {
+    @Override
+    public int compare(WorkUnit w1, WorkUnit w2) {
+      return Doubles.compare(getWorkUnitEstLoad(w2), getWorkUnitEstLoad(w1));
+    }
+  };
+
+  protected double setWorkUnitEstSizes(Map<String, List<WorkUnit>> workUnitsByTopic) {
+    double totalEstDataSize = 0;
+    for (List<WorkUnit> workUnitsForTopic : workUnitsByTopic.values()) {
+      for (WorkUnit workUnit : workUnitsForTopic) {
+        setWorkUnitEstSize(workUnit);
+        totalEstDataSize += getWorkUnitEstSize(workUnit);
+      }
+    }
+    return totalEstDataSize;
+  }
+
+  private void setWorkUnitEstSize(WorkUnit workUnit) {
+    workUnit.setProp(ESTIMATED_WORKUNIT_SIZE, this.sizeEstimator.calcEstimatedSize(workUnit));
+  }
+
+  private KafkaWorkUnitSizeEstimator getWorkUnitSizeEstimator() {
+    if (this.state.contains(KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE)) {
+      String sizeEstimatorTypeString = this.state.getProp(KAFKA_WORKUNIT_SIZE_ESTIMATOR_TYPE);
+      Optional<SizeEstimatorType> sizeEstimatorType =
+          Enums.getIfPresent(SizeEstimatorType.class, sizeEstimatorTypeString);
+      if (sizeEstimatorType.isPresent()) {
+        return getWorkUnitSizeEstimator(sizeEstimatorType.get());
+      } else {
+        throw new IllegalArgumentException("WorkUnit size estimator type " + sizeEstimatorType + " not found");
+      }
+    } else {
+      return getWorkUnitSizeEstimator(DEFAULT_SIZE_ESTIMATOR_TYPE);
+    }
+  }
+
+  private KafkaWorkUnitSizeEstimator getWorkUnitSizeEstimator(SizeEstimatorType sizeEstimatorType) {
+    switch (sizeEstimatorType) {
+      case AVG_RECORD_TIME:
+        return new KafkaAvgRecordTimeBasedWorkUnitSizeEstimator(this.state);
+      case AVG_RECORD_SIZE:
+        return new KafkaAvgRecordSizeBasedWorkUnitSizeEstimator(this.state);
+      default:
+        throw new IllegalArgumentException("WorkUnit size estimator type " + sizeEstimatorType + " not found");
+    }
+  }
+
+  private static void setWorkUnitEstSize(WorkUnit workUnit, double estSize) {
+    workUnit.setProp(ESTIMATED_WORKUNIT_SIZE, estSize);
+  }
+
+  protected static double getWorkUnitEstSize(WorkUnit workUnit) {
+    Preconditions.checkArgument(workUnit.contains(ESTIMATED_WORKUNIT_SIZE));
+    return workUnit.getPropAsDouble(ESTIMATED_WORKUNIT_SIZE);
+  }
+
+  protected static double getWorkUnitEstLoad(WorkUnit workUnit) {
+    if (workUnit instanceof MultiWorkUnit) {
+      MultiWorkUnit mwu = (MultiWorkUnit) workUnit;
+      return Math.max(getWorkUnitEstSize(workUnit), EPS) * Math.log10((double) Math.max(mwu.getWorkUnits().size(), 2));
+    } else {
+      return Math.max(getWorkUnitEstSize(workUnit), EPS) * Math.log10(2.0);
+    }
+  }
+
+  protected static void addWorkUnitToMultiWorkUnit(WorkUnit workUnit, MultiWorkUnit multiWorkUnit) {
+    multiWorkUnit.addWorkUnit(workUnit);
+    double size = multiWorkUnit.getPropAsDouble(ESTIMATED_WORKUNIT_SIZE, 0.0);
+    multiWorkUnit.setProp(ESTIMATED_WORKUNIT_SIZE, size + getWorkUnitEstSize(workUnit));
+  }
+
+  protected static void addWorkUnitsToMultiWorkUnit(List<WorkUnit> workUnits, MultiWorkUnit multiWorkUnit) {
+    for (WorkUnit workUnit : workUnits) {
+      addWorkUnitToMultiWorkUnit(workUnit, multiWorkUnit);
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  protected static WatermarkInterval getWatermarkIntervalFromWorkUnit(WorkUnit workUnit) {
+    if (workUnit instanceof MultiWorkUnit) {
+      return getWatermarkIntervalFromMultiWorkUnit((MultiWorkUnit) workUnit);
+    } else {
+      List<Long> lowWatermarkValues = Lists.newArrayList(workUnit.getLowWaterMark());
+      List<Long> expectedHighWatermarkValues = Lists.newArrayList(workUnit.getHighWaterMark());
+      return new WatermarkInterval(new MultiLongWatermark(lowWatermarkValues),
+          new MultiLongWatermark(expectedHighWatermarkValues));
+    }
+  }
+
+  @SuppressWarnings("deprecation")
+  protected static WatermarkInterval getWatermarkIntervalFromMultiWorkUnit(MultiWorkUnit multiWorkUnit) {
+    List<Long> lowWatermarkValues = Lists.newArrayList();
+    List<Long> expectedHighWatermarkValues = Lists.newArrayList();
+    for (WorkUnit workUnit : multiWorkUnit.getWorkUnits()) {
+      lowWatermarkValues.add(workUnit.getLowWaterMark());
+      expectedHighWatermarkValues.add(workUnit.getHighWaterMark());
+    }
+    return new WatermarkInterval(new MultiLongWatermark(lowWatermarkValues),
+        new MultiLongWatermark(expectedHighWatermarkValues));
+  }
+
+  /**
+   * For each input {@link MultiWorkUnit}, combine all {@link WorkUnit}s in it into a single {@link WorkUnit}.
+   */
+  protected List<WorkUnit> squeezeMultiWorkUnits(List<MultiWorkUnit> multiWorkUnits, SourceState state) {
+    List<WorkUnit> workUnits = Lists.newArrayList();
+    for (MultiWorkUnit multiWorkUnit : multiWorkUnits) {
+      workUnits.add(squeezeMultiWorkUnit(multiWorkUnit, state));
+    }
+    return workUnits;
+  }
+
+  /**
+   * Combine all {@link WorkUnit}s in the {@link MultiWorkUnit} into a single {@link WorkUnit}.
+   */
+  protected WorkUnit squeezeMultiWorkUnit(MultiWorkUnit multiWorkUnit, SourceState state) {
+    WatermarkInterval interval = getWatermarkIntervalFromMultiWorkUnit(multiWorkUnit);
+    List<KafkaPartition> partitions = getPartitionsFromMultiWorkUnit(multiWorkUnit);
+    Preconditions.checkArgument(!partitions.isEmpty(), "There must be at least one partition in the multiWorkUnit");
+    Extract extract = this.source.createExtract(KafkaSource.DEFAULT_TABLE_TYPE, KafkaSource.DEFAULT_NAMESPACE_NAME,
+        partitions.get(0).getTopicName());
+    WorkUnit workUnit = WorkUnit.create(extract, interval);
+    populateMultiPartitionWorkUnit(partitions, workUnit);
+    workUnit.setProp(ESTIMATED_WORKUNIT_SIZE, multiWorkUnit.getProp(ESTIMATED_WORKUNIT_SIZE));
+    LOG.info(String.format("Created MultiWorkUnit for partitions %s", partitions));
+    return workUnit;
+  }
+
+  /**
+   * Add a list of partitions of the same topic to a {@link WorkUnit}.
+   */
+  private static void populateMultiPartitionWorkUnit(List<KafkaPartition> partitions, WorkUnit workUnit) {
+    Preconditions.checkArgument(!partitions.isEmpty(), "There should be at least one partition");
+    workUnit.setProp(KafkaSource.TOPIC_NAME, partitions.get(0).getTopicName());
+    GobblinMetrics.addCustomTagToState(workUnit, new Tag<String>("kafkaTopic", partitions.get(0).getTopicName()));
+    workUnit.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, partitions.get(0).getTopicName());
+    for (int i = 0; i < partitions.size(); i++) {
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.PARTITION_ID, i), partitions.get(i).getId());
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.LEADER_ID, i),
+          partitions.get(i).getLeader().getId());
+      workUnit.setProp(KafkaUtils.getPartitionPropName(KafkaSource.LEADER_HOSTANDPORT, i),
+          partitions.get(i).getLeader().getHostAndPort());
+    }
+  }
+
+  private static List<KafkaPartition> getPartitionsFromMultiWorkUnit(MultiWorkUnit multiWorkUnit) {
+    List<KafkaPartition> partitions = Lists.newArrayList();
+
+    for (WorkUnit workUnit : multiWorkUnit.getWorkUnits()) {
+      partitions.add(KafkaUtils.getPartition(workUnit));
+    }
+
+    return partitions;
+  }
+
+  /**
+   * Pack a list of {@link WorkUnit}s into a smaller number of {@link MultiWorkUnit}s,
+   * using the worst-fit-decreasing algorithm.
+   *
+   * Each {@link WorkUnit} is assigned to the {@link MultiWorkUnit} with the smallest load.
+   */
+  protected List<WorkUnit> worstFitDecreasingBinPacking(List<WorkUnit> groups, int numOfMultiWorkUnits) {
+
+    // Sort workunit groups by data size desc
+    Collections.sort(groups, LOAD_DESC_COMPARATOR);
+
+    MinMaxPriorityQueue<MultiWorkUnit> pQueue =
+        MinMaxPriorityQueue.orderedBy(LOAD_ASC_COMPARATOR).expectedSize(numOfMultiWorkUnits).create();
+    for (int i = 0; i < numOfMultiWorkUnits; i++) {
+      MultiWorkUnit multiWorkUnit = new MultiWorkUnit();
+      setWorkUnitEstSize(multiWorkUnit, 0);
+      pQueue.add(multiWorkUnit);
+    }
+
+    for (WorkUnit group : groups) {
+      MultiWorkUnit lightestMultiWorkUnit = pQueue.poll();
+      addWorkUnitToMultiWorkUnit(group, lightestMultiWorkUnit);
+      pQueue.add(lightestMultiWorkUnit);
+    }
+
+    logMultiWorkUnitInfo(pQueue);
+
+    double minLoad = getWorkUnitEstLoad(pQueue.peekFirst());
+    double maxLoad = getWorkUnitEstLoad(pQueue.peekLast());
+    LOG.info(String.format("Min load of multiWorkUnit = %f; Max load of multiWorkUnit = %f; Diff = %f%%", minLoad,
+        maxLoad, (maxLoad - minLoad) / maxLoad * 100.0));
+
+    this.state.setProp(MIN_MULTIWORKUNIT_LOAD, minLoad);
+    this.state.setProp(MAX_MULTIWORKUNIT_LOAD, maxLoad);
+
+    List<WorkUnit> multiWorkUnits = Lists.newArrayList();
+    multiWorkUnits.addAll(pQueue);
+    return multiWorkUnits;
+  }
+
+  private static void logMultiWorkUnitInfo(Iterable<MultiWorkUnit> mwus) {
+    int idx = 0;
+    for (MultiWorkUnit mwu : mwus) {
+      LOG.info(String.format("MultiWorkUnit %d: estimated load=%f, partitions=%s", idx++, getWorkUnitEstLoad(mwu),
+          getMultiWorkUnitPartitions(mwu)));
+    }
+  }
+
+  protected static List<List<KafkaPartition>> getMultiWorkUnitPartitions(MultiWorkUnit mwu) {
+    List<List<KafkaPartition>> partitions = Lists.newArrayList();
+    for (WorkUnit workUnit : mwu.getWorkUnits()) {
+      partitions.add(KafkaUtils.getPartitions(workUnit));
+    }
+    return partitions;
+  }
+
+  public static KafkaWorkUnitPacker getInstance(AbstractSource<?, ?> source, SourceState state) {
+    if (state.contains(KAFKA_WORKUNIT_PACKER_TYPE)) {
+      String packerTypeStr = state.getProp(KAFKA_WORKUNIT_PACKER_TYPE);
+      Optional<PackerType> packerType = Enums.getIfPresent(PackerType.class, packerTypeStr);
+      if (packerType.isPresent()) {
+        return getInstance(packerType.get(), source, state);
+      } else {
+        throw new IllegalArgumentException("WorkUnit packer type " + packerTypeStr + " not found");
+      }
+    } else {
+      return getInstance(DEFAULT_PACKER_TYPE, source, state);
+    }
+  }
+
+  public static KafkaWorkUnitPacker getInstance(PackerType packerType, AbstractSource<?, ?> source, SourceState state) {
+    switch (packerType) {
+      case SINGLE_LEVEL:
+        return new KafkaSingleLevelWorkUnitPacker(source, state);
+      case BI_LEVEL:
+        return new KafkaBiLevelWorkUnitPacker(source, state);
+      default:
+        throw new IllegalArgumentException("WorkUnit packer type " + packerType + " not found");
+    }
+  }
+
+  /**
+   * Group {@link WorkUnit}s into {@link MultiWorkUnit}s. Each input {@link WorkUnit} corresponds to
+   * a (topic, partition).
+   */
+  public abstract List<WorkUnit> pack(Map<String, List<WorkUnit>> workUnitsByTopic, int numContainers);
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitSizeEstimator.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitSizeEstimator.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka.workunit.packer;
+
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * Estimates the size of a Kafka {@link WorkUnit}, which contains one or more partitions of the same topic.
+ *
+ * @author ziliu
+ */
+public interface KafkaWorkUnitSizeEstimator {
+
+  /**
+   * Estimates the size of a Kafka {@link WorkUnit}.
+   */
+  public double calcEstimatedSize(WorkUnit workUnit);
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
@@ -44,8 +44,8 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
 
   public AbstractTaskStateTracker(int coreThreadPoolSize, Logger logger) {
     Preconditions.checkArgument(coreThreadPoolSize > 0, "Thread pool size should be positive");
-    this.taskMetricsUpdaterExecutor = new ScheduledThreadPoolExecutor(
-        coreThreadPoolSize, ExecutorsUtils.newThreadFactory(Optional.of(logger), Optional.of("TaskStateTracker-%d")));
+    this.taskMetricsUpdaterExecutor = new ScheduledThreadPoolExecutor(coreThreadPoolSize,
+        ExecutorsUtils.newThreadFactory(Optional.of(logger), Optional.of("TaskStateTracker-%d")));
     this.logger = logger;
   }
 
@@ -60,14 +60,12 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
   }
 
   @Override
-  protected void startUp()
-      throws Exception {
+  protected void startUp() throws Exception {
     this.logger.info("Starting the task state tracker");
   }
 
   @Override
-  protected void shutDown()
-      throws Exception {
+  protected void shutDown() throws Exception {
     this.logger.info("Stopping the task state tracker");
     ExecutorsUtils.shutdownExecutorService(this.taskMetricsUpdaterExecutor, Optional.of(this.logger));
   }
@@ -80,9 +78,9 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
    * @return a {@link java.util.concurrent.ScheduledFuture} corresponding to the scheduled {@link TaskMetricsUpdater}
    */
   protected ScheduledFuture<?> scheduleTaskMetricsUpdater(Runnable taskMetricsUpdater, Task task) {
-    return this.taskMetricsUpdaterExecutor
-        .scheduleAtFixedRate(taskMetricsUpdater, task.getTaskContext().getStatusReportingInterval(),
-            task.getTaskContext().getStatusReportingInterval(), TimeUnit.MILLISECONDS);
+    return this.taskMetricsUpdaterExecutor.scheduleAtFixedRate(taskMetricsUpdater,
+        task.getTaskContext().getStatusReportingInterval(), task.getTaskContext().getStatusReportingInterval(),
+        TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -102,9 +100,8 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
       // Log record queue stats/metrics of each fork
       for (Optional<Fork> fork : task.getForks()) {
         if (fork.isPresent() && fork.get().queueStats().isPresent()) {
-          logger.info(String.format(
-              "Queue stats of fork %d of task %s: %s", fork.get().getIndex(), this.task.getTaskId(),
-              fork.get().queueStats().get().toString()));
+          logger.debug(String.format("Queue stats of fork %d of task %s: %s", fork.get().getIndex(),
+              this.task.getTaskId(), fork.get().queueStats().get().toString()));
         }
       }
     }


### PR DESCRIPTION
- Now using the avg time to pull a record for mapper load balancing, instead of avg record size. This is more accurate since the time spent on a record is not necessarily proportional to its size. This is done in the following way:
 - Each partition pulled in the previous run has an avg time per record in the workunitstate.
 - In the next run, the estimated avg time per record for each topic is the geometric mean of the avg time per record of all partitions. For example if a topic has two partitions whose avg time per record in the previous run are 2 and 8, the next run will use 4 as the estimated avg time per record. The reason to choose **geometric mean** over algebraic mean is because large numbers are likely outliers, e.g., a topic may have 5 partitions, and the avg time per record collected from the previous run could sometimes be [1.1, 1.2, 1.1, 1.3, 100].
 - If a topic was not pulled in the previous run, its estimated avg time per record is the geometric mean of the estimated avg time per record of all topics that were pulled in the previous run. If no topic was pulled in the previous run, then we use a default value 1.0.

- Previously `KafkaSource` uses a bi-level bin packing approach for assigning workunits to mappers. Now added an option to use single-level bin packing, which is the default option. Bi-level bin packing has two advantages: (1) reduce the number of small output files since it tends to pack partitions of the same topic together; (2) reduce the total number of workunits / tasks since multiple partitions of the same topic are assigned to the same task. A task has a non-trivial cost of initialization, tear down and task state persistence. **However**, bi-level bin packing has more mapper skew than single-level bin packing, because if we pack lots of partitions of the same topic to the same mapper, and we underestimate the avg time per record for this topic, then this mapper could be much slower than other mappers. In my observation, the advantages of single-level bin packing outweigh the disadvantages.
 - Note that for each skipped topic, we create an empty workunit for each partition to preserve its checkpoints. In single-level bin packing mode, we still assign all partitions of a skipped topic to the same workunit / task, so that a single empty task will be created for this topic, instead of one empty task per partition. So single-level bin packing is more like 1.5-level bin packing.

- Modified the way mapper load is calculated: added a new factor of `log(number of tasks assigned to this mapper)`. This is because, as said above, each task is associated with a non-trivial cost. So, running 1000 small tasks in a mapper takes much longer than running 3 big tasks with the same amount of data.

- Previously the existence of topic schemas was verified in the mapper, so if a topic has no schema, we would still create workunits for it as usual, e.g., create 100 huge workunits which occupy 100 mappers, and these mappers ended up doing nothing. Now this is verified in the driver and disqualified topics will be skipped.

- Some other small changes and refactoring, including changing the "Queue stats of fork" log message to debug level since it sometimes floods the mapper log.

Tested on Nertz and this has lead to a significant reduction in the time each run takes.