### PR TITLE
Removed dependency on commons-lang3

### DIFF
--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -28,7 +28,6 @@ dependencies {
   compile externalDependency.httpclient
   compile externalDependency.httpcore
   compile externalDependency.commonsLang
-  compile externalDependency.commonsLang3
   compile externalDependency.slf4j
   compile externalDependency.commonsCli
   compile externalDependency.gson

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -19,11 +19,11 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.atomic.AtomicInteger;
 
-import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
@@ -253,7 +253,7 @@ public class Task implements Runnable {
   private void failTask(Throwable t) {
     LOG.error(String.format("Task %s failed", this.taskId), t);
     this.taskState.setWorkingState(WorkUnitState.WorkingState.FAILED);
-    this.taskState.setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, ExceptionUtils.getStackTrace(t));
+    this.taskState.setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, Throwables.getStackTraceAsString(t));
   }
 
   /**


### PR DESCRIPTION
Seems `commons-lang3` was added just for one use in `gobblin-runtime`: to use the method `ExceptionUtils.getStackTrace()`. Replaced this usage with `Throwables.getStackTraceAsString()` so the dependency on `commons-lang3` can be removed.

Signed-off-by: Yinan Li <liyinan926@gmail.com>