### PR TITLE
Set partition folder time as upstreamTime for time based compaction

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
@@ -47,7 +47,10 @@ public class CompactionSlaEventHelper {
     if (job.isPresent()) {
       setRecordCount(state, job.get());
     }
-    setUpstreamTimeStamp(state, fs);
+  }
+
+  public static void setUpstreamTimeStamp(State state, long time) {
+    state.setProp(SlaEventKeys.UPSTREAM_TS_IN_MILLI_SECS_KEY, Long.toString(time));
   }
 
   private static void setDatasetUrn(State state) {
@@ -58,17 +61,6 @@ public class CompactionSlaEventHelper {
 
   private static void setPartition(State state) {
     state.setProp(SlaEventKeys.PARTITION_KEY, state.getProp(MRCompactor.COMPACTION_JOB_DEST_PARTITION));
-  }
-
-  private static void setUpstreamTimeStamp(State state, FileSystem fs) {
-
-    String inputDirectory = state.getProp(MRCompactor.COMPACTION_JOB_INPUT_DIR);
-    try {
-      FileStatus fileStatus = fs.getFileStatus(new Path(inputDirectory));
-      state.setProp(SlaEventKeys.UPSTREAM_TS_IN_MILLI_SECS_KEY, Long.toString(fileStatus.getModificationTime()));
-    } catch (IOException e) {
-      LOG.debug("Failed to get upstream time.", e);
-    }
   }
 
   private static void setPreviousPublishTime(State state, FileSystem fs) {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
@@ -33,6 +33,7 @@ import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 
+import gobblin.compaction.event.CompactionSlaEventHelper;
 import gobblin.configuration.State;
 import gobblin.util.HadoopUtils;
 
@@ -110,8 +111,10 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
       Path jobTmpDir = new Path(this.topicTmpDir, folderTime.toString(this.timeFormatter));
       if (folderWithinAllowedPeriod(status.getPath(), folderTime)) {
         if (!folderAlreadyCompacted(jobOutputDir)) {
-          allJobProps.add(createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate,
-              folderTime.toString(this.timeFormatter)));
+          State state = createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate,
+              folderTime.toString(this.timeFormatter));
+          CompactionSlaEventHelper.setUpstreamTimeStamp(state, folderTime.getMillis());
+          allJobProps.add(state);
         } else {
           List<Path> newDataFiles = getNewDataInFolder(status.getPath(), jobOutputDir);
           if (newDataFiles.isEmpty()) {


### PR DESCRIPTION
@zliu41 can you review this?
As discussed I have set the upstreamTime to midnight of partition date. This will used as date of arrival of data for compaction to compute SLA.