### PR TITLE
Separate two types of non-deduping compaction

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/event/CompactionSlaEventHelper.java
@@ -44,7 +44,7 @@ public class CompactionSlaEventHelper {
   public static void populateState(Dataset dataset, Optional<Job> job, FileSystem fs) {
     setDatasetUrn(dataset);
     setPartition(dataset);
-    setDedupeStatus(dataset.jobProps());
+    setOutputDedupeStatus(dataset.jobProps());
     setPreviousPublishTime(dataset, fs);
     if (job.isPresent()) {
       setRecordCount(dataset.jobProps(), job.get());
@@ -78,8 +78,9 @@ public class CompactionSlaEventHelper {
     }
   }
 
-  private static void setDedupeStatus(State state) {
-    if (state.getPropAsBoolean(MRCompactor.COMPACTION_DEDUPLICATE, MRCompactor.DEFAULT_COMPACTION_DEDUPLICATE)) {
+  private static void setOutputDedupeStatus(State state) {
+    if (state.getPropAsBoolean(MRCompactor.COMPACTION_OUTPUT_DEDUPLICATED,
+        MRCompactor.DEFAULT_COMPACTION_OUTPUT_DEDUPLICATED)) {
       state.setProp(SlaEventKeys.DEDUPE_STATUS_KEY, DedupeStatus.DEDUPED);
 
     } else {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/MRCompactorAvroKeyDedupJobRunner.java
@@ -99,7 +99,7 @@ public class MRCompactorAvroKeyDedupJobRunner extends MRCompactorJobRunner {
   private void configureSchema(Job job) throws IOException {
     Schema newestSchema = getNewestSchemaFromSource(job);
     AvroJob.setInputKeySchema(job, newestSchema);
-    AvroJob.setMapOutputKeySchema(job, this.deduplicate ? getKeySchema(job, newestSchema) : newestSchema);
+    AvroJob.setMapOutputKeySchema(job, this.shouldDeduplicate ? getKeySchema(job, newestSchema) : newestSchema);
     AvroJob.setMapOutputValueSchema(job, newestSchema);
     AvroJob.setOutputKeySchema(job, newestSchema);
   }

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -18,7 +18,6 @@ import static org.apache.avro.SchemaCompatibility.SchemaCompatibilityType.COMPAT
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
@@ -365,7 +364,7 @@ public class AvroUtils {
       }
     }
 
-    Schema newSchema = Schema.createRecord(record.getName(), record.getDoc(), record.getName(), false);
+    Schema newSchema = Schema.createRecord(record.getName(), record.getDoc(), record.getNamespace(), false);
     newSchema.setFields(fields);
     return Optional.of(newSchema);
   }


### PR DESCRIPTION
There are two types of non-deduping compaction: (1) the data doesn't need to be deduplicated, e.g., /data/service; (2) the data do need to be deduplicated, but the input data is already compacted, e.g., daily compaction for /data/tracking.

These two types need to be treated different when there's late data. For type (1), we simply copy late data to output folder; for type (2), we need to copy late data to _late folder. Also, for type (2), when we compact a folder for the first time, if the input folder contains late data (e.g., in `hourly_late`), then it will run a deduping compaction instead of non-deduping compaction.

Separated property `compaction.deduplicate` into `compaction.input.deduplicated` and `compaction.output.deduplicated`. In case (1), both are false. In case (2), both are true.