### PR TITLE
Permission fixes for distcp-ng

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/SerializableCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/SerializableCopyableDataset.java
@@ -15,6 +15,8 @@ package gobblin.data.management.copy;
 import java.io.IOException;
 import java.util.List;
 
+import lombok.EqualsAndHashCode;
+
 import org.apache.hadoop.fs.Path;
 
 import com.google.gson.Gson;
@@ -25,6 +27,7 @@ import com.google.gson.Gson;
  * implementations of {@link CopyableDataset} may contain additional fields that should not be serialized.
  * The class is a data object and does not carry any functionality
  */
+@EqualsAndHashCode(callSuper=false)
 public class SerializableCopyableDataset extends SinglePartitionCopyableDataset {
 
   private SerializableCopyableDataset(CopyableDataset copyableDataset) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -177,12 +177,18 @@ public class FileAwareInputStreamDataWriter implements DataWriter<FileAwareInput
     }
     FsAction newOwnerAction = ownerAndPermission.getFsPermission().getUserAction();
 
-    if (ownerAndPermission.getFsPermission().getUserAction() == FsAction.READ) {
-      newOwnerAction = FsAction.READ_EXECUTE;
-    } else if (ownerAndPermission.getFsPermission().getUserAction() == FsAction.WRITE) {
-      newOwnerAction = FsAction.WRITE_EXECUTE;
-    } else if (ownerAndPermission.getFsPermission().getUserAction() == FsAction.READ_WRITE) {
-      newOwnerAction = FsAction.ALL;
+    switch (ownerAndPermission.getFsPermission().getUserAction()) {
+      case READ:
+        newOwnerAction = FsAction.READ_EXECUTE;
+        break;
+      case WRITE:
+        newOwnerAction = FsAction.WRITE_EXECUTE;
+        break;
+      case READ_WRITE:
+        newOwnerAction = FsAction.ALL;
+        break;
+      default:
+        break;
     }
 
     FsPermission withExecute =

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/SerializableCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/SerializableCopyableDatasetTest.java
@@ -11,8 +11,13 @@
  */
 package gobblin.data.management.copy;
 
+import gobblin.configuration.WorkUnitState;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.google.common.collect.ArrayListMultimap;
+import com.google.common.collect.Multimap;
 
 public class SerializableCopyableDatasetTest {
 
@@ -25,6 +30,25 @@ public class SerializableCopyableDatasetTest {
 
     Assert.assertEquals(copyableDataset.datasetRoot(), deserialized.datasetRoot());
     Assert.assertEquals(copyableDataset.datasetTargetRoot(), deserialized.datasetTargetRoot());
+  }
+
+  @Test
+  public void testHashCode() throws Exception {
+
+    CopyableDataset copyableDataset = new TestCopyableDataset();
+
+    String serialized = SerializableCopyableDataset.serialize(copyableDataset);
+
+    CopyableDataset deserialized = SerializableCopyableDataset.deserialize(serialized);
+    CopyableDataset deserialized2 = SerializableCopyableDataset.deserialize(serialized);
+
+    Multimap<CopyableDataset, WorkUnitState> datasetRoots = ArrayListMultimap.create();
+
+    datasetRoots.put(deserialized, new WorkUnitState());
+    datasetRoots.put(deserialized2, new WorkUnitState());
+
+    Assert.assertEquals(datasetRoots.keySet().size(), 1);
+
   }
 
 }


### PR DESCRIPTION
Fixes -
1. Ancestor permissions were set on final destination path instead of staging path
2. Always grant execute permissions to directories created in staging directory to be able to publish them.

@sahilTakiar can you review this?