### PR TITLE
Remove duplicate closer registration

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -104,7 +104,8 @@ class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
    * @throws IOException if there is something wrong creating a new {@link DataFileWriter}
    */
   private DataFileWriter<GenericRecord> createDataFileWriter(CodecFactory codecFactory) throws IOException {
-    DataFileWriter<GenericRecord> writer = this.closer.register(new DataFileWriter<GenericRecord>(this.datumWriter));
+    @SuppressWarnings("resource")
+    DataFileWriter<GenericRecord> writer = new DataFileWriter<GenericRecord>(this.datumWriter);
     writer.setCodec(codecFactory);
 
     // Open the file and return the DataFileWriter


### PR DESCRIPTION
It was added in 7598696 since there was a warning in eclipse that writer is never closed. But the created writer is registered again in line 70 which causes the writer to be closed twice (which will fail).