### PR TITLE
Do not override `MultiWorkUnit` grouping in Gobblin Yarn

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -72,7 +72,7 @@ public class WorkUnitState extends State {
    * Default constructor used for deserialization.
    */
   public WorkUnitState() {
-    this.workunit = new WorkUnit(null, null);
+    this.workunit = WorkUnit.createEmpty();
   }
 
   /**

--- a/gobblin-api/src/main/java/gobblin/source/workunit/MultiWorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/MultiWorkUnit.java
@@ -40,6 +40,14 @@ public class MultiWorkUnit extends WorkUnit {
   private final List<WorkUnit> workUnits = Lists.newArrayList();
 
   /**
+   * @deprecated Use {@link #createEmpty()} instead.
+   */
+  @Deprecated
+  public MultiWorkUnit() {
+    super();
+  }
+
+  /**
    * Get an immutable list of {@link WorkUnit}s wrapped by this {@link MultiWorkUnit}.
    *
    * @return immutable list of {@link WorkUnit}s wrapped by this {@link MultiWorkUnit}
@@ -96,7 +104,7 @@ public class MultiWorkUnit extends WorkUnit {
       throws IOException {
     int numWorkUnits = in.readInt();
     for (int i = 0; i < numWorkUnits; i++) {
-      WorkUnit workUnit = new WorkUnit(null, null);
+      WorkUnit workUnit = WorkUnit.createEmpty();
       workUnit.readFields(in);
       this.workUnits.add(workUnit);
     }
@@ -129,5 +137,14 @@ public class MultiWorkUnit extends WorkUnit {
     int result = super.hashCode();
     result = prime * result + ((this.workUnits == null) ? 0 : this.workUnits.hashCode());
     return result;
+  }
+
+  /**
+   * Create a new empty {@link MultiWorkUnit} instance.
+   *
+   * @return a new empty {@link MultiWorkUnit} instance
+   */
+  public static MultiWorkUnit createEmpty() {
+    return new MultiWorkUnit();
   }
 }

--- a/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/WorkUnit.java
@@ -60,7 +60,7 @@ public class WorkUnit extends State {
    * @param state a {@link SourceState} the properties of which will be copied into this {@link WorkUnit} instance
    * @param extract an {@link Extract}
    *
-   * @deprecated Properties in {@link SourceState} should not be added to a {@link WorkUnit}. Having each 
+   * @deprecated Properties in {@link SourceState} should not be added to a {@link WorkUnit}. Having each
    * {@link WorkUnit} contain a copy of {@link SourceState} is a waste of memory. Use {@link #create(Extract)}.
    */
   @Deprecated
@@ -84,7 +84,7 @@ public class WorkUnit extends State {
    * @param extract an {@link Extract}.
    * @param watermarkInterval a {@link WatermarkInterval} which defines the range of data this {@link WorkUnit} will process.
    *
-   * @deprecated Properties in {@link SourceState} should not be added to a {@link WorkUnit}. Having each 
+   * @deprecated Properties in {@link SourceState} should not be added to a {@link WorkUnit}. Having each
    * {@link WorkUnit} contain a copy of {@link SourceState} is a waste of memory. Use {@link #create(Extract, WatermarkInterval)}.
    */
   @Deprecated
@@ -125,7 +125,7 @@ public class WorkUnit extends State {
   }
 
   /**
-   * Facotry method.
+   * Factory method.
    *
    * @return An empty {@link WorkUnit}.
    */
@@ -134,7 +134,7 @@ public class WorkUnit extends State {
   }
 
   /**
-   * Facotry method.
+   * Factory method.
    *
    * @param extract {@link Extract}
    * @return A {@link WorkUnit} with the given {@link Extract}
@@ -144,7 +144,7 @@ public class WorkUnit extends State {
   }
 
   /**
-   * Facotry method.
+   * Factory method.
    *
    * @param extract {@link Extract}
    * @param watermarkInterval {@link WatermarkInterval}
@@ -155,9 +155,9 @@ public class WorkUnit extends State {
   }
 
   /**
-   * Facotry method.
+   * Factory method.
    *
-   * @param workUnit a {@link WorkUnit} instance
+   * @param other a {@link WorkUnit} instance
    * @return A copy of the given {@link WorkUnit} instance
    */
   public static WorkUnit copyOf(WorkUnit other) {

--- a/gobblin-core/src/test/java/gobblin/configuration/workunit/MultiWorkUnitTest.java
+++ b/gobblin-core/src/test/java/gobblin/configuration/workunit/MultiWorkUnitTest.java
@@ -41,13 +41,13 @@ public class MultiWorkUnitTest {
   public void setUp() {
     this.multiWorkUnit = new MultiWorkUnit();
 
-    WorkUnit workUnit1 = new WorkUnit();
+    WorkUnit workUnit1 = WorkUnit.createEmpty();
     workUnit1.setHighWaterMark(1000);
     workUnit1.setLowWaterMark(0);
     workUnit1.setProp("k1", "v1");
     this.multiWorkUnit.addWorkUnit(workUnit1);
 
-    WorkUnit workUnit2 = new WorkUnit();
+    WorkUnit workUnit2 = WorkUnit.createEmpty();
     workUnit2.setHighWaterMark(2000);
     workUnit2.setLowWaterMark(1001);
     workUnit2.setProp("k2", "v2");

--- a/gobblin-core/src/test/java/gobblin/source/workunit/MultiWorkUnitWeightedQueueTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/workunit/MultiWorkUnitWeightedQueueTest.java
@@ -22,7 +22,7 @@ public class MultiWorkUnitWeightedQueueTest {
     int weight = 1;
 
     MultiWorkUnitWeightedQueue multiWorkUnitWeightedQueue = new MultiWorkUnitWeightedQueue();
-    WorkUnit workUnit = new WorkUnit();
+    WorkUnit workUnit = WorkUnit.createEmpty();
 
     for (int i = 0; i < numWorkUnits; i++) {
       multiWorkUnitWeightedQueue.addWorkUnit(workUnit, weight);
@@ -50,7 +50,7 @@ public class MultiWorkUnitWeightedQueueTest {
     int weight = 1;
 
     MultiWorkUnitWeightedQueue multiWorkUnitWeightedQueue = new MultiWorkUnitWeightedQueue(maxMultiWorkUnits);
-    WorkUnit workUnit = new WorkUnit();
+    WorkUnit workUnit = WorkUnit.createEmpty();
 
     for (int i = 0; i < numWorkUnits; i++) {
       multiWorkUnitWeightedQueue.addWorkUnit(workUnit, weight);

--- a/gobblin-example/src/main/java/gobblin/example/simplejson/SimpleJsonSource.java
+++ b/gobblin-example/src/main/java/gobblin/example/simplejson/SimpleJsonSource.java
@@ -57,7 +57,7 @@ public class SimpleJsonSource implements Source<String, String> {
     String filesToPull = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL);
     for (String file : Splitter.on(',').omitEmptyStrings().split(filesToPull)) {
       // Create one work unit for each file to pull
-      WorkUnit workUnit = new WorkUnit(state, extract);
+      WorkUnit workUnit = WorkUnit.create(extract);
       workUnit.setProp(SOURCE_FILE_KEY, file);
       workUnits.add(workUnit);
     }

--- a/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaSource.java
+++ b/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaSource.java
@@ -46,7 +46,7 @@ public class WikipediaSource implements Source<String, JsonElement> {
             .createExtract(TableType.SNAPSHOT_ONLY, state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY),
                 "WikipediaOutput");
 
-    WorkUnit workUnit = new WorkUnit(state, extract);
+    WorkUnit workUnit = WorkUnit.create(extract);
     return Arrays.asList(workUnit);
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -60,6 +60,9 @@ public abstract class AbstractJobLauncher implements JobLauncher {
 
   public static final String JOB_STATE_FILE_NAME = "job.state";
 
+  public static final String WORK_UNIT_FILE_EXTENSION = ".wu";
+  public static final String MULTI_WORK_UNIT_FILE_EXTENSION = ".mwu";
+
   // Job configuration properties
   protected final Properties jobProps;
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -103,9 +103,6 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
   private static final String JOB_NAME_PREFIX = "Gobblin-";
 
-  private static final String WORK_UNIT_FILE_EXTENSION = ".wu";
-  private static final String MULTI_WORK_UNIT_FILE_EXTENSION = ".mwu";
-
   private static final Splitter SPLITTER = Splitter.on(',').omitEmptyStrings().trimResults();
 
   private final Configuration conf;
@@ -599,8 +596,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
     @Override
     public void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
-      WorkUnit workUnit =
-          (value.toString().endsWith(MULTI_WORK_UNIT_FILE_EXTENSION) ? new MultiWorkUnit() : WorkUnit.createEmpty());
+      WorkUnit workUnit = (value.toString().endsWith(MULTI_WORK_UNIT_FILE_EXTENSION) ?
+          MultiWorkUnit.createEmpty() : WorkUnit.createEmpty());
       SerializationUtils.deserializeState(this.fs, new Path(value.toString()), workUnit);
 
       if (workUnit instanceof MultiWorkUnit) {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/TaskContextTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/TaskContextTest.java
@@ -55,7 +55,7 @@ public class TaskContextTest {
   @BeforeClass
   public void setUp()
       throws Exception {
-    WorkUnit workUnit = new WorkUnit();
+    WorkUnit workUnit = WorkUnit.createEmpty();
     Properties properties = new Properties();
     properties.load(new StringReader(TEST_JOB_CONFIG));
     workUnit.addAll(properties);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputCommitterTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/GobblinOutputCommitterTest.java
@@ -114,7 +114,7 @@ public class GobblinOutputCommitterTest {
    * @throws IOException
    */
   private WorkUnit createAndSetWorkUnit(String workUnitName) throws IOException {
-    WorkUnit wu = new WorkUnit();
+    WorkUnit wu = WorkUnit.createEmpty();
     wu.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.TASK_ID_KEY, 1, 0), System.nanoTime());
 
     Path wuStagingDir =

--- a/gobblin-utility/src/test/java/gobblin/util/JobLauncherUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/JobLauncherUtilsTest.java
@@ -66,18 +66,19 @@ public class JobLauncherUtilsTest {
 
   @Test
   public void testFlattenWorkUnits() {
-    List<WorkUnit> workUnitsOnly = Arrays.asList(new WorkUnit(), new WorkUnit(), new WorkUnit());
+    List<WorkUnit> workUnitsOnly =
+        Arrays.asList(WorkUnit.createEmpty(), WorkUnit.createEmpty(), WorkUnit.createEmpty());
 
     Assert.assertEquals(JobLauncherUtils.flattenWorkUnits(workUnitsOnly).size(), 3);
 
     MultiWorkUnit multiWorkUnit1 = new MultiWorkUnit();
-    multiWorkUnit1.addWorkUnits(Arrays.asList(new WorkUnit(), new WorkUnit(), new WorkUnit()));
+    multiWorkUnit1.addWorkUnits(Arrays.asList(WorkUnit.createEmpty(), WorkUnit.createEmpty(), WorkUnit.createEmpty()));
 
     MultiWorkUnit multiWorkUnit2 = new MultiWorkUnit();
-    multiWorkUnit1.addWorkUnits(Arrays.asList(new WorkUnit(), new WorkUnit(), new WorkUnit()));
+    multiWorkUnit1.addWorkUnits(Arrays.asList(WorkUnit.createEmpty(), WorkUnit.createEmpty(), WorkUnit.createEmpty()));
 
-    List<WorkUnit> workUnitsAndMultiWorkUnits =
-        Arrays.asList(new WorkUnit(), new WorkUnit(), new WorkUnit(), multiWorkUnit1, multiWorkUnit2);
+    List<WorkUnit> workUnitsAndMultiWorkUnits = Arrays.asList(WorkUnit.createEmpty(), WorkUnit.createEmpty(),
+        WorkUnit.createEmpty(), multiWorkUnit1, multiWorkUnit2);
 
     Assert.assertEquals(JobLauncherUtils.flattenWorkUnits(workUnitsAndMultiWorkUnits).size(), 9);
   }
@@ -153,12 +154,13 @@ public class JobLauncherUtilsTest {
     try {
       SourceState sourceState = new SourceState();
       WorkUnitState state =
-          new WorkUnitState(new WorkUnit(sourceState, new Extract(sourceState, TableType.APPEND_ONLY, namespace,
-              tableName)));
+          new WorkUnitState(WorkUnit.create(new Extract(sourceState, TableType.APPEND_ONLY, namespace, tableName)));
 
       state.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
-      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_BRANCH_NAME_KEY, 2, 0), branchName0);
-      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_BRANCH_NAME_KEY, 2, 1), branchName1);
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_BRANCH_NAME_KEY, 2, 0),
+          branchName0);
+      state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.FORK_BRANCH_NAME_KEY, 2, 1),
+          branchName1);
 
       state.setProp(ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, 2, 0),
           ConfigurationKeys.LOCAL_FS_URI);

--- a/gobblin-utility/src/test/java/gobblin/util/WriterUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/WriterUtilsTest.java
@@ -74,7 +74,7 @@ public class WriterUtilsTest {
 
   @Test
   public void testGetWriterFilePath() {
-    WorkUnit state = new WorkUnit();
+    WorkUnit state = WorkUnit.createEmpty();
 
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH, TEST_WRITER_FILE_PATH);
     Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), TEST_WRITER_FILE_PATH);
@@ -89,7 +89,7 @@ public class WriterUtilsTest {
     String tableName = "test-table";
 
     SourceState sourceState = new SourceState();
-    WorkUnit state = new WorkUnit(sourceState, new Extract(sourceState, TableType.APPEND_ONLY, namespace, tableName));
+    WorkUnit state = WorkUnit.create(new Extract(sourceState, TableType.APPEND_ONLY, namespace, tableName));
 
     Assert.assertEquals(WriterUtils.getWriterFilePath(state, 0, 0), new Path(state.getExtract().getOutputFilePath()));
     Assert.assertEquals(WriterUtils.getWriterFilePath(state, 2, 0), new Path(state.getExtract().getOutputFilePath(),
@@ -102,8 +102,7 @@ public class WriterUtilsTest {
     String tableName = "test-table";
 
     SourceState sourceState = new SourceState();
-    WorkUnit workUnit =
-        new WorkUnit(sourceState, new Extract(sourceState, TableType.APPEND_ONLY, namespace, tableName));
+    WorkUnit workUnit = WorkUnit.create(new Extract(sourceState, TableType.APPEND_ONLY, namespace, tableName));
     WorkUnitState workUnitState = new WorkUnitState(workUnit);
 
     Assert.assertEquals(WriterUtils.getWriterFilePath(workUnitState, 0, 0), new Path(workUnitState.getExtract()

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
@@ -41,6 +41,7 @@ import gobblin.runtime.TaskContext;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskState;
 import gobblin.runtime.TaskStateTracker;
+import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.SerializationUtils;
 
@@ -147,9 +148,11 @@ public class GobblinHelixTask implements Task {
   }
 
   private gobblin.runtime.Task buildTask() throws IOException {
-    WorkUnit workUnit = WorkUnit.createEmpty();
     Path workUnitFilePath =
         new Path(this.taskConfig.getConfigMap().get(GobblinYarnConfigurationKeys.WORK_UNIT_FILE_PATH));
+
+    WorkUnit workUnit = workUnitFilePath.getName().endsWith(AbstractJobLauncher.MULTI_WORK_UNIT_FILE_EXTENSION) ?
+            MultiWorkUnit.createEmpty() : WorkUnit.createEmpty();
     SerializationUtils.deserializeState(this.fs, workUnitFilePath, workUnit);
     workUnit.addAllIfNotExist(this.jobState);
 


### PR DESCRIPTION
Currently, the `GobblinHelixJobLauncher` flattens `MultiWorkUnit`s and hope for Helix to do a balanced assignments of tasks to containers. However, both Gobblin Kafka and IDPC HDFS Purger already have their own logic of grouping `WorkUnit`s into `MultiWorkUnit`s. It's good to keep their logic and not to override it.

Signed-off-by: Yinan Li <liyinan926@gmail.com>