### PR TITLE
Fixed an issue that may cause Kafka adapter to miss data if the Fork fails

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/JobCommitPolicy.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/JobCommitPolicy.java
@@ -12,9 +12,10 @@
 
 package gobblin.source.extractor;
 
+import java.util.Properties;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
-import java.util.Properties;
 
 
 /**
@@ -33,7 +34,17 @@ public enum JobCommitPolicy {
    * Commit a job even if some of its tasks fail. It's up to the {@link gobblin.publisher.DataPublisher}
    * to decide whether data of failed tasks of the job should be committed or not.
    */
-  COMMIT_ON_PARTIAL_SUCCESS("partial");
+  COMMIT_ON_PARTIAL_SUCCESS("partial"),
+
+  /**
+   * Commit output data of tasks whose state are {@link gobblin.configuration.WorkUnitState.WorkingState#SUCCESSFUL}.
+   * This is different from {@link #COMMIT_ON_PARTIAL_SUCCESS} in that this policy won't publish partial output data
+   * of a task if it has not succeeded, whereas {@link #COMMIT_ON_PARTIAL_SUCCESS} will.
+   *
+   * It is recommended to use this commit policy in conjunction with task-level data publishing (i.e., when
+   * {@link ConfigurationKeys#PUBLISH_DATA_AT_JOB_LEVEL} is set to {@code false}).
+   */
+  COMMIT_SUCCESSFUL_TASKS("successful");
 
   private final String name;
 
@@ -56,6 +67,10 @@ public enum JobCommitPolicy {
       return COMMIT_ON_PARTIAL_SUCCESS;
     }
 
+    if (COMMIT_SUCCESSFUL_TASKS.name.equalsIgnoreCase(name)) {
+      return COMMIT_SUCCESSFUL_TASKS;
+    }
+
     throw new IllegalArgumentException(String.format("Job commit policy with name %s is not supported", name));
   }
 
@@ -63,11 +78,22 @@ public enum JobCommitPolicy {
    * Get a {@link JobCommitPolicy} through its name specified in configuration property
    * {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY}.
    *
-   * @param jobProps job configuration properties
+   * @param jobProps a {@link Properties} instance carrying job configuration properties
    * @return a {@link JobCommitPolicy} with the given name specified in {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY}
    */
   public static JobCommitPolicy getCommitPolicy(Properties jobProps) {
     return forName(jobProps.getProperty(ConfigurationKeys.JOB_COMMIT_POLICY_KEY,
         ConfigurationKeys.DEFAULT_JOB_COMMIT_POLICY));
+  }
+
+  /**
+   * Get a {@link JobCommitPolicy} through its name specified in configuration property
+   * {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY}.
+   *
+   * @param state a {@link State} instance carrying job configuration properties
+   * @return a {@link JobCommitPolicy} with the given name specified in {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY}
+   */
+  public static JobCommitPolicy getCommitPolicy(State state) {
+    return forName(state.getProp(ConfigurationKeys.JOB_COMMIT_POLICY_KEY, ConfigurationKeys.DEFAULT_JOB_COMMIT_POLICY));
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -274,12 +274,16 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     this.workUnitState.setProp(ConfigurationKeys.ERROR_MESSAGE_INVALID_SCHEMA_ID_COUNT, this.invalidSchemaIdCount);
     this.workUnitState.setProp(ConfigurationKeys.ERROR_MESSAGE_UNDECODABLE_COUNT, this.undecodableMessageCount);
 
-    // Commit actual high watermark for each partition
-    for (int i = 0; i < this.partitions.size(); i++) {
-      LOG.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
-          this.nextWatermark.get(i), this.highWatermark.get(i)));
+    if (this.workUnitState.getWorkingState() == WorkUnitState.WorkingState.COMMITTED) {
+      // Commit actual high watermark for each partition
+      for (int i = 0; i < this.partitions.size(); i++) {
+        LOG.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
+            this.nextWatermark.get(i), this.highWatermark.get(i)));
+      }
+      this.workUnitState.setActualHighWatermark(this.nextWatermark);
+    } else {
+      LOG.info("Not updating the actual high watermark as the WorkUnitState is: " + this.workUnitState.getWorkingState());
     }
-    this.workUnitState.setActualHighWatermark(this.nextWatermark);
 
     // Commit avg time to pull a record for each partition
     for (KafkaPartition partition : this.partitions) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -274,16 +274,12 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
     this.workUnitState.setProp(ConfigurationKeys.ERROR_MESSAGE_INVALID_SCHEMA_ID_COUNT, this.invalidSchemaIdCount);
     this.workUnitState.setProp(ConfigurationKeys.ERROR_MESSAGE_UNDECODABLE_COUNT, this.undecodableMessageCount);
 
-    if (this.workUnitState.getWorkingState() == WorkUnitState.WorkingState.COMMITTED) {
-      // Commit actual high watermark for each partition
-      for (int i = 0; i < this.partitions.size(); i++) {
-        LOG.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
-            this.nextWatermark.get(i), this.highWatermark.get(i)));
-      }
-      this.workUnitState.setActualHighWatermark(this.nextWatermark);
-    } else {
-      LOG.info("Not updating the actual high watermark as the WorkUnitState is: " + this.workUnitState.getWorkingState());
+    // Commit actual high watermark for each partition
+    for (int i = 0; i < this.partitions.size(); i++) {
+      LOG.info(String.format("Actual high watermark for partition %s=%d, expected=%d", this.partitions.get(i),
+          this.nextWatermark.get(i), this.highWatermark.get(i)));
     }
+    this.workUnitState.setActualHighWatermark(this.nextWatermark);
 
     // Commit avg time to pull a record for each partition
     for (KafkaPartition partition : this.partitions) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -415,14 +415,14 @@ public class Fork implements Closeable, Runnable, FinalState {
           this.taskState.getProp(ConfigurationKeys.EXTRACTOR_ROWS_EXTRACTED));
     }
 
-    String writerRowsWrittenKey =
+    String writerRecordsWrittenKey =
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_RECORDS_WRITTEN, this.branches, this.index);
     if (this.writer.isPresent()) {
       this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, this.writer.get().recordsWritten());
-      this.taskState.setProp(writerRowsWrittenKey, this.writer.get().recordsWritten());
+      this.taskState.setProp(writerRecordsWrittenKey, this.writer.get().recordsWritten());
     } else {
       this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, 0l);
-      this.taskState.setProp(writerRowsWrittenKey, 0l);
+      this.taskState.setProp(writerRecordsWrittenKey, 0l);
     }
 
     if (schema.isPresent()) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -15,7 +15,6 @@ package gobblin.runtime;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -88,15 +87,10 @@ public class Fork implements Closeable, Runnable, FinalState {
   private final RowLevelPolicyChecker rowLevelPolicyChecker;
   private final RowLevelPolicyCheckResults rowLevelPolicyCheckingResult;
 
-  // This is used to signal the parent task of the completion of this fork
-  private final CountDownLatch countDownLatch;
-
   // A bounded blocking queue in between the parent task and this fork
   private final BoundedBlockingRecordQueue<Object> recordQueue;
 
   private final Closer closer = Closer.create();
-
-  private final boolean useEagerWriterInitialization;
 
   // The writer will be lazily created when the first data record arrives
   private Optional<InstrumentedDataWriterDecorator<Object>> writer = Optional.absent();
@@ -113,9 +107,7 @@ public class Fork implements Closeable, Runnable, FinalState {
 
   private static final String FORK_METRICS_BRANCH_NAME_KEY = "forkBranchName";
 
-  public Fork(TaskContext taskContext, Object schema, int branches, int index, CountDownLatch countDownLatch)
-      throws Exception {
-
+  public Fork(TaskContext taskContext, Object schema, int branches, int index) throws Exception {
     this.logger = LoggerFactory.getLogger(Fork.class.getName() + "-" + index);
 
     this.taskContext = taskContext;
@@ -133,8 +125,11 @@ public class Fork implements Closeable, Runnable, FinalState {
     this.rowLevelPolicyChecker = this.closer.register(this.taskContext.getRowLevelPolicyChecker(this.index));
     this.rowLevelPolicyCheckingResult = new RowLevelPolicyCheckResults();
 
-    this.useEagerWriterInitialization = this.taskState.getPropAsBoolean(
+    boolean useEagerWriterInitialization = this.taskState.getPropAsBoolean(
         ConfigurationKeys.WRITER_EAGER_INITIALIZATION_KEY, ConfigurationKeys.DEFAULT_WRITER_EAGER_INITIALIZATION);
+    if (useEagerWriterInitialization) {
+      buildWriterIfNotPresent();
+    }
 
     this.recordQueue = BoundedBlockingRecordQueue.newBuilder()
         .hasCapacity(this.taskState.getPropAsInt(
@@ -148,8 +143,6 @@ public class Fork implements Closeable, Runnable, FinalState {
             ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_TIMEOUT_UNIT)))
         .collectStats()
         .build();
-
-    this.countDownLatch = countDownLatch;
 
     this.forkState = new AtomicReference<ForkState>(ForkState.PENDING);
 
@@ -188,7 +181,6 @@ public class Fork implements Closeable, Runnable, FinalState {
     } finally {
       // Clear the queue and count down so the parent task knows this fork is done (succeeded or failed)
       this.recordQueue.clear();
-      this.countDownLatch.countDown();
     }
   }
 
@@ -348,11 +340,18 @@ public class Fork implements Closeable, Runnable, FinalState {
   }
 
   /**
+   * Get the number of records written by this {@link Fork}.
+   *
+   * @return the number of records written by this {@link Fork}
+   */
+  long getRecordsWritten() {
+    return this.writer.isPresent() ? this.writer.get().recordsWritten() : 0l;
+  }
+
+  /**
    * Build a {@link gobblin.writer.DataWriter} for writing fetched data records.
    */
-  @SuppressWarnings("unchecked")
-  private InstrumentedDataWriterDecorator<Object> buildWriter()
-      throws IOException, SchemaConversionException {
+  private InstrumentedDataWriterDecorator<Object> buildWriter() throws IOException, SchemaConversionException {
     DataWriter<Object> writer = this.taskContext.getDataWriterBuilder(this.branches, this.index)
         .writeTo(Destination.of(this.taskContext.getDestinationType(this.branches, this.index), this.taskState))
         .writeInFormat(this.taskContext.getWriterOutputFormat(this.branches, this.index))
@@ -378,10 +377,6 @@ public class Fork implements Closeable, Runnable, FinalState {
    * Get new records off the record queue and process them.
    */
   private void processRecords() throws IOException, DataConversionException {
-    if (this.useEagerWriterInitialization) {
-      buildWriterIfNotPresent();
-    }
-
     while (true) {
       try {
         Object record = this.recordQueue.get();
@@ -392,6 +387,7 @@ public class Fork implements Closeable, Runnable, FinalState {
           }
         } else {
           buildWriterIfNotPresent();
+
           // Convert the record, check its data quality, and finally write it out if quality checking passes.
           for (Object convertedRecord : this.converter.convertRecord(this.convertedSchema, record, this.taskState)) {
             if (this.rowLevelPolicyChecker.executePolicies(convertedRecord, this.rowLevelPolicyCheckingResult)) {
@@ -419,10 +415,14 @@ public class Fork implements Closeable, Runnable, FinalState {
           this.taskState.getProp(ConfigurationKeys.EXTRACTOR_ROWS_EXTRACTED));
     }
 
+    String writerRowsWrittenKey =
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_RECORDS_WRITTEN, this.branches, this.index);
     if (this.writer.isPresent()) {
       this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, this.writer.get().recordsWritten());
+      this.taskState.setProp(writerRowsWrittenKey, this.writer.get().recordsWritten());
     } else {
       this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, 0l);
+      this.taskState.setProp(writerRowsWrittenKey, 0l);
     }
 
     if (schema.isPresent()) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -14,7 +14,9 @@ package gobblin.runtime;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.CompletionService;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -80,10 +82,12 @@ public class Task implements Runnable {
   private final TaskContext taskContext;
   private final TaskState taskState;
   private final TaskStateTracker taskStateTracker;
-  private final TaskExecutor taskExecutor;
   private final Optional<CountDownLatch> countDownLatch;
 
   private final List<Optional<Fork>> forks = Lists.newArrayList();
+
+  // A CompletionService used to run the batch of Forks of this Task
+  private final CompletionService forkCompletionService;
 
   // Number of task retries
   private final AtomicInteger retryCount = new AtomicInteger();
@@ -103,7 +107,7 @@ public class Task implements Runnable {
     this.jobId = this.taskState.getJobId();
     this.taskId = this.taskState.getTaskId();
     this.taskStateTracker = taskStateTracker;
-    this.taskExecutor = taskExecutor;
+    this.forkCompletionService = new ExecutorCompletionService(taskExecutor.getForkExecutor());
     this.countDownLatch = countDownLatch;
   }
 
@@ -143,20 +147,13 @@ public class Task implements Runnable {
         throw new CopyNotSupportedException(schema + " is not copyable");
       }
 
-      // Used for the main branch to wait for all forks to finish
-      CountDownLatch forkCountDownLatch = new CountDownLatch(branches);
-
       // Create one fork for each forked branch
       for (int i = 0; i < branches; i++) {
         if (forkedSchemas.get(i)) {
-          Fork fork = closer.register(new Fork(
-              this.taskContext,
-              schema instanceof Copyable ? ((Copyable) schema).copy() : schema,
-              branches,
-              i,
-              forkCountDownLatch));
+          Fork fork = closer.register(new Fork(this.taskContext,
+              schema instanceof Copyable ? ((Copyable) schema).copy() : schema, branches, i));
           // Run the Fork
-          this.taskExecutor.execute(fork);
+          this.forkCompletionService.submit(fork, null);
           this.forks.add(Optional.of(fork));
         } else {
           this.forks.add(Optional.<Fork> absent());
@@ -187,13 +184,14 @@ public class Task implements Runnable {
         if (fork.isPresent()) {
           // Tell the fork that the main branch is done and no new incoming data records should be expected
           fork.get().markParentTaskDone();
-        } else {
-          forkCountDownLatch.countDown();
         }
       }
 
-      // Wait for all forks to finish
-      forkCountDownLatch.await();
+      for (Optional<Fork> fork : this.forks) {
+        if (fork.isPresent()) {
+          this.forkCompletionService.take();
+        }
+      }
 
       // Check if all forks succeeded
       boolean allForksSucceeded = true;
@@ -210,7 +208,6 @@ public class Task implements Runnable {
       }
 
       if (allForksSucceeded) {
-
         // Set the task state to SUCCESSFUL. The state is not set to COMMITTED
         // as the data publisher will do that upon successful data publishing.
         this.taskState.setWorkingState(WorkUnitState.WorkingState.SUCCESSFUL);
@@ -220,10 +217,11 @@ public class Task implements Runnable {
       }
 
       addConstructsFinalStateToTaskState(extractor, converter);
-
     } catch (Throwable t) {
       failTask(t);
     } finally {
+      this.taskState.setProp(ConfigurationKeys.WRITER_RECORDS_WRITTEN, getRecordsWritten());
+
       try {
         closer.close();
       } catch (Throwable t) {
@@ -232,20 +230,19 @@ public class Task implements Runnable {
 
       try {
         if (shouldPublishDataInTask()) {
-
           // If data should be published by the task, publish the data and set the task state to COMMITTED.
           // Task data can only be published after all forks have been closed by closer.close().
           publishTaskData();
           this.taskState.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
         }
-      } catch (Throwable t) {
-        failTask(t);
+      } catch (IOException ioe) {
+        failTask(ioe);
+      } finally {
+        long endTime = System.currentTimeMillis();
+        this.taskState.setEndTime(endTime);
+        this.taskState.setTaskDuration(endTime - startTime);
+        this.taskStateTracker.onTaskCompletion(this);
       }
-
-      long endTime = System.currentTimeMillis();
-      this.taskState.setEndTime(endTime);
-      this.taskState.setTaskDuration(endTime - startTime);
-      this.taskStateTracker.onTaskCompletion(this);
     }
   }
 
@@ -256,26 +253,41 @@ public class Task implements Runnable {
   }
 
   /**
-   * Whether the task should directly publish data to the final publisher output dir.
-   * The task should publish data if {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY} is set to "partial", and
-   * {@link ConfigurationKeys#PUBLISH_DATA_AT_JOB_LEVEL} is set to false.
+   * Whether the task should directly publish its output data to the final publisher output directory.
+   *
+   * <p>
+   *   The task should publish its output data directly if {@link ConfigurationKeys#PUBLISH_DATA_AT_JOB_LEVEL}
+   *   is set to false AND any of the following conditions is satisfied:
+   *
+   *   <ul>
+   *     <li>The {@link JobCommitPolicy#COMMIT_ON_PARTIAL_SUCCESS} policy is used.</li>
+   *     <li>The {@link JobCommitPolicy#COMMIT_SUCCESSFUL_TASKS} policy is used. and all {@link Fork}s of this
+   *     {@link Task} succeeded.</li>
+   *   </ul>
+   * </p>
    */
   private boolean shouldPublishDataInTask() {
-    boolean jobCommitPolicyIsPartial =
-        JobCommitPolicy.getCommitPolicy(this.taskState.getProperties()) == JobCommitPolicy.COMMIT_ON_PARTIAL_SUCCESS;
     boolean publishDataAtJobLevel = this.taskState.getPropAsBoolean(ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL,
         ConfigurationKeys.DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL);
-
     if (publishDataAtJobLevel) {
-      LOG.info(String.format("%s is true. Will publish data in driver.", ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL));
-      return false;
-    } else if (!jobCommitPolicyIsPartial) {
-      LOG.info(
-          String.format("%s is set to full. Will publish data in driver.", ConfigurationKeys.JOB_COMMIT_POLICY_KEY));
+      LOG.info(String.format("%s is true. Will publish data at the job level.",
+          ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL));
       return false;
     }
 
-    return true;
+    JobCommitPolicy jobCommitPolicy = JobCommitPolicy.getCommitPolicy(this.taskState);
+
+    if (jobCommitPolicy == JobCommitPolicy.COMMIT_SUCCESSFUL_TASKS) {
+      return this.taskState.getWorkingState() == WorkUnitState.WorkingState.SUCCESSFUL;
+    }
+
+    if (jobCommitPolicy == JobCommitPolicy.COMMIT_ON_PARTIAL_SUCCESS) {
+      return true;
+    }
+
+    LOG.info(String.format("%s is set to full. Will publish data at the job level.",
+        ConfigurationKeys.JOB_COMMIT_POLICY_KEY));
+    return false;
   }
 
   private void publishTaskData() throws IOException {
@@ -465,6 +477,21 @@ public class Task implements Runnable {
       }
     }
     return inBranches > 1;
+  }
+
+  /**
+   * Get the total number of records written by every {@link Fork}s of this {@link Task}.
+   *
+   * @return the number of records written by every {@link Fork}s of this {@link Task}
+   */
+  private long getRecordsWritten() {
+    long recordsWritten = 0;
+    for (Optional<Fork> fork : this.forks) {
+      if (fork.isPresent()) {
+        recordsWritten += fork.get().getRecordsWritten();
+      }
+    }
+    return recordsWritten;
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -285,8 +285,7 @@ public class Task implements Runnable {
       return true;
     }
 
-    LOG.info(String.format("%s is set to full. Will publish data at the job level.",
-        ConfigurationKeys.JOB_COMMIT_POLICY_KEY));
+    LOG.info("Will publish data at the job level with job commit policy: " + jobCommitPolicy);
     return false;
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -87,7 +87,6 @@ public class TaskExecutor extends AbstractIdleService {
         // The work queue is a SynchronousQueue. This essentially forces a new thread to be created for each fork.
         new SynchronousQueue<Runnable>(),
         ExecutorsUtils.newThreadFactory(Optional.of(LOG), Optional.of("ForkExecutor-%d")));
-
   }
 
   /**
@@ -205,5 +204,14 @@ public class TaskExecutor extends AbstractIdleService {
     this.taskRetryExecutor.schedule(task, interval, TimeUnit.SECONDS);
     LOG.info(String.format("Scheduled retry of failed task %s to run in %d seconds", task.getTaskId(), interval));
     task.incrementRetryCount();
+  }
+
+  /**
+   * Get the {@link ExecutorService} used to run {@link Fork}s.
+   *
+   * @return the {@link ExecutorService} used to run {@link Fork}s
+   */
+  ExecutorService getForkExecutor() {
+    return this.forkExecutor;
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -446,6 +446,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
    */
   private List<TaskState> collectOutputTaskStates(Path taskStatePath) throws IOException {
     if (!this.fs.exists(taskStatePath)) {
+      LOG.warn(String.format("Task state output path %s does not exist", taskStatePath));
       return ImmutableList.of();
     }
 
@@ -457,6 +458,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
     });
 
     if (fileStatuses == null || fileStatuses.length == 0) {
+      LOG.warn("No task state files found in " + taskStatePath);
       return ImmutableList.of();
     }
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -25,10 +25,10 @@ import org.testng.annotations.Test;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
-import gobblin.runtime.BaseLimiterType;
-import gobblin.runtime.DefaultLimiterFactory;
 import gobblin.runtime.JobLauncherTestHelper;
 import gobblin.runtime.JobState;
+import gobblin.util.limiter.BaseLimiterType;
+import gobblin.util.limiter.DefaultLimiterFactory;
 import gobblin.writer.Destination;
 import gobblin.writer.WriterOutputFormat;
 
@@ -159,6 +159,18 @@ public class LocalJobLauncherTest {
         jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithMultipleDatasets");
     try {
       this.jobLauncherTestHelper.runTestWithMultipleDatasets(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
+  @Test
+  public void testLaunchJobWithCommitSuccessfulTasksPolicy() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithCommitSuccessfulTasksPolicy");
+    try {
+      this.jobLauncherTestHelper.runTestWithCommitSuccessfulTasksPolicy(jobProps);
     } finally {
       this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
     }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -33,10 +33,10 @@ import org.testng.annotations.Test;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
-import gobblin.runtime.BaseLimiterType;
-import gobblin.runtime.DefaultLimiterFactory;
 import gobblin.runtime.JobLauncherTestHelper;
 import gobblin.runtime.JobState;
+import gobblin.util.limiter.BaseLimiterType;
+import gobblin.util.limiter.DefaultLimiterFactory;
 import gobblin.writer.Destination;
 import gobblin.writer.WriterOutputFormat;
 
@@ -226,7 +226,21 @@ public class MRJobLauncherTest extends BMNGRunner {
    * to be deleted in {@link GobblinOutputCommitter}, which further fails this test since all the output
    * {@link gobblin.runtime.TaskState}s are deleted. It works fine in Hadoop1 though by setting
    * mapred.max.map.failures.percent=100. There may be a bug in Hadoop2's LocalJobRunner.
+   *
+   * Also applicable to the two tests below.
    */
+  @Test(groups = { "Hadoop1Only" })
+  public void testLaunchJobWithCommitSuccessfulTasksPolicy() throws Exception {
+    Properties jobProps = loadJobProps();
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithCommitSuccessfulTasksPolicy");
+    try {
+      this.jobLauncherTestHelper.runTestWithCommitSuccessfulTasksPolicy(jobProps);
+    } finally {
+      this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
+    }
+  }
+
   @Test(groups = { "Hadoop1Only" })
   public void testLaunchJobWithMultipleDatasetsAndFaultyExtractor() throws Exception {
     Properties jobProps = loadJobProps();

--- a/gobblin-runtime/src/test/java/gobblin/test/TestExtractor.java
+++ b/gobblin-runtime/src/test/java/gobblin/test/TestExtractor.java
@@ -54,7 +54,7 @@ public class TestExtractor implements Extractor<String, String> {
       " ]\n" +
       "}";
 
-  private static final int TOTAL_RECORDS = 1000;
+  public static final int TOTAL_RECORDS = 1000;
 
   private DataFileReader<GenericRecord> dataFileReader;
 


### PR DESCRIPTION
1. Introduced a new `JobCommitPolicy.COMMIT_SUCCESSFUL_TASKS` that will only commit successful tasks. This is recommended to be used with jobs with task-level data publishing so tasks can control independently if their output data should be published.
2. Updated `KafkaExtractor` to skip updating the actual high watermark if the `WorkUnit` fails.
3. Used a `ExecutorCompletionService` to run `Fork`s of a `Task` and for waiting for the `Fork`s to finish, instead of a `CountDownLatch`.
4. Other code factoring.

Signed-off-by: Yinan Li <liyinan926@gmail.com>