### PR TITLE
Fixed a bug that may cause a deadlock reported in issue #340

### DIFF
--- a/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
@@ -57,6 +57,8 @@ public class GobblinMetrics {
 
   public static final String METRICS_STATE_CUSTOM_TAGS = "metrics.state.custom.tags";
 
+  protected static final GobblinMetricsRegistry GOBBLIN_METRICS_REGISTRY = GobblinMetricsRegistry.getInstance();
+
   /**
    * Enumeration of metric types.
    */
@@ -94,7 +96,7 @@ public class GobblinMetrics {
    * @param id the given {@link GobblinMetrics} ID
    * @return a {@link GobblinMetrics} instance
    */
-  public synchronized static GobblinMetrics get(String id) {
+  public static GobblinMetrics get(String id) {
     return get(id, null);
   }
 
@@ -105,7 +107,7 @@ public class GobblinMetrics {
    * @param parentContext the given parent {@link MetricContext}
    * @return a {@link GobblinMetrics} instance
    */
-  public synchronized static GobblinMetrics get(String id, MetricContext parentContext) {
+  public static GobblinMetrics get(String id, MetricContext parentContext) {
     return get(id, parentContext, Lists.<Tag<?>>newArrayList());
   }
 
@@ -118,12 +120,17 @@ public class GobblinMetrics {
    * @param tags the given list of {@link Tag}s
    * @return a {@link GobblinMetrics} instance
    */
-  public synchronized static GobblinMetrics get(String id, MetricContext parentContext, List<Tag<?>> tags) {
-    GobblinMetricsRegistry registry = GobblinMetricsRegistry.getInstance();
-    if (!registry.containsKey(id)) {
-      registry.putIfAbsent(id, new GobblinMetrics(id, parentContext, tags));
-    }
-    return registry.get(id);
+  public static GobblinMetrics get(String id, MetricContext parentContext, List<Tag<?>> tags) {
+    return GOBBLIN_METRICS_REGISTRY.getOrDefault(id, new GobblinMetrics(id, parentContext, tags));
+  }
+
+  /**
+   * Remove the {@link GobblinMetrics} instance associated with the given ID.
+   *
+   * @param id the given {@link GobblinMetrics} ID
+   */
+  public static void remove(String id) {
+    GOBBLIN_METRICS_REGISTRY.remove(id);
   }
 
   /**
@@ -193,15 +200,6 @@ public class GobblinMetrics {
       }
     }
     return tags;
-  }
-
-  /**
-   * Remove the {@link GobblinMetrics} instance with the given ID.
-   *
-   * @param id the given {@link GobblinMetrics} ID
-   */
-  public synchronized static void remove(String id) {
-    GobblinMetricsRegistry.getInstance().remove(id);
   }
 
   protected final String id;

--- a/gobblin-core/src/main/java/gobblin/metrics/GobblinMetricsRegistry.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/GobblinMetricsRegistry.java
@@ -12,6 +12,10 @@
 
 package gobblin.metrics;
 
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.base.Throwables;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -27,33 +31,78 @@ public class GobblinMetricsRegistry {
 
   private static final GobblinMetricsRegistry GLOBAL_INSTANCE = new GobblinMetricsRegistry();
 
-  public static GobblinMetricsRegistry getInstance() {
-    return GLOBAL_INSTANCE;
-  }
-
   private final Cache<String, GobblinMetrics> metricsMap = CacheBuilder.newBuilder().softValues().build();
 
+  private GobblinMetricsRegistry() {
+
+  }
+
+  /**
+   * Associate a {@link GobblinMetrics} instance with a given ID if the ID is
+   * not already associated with a {@link GobblinMetrics} instance.
+   *
+   * @param id the given {@link GobblinMetrics} ID
+   * @param gobblinMetrics the {@link GobblinMetrics} instance to be associated with the given ID
+   * @return the previous {@link GobblinMetrics} instance associated with the ID or {@code null}
+   *         if there's no previous {@link GobblinMetrics} instance associated with the ID
+   */
   public GobblinMetrics putIfAbsent(String id, GobblinMetrics gobblinMetrics) {
     return this.metricsMap.asMap().putIfAbsent(id, gobblinMetrics);
   }
 
-  public boolean containsKey(String id) {
-    return this.metricsMap.asMap().containsKey(id);
-  }
-
+  /**
+   * Get the {@link GobblinMetrics} instance associated with a given ID.
+   *
+   * @param id the given {@link GobblinMetrics} ID
+   * @return the {@link GobblinMetrics} instance associated with the ID or {@code null}
+   *         if no {@link GobblinMetrics} instance for the given ID is found
+   */
   public GobblinMetrics get(String id) {
     return this.metricsMap.getIfPresent(id);
   }
 
   /**
-   * Remove the {@link GobblinMetrics} instance with the given ID.
+   * Get the {@link GobblinMetrics} instance associated with a given ID or the given default
+   * {@link GobblinMetrics} instance if no {@link GobblinMetrics} instance for the given ID
+   * is found.
    *
    * @param id the given {@link GobblinMetrics} ID
-   * @return removed {@link GobblinMetrics} instance or <code>null</code> if no {@link GobblinMetrics}
-   *         instance for the given job is not found
+   * @param defaultValue the default {@link GobblinMetrics} instance
+   * @return the {@link GobblinMetrics} instance associated with a given ID or the given default
+   *         {@link GobblinMetrics} instance if no {@link GobblinMetrics} instance for the given ID
+   *         is found
+   */
+  public GobblinMetrics getOrDefault(String id, final GobblinMetrics defaultValue) {
+    try {
+      return this.metricsMap.get(id, new Callable<GobblinMetrics>() {
+        @Override
+        public GobblinMetrics call() throws Exception {
+          return defaultValue;
+        }
+      });
+    } catch (ExecutionException ee) {
+      throw Throwables.propagate(ee);
+    }
+  }
+
+  /**
+   * Remove the {@link GobblinMetrics} instance with a given ID.
+   *
+   * @param id the given {@link GobblinMetrics} ID
+   * @return removed {@link GobblinMetrics} instance or {@code null} if no
+   *         {@link GobblinMetrics} instance for the given ID is found
    */
   public GobblinMetrics remove(String id) {
     return this.metricsMap.asMap().remove(id);
+  }
+
+  /**
+   * Get an instance of {@link GobblinMetricsRegistry}.
+   *
+   * @return an instance of {@link GobblinMetricsRegistry}
+   */
+  public static GobblinMetricsRegistry getInstance() {
+    return GLOBAL_INSTANCE;
   }
 
 }

--- a/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
@@ -174,14 +174,13 @@ public class MetricContext extends MetricRegistry implements Taggable, Closeable
   }
 
   /**
-   * Add a child {@link MetricContext}.
+   * Add a {@link MetricContext} as a child of this {@link MetricContext} if it is not currently a child.
    *
+   * @param childContextName the name of the child {@link MetricContext}
    * @param childContext the child {@link MetricContext} to add
    */
   public void addChildContext(String childContextName, MetricContext childContext) {
-    if(this.children.asMap().putIfAbsent(childContextName, childContext) != null) {
-      throw new IllegalArgumentException("A child context named " + childContextName + " already exists");
-    }
+    this.children.asMap().putIfAbsent(childContextName, childContext);
   }
 
   /**
@@ -421,7 +420,7 @@ public class MetricContext extends MetricRegistry implements Taggable, Closeable
    *
    * <p>
    *   This method does not support registering {@link com.codahale.metrics.MetricSet}s.
-   *   See{@link #registerAll(com.codahale.metrics.MetricSet}.
+   *   See{@link #registerAll(com.codahale.metrics.MetricSet)}.
    * </p>
    *
    * <p>

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
@@ -22,7 +22,6 @@ import org.apache.hadoop.conf.Configuration;
 import com.google.common.collect.Lists;
 
 import gobblin.metrics.GobblinMetrics;
-import gobblin.metrics.GobblinMetricsRegistry;
 import gobblin.metrics.Tag;
 import gobblin.runtime.JobState;
 import gobblin.runtime.TaskState;
@@ -72,13 +71,8 @@ public class JobMetrics extends GobblinMetrics {
    * @param jobState the given {@link JobState} instance
    * @return a {@link JobMetrics} instance
    */
-  public static synchronized JobMetrics get(JobState jobState) {
-    GobblinMetricsRegistry registry = GobblinMetricsRegistry.getInstance();
-    String name = name(jobState);
-    if (!registry.containsKey(name)) {
-      registry.putIfAbsent(name, new JobMetrics(jobState));
-    }
-    return (JobMetrics) registry.get(name);
+  public static JobMetrics get(JobState jobState) {
+    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new JobMetrics(jobState));
   }
 
   /**
@@ -90,7 +84,7 @@ public class JobMetrics extends GobblinMetrics {
    * </p>
    * @param jobState the given {@link JobState} instance
    */
-  public synchronized static void remove(JobState jobState) {
+  public static void remove(JobState jobState) {
     remove(name(jobState));
     for (TaskState taskState : jobState.getTaskStates()) {
       TaskMetrics.remove(taskState);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
@@ -18,7 +18,6 @@ import com.google.common.collect.Lists;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.GobblinMetrics;
-import gobblin.metrics.GobblinMetricsRegistry;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.Tag;
 import gobblin.runtime.TaskState;
@@ -44,13 +43,8 @@ public class TaskMetrics extends GobblinMetrics {
    * @param taskState the given {@link TaskState} instance
    * @return a {@link TaskMetrics} instance
    */
-  public synchronized static TaskMetrics get(TaskState taskState) {
-    GobblinMetricsRegistry registry = GobblinMetricsRegistry.getInstance();
-    String name = name(taskState);
-    if (!registry.containsKey(name)) {
-      registry.putIfAbsent(name, new TaskMetrics(taskState));
-    }
-    return (TaskMetrics) registry.get(name);
+  public static TaskMetrics get(TaskState taskState) {
+    return (TaskMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(taskState), new TaskMetrics(taskState));
   }
 
   /**
@@ -58,7 +52,7 @@ public class TaskMetrics extends GobblinMetrics {
    *
    * @param taskState the given {@link TaskState} instance
    */
-  public synchronized static void remove(TaskState taskState) {
+  public static void remove(TaskState taskState) {
     remove(name(taskState));
   }
 


### PR DESCRIPTION
The deadlock may happen because:

1. One thread calls `JobMetrics.remove`, which tries to remove itself as well as the `TaskMetrics` of all the tasks from the `GobblinMetricsRegistry` while holding a lock on `JobMetrics.class` since `JobMetrics.remove` is `synchronized`. When it tries to remove a `TaskMetrics` it also needs to acquire the lock on `TaskMetrics.class` since `TaskMetrics.remove` is `synchronized`.
2. Another thread instantiates a `TaskContext`, which calls `TaskMetrics.get` and needs to acquire the lock on `TaskMetrics.class`. In the constructor of `TaskMetrics`, however, the method `parentContextForTask` will call `JobMetrics.get`, which will need to acquire the lock on `JobMetrics.class`.
3. So the first thread needs to acquire both locks in the order of {`JobMetrics.remove`, `TaskMetrics.remove`}, whereas the second thread needs to acquire both locks in the order of {`TaskMetrics.remove`, `JobMetrics.remove`}, resulting in a deadlock.

The fix is to remove all `synchronized` on both `get` and `remove` from both `JobMetrics` and `TaskMetrics` and delegate all synchronization work to `GobblinMetricsRegistry`.

Signed-off-by: Yinan Li <liyinan926@gmail.com>