### PR TITLE
Fix record count in compaction sla event

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
@@ -28,6 +28,7 @@ import com.google.common.base.Optional;
 
 import gobblin.compaction.mapreduce.MRCompactor;
 import gobblin.compaction.mapreduce.avro.AvroKeyDedupReducer;
+import gobblin.compaction.mapreduce.avro.AvroKeyMapper;
 import gobblin.configuration.State;
 import gobblin.metrics.event.sla.SlaEventKeys;
 
@@ -92,16 +93,26 @@ public class CompactionSlaEventHelper {
     try {
       counters = job.getCounters();
     } catch (IOException e) {
-      LOG.debug("Failed to get job counters. Record count will not be set. ", e);
+      LOG.info("Failed to get job counters. Record count will not be set. ", e);
       return;
     }
 
-    if (counters != null) {
-      Counter recordCounter = counters.findCounter(AvroKeyDedupReducer.EVENT_COUNTER.RECORD_COUNT);
-      if (recordCounter != null) {
-        state.setProp(SlaEventKeys.RECORD_COUNT_KEY, Long.toString(recordCounter.getValue()));
-      }
+    Counter recordCounter = counters.findCounter(AvroKeyDedupReducer.EVENT_COUNTER.RECORD_COUNT);
+
+    if (recordCounter != null & recordCounter.getValue() != 0) {
+      state.setProp(SlaEventKeys.RECORD_COUNT_KEY, Long.toString(recordCounter.getValue()));
+      return;
     }
+
+    recordCounter = counters.findCounter(AvroKeyMapper.EVENT_COUNTER.RECORD_COUNT);
+
+    if (recordCounter != null & recordCounter.getValue() != 0) {
+      state.setProp(SlaEventKeys.RECORD_COUNT_KEY, Long.toString(recordCounter.getValue()));
+      return;
+    }
+
+    LOG.info("Not found non zero record count in both mapper and reducer counters");
+
   }
 
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
@@ -111,7 +111,7 @@ public class CompactionSlaEventHelper {
       return;
     }
 
-    LOG.info("Not found non zero record count in both mapper and reducer counters");
+    LOG.info("Non zero record count not found in both mapper and reducer counters");
 
   }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorTimeBasedJobPropCreator.java
@@ -114,7 +114,8 @@ public class MRCompactorTimeBasedJobPropCreator extends MRCompactorJobPropCreato
         if (!folderAlreadyCompacted(jobOutputDir)) {
           State state = createJobProps(status.getPath(), jobOutputDir, jobTmpDir, this.deduplicate,
               folderTime.toString(this.timeFormatter));
-          CompactionSlaEventHelper.setUpstreamTimeStamp(state, folderTime.getMillis());
+          // Set the upstream time to partition + 1 day. E.g. for 2015/10/13 the upstream time is midnight of 2015/10/14
+          CompactionSlaEventHelper.setUpstreamTimeStamp(state, folderTime.plusDays(1).getMillis());
           allJobProps.add(state);
         } else {
           List<Path> newDataFiles = getNewDataInFolder(status.getPath(), jobOutputDir);


### PR DESCRIPTION
Fixed record count being 0 for a few topics. The compaction jobs for these topics were mapper only. The code previously only looked at reducer counters.
@zliu41 can you take a look at this?