### PR TITLE
Fix issue with queueing events in EventReporter.

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/EventReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/EventReporter.java
@@ -108,7 +108,7 @@ public abstract class EventReporter extends ScheduledReporter implements Closeab
     if(this.reportingQueue.size() > QUEUE_CAPACITY * 2 / 3) {
       immediatelyScheduleReport();
     }
-    this.reportingQueue.add(sanitizeEvent(event));
+    this.reportingQueue.offer(sanitizeEvent(event));
   }
 
   /**


### PR DESCRIPTION
queue.add() throws exception even for blocking queues, queue.offer() just blocks.