### PR TITLE
Do not add JobState to WorkUnits until when the tasks start

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -58,6 +58,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
 
   public static final String TASK_STATE_STORE_TABLE_SUFFIX = ".tst";
 
+  public static final String JOB_STATE_FILE_NAME = "job.state";
+
   // Job configuration properties
   protected final Properties jobProps;
 
@@ -319,7 +321,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   /**
    * Subclasses can override this method to do whatever processing on the {@link TaskState}s,
    * e.g., aggregate task-level metrics into job-level metrics.
-   * 
+   *
    * @deprecated Use {@link #postProcessJobState(JobState)
    */
   @Deprecated

--- a/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
@@ -14,13 +14,22 @@ package gobblin.util;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Closer;
+
+import gobblin.configuration.State;
 
 
 /**
@@ -50,7 +59,7 @@ public class SerializationUtils {
    * @param obj A {@link Serializable} object
    * @param enc The {@link BaseEncoding} used to encode a byte array.
    * @return A String representing the input object
-   * @throws IOException 
+   * @throws IOException
    */
   public static <T extends Serializable> String serialize(T obj, BaseEncoding enc) throws IOException {
     Closer closer = Closer.create();
@@ -98,6 +107,54 @@ public class SerializationUtils {
       return clazz.cast(ois.readObject());
     } catch (Throwable e) {
       throw closer.rethrow(e);
+    } finally {
+      closer.close();
+    }
+  }
+
+  /**
+   * Serialize a {@link State} instance to a file.
+   *
+   * @param fs the {@link FileSystem} instance for creating the file
+   * @param jobStateFilePath the path to the file
+   * @param state the {@link State} to serialize
+   * @param <T> the {@link State} object type
+   * @throws IOException if it fails to serialize the {@link State} instance
+   */
+  public static <T extends State> void serializeState(FileSystem fs, Path jobStateFilePath, T state)
+      throws IOException {
+    Closer closer = Closer.create();
+
+    try {
+      OutputStream os = closer.register(fs.create(jobStateFilePath));
+      DataOutputStream dataOutputStream = closer.register(new DataOutputStream(os));
+      state.write(dataOutputStream);
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
+    } finally {
+      closer.close();
+    }
+  }
+
+  /**
+   * Deserialize/read a {@link State} instance from a file.
+   *
+   * @param fs the {@link FileSystem} instance for opening the file
+   * @param jobStateFilePath the path to the file
+   * @param state an empty {@link State} instance to deserialize into
+   * @param <T> the {@link State} object type
+   * @throws IOException if it fails to deserialize the {@link State} instance
+   */
+  public static <T extends State> void deserializeState(FileSystem fs, Path jobStateFilePath, T state)
+      throws IOException {
+    Closer closer = Closer.create();
+
+    try {
+      InputStream is = closer.register(fs.open(jobStateFilePath));
+      DataInputStream dis = closer.register((new DataInputStream(is)));
+      state.readFields(dis);
+    } catch (Throwable t) {
+      throw closer.rethrow(t);
     } finally {
       closer.close();
     }

--- a/gobblin-utility/src/test/java/gobblin/util/ParallelRunnerTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ParallelRunnerTest.java
@@ -59,12 +59,12 @@ public class ParallelRunnerTest {
     try {
       ParallelRunner parallelRunner = closer.register(new ParallelRunner(2, this.fs));
 
-      WorkUnit workUnit1 = new WorkUnit();
+      WorkUnit workUnit1 = WorkUnit.createEmpty();
       workUnit1.setProp("foo", "bar");
       workUnit1.setProp("a", 10);
       parallelRunner.serializeToFile(workUnit1, new Path(this.outputPath, "wu1"));
 
-      WorkUnit workUnit2 = new WorkUnit();
+      WorkUnit workUnit2 = WorkUnit.createEmpty();
       workUnit2.setProp("foo", "baz");
       workUnit2.setProp("b", 20);
       parallelRunner.serializeToFile(workUnit2, new Path(this.outputPath, "wu2"));
@@ -78,8 +78,8 @@ public class ParallelRunnerTest {
 
   @Test(dependsOnMethods = "testSerializeToFile")
   public void testDeserializeFromFile() throws IOException {
-    WorkUnit workUnit1 = new WorkUnit();
-    WorkUnit workUnit2 = new WorkUnit();
+    WorkUnit workUnit1 = WorkUnit.createEmpty();
+    WorkUnit workUnit2 = WorkUnit.createEmpty();
 
     Closer closer = Closer.create();
     try {

--- a/gobblin-utility/src/test/java/gobblin/util/SerializationUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/SerializationUtilsTest.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * Unit tests for {@link SerializationUtils}.
+ *
+ * @author ynli
+ */
+@Test(groups = { "gobblin.util" })
+public class SerializationUtilsTest {
+
+  private FileSystem fs;
+  private Path outputPath;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    this.fs = FileSystem.getLocal(new Configuration());
+    this.outputPath = new Path(SerializationUtilsTest.class.getSimpleName());
+  }
+
+  @Test
+  public void testSerializeState() throws IOException {
+    WorkUnit workUnit1 = WorkUnit.createEmpty();
+    workUnit1.setProp("foo", "bar");
+    workUnit1.setProp("a", 10);
+    SerializationUtils.serializeState(this.fs, new Path(this.outputPath, "wu1"), workUnit1);
+
+    WorkUnit workUnit2 = WorkUnit.createEmpty();
+    workUnit2.setProp("foo", "baz");
+    workUnit2.setProp("b", 20);
+    SerializationUtils.serializeState(this.fs, new Path(this.outputPath, "wu2"), workUnit2);
+  }
+
+  @Test(dependsOnMethods = "testSerializeState")
+  public void testDeserializeState() throws IOException {
+    WorkUnit workUnit1 = WorkUnit.createEmpty();
+    WorkUnit workUnit2 = WorkUnit.createEmpty();
+
+    SerializationUtils.deserializeState(this.fs, new Path(this.outputPath, "wu1"), workUnit1);
+    SerializationUtils.deserializeState(this.fs, new Path(this.outputPath, "wu2"), workUnit2);
+
+    Assert.assertEquals(workUnit1.getPropertyNames().size(), 2);
+    Assert.assertEquals(workUnit1.getProp("foo"), "bar");
+    Assert.assertEquals(workUnit1.getPropAsInt("a"), 10);
+
+    Assert.assertEquals(workUnit2.getPropertyNames().size(), 2);
+    Assert.assertEquals(workUnit2.getProp("foo"), "baz");
+    Assert.assertEquals(workUnit2.getPropAsInt("b"), 20);
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    if (this.fs != null && this.outputPath != null) {
+      this.fs.delete(this.outputPath, true);
+    }
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
@@ -50,6 +50,7 @@ import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.JobLauncherUtils;
 import gobblin.util.ParallelRunner;
+import gobblin.util.SerializationUtils;
 
 
 /**
@@ -153,6 +154,9 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
           addWorkUnit(workUnit, stateSerDeRunner, taskConfigMap);
         }
       }
+
+      Path jobStateFilePath = new Path(this.appWorkDir, this.jobContext.getJobId() + "." + JOB_STATE_FILE_NAME);
+      SerializationUtils.serializeState(this.fs, jobStateFilePath, this.jobContext.getJobState());
     } catch (Throwable t) {
       throw closer.rethrow(t);
     } finally {


### PR DESCRIPTION
Currently in the MR mode, there's an optimization that avoids adding the JobState to the WorkUnits too early to reduce the memory footprint on the client side as well as reduce the cost of serializing the WorkUnits. The JobState is added to the WorkUnits, though, in the mappers after the WorkUnits are deserialized. Currently the Yarn mode is not doing this optimization so this PR fixes it.

Signed-off-by: Yinan Li <liyinan926@gmail.com>