### PR TITLE
Add option to use prime number of reducers in compaction

### DIFF
--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -18,6 +18,7 @@ dependencies {
   compile project(":gobblin-core")
   compile externalDependency.avro
   compile externalDependency.commonsLang
+  compile externalDependency.commonsMath
   compile externalDependency.hiveExec
 
   if (project.hasProperty('useHadoop2')) {


### PR DESCRIPTION
Add an option to use a prime number of reducers for compaction, which is less subject to hashcode skew.

Also changed the default data size a reducers processes from 256M to 512M, which brings the number of reducers a job uses more in-line with Camus.