### PR TITLE
Late data handling for compaction

### DIFF
--- a/gobblin-api/src/main/java/gobblin/util/RecordCountProvider.java
+++ b/gobblin-api/src/main/java/gobblin/util/RecordCountProvider.java
@@ -12,11 +12,34 @@
 
 package gobblin.util;
 
+import org.apache.commons.lang.NotImplementedException;
 import org.apache.hadoop.fs.Path;
 
+
 /**
- * Get record count from a given {@link Path}.
+ * A class for obtaining record counts from data.
  */
-public interface RecordCountProvider {
-  public long getRecordCount(Path path);
+public abstract class RecordCountProvider {
+
+  /**
+   * Get record count from a given {@link Path}.
+   */
+  public abstract long getRecordCount(Path path);
+
+  /**
+   * Convert a {@link Path} from another {@link RecordCountProvider} so that it can be used
+   * in {@link #getRecordCount(Path)} of this {@link RecordCountProvider}.
+   */
+  public Path convertPath(Path path, RecordCountProvider src) {
+    if (this.getClass().equals(src.getClass())) {
+      return path;
+    } else {
+      throw getNotImplementedException(src);
+    }
+  }
+
+  protected NotImplementedException getNotImplementedException(RecordCountProvider src) {
+    return new NotImplementedException(String.format("converting from %s to %s is not implemented",
+        src.getClass().getName(), this.getClass().getName()));
+  }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 
+import gobblin.compaction.Dataset;
 import gobblin.compaction.mapreduce.MRCompactor;
 import gobblin.compaction.mapreduce.avro.AvroKeyDedupReducer;
 import gobblin.compaction.mapreduce.avro.AvroKeyMapper;
@@ -40,13 +41,13 @@ public class CompactionSlaEventHelper {
 
   private static final Logger LOG = LoggerFactory.getLogger(CompactionSlaEventHelper.class);
 
-  public static void populateState(State state, Optional<Job> job, FileSystem fs) {
-    setDatasetUrn(state);
-    setPartition(state);
-    setDedupeStatus(state);
-    setPreviousPublishTime(state, fs);
+  public static void populateState(Dataset dataset, Optional<Job> job, FileSystem fs) {
+    setDatasetUrn(dataset);
+    setPartition(dataset);
+    setDedupeStatus(dataset.jobProps());
+    setPreviousPublishTime(dataset, fs);
     if (job.isPresent()) {
-      setRecordCount(state, job.get());
+      setRecordCount(dataset.jobProps(), job.get());
     }
   }
 
@@ -54,24 +55,23 @@ public class CompactionSlaEventHelper {
     state.setProp(SlaEventKeys.UPSTREAM_TS_IN_MILLI_SECS_KEY, Long.toString(time));
   }
 
-  private static void setDatasetUrn(State state) {
-    state.setProp(SlaEventKeys.DATASET_URN_KEY,
-        new Path(state.getProp(MRCompactor.COMPACTION_DEST_DIR), state.getProp(MRCompactor.COMPACTION_TOPIC))
-            .toString());
+  private static void setDatasetUrn(Dataset dataset) {
+    dataset.jobProps().setProp(SlaEventKeys.DATASET_URN_KEY,
+        new Path(dataset.jobProps().getProp(MRCompactor.COMPACTION_DEST_DIR), dataset.topic()).toString());
   }
 
-  private static void setPartition(State state) {
-    state.setProp(SlaEventKeys.PARTITION_KEY, state.getProp(MRCompactor.COMPACTION_JOB_DEST_PARTITION));
+  private static void setPartition(Dataset dataset) {
+    dataset.jobProps().setProp(SlaEventKeys.PARTITION_KEY,
+        dataset.jobProps().getProp(MRCompactor.COMPACTION_JOB_DEST_PARTITION, ""));
   }
 
-  private static void setPreviousPublishTime(State state, FileSystem fs) {
+  private static void setPreviousPublishTime(Dataset dataset, FileSystem fs) {
 
-    Path compactionCompletePath =
-        new Path(state.getProp(MRCompactor.COMPACTION_JOB_DEST_DIR), MRCompactor.COMPACTION_COMPLETE_FILE_NAME);
+    Path compactionCompletePath = new Path(dataset.outputPath(), MRCompactor.COMPACTION_COMPLETE_FILE_NAME);
 
     try {
       FileStatus fileStatus = fs.getFileStatus(compactionCompletePath);
-      state.setProp(SlaEventKeys.PREVIOUS_PUBLISH_TS_IN_MILLI_SECS_KEY,
+      dataset.jobProps().setProp(SlaEventKeys.PREVIOUS_PUBLISH_TS_IN_MILLI_SECS_KEY,
           Long.toString(fileStatus.getModificationTime()));
     } catch (IOException e) {
       LOG.debug("Failed to get previous publish time.", e);

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobPropCreator.java
@@ -14,17 +14,23 @@
 package gobblin.compaction.mapreduce;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.List;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import gobblin.compaction.Dataset;
 import gobblin.configuration.State;
+import gobblin.util.FileListUtils;
 
 
 /**
@@ -40,12 +46,13 @@ public class MRCompactorJobPropCreator {
   static class Builder<T extends Builder<?>> {
 
     String topic;
+    double priority = Dataset.DEFAULT_PRIORITY;
     Path topicInputDir;
+    Path topicInputLateDir;
     Path topicOutputDir;
     Path topicOutputLateDir;
-    Path topicTmpDir;
+    Path topicTmpOutputDir;
     FileSystem fs;
-    boolean deduplicate;
     State state;
 
     T withTopic(String topic) {
@@ -53,8 +60,18 @@ public class MRCompactorJobPropCreator {
       return (T) this;
     }
 
+    T withPriority(double priority) {
+      this.priority = priority;
+      return (T) this;
+    }
+
     T withTopicInputDir(Path topicInputDir) {
       this.topicInputDir = topicInputDir;
+      return (T) this;
+    }
+
+    T withTopicInputLateDir(Path topicInputLateDir) {
+      this.topicInputLateDir = topicInputLateDir;
       return (T) this;
     }
 
@@ -68,18 +85,13 @@ public class MRCompactorJobPropCreator {
       return (T) this;
     }
 
-    T withTopicTmpDir(Path topicTmpDir) {
-      this.topicTmpDir = topicTmpDir;
+    T withTopicTmpOutputDir(Path topicTmpOutputDir) {
+      this.topicTmpOutputDir = topicTmpOutputDir;
       return (T) this;
     }
 
     T withFileSystem(FileSystem fs) {
       this.fs = fs;
-      return (T) this;
-    }
-
-    T withDeduplicate(boolean deduplicate) {
-      this.deduplicate = deduplicate;
       return (T) this;
     }
 
@@ -95,59 +107,159 @@ public class MRCompactorJobPropCreator {
   }
 
   protected final String topic;
+  protected final double priority;
   protected final Path topicInputDir;
+  protected final Path topicInputLateDir;
   protected final Path topicOutputDir;
   protected final Path topicOutputLateDir;
-  protected final Path topicTmpDir;
+  protected final Path topicTmpOutputDir;
   protected final FileSystem fs;
-  protected final boolean deduplicate;
   protected final State state;
+  protected final boolean deduplicate;
+
+  // Whether we should recompact the input folders if new data files are found in the input folders.
+  protected final boolean recompactFromInputPaths;
+
+  // Whether we should recompact the output folders if there are late data files in the output '_late' folder.
+  // If this is set to true, input folders of the datasets will be ignored. The output folders and the
+  // output '_late' folders will be used as input to compaction jobs.
+  protected final boolean recompactFromOutputPaths;
 
   protected MRCompactorJobPropCreator(Builder<?> builder) {
     this.topic = builder.topic;
+    this.priority = builder.priority;
     this.topicInputDir = builder.topicInputDir;
+    this.topicInputLateDir = builder.topicInputLateDir;
     this.topicOutputDir = builder.topicOutputDir;
     this.topicOutputLateDir = builder.topicOutputLateDir;
-    this.topicTmpDir = builder.topicTmpDir;
+    this.topicTmpOutputDir = builder.topicTmpOutputDir;
     this.fs = builder.fs;
-    this.deduplicate = builder.deduplicate;
     this.state = builder.state;
+    this.deduplicate =
+        this.state.getPropAsBoolean(MRCompactor.COMPACTION_DEDUPLICATE, MRCompactor.DEFAULT_COMPACTION_DEDUPLICATE);
+    this.recompactFromInputPaths =
+        this.state.getPropAsBoolean(MRCompactor.COMPACTION_RECOMPACT_FROM_INPUT_FOR_LATE_DATA,
+            MRCompactor.DEFAULT_COMPACTION_RECOMPACT_FROM_INPUT_FOR_LATE_DATA);
+    this.recompactFromOutputPaths = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RECOMPACT_FROM_DEST_PATHS,
+        MRCompactor.DEFAULT_COMPACTION_RECOMPACT_FROM_DEST_PATHS);
   }
 
-  protected List<State> createJobProps() throws IOException {
-    List<State> emptyJobProps = Lists.newArrayList();
+  protected List<Dataset> createJobProps() throws IOException {
     if (!this.fs.exists(this.topicInputDir)) {
       LOG.warn("Input folder " + this.topicInputDir + " does not exist. Skipping topic " + this.topic);
-      return emptyJobProps;
+      return ImmutableList.<Dataset> of();
     }
-    return Collections
-        .singletonList(createJobProps(this.topicInputDir, this.topicOutputDir, this.topicTmpDir, this.deduplicate));
+
+    Dataset dataset = new Dataset.Builder().withTopic(this.topic).withPriority(this.priority)
+        .withInputPath(this.recompactFromOutputPaths ? this.topicOutputDir : this.topicInputDir)
+        .withInputLatePath(this.recompactFromOutputPaths ? this.topicOutputLateDir : this.topicInputLateDir)
+        .withOutputPath(this.topicOutputDir).withOutputLatePath(this.topicOutputLateDir)
+        .withOutputTmpPath(this.topicTmpOutputDir).build();
+
+    Optional<Dataset> datasetWithJobProps = createJobProps(dataset);
+    if (datasetWithJobProps.isPresent()) {
+      return ImmutableList.<Dataset> of(datasetWithJobProps.get());
+    } else {
+      return ImmutableList.<Dataset> of();
+    }
   }
 
   /**
-   * Create MR job properties for a specific input folder and output folder.
+   * Create MR job properties for a {@link Dataset}.
    */
-  protected State createJobProps(Path jobInputDir, Path jobOutputDir, Path jobTmpDir, boolean deduplicate)
-      throws IOException {
+  protected Optional<Dataset> createJobProps(Dataset dataset) throws IOException {
+    if (this.recompactFromOutputPaths
+        && (!this.fs.exists(dataset.inputLatePath()) || this.fs.listStatus(dataset.inputLatePath()).length == 0)) {
+      LOG.info(String.format("Skipping recompaction for %s since there is no late data in %s", dataset.inputPath(),
+          dataset.inputLatePath()));
+      return Optional.<Dataset> absent();
+    }
+
     State jobProps = new State();
     jobProps.addAll(this.state);
-    jobProps.setProp(MRCompactor.COMPACTION_TOPIC, this.topic);
-    jobProps.setProp(MRCompactor.COMPACTION_JOB_INPUT_DIR, jobInputDir);
-    jobProps.setProp(MRCompactor.COMPACTION_JOB_DEST_DIR, jobOutputDir);
-    jobProps.setProp(MRCompactor.COMPACTION_JOB_TMP_DIR, jobTmpDir);
     jobProps.setProp(MRCompactor.COMPACTION_ENABLE_SUCCESS_FILE, false);
-    jobProps.setProp(MRCompactor.COMPACTION_DEDUPLICATE, deduplicate);
-    LOG.info(String.format("Created MR job properties for input %s and output %s.", jobInputDir, jobOutputDir));
-    return jobProps;
+    jobProps.setProp(MRCompactor.COMPACTION_DEDUPLICATE, this.deduplicate);
+
+    if (this.recompactFromOutputPaths || !MRCompactor.datasetAlreadyCompacted(this.fs, dataset)) {
+      addInputLateFilesForFirstTimeCompaction(jobProps, dataset);
+    } else {
+      List<Path> newDataFiles = getNewDataInFolder(dataset.inputPath(), dataset.outputPath());
+      newDataFiles.addAll(getNewDataInFolder(dataset.inputLatePath(), dataset.outputPath()));
+      if (newDataFiles.isEmpty()) {
+        return Optional.<Dataset> absent();
+      }
+      addJobPropsForCompactedFolder(jobProps, dataset);
+    }
+
+    LOG.info(String.format("Created MR job properties for input %s and output %s.", dataset.inputPath(),
+        dataset.outputPath()));
+    dataset.setJobProps(jobProps);
+    return Optional.of(dataset);
+  }
+
+  private void addInputLateFilesForFirstTimeCompaction(State jobProps, Dataset dataset) throws IOException {
+    if (this.fs.exists(dataset.inputLatePath()) && this.fs.listStatus(dataset.inputLatePath()).length > 0) {
+      dataset.addAdditionalInputPath(dataset.inputLatePath());
+      jobProps.setProp(MRCompactor.COMPACTION_DEDUPLICATE, true);
+    }
+  }
+
+  private void addJobPropsForCompactedFolder(State jobProps, Dataset dataset) throws IOException {
+    if (this.recompactFromInputPaths) {
+      LOG.info(String.format("Will recompact for %s.", dataset.outputPath()));
+      addInputLateFilesForFirstTimeCompaction(jobProps, dataset);
+    } else {
+      List<Path> newDataFiles = getNewDataInFolder(dataset.inputPath(), dataset.outputPath());
+      List<Path> newDataFilesInLatePath = getNewDataInFolder(dataset.inputLatePath(), dataset.outputPath());
+      newDataFiles.addAll(newDataFilesInLatePath);
+
+      if (!newDataFilesInLatePath.isEmpty()) {
+        dataset.addAdditionalInputPath(dataset.inputLatePath());
+      }
+
+      LOG.info(String.format("Will copy %d new data files for %s", newDataFiles.size(), dataset.outputPath()));
+      jobProps.setProp(MRCompactor.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, true);
+      jobProps.setProp(MRCompactor.COMPACTION_JOB_LATE_DATA_FILES, Joiner.on(",").join(newDataFiles));
+    }
   }
 
   /**
-   * Create MR job properties for a specific input folder, output folder and partition
+   * Create MR job properties for a {@link Dataset} and partition.
    */
-  protected State createJobProps(Path jobInputDir, Path jobOutputDir, Path jobTmpDir, boolean deduplicate,
-      String partition) throws IOException {
-    State jobProps = createJobProps(jobInputDir, jobOutputDir, jobTmpDir, deduplicate);
-    jobProps.setProp(MRCompactor.COMPACTION_JOB_DEST_PARTITION, partition);
-    return jobProps;
+  protected Optional<Dataset> createJobProps(Dataset dataset, String partition) throws IOException {
+    Optional<Dataset> datasetWithJobProps = createJobProps(dataset);
+    if (datasetWithJobProps.isPresent()) {
+      datasetWithJobProps.get().jobProps().setProp(MRCompactor.COMPACTION_JOB_DEST_PARTITION, partition);
+      return datasetWithJobProps;
+    } else {
+      return Optional.<Dataset> absent();
+    }
+  }
+
+  /**
+   * Check if inputFolder contains any files which have modification times which are more
+   * recent than the last compaction time as stored within outputFolder; return any files
+   * which do. An empty list will be returned if all files are older than the last compaction time.
+   */
+  private List<Path> getNewDataInFolder(Path inputFolder, Path outputFolder) throws IOException {
+    List<Path> newFiles = Lists.newArrayList();
+
+    if (!this.fs.exists(inputFolder) || !this.fs.exists(outputFolder)) {
+      return newFiles;
+    }
+
+    DateTime lastCompactionTime = new DateTime(MRCompactor.readCompactionTimestamp(this.fs, outputFolder));
+    for (FileStatus fstat : FileListUtils.listFilesRecursively(this.fs, inputFolder)) {
+      DateTime fileModificationTime = new DateTime(fstat.getModificationTime());
+      if (fileModificationTime.isAfter(lastCompactionTime)) {
+        newFiles.add(fstat.getPath());
+      }
+    }
+    if (!newFiles.isEmpty()) {
+      LOG.info(String.format("Found %d new files within folder %s which are more recent than the previous "
+          + "compaction start time of %s.", newFiles.size(), inputFolder, lastCompactionTime));
+    }
+
+    return newFiles;
   }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
@@ -17,8 +17,6 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -26,7 +24,6 @@ import org.apache.hadoop.filecache.DistributedCache;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -45,18 +42,16 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import com.google.common.primitives.Ints;
 
-import lombok.AllArgsConstructor;
-
 import gobblin.compaction.Dataset;
 import gobblin.compaction.event.CompactionSlaEventHelper;
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.metrics.event.sla.SlaEventSubmitter;
 import gobblin.util.FileListUtils;
 import gobblin.util.HadoopUtils;
 import gobblin.util.RecordCountProvider;
+import gobblin.util.recordcount.LateFileRecordCountProvider;
 
 
 /**
@@ -67,9 +62,9 @@ import gobblin.util.RecordCountProvider;
  * compaction.max.num.reducers. The number of reducers will be the smaller of
  * [total input size] / [compaction.target.output.file.size] + 1 and [compaction.max.num.reducers].
  *
- * If {@value ConfigurationKeys#COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK} is set to true, does not
+ * If {@value MRCompactor#COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK} is set to true, does not
  * launch an MR job. Instead, just copies the files present in
- * {@value ConfigurationKeys#COMPACTION_JOB_LATE_DATA_FILES} to a 'late' subdirectory within
+ * {@value MRCompactor#COMPACTION_JOB_LATE_DATA_FILES} to a 'late' subdirectory within
  * the output directory.
  *
  * @author ziliu
@@ -89,8 +84,8 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
    * Properties related to the compaction job of a dataset.
    */
   private static final String COMPACTION_JOB_OUTPUT_DIR_PERMISSION = COMPACTION_JOB_PREFIX + "output.dir.permission";
-  private static final String COMPACTION_JOB_TARGET_OUTPUT_FILE_SIZE = COMPACTION_JOB_PREFIX
-      + "target.output.file.size";
+  private static final String COMPACTION_JOB_TARGET_OUTPUT_FILE_SIZE =
+      COMPACTION_JOB_PREFIX + "target.output.file.size";
   private static final long DEFAULT_COMPACTION_JOB_TARGET_OUTPUT_FILE_SIZE = 268435456;
   private static final String COMPACTION_JOB_MAX_NUM_REDUCERS = COMPACTION_JOB_PREFIX + "max.num.reducers";
   private static final int DEFAULT_COMPACTION_JOB_MAX_NUM_REDUCERS = 900;
@@ -121,82 +116,80 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   }
 
   protected final Dataset dataset;
-  protected final State jobProps;
-  protected final String topic;
-  protected final Path inputPath;
-  protected final Path tmpPath;
-  protected final Path outputPath;
   protected final FileSystem fs;
   protected final FsPermission perm;
   protected final boolean deduplicate;
-  protected final double priority;
+  protected final boolean recompactFromDestPaths;
   protected final EventSubmitter eventSubmitter;
-  private final LateFileRecordCountProvider recordCountProvider;
+  private final RecordCountProvider inputRecordCountProvider;
+  private final RecordCountProvider outputRecordCountProvider;
+  private final LateFileRecordCountProvider lateInputRecordCountProvider;
+  private final LateFileRecordCountProvider lateOutputRecordCountProvider;
 
   private volatile Policy policy = Policy.DO_NOT_PUBLISH_DATA;
   private volatile Status status = Status.RUNNING;
 
   protected MRCompactorJobRunner(Dataset dataset, FileSystem fs, Double priority) {
     this.dataset = dataset;
-    this.jobProps = dataset.jobProps();
-    this.topic = jobProps.getProp(MRCompactor.COMPACTION_TOPIC);
-    this.inputPath = new Path(jobProps.getProp(MRCompactor.COMPACTION_JOB_INPUT_DIR));
-    this.outputPath = new Path(jobProps.getProp(MRCompactor.COMPACTION_JOB_DEST_DIR));
-    this.tmpPath = new Path(jobProps.getProp(MRCompactor.COMPACTION_JOB_TMP_DIR));
     this.fs = fs;
-    this.perm =
-        HadoopUtils.deserializeFsPermission(this.jobProps, COMPACTION_JOB_OUTPUT_DIR_PERMISSION,
-            FsPermission.getDefault());
-    this.deduplicate =
-        this.jobProps.getPropAsBoolean(MRCompactor.COMPACTION_DEDUPLICATE, MRCompactor.DEFAULT_COMPACTION_DEDUPLICATE);
-    this.priority = priority;
-    this.eventSubmitter =
-        new EventSubmitter.Builder(GobblinMetrics.get(this.jobProps.getProp(ConfigurationKeys.JOB_NAME_KEY))
-            .getMetricContext(), MRCompactor.COMPACTION_TRACKING_EVENTS_NAMESPACE).build();
+    this.perm = HadoopUtils.deserializeFsPermission(this.dataset.jobProps(), COMPACTION_JOB_OUTPUT_DIR_PERMISSION,
+        FsPermission.getDefault());
+    this.recompactFromDestPaths = this.dataset.jobProps().getPropAsBoolean(
+        MRCompactor.COMPACTION_RECOMPACT_FROM_DEST_PATHS, MRCompactor.DEFAULT_COMPACTION_RECOMPACT_FROM_DEST_PATHS);
+    this.deduplicate = this.dataset.jobProps().getPropAsBoolean(MRCompactor.COMPACTION_DEDUPLICATE,
+        MRCompactor.DEFAULT_COMPACTION_DEDUPLICATE);
+    this.eventSubmitter = new EventSubmitter.Builder(
+        GobblinMetrics.get(this.dataset.jobProps().getProp(ConfigurationKeys.JOB_NAME_KEY)).getMetricContext(),
+        MRCompactor.COMPACTION_TRACKING_EVENTS_NAMESPACE).build();
 
     try {
-      this.recordCountProvider =
-          new LateFileRecordCountProvider((RecordCountProvider) Class.forName(
-              this.jobProps.getProp(MRCompactor.COMPACTION_RECORD_COUNT_PROVIDER,
-                  MRCompactor.DEFAULT_COMPACTION_RECORD_COUNT_PROVIDER)).newInstance());
+      this.inputRecordCountProvider = (RecordCountProvider) Class
+          .forName(this.dataset.jobProps().getProp(MRCompactor.COMPACTION_INPUT_RECORD_COUNT_PROVIDER,
+              MRCompactor.DEFAULT_COMPACTION_INPUT_RECORD_COUNT_PROVIDER))
+          .newInstance();
+      this.outputRecordCountProvider = (RecordCountProvider) Class
+          .forName(this.dataset.jobProps().getProp(MRCompactor.COMPACTION_OUTPUT_RECORD_COUNT_PROVIDER,
+              MRCompactor.DEFAULT_COMPACTION_OUTPUT_RECORD_COUNT_PROVIDER))
+          .newInstance();
+      this.lateInputRecordCountProvider = new LateFileRecordCountProvider(this.inputRecordCountProvider);
+      this.lateOutputRecordCountProvider = new LateFileRecordCountProvider(this.outputRecordCountProvider);
     } catch (Exception e) {
-      throw new RuntimeException("Failed to instantiate record count provider: " + e, e);
+      throw new RuntimeException("Failed to instantiate RecordCountProvider", e);
     }
   }
 
   @Override
   public void run() {
-    Configuration conf = HadoopUtils.getConfFromState(this.jobProps);
-    DateTime jobStartTime =
-        new DateTime(DateTimeZone.forID(this.jobProps.getProp(MRCompactor.COMPACTION_TIMEZONE,
-            MRCompactor.DEFAULT_COMPACTION_TIMEZONE)));
+    Configuration conf = HadoopUtils.getConfFromState(this.dataset.jobProps());
+
     try {
-      if (this.jobProps.getPropAsBoolean(MRCompactor.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, false)) {
+      DateTime compactionTimestamp = getCompactionTimestamp();
+      if (this.dataset.jobProps().getPropAsBoolean(MRCompactor.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, false)) {
         List<Path> newLateFilePaths = Lists.newArrayList();
-        for (String filePathString : this.jobProps.getPropAsList(MRCompactor.COMPACTION_JOB_LATE_DATA_FILES)) {
+        for (String filePathString : this.dataset.jobProps()
+            .getPropAsList(MRCompactor.COMPACTION_JOB_LATE_DATA_FILES)) {
           if (FilenameUtils.isExtension(filePathString, getApplicableFileExtensions())) {
             newLateFilePaths.add(new Path(filePathString));
           }
         }
-        Path lateDataOutputPath = this.outputPath;
-        Path lateDataDir = new Path(this.jobProps.getProp(MRCompactor.COMPACTION_JOB_DEST_LATE_DIR));
+
+        Path lateDataOutputPath = this.deduplicate ? this.dataset.outputLatePath() : this.dataset.outputPath();
+        LOG.info(String.format("Copying %d late data files to %s", newLateFilePaths.size(), lateDataOutputPath));
         if (this.deduplicate) {
-          // Update the late data output path.
-          lateDataOutputPath = lateDataDir;
-          LOG.info(String.format("Will copy to late path %s since deduplication has been done. ", lateDataOutputPath));
           if (!fs.exists(lateDataOutputPath)) {
             if (!fs.mkdirs(lateDataOutputPath)) {
-              throw new RuntimeException(String.format("Failed to create late data output directory: %s.",
-                  lateDataOutputPath.toString()));
+              throw new RuntimeException(
+                  String.format("Failed to create late data output directory: %s.", lateDataOutputPath.toString()));
             }
           }
         }
-        this.submitLateRecordCountsEvent(newLateFilePaths, lateDataDir);
-        this.copyDataFiles(lateDataOutputPath, newLateFilePaths, conf);
+        this.submitLateRecordCountsEvent(newLateFilePaths, lateDataOutputPath);
+        this.copyDataFiles(lateDataOutputPath, newLateFilePaths);
         this.status = Status.COMMITTED;
       } else {
-        if (this.fs.exists(this.outputPath) && !canOverwriteOutputDir()) {
-          LOG.warn(String.format("Output path %s exists. Will not compact %s.", this.outputPath, this.inputPath));
+        if (this.fs.exists(this.dataset.outputPath()) && !canOverwriteOutputDir()) {
+          LOG.warn(String.format("Output path %s exists. Will not compact %s.", this.dataset.outputPath(),
+              this.dataset.inputPath()));
           this.status = Status.COMMITTED;
           return;
         }
@@ -204,49 +197,72 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
         Job job = Job.getInstance(conf);
         this.configureJob(job);
         this.submitAndWait(job);
-        if (shouldPublishData(jobStartTime)) {
-          this.moveTmpPathToOutputPath();
-          this.submitSlaEvent(job);
-          LOG.info("Successfully published data for input folder " + this.inputPath);
+        if (shouldPublishData(compactionTimestamp)) {
+          moveTmpPathToOutputPath();
+          if (this.recompactFromDestPaths) {
+            deleteAdditionalInputPaths();
+          }
+          submitSlaEvent(job);
+          LOG.info("Successfully published data for input folder " + this.dataset.inputPath());
           this.status = Status.COMMITTED;
         } else {
-          LOG.info("Data not published for input folder " + this.inputPath + " due to incompleteness");
+          LOG.info("Data not published for input folder " + this.dataset.inputPath() + " due to incompleteness");
           this.status = Status.ABORTED;
           return;
         }
       }
-      this.markOutputDirAsCompleted(jobStartTime);
+      this.markOutputDirAsCompleted(compactionTimestamp);
     } catch (Throwable t) {
       throw Throwables.propagate(t);
     }
   }
 
-  private void copyDataFiles(Path outputDirectory, List<Path> inputFilePaths, Configuration conf) throws IOException {
-    for (Path filePath : inputFilePaths) {
-      String fileName = filePath.getName();
-      Path outPath;
-      do {
-        outPath = this.recordCountProvider.constructLateFilePath(fileName, this.fs, outputDirectory);
-      } while (this.fs.exists(outPath));
+  /**
+   * For regular compactions, compaction timestamp is the time the compaction job starts.
+   *
+   * If this is a recompaction from output paths, the compaction timestamp will remain the same as previously
+   * persisted compaction time. This is because such a recompaction doesn't consume input data, so next time,
+   * whether a file in the input folder is considered late file should still be based on the previous compaction
+   * timestamp.
+   */
+  private DateTime getCompactionTimestamp() throws IOException {
+    DateTimeZone timeZone = DateTimeZone.forID(
+        this.dataset.jobProps().getProp(MRCompactor.COMPACTION_TIMEZONE, MRCompactor.DEFAULT_COMPACTION_TIMEZONE));
 
-      if (FileUtil.copy(this.fs, filePath, this.fs, outPath, false, conf)) {
-        LOG.info(String.format("Copied %s to %s.", filePath, outPath));
-      } else {
-        LOG.warn(String.format("Failed to copy %s to %s.", filePath, outPath));
+    if (!this.recompactFromDestPaths) {
+      return new DateTime(timeZone);
+    } else {
+      List<Path> inputPaths = Lists.newArrayList(this.dataset.inputPath());
+      inputPaths.addAll(this.dataset.additionalInputPaths());
+      long maxTimestamp = Long.MIN_VALUE;
+      for (FileStatus status : FileListUtils.listFilesRecursively(this.fs, inputPaths)) {
+        maxTimestamp = Math.max(maxTimestamp, status.getModificationTime());
       }
+      return maxTimestamp == Long.MIN_VALUE ? new DateTime(timeZone) : new DateTime(maxTimestamp, timeZone);
+    }
+  }
+
+  private void copyDataFiles(Path outputDirectory, List<Path> inputFilePaths) throws IOException {
+    for (Path filePath : inputFilePaths) {
+      Path convertedFilePath = this.outputRecordCountProvider
+          .convertPath(this.lateInputRecordCountProvider.restoreFilePath(filePath), this.inputRecordCountProvider);
+      String targetFileName = convertedFilePath.getName();
+      Path outPath = this.lateOutputRecordCountProvider.constructLateFilePath(targetFileName, this.fs, outputDirectory);
+      HadoopUtils.copyPath(this.fs, filePath, outPath);
+      LOG.info(String.format("Copied %s to %s.", filePath, outPath));
     }
   }
 
   private boolean canOverwriteOutputDir() {
-    return this.jobProps.getPropAsBoolean(COMPACTION_JOB_OVERWRITE_OUTPUT_DIR,
+    return this.dataset.jobProps().getPropAsBoolean(COMPACTION_JOB_OVERWRITE_OUTPUT_DIR,
         DEFAULT_COMPACTION_JOB_OVERWRITE_OUTPUT_DIR);
   }
 
   private void addJars(Configuration conf) throws IOException {
-    if (!this.jobProps.contains(MRCompactor.COMPACTION_JARS)) {
+    if (!this.dataset.jobProps().contains(MRCompactor.COMPACTION_JARS)) {
       return;
     }
-    Path jarFileDir = new Path(this.jobProps.getProp(MRCompactor.COMPACTION_JARS));
+    Path jarFileDir = new Path(this.dataset.jobProps().getProp(MRCompactor.COMPACTION_JARS));
     for (FileStatus status : this.fs.listStatus(jarFileDir)) {
       DistributedCache.addFileToClassPath(status.getPath(), conf, this.fs);
     }
@@ -263,19 +279,19 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   }
 
   private void configureInputAndOutputPaths(Job job) throws IOException {
-    FileInputFormat.addInputPath(job, getInputPath());
+    for (Path inputPath : getInputPaths()) {
+      FileInputFormat.addInputPath(job, inputPath);
+    }
 
     //MR output path must not exist when MR job starts, so delete if exists.
-    this.fs.delete(getTmpPath(), true);
-    FileOutputFormat.setOutputPath(job, getTmpPath());
+    this.fs.delete(this.dataset.outputTmpPath(), true);
+    FileOutputFormat.setOutputPath(job, this.dataset.outputTmpPath());
   }
 
-  private Path getInputPath() {
-    return new Path(this.jobProps.getProp(MRCompactor.COMPACTION_JOB_INPUT_DIR));
-  }
-
-  private Path getTmpPath() {
-    return new Path(this.jobProps.getProp(MRCompactor.COMPACTION_JOB_TMP_DIR));
+  private List<Path> getInputPaths() {
+    List<Path> inputPaths = Lists.newArrayList(this.dataset.inputPath());
+    inputPaths.addAll(this.dataset.additionalInputPaths());
+    return inputPaths;
   }
 
   public Dataset getDataset() {
@@ -322,58 +338,70 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   }
 
   private long getInputSize() throws IOException {
-    return this.fs.getContentSummary(this.inputPath).getLength();
+    long inputSize = 0;
+    for (Path inputPath : this.getInputPaths()) {
+      inputSize += this.fs.getContentSummary(inputPath).getLength();
+    }
+    return inputSize;
   }
 
   private long getTargetFileSize() {
-    return this.jobProps.getPropAsLong(COMPACTION_JOB_TARGET_OUTPUT_FILE_SIZE,
+    return this.dataset.jobProps().getPropAsLong(COMPACTION_JOB_TARGET_OUTPUT_FILE_SIZE,
         DEFAULT_COMPACTION_JOB_TARGET_OUTPUT_FILE_SIZE);
   }
 
   private int getMaxNumReducers() {
-    return this.jobProps.getPropAsInt(COMPACTION_JOB_MAX_NUM_REDUCERS, DEFAULT_COMPACTION_JOB_MAX_NUM_REDUCERS);
+    return this.dataset.jobProps().getPropAsInt(COMPACTION_JOB_MAX_NUM_REDUCERS,
+        DEFAULT_COMPACTION_JOB_MAX_NUM_REDUCERS);
   }
 
   private void submitAndWait(Job job) throws ClassNotFoundException, IOException, InterruptedException {
     job.submit();
     MRCompactor.addRunningHadoopJob(this.dataset, job);
-    LOG.info(String.format("MR job submitted for topic %s, input %s, url: %s", this.topic, this.inputPath,
+    LOG.info(String.format("MR job submitted for topic %s, input %s, url: %s", this.dataset.topic(), getInputPaths(),
         job.getTrackingURL()));
     while (!job.isComplete()) {
       if (this.policy == Policy.ABORT_ASAP) {
-        LOG.info(String.format("MR job for topic %s, input %s killed due to input data incompleteness."
-            + " Will try again later", this.topic, this.inputPath));
+        LOG.info(String.format(
+            "MR job for topic %s, input %s killed due to input data incompleteness." + " Will try again later",
+            this.dataset.topic(), getInputPaths()));
         job.killJob();
         return;
       }
       Thread.sleep(MR_JOB_CHECK_COMPLETE_INTERVAL_MS);
     }
     if (!job.isSuccessful()) {
-      throw new RuntimeException(String.format("MR job failed for topic %s, input %s, url: %s", this.topic,
-          this.inputPath, job.getTrackingURL()));
+      throw new RuntimeException(String.format("MR job failed for topic %s, input %s, url: %s", this.dataset.topic(),
+          getInputPaths(), job.getTrackingURL()));
     }
   }
 
   /**
-   * Data should be published if: (1) this.policy == GO; (2) either compaction.abort.upon.new.data=false,
-   * or no new data is found in the input folder since jobStartTime.
+   * Data should be published if: (1) this.policy == {@link Policy#DO_PUBLISH_DATA}; (2) either
+   * compaction.abort.upon.new.data=false, or no new data is found in the input folder since jobStartTime.
    */
   private boolean shouldPublishData(DateTime jobStartTime) throws IOException {
     if (this.policy != Policy.DO_PUBLISH_DATA) {
       return false;
     }
-    if (!this.jobProps.getPropAsBoolean(COMPACTION_JOB_ABORT_UPON_NEW_DATA, DEFAULT_COMPACTION_JOB_ABORT_UPON_NEW_DATA)) {
+    if (!this.dataset.jobProps().getPropAsBoolean(COMPACTION_JOB_ABORT_UPON_NEW_DATA,
+        DEFAULT_COMPACTION_JOB_ABORT_UPON_NEW_DATA)) {
       return true;
     }
-    return !findNewDataSinceCompactionStarted(jobStartTime);
+    for (Path inputPath : getInputPaths()) {
+      if (findNewDataSinceCompactionStarted(inputPath, jobStartTime)) {
+        return false;
+      }
+    }
+    return true;
   }
 
-  private boolean findNewDataSinceCompactionStarted(DateTime jobStartTime) throws IOException {
-    for (FileStatus fstat : HadoopUtils.listStatusRecursive(this.fs, this.inputPath)) {
+  private boolean findNewDataSinceCompactionStarted(Path inputPath, DateTime jobStartTime) throws IOException {
+    for (FileStatus fstat : FileListUtils.listFilesRecursively(this.fs, inputPath)) {
       DateTime fileModificationTime = new DateTime(fstat.getModificationTime());
       if (fileModificationTime.isAfter(jobStartTime)) {
         LOG.info(String.format("Found new file %s in input folder %s after compaction started. Will abort compaction.",
-            fstat.getPath(), this.inputPath));
+            fstat.getPath(), inputPath));
         return true;
       }
     }
@@ -381,7 +409,7 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   }
 
   private void markOutputDirAsCompleted(DateTime jobStartTime) throws IOException {
-    Path completionFilePath = new Path(this.outputPath, MRCompactor.COMPACTION_COMPLETE_FILE_NAME);
+    Path completionFilePath = new Path(this.dataset.outputPath(), MRCompactor.COMPACTION_COMPLETE_FILE_NAME);
     Closer closer = Closer.create();
     try {
       FSDataOutputStream completionFileStream = closer.register(this.fs.create(completionFilePath));
@@ -394,17 +422,24 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   }
 
   private void moveTmpPathToOutputPath() throws IOException {
-    LOG.info(String.format("Moving %s to %s", this.tmpPath, this.outputPath));
-    this.fs.delete(this.outputPath, true);
-    this.fs.mkdirs(this.outputPath.getParent(), this.perm);
-    if (!this.fs.rename(this.tmpPath, this.outputPath)) {
-      throw new IOException(String.format("Unable to move %s to %s", this.tmpPath, this.outputPath));
+    LOG.info(String.format("Moving %s to %s", this.dataset.outputTmpPath(), this.dataset.outputPath()));
+    this.fs.delete(this.dataset.outputPath(), true);
+    this.fs.mkdirs(this.dataset.outputPath().getParent(), this.perm);
+    if (!this.fs.rename(this.dataset.outputTmpPath(), this.dataset.outputPath())) {
+      throw new IOException(
+          String.format("Unable to move %s to %s", this.dataset.outputTmpPath(), this.dataset.outputPath()));
+    }
+  }
+
+  private void deleteAdditionalInputPaths() throws IOException {
+    for (Path path : this.dataset.additionalInputPaths()) {
+      HadoopUtils.deletePathAndEmptyAncestors(this.fs, path, true);
     }
   }
 
   private void submitSlaEvent(Job job) {
-    CompactionSlaEventHelper.populateState(jobProps, Optional.of(job), fs);
-    new SlaEventSubmitter(this.eventSubmitter, "CompactionCompleted", jobProps.getProperties()).submit();
+    CompactionSlaEventHelper.populateState(this.dataset, Optional.of(job), fs);
+    new SlaEventSubmitter(this.eventSubmitter, "CompactionCompleted", this.dataset.jobProps().getProperties()).submit();
   }
 
   /**
@@ -428,7 +463,7 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
 
   @Override
   public int compareTo(MRCompactorJobRunner o) {
-    return Double.compare(o.priority, this.priority);
+    return Double.compare(o.dataset.priority(), this.dataset.priority());
   }
 
   private List<Path> getCumulativeLateFilePaths(Path lateDataDir) throws FileNotFoundException, IOException {
@@ -458,61 +493,15 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   private void submitLateRecordCountsEvent(List<Path> newLateFilePaths, Path lateDataDir) {
     try {
       Map<String, String> eventMetadataMap = Maps.newHashMap();
-      long newLateRecordCount = this.recordCountProvider.getRecordCount(newLateFilePaths);
+      long newLateRecordCount = this.lateInputRecordCountProvider.getRecordCount(newLateFilePaths);
       eventMetadataMap.put(NEW_LATE_RECORD_COUNTS, Long.toString(newLateRecordCount));
-      eventMetadataMap.put(
-          CUMULATIVE_LATE_RECORD_COUNTS,
-          Long.toString(newLateRecordCount
-              + this.recordCountProvider.getRecordCount(this.getCumulativeLateFilePaths(lateDataDir))));
+      eventMetadataMap.put(CUMULATIVE_LATE_RECORD_COUNTS, Long.toString(newLateRecordCount
+          + this.lateOutputRecordCountProvider.getRecordCount(this.getCumulativeLateFilePaths(lateDataDir))));
 
       LOG.info("Submitting late event counts: " + eventMetadataMap);
       this.eventSubmitter.submit(LATE_RECORD_COUNTS_EVENT, eventMetadataMap);
     } catch (Exception e) {
       LOG.error("Failed to submit late event count:" + e, e);
-    }
-  }
-
-  @AllArgsConstructor
-  public static class LateFileRecordCountProvider implements RecordCountProvider {
-    private static final String SEPARATOR = ".";
-    private static final String LATE_COMPONENT = ".late";
-    private static final String EMPTY_STRING = "";
-
-    private RecordCountProvider recordCountProviderWithoutSuffix;
-
-    /**
-     * Construct filename for a late file. If the file does not exists in the output dir, retain the original name.
-     * Otherwise, append a LATE_COMPONENT{RandomInteger} to the original file name.
-     * For example, if file "part1.123.avro" exists in dir "/a/b/", the returned path will be "/a/b/part1.123.late12345.avro".
-     */
-    public Path constructLateFilePath(String originalFilename, FileSystem fs, Path outputDir) throws IOException {
-      if (!fs.exists(new Path(outputDir, originalFilename))) {
-        return new Path(outputDir, originalFilename);
-      } else {
-        return constructLateFilePath(
-            FilenameUtils.getBaseName(originalFilename) + LATE_COMPONENT + new Random().nextInt(Integer.MAX_VALUE)
-                + SEPARATOR + FilenameUtils.getExtension(originalFilename), fs, outputDir);
-      }
-    }
-
-    /**
-     * Get record count from a given filename (possibly having LATE_COMPONENT{RandomInteger}), using the original {@link FileNameWithRecordCountFormat}.
-     */
-    @Override
-    public long getRecordCount(Path filepath) {
-      return this.recordCountProviderWithoutSuffix.getRecordCount(new Path(filepath.getName().replaceAll(
-          Pattern.quote(LATE_COMPONENT) + "[\\d]*", EMPTY_STRING)));
-    }
-
-    /**
-     * Get record count for a list of paths.
-     */
-    public long getRecordCount(Collection<Path> paths) {
-      long count = 0;
-      for (Path path : paths) {
-        count += getRecordCount(path);
-      }
-      return count;
     }
   }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
@@ -16,7 +16,6 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTime;
@@ -29,13 +28,11 @@ import org.joda.time.format.PeriodFormatterBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
-import com.google.common.io.Closer;
 
+import gobblin.compaction.Dataset;
 import gobblin.compaction.event.CompactionSlaEventHelper;
-import gobblin.configuration.State;
-import gobblin.util.HadoopUtils;
 
 
 /**
@@ -85,52 +82,55 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
   MRCompactorTimeBasedJobPropCreator(Builder builder) {
     super(builder);
     this.folderTimePattern = getFolderPattern();
-    this.timeZone =
-        DateTimeZone
-            .forID(this.state.getProp(MRCompactor.COMPACTION_TIMEZONE, MRCompactor.DEFAULT_COMPACTION_TIMEZONE));
+    this.timeZone = DateTimeZone
+        .forID(this.state.getProp(MRCompactor.COMPACTION_TIMEZONE, MRCompactor.DEFAULT_COMPACTION_TIMEZONE));
     this.timeFormatter = DateTimeFormat.forPattern(this.folderTimePattern).withZone(this.timeZone);
   }
 
   @Override
-  protected List<State> createJobProps() throws IOException {
-    List<State> allJobProps = Lists.newArrayList();
+  protected List<Dataset> createJobProps() throws IOException {
+    List<Dataset> datasets = Lists.newArrayList();
     if (!fs.exists(this.topicInputDir)) {
       LOG.warn("Input folder " + this.topicInputDir + " does not exist. Skipping topic " + topic);
-      return allJobProps;
+      return datasets;
     }
 
     String folderStructure = getFolderStructure();
     for (FileStatus status : this.fs.globStatus(new Path(this.topicInputDir, folderStructure))) {
+      Path jobInputPath = status.getPath();
       DateTime folderTime = null;
       try {
-        folderTime = getFolderTime(status.getPath());
+        folderTime = getFolderTime(jobInputPath);
       } catch (RuntimeException e) {
-        LOG.warn(status.getPath() + " is not a valid folder. Will be skipped.");
+        LOG.warn(jobInputPath + " is not a valid folder. Will be skipped.");
         continue;
       }
-      Path jobOutputDir = new Path(this.topicOutputDir, folderTime.toString(this.timeFormatter));
-      Path jobTmpDir = new Path(this.topicTmpDir, folderTime.toString(this.timeFormatter));
-      if (folderWithinAllowedPeriod(status.getPath(), folderTime)) {
-        if (!folderAlreadyCompacted(jobOutputDir)) {
-          State state = createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate,
-              folderTime.toString(this.timeFormatter));
-          // Set the upstream time to partition + 1 day. E.g. for 2015/10/13 the upstream time is midnight of 2015/10/14
-          CompactionSlaEventHelper.setUpstreamTimeStamp(state, folderTime.plusDays(1).getMillis());
-          allJobProps.add(state);
-        } else {
-          List<Path> newDataFiles = getNewDataInFolder(status.getPath(), jobOutputDir);
-          if (newDataFiles.isEmpty()) {
-            LOG.info(String.format("Folder %s already compacted. Skipping", jobOutputDir));
-          } else {
-            Path jobOutputLateDir = new Path(this.topicOutputLateDir, folderTime.toString(this.timeFormatter));
-            allJobProps.add(createJobPropsForLateData(status.getPath(), jobOutputDir, jobOutputLateDir, jobTmpDir,
-                newDataFiles));
+
+      if (folderWithinAllowedPeriod(jobInputPath, folderTime)) {
+        Path jobInputLatePath = appendFolderTime(this.topicInputLateDir, folderTime);
+        Path jobOutputPath = appendFolderTime(this.topicOutputDir, folderTime);
+        Path jobOutputLatePath = appendFolderTime(this.topicOutputLateDir, folderTime);
+        Path jobOutputTmpPath = appendFolderTime(this.topicTmpOutputDir, folderTime);
+
+        Dataset dataset = new Dataset.Builder().withTopic(this.topic).withPriority(this.priority)
+            .withInputPath(this.recompactFromOutputPaths ? jobOutputPath : jobInputPath)
+            .withInputLatePath(this.recompactFromOutputPaths ? jobOutputLatePath : jobInputLatePath)
+            .withOutputPath(jobOutputPath).withOutputLatePath(jobOutputLatePath).withOutputTmpPath(jobOutputTmpPath)
+            .build();
+
+        Optional<Dataset> datasetWithJobProps = createJobProps(dataset, folderTime.toString(this.timeFormatter));
+        if (datasetWithJobProps.isPresent()) {
+          datasets.add(datasetWithJobProps.get());
+          if (this.recompactFromOutputPaths || !MRCompactor.datasetAlreadyCompacted(this.fs, dataset)) {
+
+            // Set the upstream time to partition + 1 day. E.g. for 2015/10/13 the upstream time is midnight of 2015/10/14
+            CompactionSlaEventHelper.setUpstreamTimeStamp(state, folderTime.plusDays(1).getMillis());
           }
         }
       }
     }
 
-    return allJobProps;
+    return datasets;
   }
 
   private String getFolderStructure() {
@@ -172,26 +172,6 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
     }
   }
 
-  /**
-   * Return job properties for a job to handle the appearance of data within jobInputDir which is
-   * more recent than the time of the last compaction.
-   */
-  private State createJobPropsForLateData(Path jobInputDir, Path jobOutputDir, Path jobOutputLateDir, Path jobTmpDir,
-      List<Path> newDataFiles) throws IOException {
-    if (this.state.getPropAsBoolean(MRCompactor.COMPACTION_RECOMPACT_FOR_LATE_DATA,
-        MRCompactor.DEFAULT_COMPACTION_RECOMPACT_FOR_LATE_DATA)) {
-      LOG.info(String.format("Will recompact for %s.", jobOutputDir));
-      return createJobProps(jobInputDir, jobOutputDir, jobTmpDir, this.deduplicate);
-    } else {
-      LOG.info(String.format("Will copy %d new data files to %s", newDataFiles.size(), jobOutputDir));
-      State jobProps = createJobProps(jobInputDir, jobOutputDir, jobTmpDir, this.deduplicate);
-      jobProps.setProp(MRCompactor.COMPACTION_JOB_LATE_DATA_MOVEMENT_TASK, true);
-      jobProps.setProp(MRCompactor.COMPACTION_JOB_LATE_DATA_FILES, Joiner.on(",").join(newDataFiles));
-      jobProps.setProp(MRCompactor.COMPACTION_JOB_DEST_LATE_DIR, jobOutputLateDir);
-      return jobProps;
-    }
-  }
-
   private PeriodFormatter getPeriodFormatter() {
     return new PeriodFormatterBuilder().appendMonths().appendSuffix("m").appendDays().appendSuffix("d").appendHours()
         .appendSuffix("h").toFormatter();
@@ -211,46 +191,7 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
     return currentTime.minus(minTimeAgo);
   }
 
-  private boolean folderAlreadyCompacted(Path outputFolder) {
-    Path filePath = new Path(outputFolder, MRCompactor.COMPACTION_COMPLETE_FILE_NAME);
-    try {
-      return this.fs.exists(filePath);
-    } catch (IOException e) {
-      LOG.error("Failed to verify the existence of file " + filePath, e);
-      return false;
-    }
-  }
-
-  /**
-   * Check if inputFolder contains any files which have modification times which are more
-   * recent than the last compaction time as stored within outputFolder; return any files
-   * which do. An empty list will be returned if all files are older than the last compaction time.
-   */
-  private List<Path> getNewDataInFolder(Path inputFolder, Path outputFolder) throws IOException {
-    List<Path> newFiles = Lists.newArrayList();
-
-    Path filePath = new Path(outputFolder, MRCompactor.COMPACTION_COMPLETE_FILE_NAME);
-    Closer closer = Closer.create();
-    try {
-      FSDataInputStream completionFileStream = closer.register(this.fs.open(filePath));
-      DateTime lastCompactionTime = new DateTime(completionFileStream.readLong(), this.timeZone);
-      for (FileStatus fstat : HadoopUtils.listStatusRecursive(this.fs, inputFolder)) {
-        DateTime fileModificationTime = new DateTime(fstat.getModificationTime(), this.timeZone);
-        if (fileModificationTime.isAfter(lastCompactionTime)) {
-          newFiles.add(fstat.getPath());
-        }
-      }
-      if (!newFiles.isEmpty()) {
-        LOG.info(String.format("Found %d new files within folder %s which are more recent than the previous "
-            + "compaction start time of %s.", newFiles.size(), inputFolder, lastCompactionTime));
-      }
-    } catch (IOException e) {
-      LOG.error("Failed to check for new data within folder: " + inputFolder, e);
-    } catch (Throwable e) {
-      throw closer.rethrow(e);
-    } finally {
-      closer.close();
-    }
-    return newFiles;
+  private Path appendFolderTime(Path path, DateTime folderTime) {
+    return new Path(path, folderTime.toString(this.timeFormatter));
   }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyCompactorOutputCommitter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyCompactorOutputCommitter.java
@@ -14,8 +14,6 @@ package gobblin.compaction.mapreduce.avro;
 
 import java.io.IOException;
 import java.lang.reflect.Method;
-import java.util.Random;
-import java.util.regex.Pattern;
 
 import org.apache.commons.io.FilenameUtils;
 import org.apache.hadoop.fs.FileStatus;
@@ -29,9 +27,7 @@ import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.Preconditions;
-
-import gobblin.util.RecordCountProvider;
+import gobblin.util.recordcount.CompactionRecordCountProvider;
 
 
 /**
@@ -44,11 +40,6 @@ import gobblin.util.RecordCountProvider;
 public class AvroKeyCompactorOutputCommitter extends FileOutputCommitter {
 
   private static final Logger LOG = LoggerFactory.getLogger(AvroKeyCompactorOutputCommitter.class);
-
-  private static final String MR_OUTPUT_FILE_PREFIX = "part-r-";
-  private static final String M_OUTPUT_FILE_PREFIX = "part-m-";
-
-  private static final Random RANDOM = new Random();
 
   public AvroKeyCompactorOutputCommitter(Path output, TaskAttemptContext context) throws IOException {
     super(output, context);
@@ -73,13 +64,12 @@ public class AvroKeyCompactorOutputCommitter extends FileOutputCommitter {
 
         // recordCount == 0 indicates that it is a map-only, non-dedup job, and thus record count should
         // be obtained from mapper counter.
-        fileNamePrefix = M_OUTPUT_FILE_PREFIX;
+        fileNamePrefix = CompactionRecordCountProvider.M_OUTPUT_FILE_PREFIX;
         recordCount = getRecordCountFromCounter(context, AvroKeyMapper.EVENT_COUNTER.RECORD_COUNT);
       } else {
-        fileNamePrefix = MR_OUTPUT_FILE_PREFIX;
+        fileNamePrefix = CompactionRecordCountProvider.MR_OUTPUT_FILE_PREFIX;
       }
-      String fileName =
-          new FilenameRecordCountProvider().constructFileName(fileNamePrefix, recordCount);
+      String fileName = new CompactionRecordCountProvider().constructFileName(fileNamePrefix, recordCount);
 
       for (FileStatus status : fs.listStatus(workPath, new PathFilter() {
         @Override
@@ -111,51 +101,4 @@ public class AvroKeyCompactorOutputCommitter extends FileOutputCommitter {
     }
   }
 
-  /**
-   * Implementation of {@link RecordCountProvider}, which provides record count from file path.
-   * The file name should follow the pattern: {Prefix}{RecordCount}.{SystemCurrentTimeInMills}.{RandomInteger}{SUFFIX}.
-   * The prefix should be either {@link AvroKeyCompactorOutputCommitter#M_OUTPUT_FILE_PREFIX} or {@link AvroKeyCompactorOutputCommitter#MR_OUTPUT_FILE_PREFIX}.
-   * For example, given a file path: "/a/b/c/part-m-123.1444437036.12345.avro", the record count will be 123.
-   */
-  public static class FilenameRecordCountProvider implements RecordCountProvider {
-    private static final String SEPARATOR = ".";
-    private static final String SUFFIX = ".avro";
-
-    /**
-     * Construct the file name as {filenamePrefix}{recordCount}.{SystemCurrentTimeInMills}.{RandomInteger}{SUFFIX}.
-     */
-    public String constructFileName(String filenamePrefix, long recordCount) {
-      Preconditions.checkArgument(
-          filenamePrefix.equals(M_OUTPUT_FILE_PREFIX) || filenamePrefix.equals(MR_OUTPUT_FILE_PREFIX), String.format(
-              "%s is not a supported prefix, which should be %s, or %s.", filenamePrefix, M_OUTPUT_FILE_PREFIX,
-              MR_OUTPUT_FILE_PREFIX));
-      StringBuilder sb = new StringBuilder();
-      sb.append(filenamePrefix);
-      sb.append(Long.toString(recordCount));
-      sb.append(SEPARATOR);
-      sb.append(Long.toString(System.currentTimeMillis()));
-      sb.append(SEPARATOR);
-      sb.append(Integer.toString(RANDOM.nextInt(Integer.MAX_VALUE)));
-      sb.append(SUFFIX);
-      return sb.toString();
-    }
-
-    /**
-     * Get the record count through filename.
-     */
-    @Override
-    public long getRecordCount(Path filepath) {
-      String filename = filepath.getName();
-      Preconditions.checkArgument(
-          filename.startsWith(M_OUTPUT_FILE_PREFIX) || filename.startsWith(MR_OUTPUT_FILE_PREFIX), String.format(
-              "%s is not a supported filename, which should start with %s, or %s.", filename, M_OUTPUT_FILE_PREFIX,
-              MR_OUTPUT_FILE_PREFIX));
-      String prefixWithCounts = filename.split(Pattern.quote(SEPARATOR))[0];
-      if (filename.startsWith(M_OUTPUT_FILE_PREFIX)) {
-        return Long.parseLong(prefixWithCounts.substring(M_OUTPUT_FILE_PREFIX.length()));
-      } else {
-        return Long.parseLong(prefixWithCounts.substring(MR_OUTPUT_FILE_PREFIX.length()));
-      }
-    }
-  }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyRecursiveCombineFileInputFormat.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyRecursiveCombineFileInputFormat.java
@@ -12,7 +12,7 @@
 
 package gobblin.compaction.mapreduce.avro;
 
-import gobblin.util.HadoopUtils;
+import gobblin.util.FileListUtils;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -115,7 +115,7 @@ public class AvroKeyRecursiveCombineFileInputFormat
     List<Path> files = Lists.newArrayList();
 
     for (Path dir : dirs) {
-      for (FileStatus status : HadoopUtils.listStatusRecursive(fs, dir)) {
+      for (FileStatus status : FileListUtils.listFilesRecursively(fs, dir)) {
         if (FilenameUtils.isExtension(status.getPath().getName(), AVRO)) {
           files.add(status.getPath());
         }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
@@ -238,20 +238,20 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
   }
 
   private DedupKeyOption getDedupKeyOption() {
-    if (!this.jobProps.contains(COMPACTION_JOB_DEDUP_KEY)) {
+    if (!this.dataset.jobProps().contains(COMPACTION_JOB_DEDUP_KEY)) {
       return DEFAULT_DEDUP_KEY_OPTION;
     }
-    Optional<DedupKeyOption> option =
-        Enums.getIfPresent(DedupKeyOption.class, this.jobProps.getProp(COMPACTION_JOB_DEDUP_KEY).toUpperCase());
+    Optional<DedupKeyOption> option = Enums.getIfPresent(DedupKeyOption.class,
+        this.dataset.jobProps().getProp(COMPACTION_JOB_DEDUP_KEY).toUpperCase());
     return option.isPresent() ? option.get() : DEFAULT_DEDUP_KEY_OPTION;
   }
 
   private boolean keySchemaFileSpecified() {
-    return this.jobProps.contains(COMPACTION_JOB_AVRO_KEY_SCHEMA_LOC);
+    return this.dataset.jobProps().contains(COMPACTION_JOB_AVRO_KEY_SCHEMA_LOC);
   }
 
   private Path getKeySchemaFile() {
-    return new Path(this.jobProps.getProp(COMPACTION_JOB_AVRO_KEY_SCHEMA_LOC));
+    return new Path(this.dataset.jobProps().getProp(COMPACTION_JOB_AVRO_KEY_SCHEMA_LOC));
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -22,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
-import gobblin.util.HadoopUtils;
+import gobblin.util.FileListUtils;
 import gobblin.util.ParallelRunner;
 import gobblin.util.WriterUtils;
 
@@ -54,7 +54,8 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
   protected void addWriterOutputToExistingDir(Path writerOutput, Path publisherOutput, WorkUnitState workUnitState,
       int branchId, ParallelRunner parallelRunner) throws IOException {
 
-    for (FileStatus status : HadoopUtils.listStatusRecursive(this.fileSystemByBranches.get(branchId), writerOutput)) {
+    for (FileStatus status : FileListUtils.listFilesRecursively(this.fileSystemByBranches.get(branchId),
+        writerOutput)) {
       String filePathStr = status.getPath().toString();
       String pathSuffix =
           filePathStr.substring(filePathStr.indexOf(writerOutput.toString()) + writerOutput.toString().length() + 1);
@@ -64,7 +65,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
           this.permissions.get(branchId));
 
       LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));
-      parallelRunner.renamePath(status.getPath(), outputPath, Optional.<String>absent());
+      parallelRunner.renamePath(status.getPath(), outputPath, Optional.<String> absent());
     }
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/DatasetFilterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/DatasetFilterUtils.java
@@ -29,7 +29,7 @@ public class DatasetFilterUtils {
   public static List<Pattern> getPatternsFromStrings(List<String> strings) {
     List<Pattern> patterns = Lists.newArrayList();
     for (String s : strings) {
-      patterns.add(Pattern.compile(s, Pattern.CASE_INSENSITIVE));
+      patterns.add(Pattern.compile(s));
     }
     return patterns;
   }

--- a/gobblin-utility/src/main/java/gobblin/util/FileListUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/FileListUtils.java
@@ -29,9 +29,18 @@ public class FileListUtils {
     }
   };
 
-  public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path) throws FileNotFoundException,
-      IOException {
+  public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path)
+      throws FileNotFoundException, IOException {
     return listFilesRecursively(fs, path, NO_OP_PATH_FILTER);
+  }
+
+  public static List<FileStatus> listFilesRecursively(FileSystem fs, Iterable<Path> paths)
+      throws FileNotFoundException, IOException {
+    List<FileStatus> results = Lists.newArrayList();
+    for (Path path : paths) {
+      results.addAll(listFilesRecursively(fs, path));
+    }
+    return results;
   }
 
   /**
@@ -43,6 +52,7 @@ public class FileListUtils {
     return listFilesRecursivelyHelper(fs, Lists.<FileStatus> newArrayList(), fs.getFileStatus(path), fileFilter);
   }
 
+  @SuppressWarnings("deprecation")
   private static List<FileStatus> listFilesRecursivelyHelper(FileSystem fs, List<FileStatus> files,
       FileStatus fileStatus, PathFilter fileFilter) throws FileNotFoundException, IOException {
     if (fileStatus.isDir()) {
@@ -58,8 +68,8 @@ public class FileListUtils {
   /**
    * Method to list out all files, or directory if no file exists, under a specified path.
    */
-  public static List<FileStatus> listMostNestedPathRecursively(FileSystem fs, Path path) throws FileNotFoundException,
-      IOException {
+  public static List<FileStatus> listMostNestedPathRecursively(FileSystem fs, Path path)
+      throws FileNotFoundException, IOException {
     return listMostNestedPathRecursively(fs, path, NO_OP_PATH_FILTER);
   }
 
@@ -73,6 +83,7 @@ public class FileListUtils {
         fileFilter);
   }
 
+  @SuppressWarnings("deprecation")
   private static List<FileStatus> listMostNestedPathRecursivelyHelper(FileSystem fs, List<FileStatus> files,
       FileStatus fileStatus, PathFilter fileFilter) throws FileNotFoundException, IOException {
     if (fileStatus.isDir()) {
@@ -99,6 +110,7 @@ public class FileListUtils {
     return listPathsRecursivelyHelper(fs, Lists.<FileStatus> newArrayList(), fs.getFileStatus(path), fileFilter);
   }
 
+  @SuppressWarnings("deprecation")
   private static List<FileStatus> listPathsRecursivelyHelper(FileSystem fs, List<FileStatus> files,
       FileStatus fileStatus, PathFilter fileFilter) {
     if (fileFilter.accept(fileStatus.getPath())) {

--- a/gobblin-utility/src/main/java/gobblin/util/recordcount/CompactionRecordCountProvider.java
+++ b/gobblin-utility/src/main/java/gobblin/util/recordcount/CompactionRecordCountProvider.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.recordcount;
+
+import java.util.Random;
+import java.util.regex.Pattern;
+
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.util.RecordCountProvider;
+
+
+/**
+ * Implementation of {@link RecordCountProvider}, which provides record count from file path.
+ * The file name should follow the pattern: {Prefix}{RecordCount}.{SystemCurrentTimeInMills}.{RandomInteger}{SUFFIX}.
+ * The prefix should be either {@link #M_OUTPUT_FILE_PREFIX} or {@link #MR_OUTPUT_FILE_PREFIX}.
+ * For example, given a file path: "/a/b/c/part-m-123.1444437036.12345.avro", the record count will be 123.
+ */
+public class CompactionRecordCountProvider extends RecordCountProvider {
+
+  public static final String MR_OUTPUT_FILE_PREFIX = "part-r-";
+  public static final String M_OUTPUT_FILE_PREFIX = "part-m-";
+
+  private static final String SEPARATOR = ".";
+  private static final String SUFFIX = ".avro";
+  private static final Random RANDOM = new Random();
+
+  /**
+   * Construct the file name as {filenamePrefix}{recordCount}.{SystemCurrentTimeInMills}.{RandomInteger}{SUFFIX}.
+   */
+  public String constructFileName(String filenamePrefix, long recordCount) {
+    Preconditions.checkArgument(
+        filenamePrefix.equals(M_OUTPUT_FILE_PREFIX) || filenamePrefix.equals(MR_OUTPUT_FILE_PREFIX),
+        String.format("%s is not a supported prefix, which should be %s, or %s.", filenamePrefix, M_OUTPUT_FILE_PREFIX,
+            MR_OUTPUT_FILE_PREFIX));
+    StringBuilder sb = new StringBuilder();
+    sb.append(filenamePrefix);
+    sb.append(Long.toString(recordCount));
+    sb.append(SEPARATOR);
+    sb.append(Long.toString(System.currentTimeMillis()));
+    sb.append(SEPARATOR);
+    sb.append(Integer.toString(RANDOM.nextInt(Integer.MAX_VALUE)));
+    sb.append(SUFFIX);
+    return sb.toString();
+  }
+
+  /**
+   * Get the record count through filename.
+   */
+  @Override
+  public long getRecordCount(Path filepath) {
+    String filename = filepath.getName();
+    Preconditions.checkArgument(filename.startsWith(M_OUTPUT_FILE_PREFIX) || filename.startsWith(MR_OUTPUT_FILE_PREFIX),
+        String.format("%s is not a supported filename, which should start with %s, or %s.", filename,
+            M_OUTPUT_FILE_PREFIX, MR_OUTPUT_FILE_PREFIX));
+    String prefixWithCounts = filename.split(Pattern.quote(SEPARATOR))[0];
+    if (filename.startsWith(M_OUTPUT_FILE_PREFIX)) {
+      return Long.parseLong(prefixWithCounts.substring(M_OUTPUT_FILE_PREFIX.length()));
+    } else {
+      return Long.parseLong(prefixWithCounts.substring(MR_OUTPUT_FILE_PREFIX.length()));
+    }
+  }
+
+  /**
+   * This method currently supports converting the given {@link Path} from {@link IngestionRecordCountProvider}.
+   * The converted {@link Path} will start with {@link #M_OUTPUT_FILE_PREFIX}.
+   */
+  @Override
+  public Path convertPath(Path path, RecordCountProvider src) {
+    if (this.getClass().equals(src.getClass())) {
+      return path;
+    } else if (src.getClass().equals(IngestionRecordCountProvider.class)) {
+      String newFileName = constructFileName(M_OUTPUT_FILE_PREFIX, src.getRecordCount(path));
+      return new Path(path.getParent(), newFileName);
+    } else {
+      throw getNotImplementedException(src);
+    }
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/recordcount/IngestionRecordCountProvider.java
+++ b/gobblin-utility/src/main/java/gobblin/util/recordcount/IngestionRecordCountProvider.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.recordcount;
+
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.Files;
+
+import gobblin.util.RecordCountProvider;
+
+
+/**
+ * Implementation of {@link RecordCountProvider}, which provides record count from file path.
+ * The file path should follow the pattern: {Filename}.{RecordCount}.{Extension}.
+ * For example, given a file path: "/a/b/c/file.123.avro", the record count will be 123.
+ */
+public class IngestionRecordCountProvider extends RecordCountProvider {
+
+  private static final String SEPARATOR = ".";
+
+  /**
+   * Construct a new file path by appending record count to the filename of the given file path, separated by SEPARATOR.
+   * For example, given path: "/a/b/c/file.avro" and record count: 123,
+   * the new path returned will be: "/a/b/c/file.123.avro"
+   */
+  public String constructFilePath(String oldFilePath, long recordCounts) {
+    return new Path(new Path(oldFilePath).getParent(), Files.getNameWithoutExtension(oldFilePath).toString() + SEPARATOR
+        + recordCounts + SEPARATOR + Files.getFileExtension(oldFilePath)).toString();
+  }
+
+  /**
+   * The record count should be the last component before the filename extension.
+   */
+  @Override
+  public long getRecordCount(Path filepath) {
+    String[] components = filepath.getName().split(Pattern.quote(SEPARATOR));
+    Preconditions.checkArgument(components.length >= 2 && StringUtils.isNumeric(components[components.length - 2]),
+        String.format("Filename %s does not follow the pattern: FILENAME.RECORDCOUNT.EXTENSION", filepath));
+    return Long.parseLong(components[components.length - 2]);
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/recordcount/LateFileRecordCountProvider.java
+++ b/gobblin-utility/src/main/java/gobblin/util/recordcount/LateFileRecordCountProvider.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.recordcount;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Random;
+import java.util.regex.Pattern;
+
+import org.apache.commons.io.FilenameUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import gobblin.util.RecordCountProvider;
+import lombok.AllArgsConstructor;
+
+
+@AllArgsConstructor
+public class LateFileRecordCountProvider extends RecordCountProvider {
+  private static final String SEPARATOR = ".";
+  private static final String LATE_COMPONENT = ".late";
+  private static final String EMPTY_STRING = "";
+
+  private RecordCountProvider recordCountProviderWithoutSuffix;
+
+  /**
+   * Construct filename for a late file. If the file does not exists in the output dir, retain the original name.
+   * Otherwise, append a LATE_COMPONENT{RandomInteger} to the original file name.
+   * For example, if file "part1.123.avro" exists in dir "/a/b/", the returned path will be "/a/b/part1.123.late12345.avro".
+   */
+  public Path constructLateFilePath(String originalFilename, FileSystem fs, Path outputDir) throws IOException {
+    if (!fs.exists(new Path(outputDir, originalFilename))) {
+      return new Path(outputDir, originalFilename);
+    } else {
+      return constructLateFilePath(FilenameUtils.getBaseName(originalFilename) + LATE_COMPONENT
+          + new Random().nextInt(Integer.MAX_VALUE) + SEPARATOR + FilenameUtils.getExtension(originalFilename), fs,
+          outputDir);
+    }
+  }
+
+  /**
+   * Remove the late components in the path added by {@link LateFileRecordCountProvider}.
+   */
+  public Path restoreFilePath(Path path) {
+    return new Path(path.getName().replaceAll(Pattern.quote(LATE_COMPONENT) + "[\\d]*", EMPTY_STRING));
+  }
+
+  /**
+   * Get record count from a given filename (possibly having LATE_COMPONENT{RandomInteger}), using the original {@link FileNameWithRecordCountFormat}.
+   */
+  @Override
+  public long getRecordCount(Path path) {
+    return this.recordCountProviderWithoutSuffix.getRecordCount(restoreFilePath(path));
+  }
+
+  /**
+   * Get record count for a list of paths.
+   */
+  public long getRecordCount(Collection<Path> paths) {
+    long count = 0;
+    for (Path path : paths) {
+      count += getRecordCount(path);
+    }
+    return count;
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/recordcount/CompactionRecordCountProviderTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/recordcount/CompactionRecordCountProviderTest.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.compaction.mapreduce.avro;
+package gobblin.util.recordcount;
 
 import java.util.regex.Pattern;
 
@@ -20,14 +20,13 @@ import org.testng.annotations.Test;
 
 
 /**
- * Tests for {@link AvroKeyCompactorOutputCommitter.FilenameRecordCountProvider}.
+ * Tests for {@link CompactionRecordCountProvider}.
  */
-@Test(groups = { "gobblin.compaction.mapreduce.avro" })
-public class AvroKeyCompactorOutputCommitterFileNameRecordCountProviderTest {
+@Test(groups = { "gobblin.util.recordcount" })
+public class CompactionRecordCountProviderTest {
   @Test
   public void testFileNameRecordCountProvider() {
-    AvroKeyCompactorOutputCommitter.FilenameRecordCountProvider filenameRecordCountProvider =
-        new AvroKeyCompactorOutputCommitter.FilenameRecordCountProvider();
+    CompactionRecordCountProvider filenameRecordCountProvider = new CompactionRecordCountProvider();
 
     Pattern pattern = Pattern.compile("part\\-r\\-123\\.[\\d]*\\.[\\d]*\\.avro");
     Assert.assertTrue(pattern.matcher(filenameRecordCountProvider.constructFileName("part-r-", 123)).matches());

--- a/gobblin-utility/src/test/java/gobblin/util/recordcount/IngestionRecordCountProviderTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/recordcount/IngestionRecordCountProviderTest.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.writer;
+package gobblin.util.recordcount;
 
 import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
@@ -18,15 +18,16 @@ import org.testng.annotations.Test;
 
 
 /**
- * Tests for {@link AvroHdfsTimePartitionedWithRecordCountsWriter.FilenameRecordCountProvider}.
+ * Tests for {@link IngestionRecordCountProvider}.
  */
-@Test(groups = { "gobblin.writer" })
-public class AvroHdfsTimePartitionedWithRecordCountsWriterFileNameFormatTest {
+@Test(groups = { "gobblin.util.recordcount" })
+public class IngestionRecordCountProviderTest {
+
   @Test
   public void testFileNameFormat() {
-    AvroHdfsTimePartitionedWithRecordCountsWriter.FilenameRecordCountProvider filenameRecordCountProvider =
-        new AvroHdfsTimePartitionedWithRecordCountsWriter.FilenameRecordCountProvider();
-   Assert.assertEquals(filenameRecordCountProvider.constructFilePath("/a/b/c.avro", 123), "/a/b/c.123.avro");
-   Assert.assertEquals(filenameRecordCountProvider.getRecordCount(new Path("/a/b/c.123.avro")), 123);
+    IngestionRecordCountProvider filenameRecordCountProvider = new IngestionRecordCountProvider();
+    Assert.assertEquals(filenameRecordCountProvider.constructFilePath("/a/b/c.avro", 123), "/a/b/c.123.avro");
+    Assert.assertEquals(filenameRecordCountProvider.getRecordCount(new Path("/a/b/c.123.avro")), 123);
   }
+
 }


### PR DESCRIPTION
Main changes:
- Moved all folders (e.g., `inputPath`, `inputLatePath`, etc.) as fields of `Dataset` to avoid passing all of them around in method signatures.
- Moved the logic for finding late data files from `MRCompactorTimeBasedJobPropCreator` to `MRCompactorJobPropCreator` since they are also applicable to non time-based compaction.
- Added support for handling input late paths (since hourly compaction may create `hourly_late`, which will be the input late path for daily compaction) for both dedup and non-dedup cases. If input late dir has data and the dataset has not been compacted before, the dataset will always be deduped.
- For hourly compaction, the output file format in `hourly` folder is compaction format (start with `part-r`), while the file format in `hourly_late` folder is writer format. Both folders may contain late data which will be copied to `daily_late`, causing files in `daily_late` to have two different formats. The following has been done to resolve this inconsistency:
 - split `compaction.record.count.provider` into `compaction.input.record.count.provider` and `compaction.output.record.count.provider`.
 - change `RecordCountProvider` from interface to abstract class, and added new method `convertPath()`.
 - when a late data file is copied to output late dir, its file name is converted according to `compaction.output.record.count.provider`.
- Put all `RecordCountProvider` implementations in `gobblin-utility` to avoid circular dependency.
- Added option `compaction.recompact.from.dest.paths` for manual recompaction from output paths. When this is enabled, a dataset will be recompacted if there are late data in its `output_late` folder (e.g., `daily_late` for daily compaction). Its input folders (e.g., `hourly` and `hourly_late`) will be ignored. Also, in this case the compaction timestamp is not the compaction start time, but the latest modification time of all input files. The reason we can't use compaction job start time in this case is that between this two timestamps (i.e., latest modification time of all input files and compaction job start time), new data may be written into the input paths. These new data should be considered late data the next time we compact from the input paths.