### PR TITLE
Ignoring FindBugs warning NM_SAME_SIMPLE_NAME_AS_SUPERCLASS

### DIFF
--- a/ligradle/findbugs/findbugsExclude.xml
+++ b/ligradle/findbugs/findbugsExclude.xml
@@ -9,6 +9,8 @@
    <Match>
      <!-- Ignore "UrF: Unread public/protected field (URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD)" since it is mostly false positives  -->
       <Bug code="UrF" />
+     <!-- Ignore "NM_SAME_SIMPLE_NAME_AS_SUPERCLASS: shadows the simple name of the superclass" -->
+     <Bug pattern="NM_SAME_SIMPLE_NAME_AS_SUPERCLASS" />
    </Match>
 </FindBugsFilter>
 


### PR DESCRIPTION
Ignoring FindBugs warning NM_SAME_SIMPLE_NAME_AS_SUPERCLASS given for deprecated limiter classes