### PR TITLE
Bug fixes to sftp copy

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CloseableFsCopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CloseableFsCopySource.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy;
+
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.copy.extractor.CloseableFsFileAwareInputStreamExtractor;
+import gobblin.source.extractor.Extractor;
+import gobblin.source.extractor.extract.sftp.SftpLightWeightFileSystem;
+import gobblin.util.HadoopUtils;
+
+import java.io.IOException;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import com.google.common.io.Closer;
+
+
+/**
+ * Used instead of {@link CopySource} for {@link FileSystem}s that need be closed after use E.g
+ * {@link SftpLightWeightFileSystem}.
+ * <p>
+ * Note that all {@link FileSystem} implementations should not be closed as Hadoop's
+ * {@link FileSystem#get(org.apache.hadoop.conf.Configuration)} API returns a cached copy of {@link FileSystem} by
+ * default. The same {@link FileSystem} instance may be used by other classes in the same JVM. Closing a cached
+ * {@link FileSystem} may cause {@link IOException} at other parts of the code using the same instance.
+ * </p>
+ * <p>
+ * For {@link SftpLightWeightFileSystem} a new instance is returned on every
+ * {@link FileSystem#get(org.apache.hadoop.conf.Configuration)} call. Closing is necessary as the file system maintains
+ * a session with the remote server.
+ *
+ * @see {@link HadoopUtils#newConfiguration()}
+ * @See {@link SftpLightWeightFileSystem}
+ *      </p>
+ */
+@Slf4j
+public class CloseableFsCopySource extends CopySource {
+
+  private final Closer closer = Closer.create();
+
+  protected FileSystem getSourceFileSystem(State state) throws IOException {
+    return closer.register(super.getSourceFileSystem(state));
+  }
+
+  @Override
+  public void shutdown(SourceState state) {
+    try {
+      closer.close();
+    } catch (IOException e) {
+      log.warn("Failed to close all closeables", e);
+    }
+  }
+
+  @Override
+  public Extractor<String, FileAwareInputStream> getExtractor(WorkUnitState state) throws IOException {
+
+    List<CopyableFile> copyableFiles = deserializeCopyableFiles(state);
+
+    return new CloseableFsFileAwareInputStreamExtractor(getSourceFileSystem(state), copyableFiles.iterator());
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/extractor/CloseableFsFileAwareInputStreamExtractor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/extractor/CloseableFsFileAwareInputStreamExtractor.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy.extractor;
+
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.source.extractor.extract.sftp.SftpLightWeightFileSystem;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import com.google.common.io.Closer;
+
+
+/**
+ * Used instead of {@link FileAwareInputStreamExtractor} for {@link FileSystem}s that need be closed after use E.g
+ * {@link SftpLightWeightFileSystem}.
+ */
+public class CloseableFsFileAwareInputStreamExtractor extends FileAwareInputStreamExtractor {
+
+  private final Closer closer = Closer.create();
+
+  public CloseableFsFileAwareInputStreamExtractor(FileSystem fs, Iterator<CopyableFile> filesIterator)
+      throws IOException {
+
+    super(fs, filesIterator);
+    closer.register(fs);
+  }
+
+  @Override
+  public void close() throws IOException {
+    closer.close();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
@@ -16,6 +16,7 @@ import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.FileAwareInputStream;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
+import gobblin.source.extractor.extract.sftp.SftpLightWeightFileSystem;
 
 import java.io.IOException;
 import java.io.InputStream;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -22,7 +22,6 @@ import gobblin.util.FileListUtils;
 import gobblin.util.ForkOperatorUtils;
 import gobblin.util.HadoopUtils;
 import gobblin.util.WriterUtils;
-import gobblin.util.io.StreamUtils;
 import gobblin.writer.DataWriter;
 
 import java.io.IOException;
@@ -186,7 +185,9 @@ public class FileAwareInputStreamDataWriter implements DataWriter<FileAwareInput
    */
   @Override
   public void commit() throws IOException {
-    HadoopUtils.safeRenameRecursively(fs, stagingDir, outputDir);
+    log.info(String.format("Committing data from %s to %s", stagingDir, outputDir));
+    HadoopUtils.renameRecursively(fs, stagingDir, outputDir);
+    fs.delete(stagingDir, true);
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
@@ -16,13 +16,9 @@ import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.FileAwareInputStream;
 import gobblin.data.management.util.PathUtils;
-import gobblin.util.io.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.nio.channels.Channels;
-import java.nio.channels.ReadableByteChannel;
-import java.nio.channels.WritableByteChannel;
 import java.util.zip.GZIPInputStream;
 
 import lombok.extern.slf4j.Slf4j;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterBuilder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterBuilder.java
@@ -11,22 +11,21 @@
  */
 package gobblin.data.management.copy.writer;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
 import gobblin.data.management.copy.FileAwareInputStream;
 import gobblin.writer.DataWriter;
 import gobblin.writer.DataWriterBuilder;
 
 import java.io.IOException;
 
+
 /**
  * A {@link DataWriterBuilder} for {@link TarArchiveInputStreamDataWriter}
  */
-public class TarArchiveInputStreamDataWriterBuilder extends DataWriterBuilder<String, FileAwareInputStream> {
+public class TarArchiveInputStreamDataWriterBuilder extends FileAwareInputStreamDataWriterBuilder {
+
   @Override
-  public DataWriter<FileAwareInputStream> build() throws IOException {
-    State properties = this.destination.getProperties();
-    properties.setProp(ConfigurationKeys.WRITER_FILE_PATH, this.writerId);
-    return new TarArchiveInputStreamDataWriter(properties, this.branches, this.branch);
+  protected DataWriter<FileAwareInputStream> buildWriter() throws IOException {
+    return new TarArchiveInputStreamDataWriter(this.destination.getProperties(), this.branches, this.branch);
   }
+
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -42,7 +42,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.NLineInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -63,6 +62,7 @@ import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.event.TimingEvent;
+import gobblin.password.PasswordManager;
 import gobblin.runtime.AbstractJobLauncher;
 import gobblin.runtime.FileBasedJobLock;
 import gobblin.runtime.JobLauncher;
@@ -376,6 +376,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
    */
   private void addHDFSFiles(String jobFileList) throws IOException {
     DistributedCache.createSymlink(this.conf);
+    jobFileList = PasswordManager.getInstance(jobProps).readPassword(jobFileList);
     for (String jobFile : SPLITTER.split(jobFileList)) {
       Path srcJobFile = new Path(jobFile);
       // Create a URI that is in the form path#symlink

--- a/gobblin-test-harness/resource/dataManagement/copy/job-props/copy.pull
+++ b/gobblin-test-harness/resource/dataManagement/copy/job-props/copy.pull
@@ -14,7 +14,7 @@ source.class=gobblin.data.management.copy.CopySource
 
 writer.builder.class=gobblin.data.management.copy.writer.TarArchiveInputStreamDataWriterBuilder
 
-gobblin.retention.dataset.pattern=gobblin-test-harness/resource/dataManagement/copy/data/
+gobblin.dataset.pattern=gobblin-test-harness/resource/dataManagement/copy/data/
 
 converter.classes=gobblin.data.management.copy.converter.UnGzipConverter
 


### PR DESCRIPTION
The pr has some bug fixes to sftp copy. 
@ibuenros can you review?
Tested on both MR mode and local mode

**Bugs/improvements**

1. SftpFsHelper - Added support to read private key file from HDFS for password-less sftp connection
2.  SftpLightWeightFileSystem.java - 
	* Removed scheme and authority from paths since jsch expects raw path strings. 
	* Create a new sftp filesystem each time instead of cached copy. (Note that new instance is created only for sftp file system. Other fs still use cached copy). In the continuous execution model, multiple jobs can run in the same container/jvm. If a cached copy is used per jvm, an authenticated session created by one job will be used by another job.
3. CopySource.java - CopyableDataset was incorrectly serialized in SourceState instead of WorkUnitStates. ***Already have test for this***
4. FileAwareInputStreamDataWriterBuilder.java - Use job specific task-staging and task-output directories. Previously the task-ouput and task-staging paths were /some/path/gobblin/task-staging and /some/path/gobblin/task-output. Not the path will be /some/path/gobblin/task-staging/job_id and /some/path/gobblin/task-output/job_id ***Already have test for this***
This is make sure uncleaned data from previous execution will not affect the current execution.
5. ConfigurableGlobDatasetFinder.java - Deprecated config key gobblin.cleanable.dataset.pattern in favor of gobblin.dataset.pattern ***Already have test for this. See copy.pull***
6. HadoopUtils.java - For rename operations, some file systems do not create the necessary parent directories at the destination. Fixed that. ***Already have test for this***

@sahilTakiar can you review 1 and 2