### PR TITLE
Make sure properties set in a pre-fork converter is not lost

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -149,8 +149,12 @@ public class Task implements Runnable {
       // Create one fork for each forked branch
       for (int i = 0; i < branches; i++) {
         if (forkedSchemas.get(i)) {
-          Fork fork = closer.register(new Fork(this.taskContext, this.taskState,
-              schema instanceof Copyable ? ((Copyable) schema).copy() : schema, branches, i, forkCountDownLatch));
+          Fork fork = closer.register(new Fork(
+              this.taskContext,
+              schema instanceof Copyable ? ((Copyable) schema).copy() : schema,
+              branches,
+              i,
+              forkCountDownLatch));
           // Run the Fork
           this.taskExecutor.execute(fork);
           this.forks.add(Optional.of(fork));


### PR DESCRIPTION
Currently in `TaskContext.getConverters(int index)`, a local copy of the `taskState` is created and used to initialize the converters. Because of this, any user-set properties in the converters are not available in the original task-level `TaskState` and therefore are lost. This PR fixed this. 

Signed-off-by: Yinan Li <liyinan926@gmail.com>