### PR TITLE
Fixed Gobblin Yarn to be able to run MultiWorkUnits

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaUtils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaUtils.java
@@ -30,7 +30,8 @@ public class KafkaUtils {
    * {@link KafkaSource#TOPIC_NAME}.
    */
   public static String getTopicName(State state) {
-    Preconditions.checkArgument(state.contains(KafkaSource.TOPIC_NAME));
+    Preconditions.checkArgument(state.contains(KafkaSource.TOPIC_NAME),
+        "Missing configuration property " + KafkaSource.TOPIC_NAME);
 
     return state.getProp(KafkaSource.TOPIC_NAME);
   }
@@ -41,7 +42,10 @@ public class KafkaUtils {
    * {@link KafkaSource#LEADER_ID} and {@link KafkaSource#LEADER_HOSTANDPORT}.
    */
   public static KafkaPartition getPartition(State state) {
-    Preconditions.checkArgument(state.contains(KafkaSource.TOPIC_NAME) && state.contains(KafkaSource.PARTITION_ID));
+    Preconditions.checkArgument(state.contains(KafkaSource.TOPIC_NAME),
+        "Missing configuration property " + KafkaSource.TOPIC_NAME);
+    Preconditions.checkArgument(state.contains(KafkaSource.PARTITION_ID),
+        "Missing configuration property " + KafkaSource.PARTITION_ID);
 
     KafkaPartition.Builder builder = new KafkaPartition.Builder().withTopicName(state.getProp(KafkaSource.TOPIC_NAME))
         .withId(state.getPropAsInt(KafkaSource.PARTITION_ID));

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -43,7 +43,8 @@ import gobblin.source.workunit.WorkUnit;
 
 
 /**
- * An abstract class for packing Kafka {@link WorkUnits} into {@link MultiWorkUnits} based on the number of containers.
+ * An abstract class for packing Kafka {@link WorkUnit}s into {@link MultiWorkUnit}s
+ * based on the number of containers.
  *
  * @author ziliu
  */

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -113,7 +113,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
     TimingEvent workUnitsRunTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.WORK_UNITS_RUN);
 
     this.countDownLatch = new CountDownLatch(workUnitsToRun.size());
-    List<Task> tasks = AbstractJobLauncher.submitWorkUnits(this.jobContext.getJobId(), workUnitsToRun,
+    List<Task> tasks = AbstractJobLauncher.runWorkUnits(this.jobContext.getJobId(), workUnitsToRun,
         this.taskStateTracker, this.taskExecutor, this.countDownLatch);
 
     LOG.info(String.format("Waiting for submitted tasks of job %s to complete...", jobId));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -21,7 +21,6 @@ import java.net.URI;
 import java.util.List;
 import java.util.Properties;
 import java.util.Queue;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -57,8 +56,6 @@ import com.google.common.io.Closer;
 import com.google.common.util.concurrent.ServiceManager;
 
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.WorkUnitState;
-import gobblin.instrumented.Instrumented;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
 import gobblin.metrics.GobblinMetrics;
@@ -533,8 +530,9 @@ public class MRJobLauncher extends AbstractJobLauncher {
     protected void setup(Context context) {
       try {
         this.fs = FileSystem.get(context.getConfiguration());
-        this.taskStateStore = new FsStateStore<TaskState>(this.fs,
-            SequenceFileOutputFormat.getOutputPath(context).toUri().getPath(), TaskState.class);
+        this.taskStateStore =
+            new FsStateStore<TaskState>(this.fs, SequenceFileOutputFormat.getOutputPath(context).toUri().getPath(),
+                TaskState.class);
 
         Path jobStateFilePath = new Path(context.getConfiguration().get(ConfigurationKeys.JOB_STATE_FILE_PATH_KEY));
         SerializationUtils.deserializeState(this.fs, jobStateFilePath, this.jobState);
@@ -582,14 +580,16 @@ public class MRJobLauncher extends AbstractJobLauncher {
           this.map(context.getCurrentKey(), context.getCurrentValue(), context);
         }
         // Actually run the list of WorkUnits
-        runWorkUnits(this.workUnits, context);
+        runWorkUnits(this.jobState.getJobId(), context.getTaskAttemptID().toString(), this.workUnits,
+            this.taskStateTracker, this.taskExecutor, this.taskStateStore, LOG);
       } finally {
         this.cleanup(context);
       }
     }
 
     @Override
-    public void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
+    public void map(LongWritable key, Text value, Context context)
+        throws IOException, InterruptedException {
       WorkUnit workUnit = (value.toString().endsWith(MULTI_WORK_UNIT_FILE_EXTENSION) ?
           MultiWorkUnit.createEmpty() : WorkUnit.createEmpty());
       SerializationUtils.deserializeState(this.fs, new Path(value.toString()), workUnit);
@@ -608,7 +608,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
     }
 
     @Override
-    protected void cleanup(Context context) throws IOException, InterruptedException {
+    protected void cleanup(Context context)
+        throws IOException, InterruptedException {
       try {
         this.serviceManager.stopAsync().awaitStopped(5, TimeUnit.SECONDS);
       } catch (TimeoutException te) {
@@ -622,67 +623,6 @@ public class MRJobLauncher extends AbstractJobLauncher {
             JobMetrics.remove(this.jobMetrics.get().getName());
           }
         }
-      }
-    }
-
-    /**
-     * Run the given list of {@link WorkUnit}s sequentially. If any work unit/task fails,
-     * an {@link java.io.IOException} is thrown so the mapper is failed and retried.
-     */
-    private void runWorkUnits(List<WorkUnit> workUnits, Context context) throws IOException, InterruptedException {
-      if (workUnits.isEmpty()) {
-        LOG.warn("No work units to run in mapper " + context.getTaskAttemptID());
-        return;
-      }
-
-      String jobId = workUnits.get(0).getProp(ConfigurationKeys.JOB_ID_KEY);
-
-      for (WorkUnit workUnit : workUnits) {
-        if (this.jobMetrics.isPresent()) {
-          workUnit.setProp(Instrumented.METRIC_CONTEXT_NAME_KEY, this.jobMetrics.get().getName());
-        }
-        String taskId = workUnit.getProp(ConfigurationKeys.TASK_ID_KEY);
-        // Delete the task state file for the task if it already exists.
-        // This usually happens if the task is retried upon failure.
-        if (this.taskStateStore.exists(jobId, taskId + TASK_STATE_STORE_TABLE_SUFFIX)) {
-          this.taskStateStore.delete(jobId, taskId + TASK_STATE_STORE_TABLE_SUFFIX);
-        }
-      }
-
-      CountDownLatch countDownLatch = new CountDownLatch(workUnits.size());
-      List<Task> tasks = AbstractJobLauncher.submitWorkUnits(jobId, workUnits, this.taskStateTracker, this.taskExecutor,
-          countDownLatch);
-
-      LOG.info(String.format("Waiting for submitted tasks of job %s to complete in mapper %s...", jobId,
-          context.getTaskAttemptID()));
-      while (countDownLatch.getCount() > 0) {
-        LOG.info(String.format("%d out of %d tasks of job %s are running in mapper %s", countDownLatch.getCount(),
-            workUnits.size(), jobId, context.getTaskAttemptID()));
-        if (countDownLatch.await(10, TimeUnit.SECONDS)) {
-          break;
-        }
-      }
-      LOG.info(String.format("All tasks of job %s have completed in mapper %s", jobId, context.getTaskAttemptID()));
-
-      boolean hasTaskFailure = false;
-      for (Task task : tasks) {
-        LOG.info("Writing task state for task " + task.getTaskId());
-        this.taskStateStore.put(task.getJobId(), task.getTaskId() + TASK_STATE_STORE_TABLE_SUFFIX, task.getTaskState());
-
-        if (task.getTaskState().getWorkingState() == WorkUnitState.WorkingState.FAILED) {
-          hasTaskFailure = true;
-        }
-      }
-
-      if (hasTaskFailure) {
-        for (Task task : tasks) {
-          if (task.getTaskState().contains(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY)) {
-            LOG.error(String.format("Task %s failed due to exception: %s", task.getTaskId(),
-                task.getTaskState().getProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY)));
-          }
-        }
-        throw new IOException(
-            String.format("Not all tasks running in mapper %s completed successfully", context.getTaskAttemptID()));
       }
     }
   }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
@@ -48,6 +48,7 @@ import gobblin.runtime.JobState;
 import gobblin.runtime.TaskState;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.JobLauncherUtils;
 import gobblin.util.ParallelRunner;
 import gobblin.util.SerializationUtils;
 
@@ -169,7 +170,11 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
     try {
       ParallelRunner stateSerDeRunner = closer.register(new ParallelRunner(this.stateSerDeRunnerThreads, this.fs));
 
+      int multiTaskIdSequence = 0;
       for (WorkUnit workUnit : workUnits) {
+        if (workUnit instanceof MultiWorkUnit) {
+          workUnit.setId(JobLauncherUtils.newMultiTaskId(this.jobContext.getJobId(), multiTaskIdSequence++));
+        }
         addWorkUnit(workUnit, stateSerDeRunner, taskConfigMap);
       }
 


### PR DESCRIPTION
Originally Gobblin on Yarn was written with the assumption that we would rely on Helix to group/pack `WorkUnit`s into groups and assign them properly to the available containers. So the code originally flattened the `MultiWorkUnit`s. Later it was realized this would not be too practical since Helix does not have the knowledge of loads of individual `WorkUnit`s. In addition, the Gobblin Kafka adapter is already doing bin packing so we decided to not override that logic and changed the code to not flatten `MultiWorkUnit`s. However, the parts that actually run the job/tasks are not updated accordingly to work with `MultiWorkUnit`s. This PR fixed it. 

Signed-off-by: Yinan Li <liyinan926@gmail.com>