### PR TITLE
Make partitioned data writer class configurable

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -235,6 +235,7 @@ public class ConfigurationKeys {
   public static final String DEFAULT_WRITER_FILE_PATH_TYPE = "default";
   public static final String SIMPLE_WRITER_DELIMITER = "simple.writer.delimiter";
   public static final String SIMPLE_WRITER_PREPEND_SIZE = "simple.writer.prepend.size";
+  public static final String PARTITIONED_DATA_WRITER_CLASS = "partitioned.data.writer.class";
 
   /**
    * Writer configuration properties used internally.

--- a/gobblin-core/src/main/java/gobblin/writer/PartitionedDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/PartitionedDataWriter.java
@@ -49,7 +49,8 @@ public class PartitionedDataWriter<S, D> implements DataWriter<D> {
   private static final GenericRecord NON_PARTITIONED_WRITER_KEY =
       new GenericData.Record(SchemaBuilder.record("Dummy").fields().endRecord());
 
-  private final Optional<WriterPartitioner> partitioner;
+  protected final State state;
+  protected final Optional<WriterPartitioner> partitioner;
   private final LoadingCache<GenericRecord, DataWriter<D>> partitionWriters;
   private final Optional<PartitionAwareDataWriterBuilder> builder;
   private final boolean shouldPartition;
@@ -57,6 +58,7 @@ public class PartitionedDataWriter<S, D> implements DataWriter<D> {
 
   public PartitionedDataWriter(DataWriterBuilder<S, D> builder, final State state) throws IOException {
 
+    this.state = state;
     this.closer = Closer.create();
     this.partitionWriters = CacheBuilder.newBuilder().build(new CacheLoader<GenericRecord, DataWriter<D>>() {
       @Override

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -28,6 +28,7 @@ dependencies {
   compile externalDependency.httpclient
   compile externalDependency.httpcore
   compile externalDependency.commonsLang
+  compile externalDependency.commonsLang3
   compile externalDependency.slf4j
   compile externalDependency.commonsCli
   compile externalDependency.gson


### PR DESCRIPTION
Need to extend `PartitionedDataWriter` in Kafka adapter for collecting audit counts for each record written.