### PR TITLE
A couple of enhancement to Gobblin on Yarn

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -226,7 +226,7 @@ public class ConfigurationKeys {
   public static final String WRITER_DEFLATE_LEVEL = WRITER_PREFIX + ".deflate.level";
   public static final String WRITER_CODEC_TYPE = WRITER_PREFIX + ".codec.type";
   public static final String WRITER_EAGER_INITIALIZATION_KEY = WRITER_PREFIX + ".eager.initialization";
-  public static final boolean DEFAULT_EAGER_WRITER_INITIALIZATION = false;
+  public static final boolean DEFAULT_WRITER_EAGER_INITIALIZATION = false;
 
   // Deprecated. Use WRITER_PARTITION_COLUMNS
   @Deprecated

--- a/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
@@ -17,7 +17,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.SortedMap;
 import java.util.SortedSet;
 import java.util.UUID;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -144,8 +144,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       Task task = new Task(new TaskContext(workUnitState), stateTracker, taskExecutor, Optional.of(countDownLatch));
       stateTracker.registerNewTask(task);
       tasks.add(task);
-      LOG.info(String.format("Submitting task %s to run", taskId));
-      taskExecutor.submit(task);
+      taskExecutor.execute(task);
     }
 
     new EventSubmitter.Builder(JobMetrics.get(jobId).getMetricContext(), "gobblin.runtime").build()

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -151,8 +151,8 @@ public class Task implements Runnable {
         if (forkedSchemas.get(i)) {
           Fork fork = closer.register(new Fork(this.taskContext, this.taskState,
               schema instanceof Copyable ? ((Copyable) schema).copy() : schema, branches, i, forkCountDownLatch));
-          // Schedule the fork to run
-          this.taskExecutor.submit(fork);
+          // Run the Fork
+          this.taskExecutor.execute(fork);
           this.forks.add(Optional.of(fork));
         } else {
           this.forks.add(Optional.<Fork> absent());

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -99,7 +99,8 @@ public class GobblinApplicationMaster {
 
   private final ServiceManager serviceManager;
 
-  private final EventBus eventBus;
+  // An EventBus used for communications between services running in the ApplicationMaster
+  private final EventBus eventBus = new EventBus(GobblinApplicationMaster.class.getSimpleName());
 
   private final HelixManager helixManager;
 
@@ -110,10 +111,6 @@ public class GobblinApplicationMaster {
   private volatile boolean stopInProgress = false;
 
   public GobblinApplicationMaster(String applicationName, Config config) throws Exception {
-    // An EventBus used for communications between services running in the ApplicationMaster
-    this.eventBus = new EventBus(GobblinApplicationMaster.class.getSimpleName());
-    this.eventBus.register(this);
-
     ContainerId containerId =
         ConverterUtils.toContainerId(System.getenv().get(ApplicationConstants.Environment.CONTAINER_ID.key()));
     ApplicationAttemptId applicationAttemptId = containerId.getApplicationAttemptId();
@@ -174,6 +171,8 @@ public class GobblinApplicationMaster {
 
     // Add a shutdown hook so the task scheduler gets properly shutdown
     addShutdownHook();
+
+    this.eventBus.register(this);
 
     try {
       this.helixManager.connect();

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobScheduler.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobScheduler.java
@@ -47,6 +47,7 @@ public class GobblinHelixJobScheduler extends JobScheduler {
 
   private final Properties properties;
   private final HelixManager helixManager;
+  private final EventBus eventBus;
   private final Path appWorkDir;
 
   public GobblinHelixJobScheduler(Properties properties, HelixManager helixManager, EventBus eventBus,
@@ -54,8 +55,14 @@ public class GobblinHelixJobScheduler extends JobScheduler {
     super(properties);
     this.properties = properties;
     this.helixManager = helixManager;
+    this.eventBus = eventBus;
     this.appWorkDir = appWorkDir;
-    eventBus.register(this);
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    this.eventBus.register(this);
+    super.startUp();
   }
 
   @Override

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
@@ -51,12 +51,13 @@ import gobblin.source.workunit.WorkUnit;
  * {@link gobblin.runtime.Task}.
  *
  * <p>
- *   Upon startup, a {@link GobblinHelixTask} reads the property {@link GobblinYarnConfigurationKeys#WORK_UNIT_FILE_PATH}
- *   for the path of the file storing a serialized {@link WorkUnit} on the {@link FileSystem} of choice and
- *   de-serializes the {@link WorkUnit}. It then creates a Gobblin {@link gobblin.runtime.Task} to run the
- *   {@link WorkUnit} and waits for the Gobblin {@link gobblin.runtime.Task} to finish. Upon completion of the
- *   Gobblin {@link gobblin.runtime.Task}, it persists the {@link TaskState} to a file that will be collected by
- *   the {@link GobblinHelixJobLauncher} later upon completion of the job.
+ *   Upon startup, a {@link GobblinHelixTask} reads the property
+ *   {@link GobblinYarnConfigurationKeys#WORK_UNIT_FILE_PATH} for the path of the file storing a serialized
+ *   {@link WorkUnit} on the {@link FileSystem} of choice and de-serializes the {@link WorkUnit}. It then
+ *   creates a Gobblin {@link gobblin.runtime.Task} to run the {@link WorkUnit} and waits for the Gobblin
+ *   {@link gobblin.runtime.Task} to finish. Upon completion of the Gobblin {@link gobblin.runtime.Task},
+ *   it persists the {@link TaskState} to a file that will be collected by the {@link GobblinHelixJobLauncher}
+ *   later upon completion of the job.
  * </p>
  *
  * @author ynli

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
@@ -102,7 +102,7 @@ public class GobblinWorkUnitRunner {
 
   private final ServiceManager serviceManager;
 
-  private final EventBus eventBus;
+  private final EventBus eventBus = new EventBus(GobblinWorkUnitRunner.class.getSimpleName());
 
   private final TaskStateModelFactory taskStateModelFactory;
 
@@ -129,8 +129,6 @@ public class GobblinWorkUnitRunner {
         InstanceType.PARTICIPANT, zkConnectionString);
 
     Properties properties = YarnHelixUtils.configToProperties(config);
-
-    this.eventBus = new EventBus();
 
     TaskExecutor taskExecutor = new TaskExecutor(properties);
     TaskStateTracker taskStateTracker = new GobblinHelixTaskStateTracker(properties, this.helixManager);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -114,7 +114,7 @@ public class GobblinYarnAppLauncher {
   private final YarnClient yarnClient;
   private final FileSystem fs;
 
-  private final EventBus eventBus = new EventBus();
+  private final EventBus eventBus = new EventBus(GobblinYarnAppLauncher.class.getSimpleName());
 
   private final ScheduledExecutorService applicationStatusMonitor;
   private final long appReportIntervalMinutes;
@@ -159,8 +159,6 @@ public class GobblinYarnAppLauncher {
     }
     this.serviceManager = new ServiceManager(services);
 
-    this.eventBus.register(this);
-
     this.applicationStatusMonitor = Executors.newSingleThreadScheduledExecutor(
         ExecutorsUtils.newThreadFactory(Optional.of(LOGGER), Optional.of("GobblinYarnAppStatusMonitor")));
     this.appReportIntervalMinutes = config.getLong(GobblinYarnConfigurationKeys.APP_REPORT_INTERVAL_MINUTES_KEY);
@@ -175,6 +173,8 @@ public class GobblinYarnAppLauncher {
    * @throws YarnException if there's something wrong launching the application
    */
   public void launch() throws IOException, YarnException {
+    this.eventBus.register(this);
+
     createGobblinYarnHelixCluster();
 
     try {

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnContainerSecurityManager.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnContainerSecurityManager.java
@@ -51,11 +51,12 @@ public class YarnContainerSecurityManager extends AbstractIdleService {
 
   private final FileSystem fs;
   private final Path tokenFilePath;
+  private final EventBus eventBus;
 
   public YarnContainerSecurityManager(Config config, FileSystem fs, EventBus eventBus) {
     this.fs = fs;
     this.tokenFilePath = new Path(config.getString(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH));
-    eventBus.register(this);
+    this.eventBus = eventBus;
   }
 
   @SuppressWarnings("unused")
@@ -70,7 +71,7 @@ public class YarnContainerSecurityManager extends AbstractIdleService {
 
   @Override
   protected void startUp() throws Exception {
-    // Nothing to do
+    this.eventBus.register(this);
   }
 
   @Override

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
@@ -143,9 +143,6 @@ public class YarnService extends AbstractIdleService {
     this.containerJvmArgs = containerJvmArgs;
 
     this.tokens = getSecurityTokens();
-
-    // Register itself with the EventBus for container-related requests
-    this.eventBus.register(this);
   }
 
   @SuppressWarnings("unused")
@@ -186,6 +183,10 @@ public class YarnService extends AbstractIdleService {
   @Override
   protected void startUp() throws Exception {
     LOGGER.info("Starting the YarnService");
+
+    // Register itself with the EventBus for container-related requests
+    this.eventBus.register(this);
+
     this.amrmClientAsync.start();
     this.nmClientAsync.start();
 


### PR DESCRIPTION
1. Moved code that registers with a `EventBus` instance outside the constructors so to prevent objects to be registered from being exposed too early before exiting the constructors.
2. Use `TaskExecutor.execute` instead of `submit` whenever possible as `ExecutorService.submit` will not trigger uncaught exception handler if a task throws an unchecked exception.
3. Other minor code refactoring.