### PR TITLE
Kafka Adapter: Adding support for topic specific configs

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -19,12 +19,17 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
-import org.apache.hadoop.io.Text;
-import org.apache.hadoop.io.Writable;
-
 import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableSortedSet;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonParser;
+
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
 
 
 /**
@@ -37,6 +42,7 @@ public class State implements Writable {
   private String id;
 
   private final Properties properties;
+  private final JsonParser jsonParser = new JsonParser();
 
   public State() {
     this.properties = new Properties();
@@ -362,6 +368,19 @@ public class State implements Writable {
    */
   public boolean getPropAsBoolean(String key, boolean def) {
     return Boolean.parseBoolean(getProperty(key, String.valueOf(def)));
+  }
+
+  /**
+   * Get the value of a property as a {@link JsonArray}.
+   *
+   * @param key property key
+   * @return {@link JsonArray} value associated with the key
+   */
+  public JsonArray getPropAsJsonArray(String key) {
+    JsonElement jsonElement = this.jsonParser.parse(getProp(key));
+    Preconditions.checkArgument(jsonElement.isJsonArray(),
+        "Value for key " + key + " is malformed, it must be a JsonArray: " + jsonElement);
+    return jsonElement.getAsJsonArray();
   }
 
   /**

--- a/gobblin-api/src/main/java/gobblin/configuration/StateUtils.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/StateUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.configuration;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+
+/**
+ * Utility class for dealing with {@link State} objects.
+ */
+public class StateUtils {
+
+  /**
+   * Converts a {@link JsonObject} to a {@link State} object. It does not add any keys specified in the excludeKeys array
+   */
+  public static State jsonObjectToState(JsonObject jsonObject, String... excludeKeys) {
+    State state = new State();
+    List<String> excludeKeysList = excludeKeys == null ? Lists.<String>newArrayList() : Arrays.asList(excludeKeys);
+    for (Map.Entry<String, JsonElement> jsonObjectEntry : jsonObject.entrySet()) {
+      if (!excludeKeysList.contains(jsonObjectEntry.getKey())) {
+        state.setProp(jsonObjectEntry.getKey(), jsonObjectEntry.getValue().getAsString());
+      }
+    }
+    return state;
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/KafkaSourceTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.io.IOException;
+import java.util.Map;
+
+import com.google.common.collect.Lists;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.Extractor;
+
+
+/**
+ * Tests for {@link KafkaSource}
+ */
+@Test(groups = { "gobblin.source.extractor.extract.kafka" })
+public class KafkaSourceTest {
+
+  @Test
+  public void testGetTopicSpecificState() {
+    String topicName1 = "testTopic1";
+    String topicName2 = "testTopic2";
+    String topicName3 = "testTopic3";
+
+    KafkaTopic topic1 = createDummyKafkaTopic(topicName1);
+    KafkaTopic topic2 = createDummyKafkaTopic(topicName2);
+    KafkaTopic topic3 = createDummyKafkaTopic(topicName3);
+
+    String testKey1 = "testKey1";
+    String testValue1 = "testValue1";
+
+    SourceState state = new SourceState();
+    state.setProp(KafkaSource.KAFKA_TOPIC_SPECIFIC_STATE,
+        "[{\"topic.name\" : \"" + topicName1 + "\", \"" + testKey1 + "\" : \"" + testValue1
+            + "\"}, {\"topic.name\" : \"" + topicName2 + "\", \"" + testKey1 + "\" : \"" + testValue1 + "\"}]");
+
+    KafkaSource<?, ?> dummyKafkaSource = new KafkaDummySource();
+    Map<KafkaTopic, State> topicSpecificStateMap =
+        dummyKafkaSource.getTopicSpecificState(Lists.newArrayList(topic1, topic3), state);
+
+    State topic1ExpectedState = new State();
+    topic1ExpectedState.setProp(testKey1, testValue1);
+
+    Assert.assertEquals(topicSpecificStateMap.get(topic1), topic1ExpectedState);
+    Assert.assertNull(topicSpecificStateMap.get(topic2));
+    Assert.assertNull(topicSpecificStateMap.get(topic3));
+  }
+
+  @Test
+  public void testGetTopicSpecificStateWithRegex() {
+    String topicName1 = "testTopic1";
+    String topicName2 = "testTopic2";
+    String topicName3 = "otherTestTopic1";
+
+    KafkaTopic topic1 = createDummyKafkaTopic(topicName1);
+    KafkaTopic topic2 = createDummyKafkaTopic(topicName2);
+    KafkaTopic topic3 = createDummyKafkaTopic(topicName3);
+
+    String testKey1 = "testKey1";
+    String testValue1 = "testValue1";
+
+    SourceState state = new SourceState();
+    state.setProp(KafkaSource.KAFKA_TOPIC_SPECIFIC_STATE,
+        "[{\"topic.name\" : \"testTopic.*\", \"" + testKey1 + "\" : \"" + testValue1
+            + "\"}]");
+
+    KafkaSource<?, ?> dummyKafkaSource = new KafkaDummySource();
+    Map<KafkaTopic, State> topicSpecificStateMap =
+        dummyKafkaSource.getTopicSpecificState(Lists.newArrayList(topic1, topic2, topic3), state);
+
+    State topic1ExpectedState = new State();
+    topic1ExpectedState.setProp(testKey1, testValue1);
+
+    State topic2ExpectedState = new State();
+    topic2ExpectedState.setProp(testKey1, testValue1);
+
+    Assert.assertEquals(topicSpecificStateMap.get(topic1), topic1ExpectedState);
+    Assert.assertEquals(topicSpecificStateMap.get(topic2), topic2ExpectedState);
+    Assert.assertNull(topicSpecificStateMap.get(topic3));
+  }
+
+  private KafkaTopic createDummyKafkaTopic(String topicName) {
+    KafkaPartition partition =
+        new KafkaPartition.Builder()
+            .withTopicName(topicName)
+            .withId(1)
+            .withLeaderHostAndPort("testHost", 1)
+            .withLeaderId(1)
+            .build();
+
+    return new KafkaTopic(topicName, Lists.newArrayList(partition));
+  }
+
+  private static class KafkaDummySource extends KafkaSource {
+
+    @Override
+    public Extractor getExtractor(WorkUnitState state) throws IOException {
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
Adding a feature that allows users to specify configuration key, value pairs on a per topic basis. The approach is to use a config key called `kafka.topic.specific.state` that takes in a JSON array. More information is in the Java Docs.

Still working on finding a way to test the code.

@zliu41 can you review?