### PR TITLE
Add loop parallelization utility to ExecutorsUtils

### DIFF
--- a/gobblin-utility/src/test/java/gobblin/util/ExecutorsUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ExecutorsUtilsTest.java
@@ -12,13 +12,20 @@
 
 package gobblin.util;
 
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
 
 import org.mockito.Mockito;
 import org.slf4j.Logger;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -46,5 +53,75 @@ public class ExecutorsUtilsTest {
     Mockito.doThrow(runtimeException).when(logger).error(errorMessage, runtimeException);
 
     thread.run();
+  }
+
+  /**
+   * Test to verify that {@link ExecutorsUtils#parallelize(List, Function, int, int, Optional)} returns the result in
+   * the same order as the input
+   *
+   */
+  @Test
+  public void testParallelize() throws Exception {
+    List<Integer> nums = ImmutableList.of(3, 5, 10, 5, 20);
+    final int factor = 5;
+
+    Function<Integer, String> multiply = new Function<Integer, String>() {
+      @Override
+      public String apply(Integer input) {
+        return Integer.toString(input * factor);
+      }
+    };
+
+    List<String> result = ExecutorsUtils.parallelize(nums, multiply, 2, 60, Optional.<Logger> absent());
+    Assert.assertEquals(Arrays.asList("15", "25", "50", "25", "100"), result);
+  }
+
+  /**
+   * Test to verify that {@link ExecutorsUtils#parallelize(List, Function, int, int, Optional)} throws
+   * {@link ExecutionException} when any of the threads throw and exception
+   */
+  @Test(expectedExceptions = ExecutionException.class)
+  public void testParallelizeException() throws Exception {
+    List<Integer> nums = ImmutableList.of(3, 5);
+    final int factor = 5;
+
+    Function<Integer, String> exceptionFunction = new Function<Integer, String>() {
+      @Override
+      public String apply(Integer input) {
+        if (input == 3) {
+          throw new RuntimeException("testParallelizeException thrown for testing");
+        }
+        return Integer.toString(input * factor);
+      }
+    };
+
+    ExecutorsUtils.parallelize(nums, exceptionFunction, 2, 1, Optional.<Logger> absent());
+
+  }
+
+  /**
+   * Test to verify that {@link ExecutorsUtils#parallelize(List, Function, int, int, Optional)} throws
+   * {@link ExecutionException} when any of the threads timesout.
+   */
+  @Test(expectedExceptions = ExecutionException.class)
+  public void testParallelizeTimeout() throws Exception {
+    List<Integer> nums = ImmutableList.of(3, 5);
+    final int factor = 5;
+
+    Function<Integer, String> sleepAndMultiply = new Function<Integer, String>() {
+      @Override
+      public String apply(Integer input) {
+        try {
+          if (input == 5) {
+            TimeUnit.SECONDS.sleep(2);
+          }
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+        return Integer.toString(input * factor);
+      }
+    };
+
+    ExecutorsUtils.parallelize(nums, sleepAndMultiply, 2, 1, Optional.<Logger> absent());
   }
 }


### PR DESCRIPTION
We find loop parallelizing logic in several parts of the code base hence trying to make a standard way of doing it.
Added a utility method to parallelize loops. Applies a {@link Function} to every element in a {@link List} in parallel by spawning threads. A list containing the result obtained by applying the function is returned. The method is a blocking call and will wait for all the elements in the list to be processed or timeoutInSecs which ever is earlier.

@chavdar can you review?