### PR TITLE
Set group after the staging output file gets created

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -66,6 +66,8 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
     this.stagingFileOutputStream = createStagingFileOutputStream();
     this.datumWriter = new GenericDatumWriter<GenericRecord>();
     this.writer = this.closer.register(createDataFileWriter(codecFactory));
+
+    setStagingFileGroup();
   }
 
   public FileSystem getFileSystem() {

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -65,6 +65,8 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
     this.recordsWritten = 0;
     this.bytesWritten = 0;
     this.stagingFileOutputStream = createStagingFileOutputStream();
+
+    setStagingFileGroup();
   }
 
   /**


### PR DESCRIPTION
Due to some recent changes to `FsDataWriter` and its subclasses, `FsDataWriter` will throw an `FileNotFoundException` if a group is specified and it tries to set the group on the staging output file, which won't be created until later in the constructor of `AvroHdfsDataWriter` and `SimpleDataWriter`. Attempt to set group on a file that does not exist will throw an `FileNotFoundException`. 

Signed-off-by: Yinan Li <liyinan926@gmail.com>