### PR TITLE
Hive SerDe support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ if (!project.hasProperty('hadoopVersion')) {
 }
 
 if (!project.hasProperty('hiveVersion')) {
-  hiveVersion = '0.13.0'
+  hiveVersion = '0.13.1'
 }
 
 if (!project.hasProperty('pegasusVersion')) {
@@ -78,6 +78,7 @@ ext.externalDependency = [
   "hiveJdbc": "org.apache.hive:hive-jdbc:"+hiveVersion,
   "hiveMetastore": "org.apache.hive:hive-metastore:"+hiveVersion,
   "hiveExec": "org.apache.hive:hive-exec:"+hiveVersion,
+  "hiveSerDe": "org.apache.hive:hive-serde:"+hiveVersion,
   "httpclient": "org.apache.httpcomponents:httpclient:4.5",
   "httpcore": "org.apache.httpcomponents:httpcore:4.4.1",
   "kafka": "org.apache.kafka:kafka_2.10:0.8.2.1",

--- a/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
+++ b/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
@@ -21,6 +21,7 @@ public enum WriterOutputFormat {
   AVRO("avro"),
   PARQUET("parquet"),
   PROTOBUF("protobuf"),
+  ORC("orc"),
   CSV("csv");
 
   /**

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -29,6 +29,8 @@ dependencies {
   compile externalDependency.jsch
   compile externalDependency.commonsLang
   compile externalDependency.commonsIo
+  compile externalDependency.hiveExec
+  compile externalDependency.hiveSerDe
   compile externalDependency.httpclient
   compile externalDependency.httpcore
   compile externalDependency.metricsCore

--- a/gobblin-core/src/main/java/gobblin/converter/serde/HiveSerDeConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/serde/HiveSerDeConverter.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.converter.serde;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.SerDeException;
+import org.apache.hadoop.io.Writable;
+
+import com.google.common.base.Throwables;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.converter.SingleRecordIterable;
+import gobblin.instrumented.converter.InstrumentedConverter;
+import gobblin.serde.HiveSerDeWrapper;
+import gobblin.util.HadoopUtils;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * An {@link InstrumentedConverter} that takes a {@link Writable} record, uses a Hive {@link SerDe} to
+ * deserialize it, and uses another Hive {@link SerDe} to serialize it into a {@link Writable} record.
+ *
+ * The serializer and deserializer are specified using {@link HiveSerDeWrapper#SERDE_SERIALIZER_TYPE}
+ * and {@link HiveSerDeWrapper#SERDE_DESERIALIZER_TYPE}.
+ *
+ * @author ziliu
+ */
+@SuppressWarnings("deprecation")
+@Slf4j
+public class HiveSerDeConverter extends InstrumentedConverter<Object, Object, Writable, Writable> {
+
+  private SerDe serializer;
+  private SerDe deserializer;
+
+  public HiveSerDeConverter init(WorkUnitState state) {
+    super.init(state);
+    Configuration conf = HadoopUtils.getConfFromState(state);
+
+    try {
+      this.serializer = HiveSerDeWrapper.getSerializer(state).getSerDe();
+      this.deserializer = HiveSerDeWrapper.getDeserializer(state).getSerDe();
+      serializer.initialize(conf, state.getProperties());
+      deserializer.initialize(conf, state.getProperties());
+    } catch (IOException e) {
+      log.error("Failed to instantiate serializer and deserializer", e);
+      throw Throwables.propagate(e);
+    } catch (SerDeException e) {
+      log.error("Failed to initialize serializer and deserializer", e);
+      throw Throwables.propagate(e);
+    }
+
+    return this;
+  }
+
+  @Override
+  public Iterable<Writable> convertRecordImpl(Object outputSchema, Writable inputRecord, WorkUnitState workUnit)
+      throws DataConversionException {
+
+    try {
+      Object deserialized = this.deserializer.deserialize(inputRecord);
+      Writable convertedRecord = this.serializer.serialize(deserialized, this.deserializer.getObjectInspector());
+      return new SingleRecordIterable<Writable>(convertedRecord);
+    } catch (SerDeException e) {
+      throw new DataConversionException(e);
+    }
+  }
+
+  @Override
+  public Object convertSchema(Object inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
+    return inputSchema;
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/serde/HiveSerDeWrapper.java
+++ b/gobblin-core/src/main/java/gobblin/serde/HiveSerDeWrapper.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.serde;
+
+import java.io.IOException;
+
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
+import org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat;
+import org.apache.hadoop.hive.ql.io.orc.OrcSerde;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
+import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
+import org.apache.hadoop.hive.serde2.SerDe;
+import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+
+import com.google.common.base.Enums;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.configuration.State;
+import gobblin.writer.WriterOutputFormat;
+
+
+/**
+ * A wrapper around {@link SerDe} that bundles input format, output format and file extension with a {@link SerDe},
+ * and provides additional functionalities.
+ *
+ * @author ziliu
+ */
+@SuppressWarnings("deprecation")
+public class HiveSerDeWrapper {
+
+  private static final String SERDE_SERIALIZER_PREFIX = "serde.serializer.";
+  private static final String SERDE_DESERIALIZER_PREFIX = "serde.deserializer.";
+
+  public static final String SERDE_SERIALIZER_TYPE = SERDE_SERIALIZER_PREFIX + "type";
+  public static final String SERDE_SERIALIZER_INPUT_FORMAT_TYPE = SERDE_SERIALIZER_PREFIX + "input.format.type";
+  public static final String SERDE_SERIALIZER_OUTPUT_FORMAT_TYPE = SERDE_SERIALIZER_PREFIX + "output.format.type";
+  public static final String SERDE_SERIALIZER_FILE_EXTENSION = SERDE_SERIALIZER_PREFIX + "extension";
+
+  public static final String SERDE_DESERIALIZER_TYPE = SERDE_DESERIALIZER_PREFIX + "type";
+  public static final String SERDE_DESERIALIZER_INPUT_FORMAT_TYPE = SERDE_DESERIALIZER_PREFIX + "input.format.type";
+  public static final String SERDE_DESERIALIZER_OUTPUT_FORMAT_TYPE = SERDE_DESERIALIZER_PREFIX + "output.format.type";
+  public static final String SERDE_DESERIALIZER_FILE_EXTENSION = SERDE_DESERIALIZER_PREFIX + "extension";
+
+  public enum BuiltInHiveSerDe {
+
+    AVRO(AvroSerDe.class.getName(), AvroContainerInputFormat.class.getName(), AvroContainerOutputFormat.class.getName(),
+        WriterOutputFormat.AVRO.getExtension()),
+    ORC(OrcSerde.class.getName(), OrcInputFormat.class.getName(), OrcOutputFormat.class.getName(),
+        WriterOutputFormat.ORC.getExtension()),
+    PARQUET(ParquetHiveSerDe.class.getName(), MapredParquetInputFormat.class.getName(),
+        MapredParquetOutputFormat.class.getName(), WriterOutputFormat.PARQUET.getExtension());
+
+    private final String serDeClassName;
+    private final String inputFormatClassName;
+    private final String outputFormatClassName;
+    private final String extension;
+
+    private BuiltInHiveSerDe(String serDeClassName, String inputFormatClassName, String outputFormatClassName,
+        String extension) {
+      this.serDeClassName = serDeClassName;
+      this.inputFormatClassName = inputFormatClassName;
+      this.outputFormatClassName = outputFormatClassName;
+      this.extension = extension;
+    }
+
+    @Override
+    public String toString() {
+      return this.serDeClassName;
+    }
+  }
+
+  private Optional<SerDe> serDe = Optional.absent();
+  private final String serDeClassName;
+  private final String inputFormatClassName;
+  private final String outputFormatClassName;
+  private final String extension;
+
+  private HiveSerDeWrapper(BuiltInHiveSerDe hiveSerDe) {
+    this(hiveSerDe.serDeClassName, hiveSerDe.inputFormatClassName, hiveSerDe.outputFormatClassName,
+        hiveSerDe.extension);
+  }
+
+  private HiveSerDeWrapper(String serDeClassName, String inputFormatClassName, String outputFormatClassName,
+      String extension) {
+    this.serDeClassName = serDeClassName;
+    this.inputFormatClassName = inputFormatClassName;
+    this.outputFormatClassName = outputFormatClassName;
+    this.extension = extension;
+  }
+
+  /**
+   * Get the {@link SerDe} instance associated with this {@link HiveSerDeWrapper}.
+   * This method performs lazy initialization.
+   */
+  public SerDe getSerDe() throws IOException {
+    if (!this.serDe.isPresent()) {
+      try {
+        this.serDe = Optional.of(SerDe.class.cast(Class.forName(this.serDeClassName).newInstance()));
+      } catch (Throwable t) {
+        throw new IOException("Failed to instantiate SerDe " + this.serDeClassName, t);
+      }
+    }
+    return this.serDe.get();
+  }
+
+  /**
+   * Get the input format class name associated with this {@link HiveSerDeWrapper}.
+   */
+  public String getInputFormatClassName() {
+    return this.inputFormatClassName;
+  }
+
+  /**
+   * Get the output format class name associated with this {@link HiveSerDeWrapper}.
+   */
+  public String getOutputFormatClassName() {
+    return this.outputFormatClassName;
+  }
+
+  /**
+   * Get the output file extension associated with this {@link HiveSerDeWrapper}.
+   */
+  public String getExtension() {
+    return this.extension;
+  }
+
+  /**
+   * Get an instance of {@link HiveSerDeWrapper}.
+   *
+   * @param serDeType The SerDe type. This should be one of the available {@link HiveSerDeWrapper.BuiltInHiveSerDe}s.
+   */
+  public static HiveSerDeWrapper get(String serDeType) {
+    return get(serDeType, Optional.<String> absent(), Optional.<String> absent(), Optional.<String> absent());
+  }
+
+  /**
+   * Get an instance of {@link HiveSerDeWrapper}.
+   *
+   * @param serDeType The SerDe type. If serDeType is one of the available {@link HiveSerDeWrapper.BuiltInHiveSerDe},
+   * the other three parameters are not used. Otherwise, serDeType should be the class name of a {@link SerDe},
+   * and the other three parameters must be present.
+   */
+  public static HiveSerDeWrapper get(String serDeType, Optional<String> inputFormatClassName,
+      Optional<String> outputFormatClassName, Optional<String> extension) {
+    Optional<BuiltInHiveSerDe> hiveSerDe = Enums.getIfPresent(BuiltInHiveSerDe.class, serDeType.toUpperCase());
+    if (hiveSerDe.isPresent()) {
+      return new HiveSerDeWrapper(hiveSerDe.get());
+    } else {
+      Preconditions.checkArgument(inputFormatClassName.isPresent(),
+          "Missing input format class name for SerDe " + serDeType);
+      Preconditions.checkArgument(outputFormatClassName.isPresent(),
+          "Missing output format class name for SerDe " + serDeType);
+      Preconditions.checkArgument(extension.isPresent(), "Missing file extension for SerDe " + serDeType);
+      return new HiveSerDeWrapper(serDeType, inputFormatClassName.get(), outputFormatClassName.get(), extension.get());
+    }
+  }
+
+  /**
+   * Get an instance of {@link HiveSerDeWrapper} from a {@link State}.
+   *
+   * @param state The state should contain property {@link #SERDE_SERIALIZER_TYPE}, and optionally contain properties
+   * {@link #SERDE_SERIALIZER_INPUT_FORMAT_TYPE}, {@link #SERDE_SERIALIZER_OUTPUT_FORMAT_TYPE} and
+   * {@link #SERDE_SERIALIZER_FILE_EXTENSION}.
+   */
+  public static HiveSerDeWrapper getSerializer(State state) {
+    Preconditions.checkArgument(state.contains(SERDE_SERIALIZER_TYPE),
+        "Missing required property " + SERDE_SERIALIZER_TYPE);
+    return get(state.getProp(SERDE_SERIALIZER_TYPE),
+        Optional.fromNullable(state.getProp(SERDE_SERIALIZER_INPUT_FORMAT_TYPE)),
+        Optional.fromNullable(state.getProp(SERDE_SERIALIZER_OUTPUT_FORMAT_TYPE)),
+        Optional.fromNullable(state.getProp(SERDE_SERIALIZER_FILE_EXTENSION)));
+  }
+
+  /**
+   * Get an instance of {@link HiveSerDeWrapper} from a {@link State}.
+   *
+   * @param state The state should contain property {@link #SERDE_DESERIALIZER_TYPE}, and optionally contain properties
+   * {@link #SERDE_DESERIALIZER_INPUT_FORMAT_TYPE}, {@link #SERDE_DESERIALIZER_OUTPUT_FORMAT_TYPE} and
+   * {@link #SERDE_DESERIALIZER_FILE_EXTENSION}.
+   */
+  public static HiveSerDeWrapper getDeserializer(State state) {
+    Preconditions.checkArgument(state.contains(SERDE_DESERIALIZER_TYPE),
+        "Missing required property " + SERDE_DESERIALIZER_TYPE);
+    return get(state.getProp(SERDE_DESERIALIZER_TYPE),
+        Optional.fromNullable(state.getProp(SERDE_DESERIALIZER_INPUT_FORMAT_TYPE)),
+        Optional.fromNullable(state.getProp(SERDE_DESERIALIZER_OUTPUT_FORMAT_TYPE)),
+        Optional.fromNullable(state.getProp(SERDE_DESERIALIZER_FILE_EXTENSION)));
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiWritableFileExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiWritableFileExtractor.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.io.IOException;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.RecordReader;
+
+
+/**
+ * An extension of {@link OldApiHadoopFileInputExtractor} for extracting {@link Writable} records.
+ *
+ * @author ziliu
+ */
+public class OldApiWritableFileExtractor extends OldApiHadoopFileInputExtractor<Object, Writable, Object, Writable> {
+
+  public OldApiWritableFileExtractor(RecordReader<Object, Writable> recordReader, boolean readKeys) {
+    super(recordReader, readKeys);
+  }
+
+  @Override
+  public Object getSchema() throws IOException {
+    return null;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiWritableFileSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/OldApiWritableFileSource.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.hadoop;
+
+import java.util.List;
+
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.FileSplit;
+
+import org.apache.hadoop.mapred.RecordReader;
+
+import gobblin.configuration.SourceState;
+import gobblin.configuration.WorkUnitState;
+import gobblin.serde.HiveSerDeWrapper;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * An extension of {@link OldApiHadoopFileInputSource} for sources in {@link Writable} format using a
+ * {@link org.apache.hadoop.mapred.FileInputFormat}.
+ *
+ * The {@link org.apache.hadoop.mapred.FileInputFormat} can either be specified using
+ * {@link HadoopFileInputSource#FILE_INPUT_FORMAT_CLASS_KEY}, or by specifying a deserializer via
+ * {@link HiveSerDeWrapper#SERDE_DESERIALIZER_TYPE}.
+ *
+ * @author ziliu
+ */
+public class OldApiWritableFileSource extends OldApiHadoopFileInputSource<Object, Writable, Object, Writable> {
+
+  @Override
+  public List<WorkUnit> getWorkunits(SourceState state) {
+    if (!state.contains(HadoopFileInputSource.FILE_INPUT_FORMAT_CLASS_KEY)) {
+      state.setProp(HadoopFileInputSource.FILE_INPUT_FORMAT_CLASS_KEY,
+          HiveSerDeWrapper.getDeserializer(state).getInputFormatClassName());
+    }
+    return super.getWorkunits(state);
+  }
+
+  @Override
+  protected OldApiHadoopFileInputExtractor<Object, Writable, Object, Writable> getExtractor(WorkUnitState workUnitState,
+      RecordReader<Object, Writable> recordReader, FileSplit fileSplit, boolean readKeys) {
+    return new OldApiWritableFileExtractor(recordReader, readKeys);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -13,6 +13,7 @@
 package gobblin.writer;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.avro.Schema;
@@ -46,6 +47,7 @@ import gobblin.util.WriterUtils;
 class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
 
   private final Schema schema;
+  private final OutputStream stagingFileOutputStream;
   private final DatumWriter<GenericRecord> datumWriter;
   private final DataFileWriter<GenericRecord> writer;
 
@@ -57,12 +59,14 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
     super(properties, fileName, numBranches, branchId);
 
     CodecFactory codecFactory =
-        WriterUtils.getCodecFactory(Optional.fromNullable(properties.getProp(
-            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId))),
+        WriterUtils.getCodecFactory(
             Optional.fromNullable(properties.getProp(ForkOperatorUtils
-                .getPropertyNameForBranch(ConfigurationKeys.WRITER_DEFLATE_LEVEL, numBranches, branchId))));
+                .getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branchId))),
+        Optional.fromNullable(properties.getProp(ForkOperatorUtils
+            .getPropertyNameForBranch(ConfigurationKeys.WRITER_DEFLATE_LEVEL, numBranches, branchId))));
 
     this.schema = schema;
+    this.stagingFileOutputStream = createStagingFileOutputStream();
     this.datumWriter = new GenericDatumWriter<GenericRecord>();
     this.writer = this.closer.register(createDataFileWriter(codecFactory));
   }
@@ -101,7 +105,7 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
    * @throws IOException if there is something wrong creating a new {@link DataFileWriter}
    */
   private DataFileWriter<GenericRecord> createDataFileWriter(CodecFactory codecFactory) throws IOException {
-    DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(this.datumWriter);
+    DataFileWriter<GenericRecord> writer = this.closer.register(new DataFileWriter<GenericRecord>(this.datumWriter));
     writer.setCodec(codecFactory);
 
     // Open the file and return the DataFileWriter

--- a/gobblin-core/src/main/java/gobblin/writer/HiveWritableHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/HiveWritableHdfsDataWriter.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.hadoop.hive.ql.exec.FileSinkOperator.RecordWriter;
+import org.apache.hadoop.hive.ql.io.HiveOutputFormat;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapred.JobConf;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.configuration.State;
+
+
+/**
+ * An extension to {@link FsDataWriter} that writes {@link Writable} records using an
+ * {@link org.apache.hadoop.mapred.OutputFormat} that implements {@link HiveOutputFormat}.
+ *
+ * The records are written using a {@link RecordWriter} created by
+ * {@link HiveOutputFormat#getHiveRecordWriter(JobConf, org.apache.hadoop.fs.Path, Class, boolean,
+ * java.util.Properties, org.apache.hadoop.util.Progressable)}.
+ *
+ * @author ziliu
+ */
+public class HiveWritableHdfsDataWriter extends FsDataWriter<Writable> {
+
+  protected final RecordWriter writer;
+  protected final AtomicLong count = new AtomicLong(0);
+
+  public HiveWritableHdfsDataWriter(State properties, String fileName, int numBranches, int branchId)
+      throws IOException {
+    super(properties, fileName, numBranches, branchId);
+
+    Preconditions.checkArgument(this.properties.contains(HiveWritableHdfsDataWriterBuilder.WRITER_OUTPUT_FORMAT_CLASS));
+    this.writer = getWriter();
+  }
+
+  private RecordWriter getWriter() throws IOException {
+    try {
+      HiveOutputFormat<?, ?> outputFormat = HiveOutputFormat.class
+          .cast(Class.forName(this.properties.getProp(HiveWritableHdfsDataWriterBuilder.WRITER_OUTPUT_FORMAT_CLASS))
+              .newInstance());
+
+      @SuppressWarnings("unchecked")
+      Class<? extends Writable> writableClass = (Class<? extends Writable>) Class
+          .forName(this.properties.getProp(HiveWritableHdfsDataWriterBuilder.WRITER_WRITABLE_CLASS));
+
+      return outputFormat.getHiveRecordWriter(new JobConf(), this.stagingFile, writableClass, true,
+          this.properties.getProperties(), null);
+    } catch (Throwable t) {
+      throw new IOException(String.format("Failed to create writer"), t);
+    }
+  }
+
+  @Override
+  public void write(Writable record) throws IOException {
+    Preconditions.checkNotNull(record);
+
+    this.writer.write(record);
+    this.count.incrementAndGet();
+  }
+
+  @Override
+  public long recordsWritten() {
+    return this.count.get();
+  }
+
+  @Override
+  public long bytesWritten() throws IOException {
+    if (!this.fs.exists(this.outputFile)) {
+      return 0;
+    }
+
+    return this.fs.getFileStatus(this.outputFile).getLen();
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.writer.close(false);
+    super.close();
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/writer/HiveWritableHdfsDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/HiveWritableHdfsDataWriterBuilder.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer;
+
+import java.io.IOException;
+
+import org.apache.hadoop.io.Writable;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+
+import gobblin.configuration.State;
+import gobblin.serde.HiveSerDeWrapper;
+import gobblin.util.WriterUtils;
+
+
+/**
+ * A {@link DataWriterBuilder} for building {@link HiveWritableHdfsDataWriter}.
+ *
+ * If properties {@link #WRITER_WRITABLE_CLASS}, {@link #WRITER_OUTPUT_FORMAT_CLASS} and
+ * {@link #WRITER_OUTPUT_FILE_EXTENSION} are all specified, their values will be used to create
+ * {@link HiveWritableHdfsDataWriter}. Otherwise, property {@link HiveSerDeWrapper#SERDE_SERIALIZER_TYPE} is required,
+ * which will be used to create a {@link HiveSerDeWrapper} that contains the information needed to create
+ * {@link HiveWritableHdfsDataWriter}.
+ *
+ * @author ziliu
+ */
+public class HiveWritableHdfsDataWriterBuilder extends DataWriterBuilder<Object, Writable> {
+
+  public static final String WRITER_WRITABLE_CLASS = "writer.writable.class";
+  public static final String WRITER_OUTPUT_FORMAT_CLASS = "writer.output.format.class";
+  public static final String WRITER_OUTPUT_FILE_EXTENSION = "writer.output.file.extension";
+
+  @SuppressWarnings("deprecation")
+  @Override
+  public DataWriter<Writable> build() throws IOException {
+    Preconditions.checkNotNull(this.destination);
+    Preconditions.checkArgument(!Strings.isNullOrEmpty(this.writerId));
+
+    State properties = this.destination.getProperties();
+
+    if (!properties.contains(WRITER_WRITABLE_CLASS) || !properties.contains(WRITER_OUTPUT_FORMAT_CLASS)
+        || !properties.contains(WRITER_OUTPUT_FILE_EXTENSION)) {
+      HiveSerDeWrapper serializer = HiveSerDeWrapper.getSerializer(properties);
+      properties.setProp(WRITER_WRITABLE_CLASS, serializer.getSerDe().getSerializedClass().getName());
+      properties.setProp(WRITER_OUTPUT_FORMAT_CLASS, serializer.getOutputFormatClassName());
+      properties.setProp(WRITER_OUTPUT_FILE_EXTENSION, serializer.getExtension());
+    }
+
+    String fileName = WriterUtils.getWriterFileName(properties, this.branches, this.branch, this.writerId,
+        properties.getProp(WRITER_OUTPUT_FILE_EXTENSION));
+
+    return new HiveWritableHdfsDataWriter(properties, fileName, this.branches, this.branch);
+
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -13,6 +13,7 @@
 package gobblin.writer;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
@@ -24,6 +25,7 @@ import com.google.common.primitives.Longs;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
+
 
 /**
  * An implementation of {@link DataWriter} that writes bytes directly to HDFS.
@@ -48,6 +50,8 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
   private int recordsWritten;
   private int bytesWritten;
 
+  private final OutputStream stagingFileOutputStream;
+
   public SimpleDataWriter(State properties, String fileName, int numBranches, int branchId) throws IOException {
     super(properties, fileName, numBranches, branchId);
     String delim;
@@ -60,7 +64,9 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
     this.prependSize = properties.getPropAsBoolean(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, true);
     this.recordsWritten = 0;
     this.bytesWritten = 0;
+    this.stagingFileOutputStream = createStagingFileOutputStream();
   }
+
   /**
    * Write a source record to the staging file
    *


### PR DESCRIPTION
1. Added a `Source`, an `Extractor`, a `Converter` and a `DataWriter` for supporting Hive SerDes.
2. Moved `stagingFileOutputStream` out of `FsDataWriter`, since Hive SerDes use `RecordWriter` to write data to staging files, which may fail if there is already an open `stagingFileOutputStream`.

Tested with Avro serde in and Orc serde out.