### PR TITLE
Replace postProcessTaskStates() with postProcessJobState()

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -270,7 +270,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
       TimingEvent jobCommitTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.LauncherTimings.JOB_COMMIT);
       this.jobContext.finalizeJobStateBeforeCommit();
       this.jobContext.commit();
-      postProcessTaskStates(jobState.getTaskStates());
+      postProcessJobState(jobState);
       jobCommitTimer.stop();
     } catch (Throwable t) {
       jobState.setState(JobState.RunningState.FAILED);
@@ -319,9 +319,20 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   /**
    * Subclasses can override this method to do whatever processing on the {@link TaskState}s,
    * e.g., aggregate task-level metrics into job-level metrics.
+   * 
+   * @deprecated Use {@link #postProcessJobState(JobState)
    */
+  @Deprecated
   protected void postProcessTaskStates(List<TaskState> taskStates) {
     // Do nothing
+  }
+
+  /**
+   * Subclasses can override this method to do whatever processing on the {@link JobState} and its
+   * associated {@link TaskState}s, e.g., aggregate task-level metrics into job-level metrics.
+   */
+  protected void postProcessJobState(JobState jobState) {
+    postProcessTaskStates(jobState.getTaskStates());
   }
 
   @Override


### PR DESCRIPTION
Some metrics, e.g., `FAIL_TO_GET_OFFSET_COUNT`, are obtained in `Source` and added to `SourceState`, so they will be in `JobState` instead of `TaskState`.