### PR TITLE
Added log aggregation to Gobblin on Yarn

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -112,7 +112,7 @@ ext.externalDependency = [
   "lombok":"org.projectlombok:lombok:1.16.4",
   "mockRunnerJdbc":"com.mockrunner:mockrunner-jdbc:1.0.8",
   "xerces":"xercesImpl:2.11.0",
-  "typesafeConfig": "com.typesafe:config:1.3.0",
+  "typesafeConfig": "com.typesafe:config:1.2.1",
   "byteman": "org.jboss.byteman:byteman:"+bytemanVersion,
   "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:"+bytemanVersion,
   "pegasus" : [

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -11,6 +11,7 @@ gobblin.yarn.lib.jars.dir=<directory where Gobblin on Yarn lib jars are located>
 gobblin.yarn.app.master.files.local=${gobblin.yarn.conf.dir}"/log4j-yarn.properties,"${gobblin.yarn.conf.dir}"/application.conf,"${gobblin.yarn.conf.dir}"/reference.conf"
 gobblin.yarn.container.files.local=${gobblin.yarn.app.master.files.local}
 gobblin.yarn.job.conf.package.path=<path where Gobblin job configuration file package is located>
+gobblin.yarn.logs.sink.root.dir=<root sink directory for aggregated application/container logs stored on the launcher side>
 
 # File system URIs
 writer.fs.uri=${fs.uri}

--- a/gobblin-scheduler/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-scheduler/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -215,7 +215,7 @@ public class JobScheduler extends AbstractIdleService {
       // A job without a cron schedule is considered a one-time job
       jobProps.setProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "true");
       // Submit the job to run
-      this.jobExecutor.submit(new NonScheduledJobRunner(jobProps, jobListener));
+      this.jobExecutor.execute(new NonScheduledJobRunner(jobProps, jobListener));
       return;
     }
 

--- a/gobblin-utility/src/main/java/gobblin/util/logs/LogCopier.java
+++ b/gobblin-utility/src/main/java/gobblin/util/logs/LogCopier.java
@@ -1,0 +1,446 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.logs;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.OutputStreamWriter;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+import com.google.common.io.Closer;
+import com.google.common.io.Files;
+import com.google.common.util.concurrent.AbstractScheduledService;
+
+import gobblin.util.ExecutorsUtils;
+import gobblin.util.FileListUtils;
+
+
+/**
+ * A utility class that periodically reads log files in a source log file directory for changes
+ * since the last reads and appends the changes to destination log files with the same names as
+ * the source log files in a destination log directory. The source and destination log files
+ * can be on different {@link FileSystem}s.
+ *
+ * <p>
+ *   This class extends the {@link AbstractScheduledService} so it can be used with a
+ *   {@link com.google.common.util.concurrent.ServiceManager} that manages the lifecycle of
+ *   a {@link LogCopier}.
+ * </p>
+ *
+ * <p>
+ *   This class is intended to be used in the following pattern:
+ *
+ *   <pre>
+ *     {@code
+ *       LogCopier.Builder logCopierBuilder = LogCopier.newBuilder();
+ *       LogCopier logCopier = logCopierBuilder
+ *           .useSrcFileSystem(FileSystem.getLocal(new Configuration()))
+ *           .useDestFileSystem(FileSystem.get(URI.create(destFsUri), new Configuration()))
+ *           .readFrom(new Path(srcLogDir))
+ *           .writeTo(new Path(destLogDir))
+ *           .useInitialDelay(60)
+ *           .useCopyInterval(60)
+ *           .useTimeUnit(TimeUnit.SECONDS)
+ *           .build();
+ *
+ *       ServiceManager serviceManager = new ServiceManager(Lists.newArrayList(logCopier));
+ *       serviceManager.startAsync();
+ *
+ *       // ...
+ *       serviceManager.stopAsync().awaitStopped(60, TimeUnit.SECONDS);
+ *     }
+ *   </pre>
+ *
+ *   Checkout the Javadoc of {@link LogCopier.Builder} to see the available options for customization.
+ * </p>
+ *
+ * @author ynli
+ */
+public class LogCopier extends AbstractScheduledService {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(LogCopier.class);
+
+  private static final long DEFAULT_SOURCE_LOG_FILE_MONITOR_INTERVAL = 120;
+  private static final long DEFAULT_LOG_COPY_INTERVAL_SECONDS = 60;
+  private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.SECONDS;
+  private static final int DEFAULT_LINES_WRITTEN_BEFORE_FLUSH = 100;
+
+  private final FileSystem srcFs;
+  private final FileSystem destFs;
+  private final Path srcLogDir;
+  private final Path destLogDir;
+
+  private final long sourceLogFileMonitorInterval;
+  private final long copyInterval;
+  private final TimeUnit timeUnit;
+
+  private final Set<String> logFileExtensions;
+
+  private final Optional<Pattern> filterRegexPattern;
+
+  private final Optional<String> logFileNamePrefix;
+
+  private final int linesWrittenBeforeFlush;
+
+  private final ScheduledExecutorService logCopyExecutor;
+
+  // A set of current source log files being copied
+  private final Set<Path> srcLogFiles = Sets.newHashSet();
+
+  // A map from source log file paths to the most recent positions the copier have copied to
+  private final Map<Path, Long> currentPosMap = Maps.newHashMap();
+
+  private LogCopier(Builder builder) {
+    this.srcFs = builder.srcFs;
+    this.destFs = builder.destFs;
+
+    this.srcLogDir = this.srcFs.makeQualified(builder.srcLogDir);
+    this.destLogDir = this.destFs.makeQualified(builder.destLogDir);
+
+    this.sourceLogFileMonitorInterval = builder.sourceLogFileMonitorInterval;
+    this.copyInterval = builder.copyInterval;
+    this.timeUnit = builder.timeUnit;
+
+    this.logFileExtensions = builder.logFileExtensions;
+
+    this.filterRegexPattern = Optional.fromNullable(builder.filterRegexPattern);
+
+    this.logFileNamePrefix = Optional.fromNullable(builder.logFileNamePrefix);
+
+    this.linesWrittenBeforeFlush = builder.linesWrittenBeforeFlush;
+
+    this.logCopyExecutor = Executors.newScheduledThreadPool(0, ExecutorsUtils
+        .newThreadFactory(Optional.of(LOGGER), Optional.of("LogCopyExecutor")));
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    ExecutorsUtils.shutdownExecutorService(this.logCopyExecutor, Optional.of(LOGGER));
+  }
+
+  @Override
+  protected void runOneIteration() throws IOException {
+    checkSrcLogFiles();
+  }
+
+  @Override
+  protected Scheduler scheduler() {
+    return Scheduler.newFixedRateSchedule(0, this.sourceLogFileMonitorInterval, this.timeUnit);
+  }
+
+  /**
+   * Perform a check on new source log files and submit copy tasks for new log files.
+   */
+  private void checkSrcLogFiles() throws IOException {
+    List<FileStatus> srcLogFiles = FileListUtils.listFilesRecursively(this.srcFs, this.srcLogDir, new PathFilter() {
+      @Override
+      public boolean accept(Path path) {
+        return logFileExtensions.contains(Files.getFileExtension(path.getName()));
+      }
+    });
+
+    if (srcLogFiles.isEmpty()) {
+      LOGGER.warn("No log file found under directory " + this.srcLogDir);
+      return;
+    }
+
+    Set<Path> currentSrcLogFiles = Sets.newHashSet();
+    for (FileStatus srcLogFile : srcLogFiles) {
+      currentSrcLogFiles.add(srcLogFile.getPath());
+    }
+
+    Set<Path> newLogFiles = Sets.newHashSet(currentSrcLogFiles);
+    synchronized (this.srcLogFiles) {
+      // Compute the set of new log files since the last check
+      newLogFiles.removeAll(this.srcLogFiles);
+      this.srcLogFiles.addAll(newLogFiles);
+    }
+
+    for (final Path srcLogFile : newLogFiles) {
+      String destLogFileName = this.logFileNamePrefix.isPresent() ?
+          this.logFileNamePrefix.get() + "." + srcLogFile.getName() : srcLogFile.getName();
+      final Path destLogFile = new Path(this.destLogDir, destLogFileName);
+
+      // Submit one copy task per new source log file
+      this.logCopyExecutor.scheduleAtFixedRate(new Runnable() {
+        @Override
+        public void run() {
+          try {
+            LOGGER.debug(String.format("Copying changes from %s to %s", srcLogFile, destLogFile));
+            copyChangesOfLogFile(srcFs.makeQualified(srcLogFile), destFs.makeQualified(destLogFile));
+          } catch (IOException ioe) {
+            LOGGER.error(String.format("Failed while copying logs from %s to %s", srcLogFile, destLogFile), ioe);
+          }
+        }
+      }, 0, this.copyInterval, this.timeUnit);
+    }
+  }
+
+  /**
+   * Copy changes for a single log file.
+   */
+  private void copyChangesOfLogFile(Path srcFile, Path destFile) throws IOException {
+    if (!this.srcFs.exists(srcFile)) {
+      LOGGER.warn("Source log file not found: " + srcFile);
+      return;
+    }
+
+    Closer closer = Closer.create();
+    // We need to use fsDataInputStream in the finally clause so it has to be defined outside try-catch-finally
+    FSDataInputStream fsDataInputStream = null;
+
+    try {
+      fsDataInputStream = closer.register(this.srcFs.open(srcFile));
+      synchronized (this.currentPosMap) {
+        // Seek to the the most recent position if it is available
+        if (this.currentPosMap.containsKey(srcFile)) {
+          long previousPos = this.currentPosMap.get(srcFile);
+          LOGGER.debug(String.format("Reading log file %s from position %d", srcFile, previousPos));
+          fsDataInputStream.seek(previousPos);
+        }
+      }
+      BufferedReader srcLogFileReader = closer.register(new BufferedReader(new InputStreamReader(fsDataInputStream)));
+
+      FSDataOutputStream outputStream = this.destFs.exists(destFile) ?
+          this.destFs.append(destFile) : this.destFs.create(destFile);
+      BufferedWriter destLogFileWriter = closer.register(new BufferedWriter(new OutputStreamWriter(outputStream)));
+
+      String line;
+      int linesProcessed = 0;
+      while (!Thread.currentThread().isInterrupted() && (line = srcLogFileReader.readLine()) != null) {
+        if (this.filterRegexPattern.isPresent() && !this.filterRegexPattern.get().matcher(line).matches()) {
+          continue;
+        }
+
+        destLogFileWriter.write(line);
+        destLogFileWriter.newLine();
+        linesProcessed++;
+        if (linesProcessed % this.linesWrittenBeforeFlush == 0) {
+          destLogFileWriter.flush();
+        }
+      }
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      try {
+        closer.close();
+      } finally {
+        if (fsDataInputStream != null) {
+          synchronized (this.currentPosMap) {
+            // Remember the current input log file position
+            this.currentPosMap.put(srcFile, fsDataInputStream.getPos());
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Get a new {@link LogCopier.Builder} instance for building a {@link LogCopier}.
+   *
+   * @return a new {@link LogCopier.Builder} instance
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * A builder class for {@link LogCopier}.
+   */
+  public static class Builder {
+
+    private FileSystem srcFs;
+    private Path srcLogDir;
+    private FileSystem destFs;
+    private Path destLogDir;
+
+    private long sourceLogFileMonitorInterval = DEFAULT_SOURCE_LOG_FILE_MONITOR_INTERVAL;
+    private long copyInterval = DEFAULT_LOG_COPY_INTERVAL_SECONDS;
+    private TimeUnit timeUnit = DEFAULT_TIME_UNIT;
+
+    private Set<String> logFileExtensions;
+
+    private Pattern filterRegexPattern;
+
+    private String logFileNamePrefix;
+
+    private int linesWrittenBeforeFlush = DEFAULT_LINES_WRITTEN_BEFORE_FLUSH;
+
+    /**
+     * Set the interval between two checks for the source log file monitor.
+     *
+     * @param sourceLogFileMonitorInterval the interval between two checks for the source log file monitor
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useSourceLogFileMonitorInterval(long sourceLogFileMonitorInterval) {
+      Preconditions.checkArgument(sourceLogFileMonitorInterval > 0,
+          "Source log file monitor interval must be positive");
+      this.sourceLogFileMonitorInterval = sourceLogFileMonitorInterval;
+      return this;
+    }
+
+    /**
+     * Set the copy interval between two iterations of copies.
+     *
+     * @param copyInterval the copy interval between two iterations of copies
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useCopyInterval(long copyInterval) {
+      Preconditions.checkArgument(copyInterval > 0, "Copy interval must be positive");
+      this.copyInterval = copyInterval;
+      return this;
+    }
+
+    /**
+     * Set the {@link TimeUnit} used for the source log file monitor interval, initial delay, copy interval.
+     *
+     * @param timeUnit the {@link TimeUnit} used for the initial delay and copy interval
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useTimeUnit(TimeUnit timeUnit) {
+      Preconditions.checkNotNull(timeUnit);
+      this.timeUnit = timeUnit;
+      return this;
+    }
+
+    /**
+     * Set the set of acceptable log file extensions.
+     *
+     * @param logFileExtensions the set of acceptable log file extensions
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder acceptsLogFileExtensions(Set<String> logFileExtensions) {
+      Preconditions.checkNotNull(logFileExtensions);
+      this.logFileExtensions = ImmutableSet.copyOf(logFileExtensions);
+      return this;
+    }
+
+    /**
+     * Set the log filter regex pattern used to filter logs.
+     *
+     * @param regex the log filter regex pattern used to filter logs
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useFilterRegexPattern(String regex) {
+      Preconditions.checkNotNull(regex);
+      this.filterRegexPattern = Pattern.compile(regex);
+      return this;
+    }
+
+    /**
+     * Set the source {@link FileSystem} for reading the source log file.
+     *
+     * @param srcFs the source {@link FileSystem} for reading the source log file
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useSrcFileSystem(FileSystem srcFs) {
+      Preconditions.checkNotNull(srcFs);
+      this.srcFs = srcFs;
+      return this;
+    }
+
+    /**
+     * Set the destination {@link FileSystem} for writing the destination log file.
+     *
+     * @param destFs the destination {@link FileSystem} for writing the destination log file
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useDestFileSystem(FileSystem destFs) {
+      Preconditions.checkNotNull(destFs);
+      this.destFs = destFs;
+      return this;
+    }
+
+    /**
+     * Set the path of the source log file directory to read from.
+     *
+     * @param srcLogDir the path of the source log file directory to read from
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder readFrom(Path srcLogDir) {
+      Preconditions.checkNotNull(srcLogDir);
+      this.srcLogDir = srcLogDir;
+      return this;
+    }
+
+    /**
+     * Set the path of the destination log file directory to write to.
+     *
+     * @param destLogDir the path of the destination log file directory to write to
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder writeTo(Path destLogDir) {
+      Preconditions.checkNotNull(destLogDir);
+      this.destLogDir = destLogDir;
+      return this;
+    }
+
+    /**
+     * Set the log file name prefix at the destination.
+     *
+     * @param logFileNamePrefix the log file name prefix at the destination
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useLogFileNamePrefix(String logFileNamePrefix) {
+      Preconditions.checkArgument(!Strings.isNullOrEmpty(logFileNamePrefix),
+          "Invalid log file name prefix: " + logFileNamePrefix);
+      this.logFileNamePrefix = logFileNamePrefix;
+      return this;
+    }
+
+    /**
+     * Set the number of lines written before they are flushed to disk.
+     *
+     * @param linesWrittenBeforeFlush the number of lines written before they are flushed to disk
+     * @return this {@link LogCopier.Builder} instance
+     */
+    public Builder useLinesWrittenBeforeFlush(int linesWrittenBeforeFlush) {
+      Preconditions.checkArgument(linesWrittenBeforeFlush > 0,
+          "The value specifying the lines to write before flush must be positive");
+      this.linesWrittenBeforeFlush = linesWrittenBeforeFlush;
+      return this;
+    }
+
+    /**
+     * Build a new {@link LogCopier} instance.
+     *
+     * @return a new {@link LogCopier} instance
+     */
+    public LogCopier build() {
+      return new LogCopier(this);
+    }
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -93,14 +93,14 @@ import gobblin.yarn.event.DelegationTokenUpdatedEvent;
  *
  * @author ynli
  */
-public class GobblinApplicationMaster {
+public class GobblinApplicationMaster extends GobblinYarnLogSource {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GobblinApplicationMaster.class);
 
-  private final ServiceManager serviceManager;
-
   // An EventBus used for communications between services running in the ApplicationMaster
   private final EventBus eventBus = new EventBus(GobblinApplicationMaster.class.getSimpleName());
+
+  private final ServiceManager serviceManager;
 
   private final HelixManager helixManager;
 
@@ -143,6 +143,7 @@ public class GobblinApplicationMaster {
     services.add(new JobConfigurationManager(this.eventBus,
         config.hasPath(GobblinYarnConfigurationKeys.JOB_CONF_PACKAGE_PATH_KEY) ? Optional
             .of(config.getString(GobblinYarnConfigurationKeys.JOB_CONF_PACKAGE_PATH_KEY)) : Optional.<String>absent()));
+    services.add(buildLogCopier(containerId, fs, appWorkDir));
 
     this.serviceManager = new ServiceManager(services);
 

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobScheduler.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobScheduler.java
@@ -100,10 +100,11 @@ public class GobblinHelixJobScheduler extends JobScheduler {
         LOGGER.info("Scheduling new job " + newJobArrival.getJobName());
         scheduleJob(newJobArrival.getJobConfig(), null);
       } else {
-        this.jobExecutor.submit(new NonScheduledJobRunner(jobConfig, null));
+        LOGGER.info("No job schedule found, so running new job " + newJobArrival.getJobName());
+        this.jobExecutor.execute(new NonScheduledJobRunner(jobConfig, null));
       }
     } catch (JobException je) {
-      LOGGER.error("Failed to schedule job " + newJobArrival.getJobName());
+      LOGGER.error("Failed to schedule or run job " + newJobArrival.getJobName());
     }
   }
 

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
@@ -137,7 +137,7 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
     TaskStateTracker taskStateTracker = new GobblinHelixTaskStateTracker(properties, this.helixManager);
 
     List<Service> services = Lists.newArrayList();
-    if (config.hasPath(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH)) {
+    if (config.hasPath(GobblinYarnConfigurationKeys.KEYTAB_FILE_PATH)) {
       LOGGER.info("Adding YarnContainerSecurityManager since login is keytab based");
       services.add(new YarnContainerSecurityManager(config, fs, this.eventBus));
     }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -205,7 +205,7 @@ public class GobblinYarnAppLauncher {
     }, 0, this.appReportIntervalMinutes, TimeUnit.MINUTES);
 
     List<Service> services = Lists.newArrayList();
-    if (config.hasPath(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH)) {
+    if (config.hasPath(GobblinYarnConfigurationKeys.KEYTAB_FILE_PATH)) {
       LOGGER.info("Adding YarnAppSecurityManager since login is keytab based");
       services.add(new YarnAppSecurityManager(config, this.helixManager, this.fs));
     }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -22,11 +22,13 @@ import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.RawLocalFileSystem;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
@@ -66,6 +68,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
@@ -80,6 +83,7 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.util.ExecutorsUtils;
+import gobblin.util.logs.LogCopier;
 import gobblin.yarn.event.ApplicationReportArrivalEvent;
 
 
@@ -108,8 +112,6 @@ public class GobblinYarnAppLauncher {
 
   private final HelixManager helixManager;
 
-  private final ServiceManager serviceManager;
-
   private final Configuration yarnConfiguration;
   private final YarnClient yarnClient;
   private final FileSystem fs;
@@ -121,8 +123,14 @@ public class GobblinYarnAppLauncher {
 
   private final String appMasterJvmArgs;
 
+  private final Path sinkLogRootDir;
+
+  private final Closer fsCloser = Closer.create();
+
   // Yarn application ID
   private volatile Optional<ApplicationId> applicationId = Optional.absent();
+
+  private volatile Optional<ServiceManager> serviceManager = Optional.absent();
 
   // This flag tells if the Yarn application has already completed. This is used to
   // tell if it is necessary to send a shutdown message to the ApplicationMaster.
@@ -151,19 +159,15 @@ public class GobblinYarnAppLauncher {
     this.fs = config.hasPath(ConfigurationKeys.FS_URI_KEY) ?
         FileSystem.get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), this.yarnConfiguration) :
         FileSystem.get(this.yarnConfiguration);
-
-    List<Service> services = Lists.newArrayList();
-    if (config.hasPath(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH)) {
-      LOGGER.info("Adding YarnAppSecurityManager since login is keytab based");
-      services.add(new YarnAppSecurityManager(config, this.helixManager, this.fs));
-    }
-    this.serviceManager = new ServiceManager(services);
+    this.fsCloser.register(this.fs);
 
     this.applicationStatusMonitor = Executors.newSingleThreadScheduledExecutor(
         ExecutorsUtils.newThreadFactory(Optional.of(LOGGER), Optional.of("GobblinYarnAppStatusMonitor")));
     this.appReportIntervalMinutes = config.getLong(GobblinYarnConfigurationKeys.APP_REPORT_INTERVAL_MINUTES_KEY);
 
     this.appMasterJvmArgs = Strings.nullToEmpty(config.getString(GobblinYarnConfigurationKeys.APP_MASTER_JVM_ARGS_KEY));
+
+    this.sinkLogRootDir = new Path(config.getString(GobblinYarnConfigurationKeys.LOGS_SINK_ROOT_DIR_KEY));
   }
 
   /**
@@ -184,9 +188,6 @@ public class GobblinYarnAppLauncher {
       throw Throwables.propagate(e);
     }
 
-    // Start all the services running in the ApplicationMaster
-    this.serviceManager.startAsync();
-
     this.yarnClient.start();
     this.applicationId = Optional.of(setupAndSubmitApplication());
 
@@ -202,6 +203,19 @@ public class GobblinYarnAppLauncher {
         }
       }
     }, 0, this.appReportIntervalMinutes, TimeUnit.MINUTES);
+
+    List<Service> services = Lists.newArrayList();
+    if (config.hasPath(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH)) {
+      LOGGER.info("Adding YarnAppSecurityManager since login is keytab based");
+      services.add(new YarnAppSecurityManager(config, this.helixManager, this.fs));
+    }
+    services.add(buildLogCopier(
+        new Path(this.sinkLogRootDir, this.applicationName + Path.SEPARATOR + this.applicationId.get().toString()),
+        YarnHelixUtils.getAppWorkDirPath(this.fs, this.applicationName, this.applicationId.get())));
+
+    this.serviceManager = Optional.of(new ServiceManager(services));
+    // Start all the services running in the ApplicationMaster
+    this.serviceManager.get().startAsync();
   }
 
   /**
@@ -209,7 +223,7 @@ public class GobblinYarnAppLauncher {
    *
    * @throws IOException if this {@link GobblinYarnAppLauncher} instance fails to clean up its working directory.
    */
-  public synchronized void stop() throws IOException {
+  public synchronized void stop() throws IOException, TimeoutException {
     if (this.stopped) {
       return;
     }
@@ -220,6 +234,10 @@ public class GobblinYarnAppLauncher {
       if (this.applicationId.isPresent() && !this.applicationCompleted) {
         // Only send the shutdown message if the application has been successfully submitted and is still running
         sendShutdownRequest();
+      }
+
+      if (this.serviceManager.isPresent()) {
+        this.serviceManager.get().stopAsync().awaitStopped(5, TimeUnit.MINUTES);
       }
 
       ExecutorsUtils.shutdownExecutorService(this.applicationStatusMonitor, Optional.of(LOGGER), 5, TimeUnit.MINUTES);
@@ -235,7 +253,7 @@ public class GobblinYarnAppLauncher {
           cleanUpAppWorkDirectory(this.applicationId.get());
         }
       } finally {
-        this.fs.close();
+        this.fsCloser.close();
       }
     }
 
@@ -267,6 +285,8 @@ public class GobblinYarnAppLauncher {
         GobblinYarnAppLauncher.this.stop();
       } catch (IOException ioe) {
         LOGGER.error("Failed to close the " + GobblinYarnAppLauncher.class.getSimpleName(), ioe);
+      } catch (TimeoutException te) {
+        LOGGER.error("Timeout in stopping the service manager", te);
       }
     }
   }
@@ -511,6 +531,28 @@ public class GobblinYarnAppLauncher {
     }
   }
 
+  private LogCopier buildLogCopier(Path sinkLogDir, Path appWorkDir) throws IOException {
+    FileSystem rawLocalFs = this.fsCloser.register(new RawLocalFileSystem());
+    rawLocalFs.initialize(URI.create(ConfigurationKeys.LOCAL_FS_URI), new Configuration());
+
+    return LogCopier.newBuilder()
+        .useSrcFileSystem(this.fs)
+        .useDestFileSystem(rawLocalFs)
+        .readFrom(getHdfsLogDir(appWorkDir))
+        .writeTo(sinkLogDir)
+        .acceptsLogFileExtensions(ImmutableSet.of(ApplicationConstants.STDOUT, ApplicationConstants.STDERR))
+        .build();
+  }
+
+  private Path getHdfsLogDir(Path appWorkDir) throws IOException {
+    Path logRootDir = new Path(appWorkDir, GobblinYarnConfigurationKeys.APP_LOGS_DIR_NAME);
+    if (!this.fs.exists(logRootDir)) {
+      this.fs.mkdirs(logRootDir);
+    }
+
+    return logRootDir;
+  }
+
   private void sendShutdownRequest() {
     Criteria criteria = new Criteria();
     criteria.setInstanceName("%");
@@ -550,6 +592,8 @@ public class GobblinYarnAppLauncher {
           gobblinYarnAppLauncher.stop();
         } catch (IOException ioe) {
           LOGGER.error("Failed to shutdown the " + GobblinYarnAppLauncher.class.getSimpleName(), ioe);
+        } catch (TimeoutException te) {
+          LOGGER.error("Timeout in stopping the service manager", te);
         }
       }
     });

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -337,7 +337,7 @@ public class GobblinYarnAppLauncher {
 
     ContainerLaunchContext amContainerLaunchContext = Records.newRecord(ContainerLaunchContext.class);
     amContainerLaunchContext.setLocalResources(appMasterLocalResources);
-    amContainerLaunchContext.setEnvironment(YarnHelixUtils.getEnvironmentVariables(this.yarnConfiguration, this.config));
+    amContainerLaunchContext.setEnvironment(YarnHelixUtils.getEnvironmentVariables(this.yarnConfiguration));
     amContainerLaunchContext.setCommands(Lists.newArrayList(buildApplicationMasterCommand(resource.getMemory())));
     if (UserGroupInformation.isSecurityEnabled()) {
       setupSecurityTokens(amContainerLaunchContext);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -64,7 +64,7 @@ public class GobblinYarnConfigurationKeys {
    */
   public static final String KEYTAB_FILE_PATH = GOBBLIN_YARN_PREFIX + "keytab.file.path";
   public static final String KEYTAB_PRINCIPAL_NAME = GOBBLIN_YARN_PREFIX + "keytab.principal.name";
-  public static final String TOKEN_FILE_PATH = GOBBLIN_YARN_PREFIX + "token.file.path";
+  public static final String TOKEN_FILE_NAME = ".token";
   public static final String LOGIN_INTERVAL_IN_MINUTES = GOBBLIN_YARN_PREFIX + "login.interval.minutes";
   public static final String TOKEN_RENEW_INTERVAL_IN_MINUTES = GOBBLIN_YARN_PREFIX + "token.renew.interval.minutes";
 

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -73,11 +73,13 @@ public class GobblinYarnConfigurationKeys {
    */
   public static final String LIB_JARS_DIR_KEY = GOBBLIN_YARN_PREFIX + "lib.jars.dir";
   public static final String JOB_CONF_PACKAGE_PATH_KEY = GOBBLIN_YARN_PREFIX + "job.conf.package.path";
+  public static final String LOGS_SINK_ROOT_DIR_KEY = GOBBLIN_YARN_PREFIX + "logs.sink.root.dir";
   public static final String LIB_JARS_DIR_NAME = "_libjars";
   public static final String APP_JARS_DIR_NAME = "_appjars";
   public static final String APP_FILES_DIR_NAME = "_appfiles";
   public static final String INPUT_WORK_UNIT_DIR_NAME = "_workunits";
   public static final String OUTPUT_TASK_STATE_DIR_NAME = "_taskstates";
+  public static final String APP_LOGS_DIR_NAME = "_applogs";
 
   /**
    * Other misc configuration properties.

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnLogSource.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnLogSource.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.yarn;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ContainerId;
+
+import com.google.common.collect.ImmutableSet;
+
+import gobblin.util.logs.LogCopier;
+
+
+/**
+ * A base class for container processes that are sources of Gobblin Yarn application logs.
+ *
+ * <p>
+ *   The source log files are supposed to be on the local {@link FileSystem} and will
+ *   be copied to a given destination {@link FileSystem}, which is typically HDFS.
+ * </p>
+ *
+ * @author ynli
+ */
+class GobblinYarnLogSource {
+
+  /**
+   * Build a {@link LogCopier} instance used to copy the logs out from this {@link GobblinYarnLogSource}.
+   *
+   * @param containerId the {@link ContainerId} of the container the {@link LogCopier} runs in
+   * @param destFs the destination {@link FileSystem}
+   * @param appWorkDir the Gobblin Yarn application working directory on HDFS
+   * @return a {@link LogCopier} instance
+   * @throws IOException if it fails on any IO operation
+   */
+  protected LogCopier buildLogCopier(ContainerId containerId, FileSystem destFs, Path appWorkDir)
+      throws IOException {
+    return LogCopier.newBuilder()
+        .useSrcFileSystem(FileSystem.getLocal(new Configuration()))
+        .useDestFileSystem(destFs)
+        .readFrom(getLocalLogDir())
+        .writeTo(getHdfsLogDir(destFs, appWorkDir))
+        .acceptsLogFileExtensions(ImmutableSet.of(ApplicationConstants.STDOUT, ApplicationConstants.STDERR))
+        .useLogFileNamePrefix(containerId.toString())
+        .build();
+  }
+
+  private Path getLocalLogDir() throws IOException {
+    return new Path(System.getenv(ApplicationConstants.Environment.LOG_DIRS.toString()));
+  }
+
+  private Path getHdfsLogDir(FileSystem destFs, Path appWorkDir) throws IOException {
+    Path logRootDir = new Path(appWorkDir, GobblinYarnConfigurationKeys.APP_LOGS_DIR_NAME);
+    if (!destFs.exists(logRootDir)) {
+      destFs.mkdirs(logRootDir);
+    }
+
+    return new Path(logRootDir, System.getenv(ApplicationConstants.Environment.CONTAINER_ID.toString()));
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnAppSecurityManager.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnAppSecurityManager.java
@@ -96,7 +96,9 @@ public class YarnAppSecurityManager extends AbstractIdleService {
     this.helixManager = helixManager;
     this.fs = fs;
 
-    this.tokenFilePath = new Path(config.getString(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH));
+    this.tokenFilePath = new Path(this.fs.getHomeDirectory(),
+        config.getString(GobblinYarnConfigurationKeys.APPLICATION_NAME_KEY) + Path.SEPARATOR
+            + GobblinYarnConfigurationKeys.TOKEN_FILE_NAME);
     this.fs.makeQualified(tokenFilePath);
     this.loginUser = UserGroupInformation.getLoginUser();
     this.loginIntervalInMinutes = config.getLong(GobblinYarnConfigurationKeys.LOGIN_INTERVAL_IN_MINUTES);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnContainerSecurityManager.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnContainerSecurityManager.java
@@ -55,7 +55,9 @@ public class YarnContainerSecurityManager extends AbstractIdleService {
 
   public YarnContainerSecurityManager(Config config, FileSystem fs, EventBus eventBus) {
     this.fs = fs;
-    this.tokenFilePath = new Path(config.getString(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH));
+    this.tokenFilePath = new Path(this.fs.getHomeDirectory(),
+        config.getString(GobblinYarnConfigurationKeys.APPLICATION_NAME_KEY) + Path.SEPARATOR
+            + GobblinYarnConfigurationKeys.TOKEN_FILE_NAME);
     this.eventBus = eventBus;
   }
 

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnHelixUtils.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnHelixUtils.java
@@ -25,7 +25,6 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.Credentials;
-import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
@@ -162,10 +161,9 @@ public class YarnHelixUtils {
    * Get environment variables in a {@link java.util.Map} used when launching a Yarn container.
    *
    * @param yarnConfiguration a Hadoop {@link Configuration} object carrying Hadoop/Yarn configuration properties
-   * @param config a {@link Config} object carrying Gobblin Yarn application configuration properties
    * @return a {@link java.util.Map} storing environment variables used when launching a Yarn container
    */
-  public static Map<String, String> getEnvironmentVariables(Configuration yarnConfiguration, Config config) {
+  public static Map<String, String> getEnvironmentVariables(Configuration yarnConfiguration) {
     Map<String, String> environmentVariableMap = Maps.newHashMap();
 
     Apps.addToEnvironment(environmentVariableMap, ApplicationConstants.Environment.JAVA_HOME.key(),
@@ -184,11 +182,6 @@ public class YarnHelixUtils {
         Apps.addToEnvironment(
             environmentVariableMap, ApplicationConstants.Environment.CLASSPATH.key(), classpath.trim());
       }
-    }
-
-    if (UserGroupInformation.isSecurityEnabled()) {
-      Apps.addToEnvironment(environmentVariableMap, "HADOOP_TOKEN_FILE_LOCATION",
-          config.getString(GobblinYarnConfigurationKeys.TOKEN_FILE_PATH));
     }
 
     return environmentVariableMap;

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
@@ -268,7 +268,7 @@ public class YarnService extends AbstractIdleService {
 
     ContainerLaunchContext containerLaunchContext = Records.newRecord(ContainerLaunchContext.class);
     containerLaunchContext.setLocalResources(resourceMap);
-    containerLaunchContext.setEnvironment(YarnHelixUtils.getEnvironmentVariables(this.yarnConfiguration, this.config));
+    containerLaunchContext.setEnvironment(YarnHelixUtils.getEnvironmentVariables(this.yarnConfiguration));
     containerLaunchContext.setCommands(Lists.newArrayList(buildContainerCommand(container)));
 
     if (UserGroupInformation.isSecurityEnabled()) {


### PR DESCRIPTION
This PR adds log aggregation to Gobblin on Yarn. Implementation notes as follows:
1. There's a utility class `LogCopier` that is an `AbstractScheduledService` that periodically scans for new log files in a given source log directory and schedules a new copy task for each new source log file. Each source log file is copied to a destination directory on the destination file system.
2. The `LogCopier` remembers the current position in the input file stream of each log file and will seek to that position whenever the task starts to copy.
3. Both `GobblinApplicationMaster` and `GobblinWorkUnitRunner` now extend `GobblinYarnLogSource`, which handles to details of building a `LogCopier` to copy the container logs to HDFS.
4. `GobblinYarnAppLauncher` is a sink for logs that copies log files from HDFS to a local directory.

This PR also gets rid of the config key `gobblin.yarn.token.file.path` to favor a path under the app's working directory so we have one less config key to worry about.

Signed-off-by: Yinan Li <liyinan926@gmail.com>