### PR TITLE
Do not throw Exception in ParallelRunner.rename if dst exists

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -16,10 +16,12 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
@@ -96,6 +98,13 @@ public class HadoopUtils {
    * {@link FileSystem#rename(Path, Path)} returns False.
    */
   public static void renamePath(FileSystem fs, Path oldName, Path newName) throws IOException {
+    if (!fs.exists(oldName)) {
+      throw new FileNotFoundException(String.format("Failed to rename %s to %s: src not found", oldName, newName));
+    }
+    if (fs.exists(newName)) {
+      throw new FileAlreadyExistsException(
+          String.format("Failed to rename %s to %s: dst already exists", oldName, newName));
+    }
     if (!fs.rename(oldName, newName)) {
       throw new IOException(String.format("Failed to rename %s to %s", oldName, newName));
     }

--- a/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.locks.Lock;
 
+import org.apache.hadoop.fs.FileAlreadyExistsException;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.SequenceFile;
@@ -248,6 +249,9 @@ public class ParallelRunner implements Closeable {
               HadoopUtils.setGroup(fs, dst, group.get());
             }
           }
+          return null;
+        } catch (FileAlreadyExistsException e) {
+          LOGGER.warn(String.format("Failed to rename %s to %s: dst already exists"), e);
           return null;
         } finally {
           lock.unlock();


### PR DESCRIPTION
If a mapper publishes data for some tasks and then failed, and a new mapper is launched for the same tasks, the new mapper will still fail because it will fail to publish data for those tasks since they already exist in the dest folder.