### PR TITLE
Report events before closing EventReporter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
@@ -366,10 +366,6 @@ public class GobblinMetrics {
       this.jmxReporter.get().stop();
     }
 
-    for (ScheduledReporter reporter : this.scheduledReporters) {
-      reporter.close();
-    }
-
     try {
       this.closer.close();
     } catch (IOException ioe) {
@@ -511,7 +507,7 @@ public class GobblinMetrics {
       try {
         ScheduledReporter reporter = ((CustomReporterFactory) Class.forName(reporterClass)
             .getConstructor().newInstance()).newScheduledReporter(this.metricContext, properties);
-        this.scheduledReporters.add(reporter);
+        this.scheduledReporters.add(this.closer.register(reporter));
       } catch(ClassNotFoundException exception) {
         LOGGER.warn(
             String.format("Failed to create metric reporter: requested CustomReporterFactory %s not found.",

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaEventReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaEventReporter.java
@@ -59,7 +59,10 @@ public class KafkaEventReporter extends EventReporter {
       events.add(this.serializer.serializeRecord(nextEvent));
     }
 
-    this.kafkaPusher.pushMessages(events);
+    if (!events.isEmpty()) {
+      this.kafkaPusher.pushMessages(events);
+    }
+
   }
 
   protected AvroSerializer<GobblinTrackingEvent> createSerializer(SchemaVersionWriter schemaVersionWriter) throws IOException {

--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/EventReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/EventReporter.java
@@ -21,6 +21,8 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
+import javax.annotation.Nullable;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,8 +39,6 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Queues;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.MoreExecutors;
-
-import javax.annotation.Nullable;
 
 import gobblin.metrics.GobblinTrackingEvent;
 import gobblin.metrics.MetricContext;
@@ -165,6 +165,7 @@ public abstract class EventReporter extends ScheduledReporter implements Closeab
   @Override
   public void close() {
     try {
+      this.report();
       this.closer.close();
     } catch(Exception e) {
       LOGGER.warn("Exception when closing KafkaReporter", e);


### PR DESCRIPTION
- Report all the events before closing the reporter
- Removed call to close all reporters in GobblinMetrics as the reporters are already registered with closer.

@ibuenros can you take a look at this?