### PR TITLE
Set Guava to version 15.0 in gobblin-mapreduce.sh

### DIFF
--- a/bin/gobblin-mapreduce.sh
+++ b/bin/gobblin-mapreduce.sh
@@ -100,7 +100,7 @@ set_user_jars "$JARS"
 # Jars Gobblin runtime depends on
 LIBJARS=$USER_JARS$separator$FWDIR_LIB/gobblin-metastore.jar,$FWDIR_LIB/gobblin-metrics.jar,\
 $FWDIR_LIB/gobblin-core.jar,$FWDIR_LIB/gobblin-api.jar,$FWDIR_LIB/gobblin-utility.jar,\
-$FWDIR_LIB/guava-18.0.jar,$FWDIR_LIB/avro-1.7.7.jar,$FWDIR_LIB/metrics-core-3.1.0.jar,\
+$FWDIR_LIB/guava-15.0.jar,$FWDIR_LIB/avro-1.7.7.jar,$FWDIR_LIB/metrics-core-3.1.0.jar,\
 $FWDIR_LIB/gson-2.3.1.jar,$FWDIR_LIB/joda-time-2.8.1.jar,$FWDIR_LIB/data-1.15.9.jar
 
 # Add libraries to the Hadoop classpath


### PR DESCRIPTION
It seems to me that the Guava version was not adjusted in ```gobblin-mapreduce.sh``` when [Pull#280](https://github.com/linkedin/gobblin/pull/280) downgraded the version from 18 to 15.
