### PR TITLE
Submitting event metadata for each successful job, including task exceptions

### DIFF
--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -38,6 +38,7 @@ dependencies {
   compile externalDependency.guice
   compile externalDependency.javaxInject
   compile externalDependency.findBugs
+  compile externalDependency.lombok
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2
   } else {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -264,6 +264,9 @@ public abstract class AbstractJobLauncher implements JobLauncher {
         // Write job execution info to the job history store upon job termination
         this.jobContext.storeJobExecutionInfo();
 
+        // Emit events about this job execution
+        this.jobContext.submitJobExecutionEvents();
+
         if (this.jobContext.getJobMetricsOptional().isPresent()) {
           this.jobContext.getJobMetricsOptional().get().triggerMetricReporting();
           this.jobContext.getJobMetricsOptional().get().stopMetricReporting();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobExecutionEventSubmitter.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobExecutionEventSubmitter.java
@@ -1,0 +1,116 @@
+package gobblin.runtime;
+
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+
+import gobblin.metrics.event.EventSubmitter;
+
+import lombok.AllArgsConstructor;
+
+
+@AllArgsConstructor
+
+/**
+ * Submits metadata about a completed {@link JobState} using the provided {@link EventSubmitter}.
+ */
+public class JobExecutionEventSubmitter {
+
+  private final EventSubmitter eventSubmitter;
+
+  // Event names
+  private static final String JOB_STATE_EVENT = "jobStateEvent";
+  private static final String TASK_STATE_EVENT = "taskStateEvent";
+
+  // Job Event metadata keys
+  private static final String JOB_ID = "jobId";
+  private static final String JOB_NAME = "jobName";
+  private static final String JOB_START_TIME = "jobBeginTime";
+  private static final String JOB_END_TIME = "jobEndTime";
+  private static final String JOB_STATE = "jobState";
+  private static final String JOB_LAUNCHED_TASKS = "jobLaunchedTasks";
+  private static final String JOB_COMPLETED_TASKS = "jobCompletedTasks";
+  private static final String JOB_LAUNCHER_TYPE = "jobLauncherType";
+  private static final String JOB_TRACKING_URL = "jobTrackingURL";
+
+  // Task Event metadata keys
+  private static final String TASK_ID = "taskId";
+  private static final String TASK_START_TIME = "taskStartTime";
+  private static final String TASK_END_TIME = "taskEndTime";
+  private static final String TASK_WORKING_STATE = "taskWorkingState";
+  private static final String TASK_FAILURE_CONTEXT = "taskFailureContext";
+
+  // The value of any metadata key that cannot be determined
+  private static final String UNKNOWN_VALUE = "UNKNOWN";
+
+  /**
+   * Submits metadata about a given {@link JobState} and each of its {@link TaskState}s. This method will submit a
+   * single event for the {@link JobState} called {@link #JOB_STATE_EVENT}. It will submit an event for each
+   * {@link TaskState} called {@link #TASK_STATE_EVENT}.
+   *
+   * @param jobState is the {@link JobState} to emit events for
+   */
+  public void submitJobExecutionEvents(JobState jobState) {
+    submitJobStateEvent(jobState);
+    submitTaskStateEvents(jobState);
+  }
+
+  /**
+   * Submits an event for the given {@link JobState}.
+   */
+  private void submitJobStateEvent(JobState jobState) {
+    ImmutableMap.Builder<String, String> jobMetadataBuilder = new ImmutableMap.Builder<String, String>();
+
+    jobMetadataBuilder.put(JOB_ID, jobState.getJobId());
+    jobMetadataBuilder.put(JOB_NAME, jobState.getJobName());
+    jobMetadataBuilder.put(JOB_START_TIME, Long.toString(jobState.getStartTime()));
+    jobMetadataBuilder.put(JOB_END_TIME, Long.toString(jobState.getEndTime()));
+    jobMetadataBuilder.put(JOB_STATE, jobState.getState().toString());
+    jobMetadataBuilder.put(JOB_LAUNCHED_TASKS, Integer.toString(jobState.getTaskCount()));
+    jobMetadataBuilder.put(JOB_COMPLETED_TASKS, Integer.toString(jobState.getCompletedTasks()));
+    jobMetadataBuilder.put(JOB_LAUNCHER_TYPE, jobState.getLauncherType().toString());
+    jobMetadataBuilder.put(JOB_TRACKING_URL, getValueIfPresent(jobState.getTrackingURL()));
+
+    this.eventSubmitter.submit(JOB_STATE_EVENT, jobMetadataBuilder.build());
+  }
+
+  /**
+   * Submits an event for each {@link TaskState} in the given {@link JobState}.
+   */
+  private void submitTaskStateEvents(JobState jobState) {
+    // Build Job Metadata applicable for TaskStates
+    ImmutableMap.Builder<String, String> jobMetadataBuilder = new ImmutableMap.Builder<String, String>();
+    jobMetadataBuilder.put(JOB_ID, jobState.getJobId());
+    jobMetadataBuilder.put(JOB_NAME, jobState.getJobName());
+    Map<String, String> jobMetadata = jobMetadataBuilder.build();
+
+    // Submit event for each TaskState
+    for (TaskState taskState : jobState.getTaskStates()) {
+      submitTaskStateEvent(taskState, jobMetadata);
+    }
+  }
+
+  /**
+   * Submits an event for a given {@link TaskState}. It will include all metadata specified in the jobMetadata parameter.
+   */
+  private void submitTaskStateEvent(TaskState taskState, Map<String, String> jobMetadata) {
+    ImmutableMap.Builder<String, String> taskMetadataBuilder = new ImmutableMap.Builder<String, String>();
+
+    taskMetadataBuilder.putAll(jobMetadata);
+    taskMetadataBuilder.put(TASK_ID, taskState.getTaskId());
+    taskMetadataBuilder.put(TASK_START_TIME, Long.toString(taskState.getStartTime()));
+    taskMetadataBuilder.put(TASK_END_TIME, Long.toString(taskState.getEndTime()));
+    taskMetadataBuilder.put(TASK_WORKING_STATE, taskState.getWorkingState().toString());
+    taskMetadataBuilder.put(TASK_FAILURE_CONTEXT, getValueIfPresent(taskState.getTaskFailureException()));
+
+    this.eventSubmitter.submit(TASK_STATE_EVENT, taskMetadataBuilder.build());
+  }
+
+  /**
+   * Gets a {@link String} representation of the given {@link Optional} if present, else returns {@link #UNKNOWN_VALUE}.
+   */
+  private String getValueIfPresent(Optional<?> value) {
+    return value.isPresent() ? value.get().toString() : UNKNOWN_VALUE;
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -26,6 +26,7 @@ import com.codahale.metrics.Counter;
 import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -317,6 +318,15 @@ public class JobState extends SourceState {
     return builder.build();
   }
 
+  public LauncherTypeEnum getLauncherType() {
+    return LauncherTypeEnum.valueOf(
+        this.getProp(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY, JobLauncherFactory.JobLauncherType.LOCAL.name()));
+  }
+
+  public Optional<String> getTrackingURL() {
+    return Optional.fromNullable(this.getProp(ConfigurationKeys.JOB_TRACKING_URL_KEY));
+  }
+
   @Override
   public void readFields(DataInput in)
       throws IOException {
@@ -450,10 +460,9 @@ public class JobState extends SourceState {
     jobExecutionInfo.setState(JobStateEnum.valueOf(this.state.name()));
     jobExecutionInfo.setLaunchedTasks(this.taskCount);
     jobExecutionInfo.setCompletedTasks(this.getCompletedTasks());
-    jobExecutionInfo.setLauncherType(LauncherTypeEnum.valueOf(this.getProp(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY,
-        JobLauncherFactory.JobLauncherType.LOCAL.name())));
-    if (this.contains(ConfigurationKeys.JOB_TRACKING_URL_KEY)) {
-      jobExecutionInfo.setTrackingUrl(this.getProp(ConfigurationKeys.JOB_TRACKING_URL_KEY));
+    jobExecutionInfo.setLauncherType(getLauncherType());
+    if (getTrackingURL().isPresent()) {
+      jobExecutionInfo.setTrackingUrl(getTrackingURL().get());
     }
 
     // Add task execution information

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -304,11 +304,13 @@ public class Task implements Runnable {
 
       LOG.info("Publishing data from task " + this.taskId);
       publisher.publish(this.taskState);
-    } catch (IOException e) {
-      throw closer.rethrow(e);
-    } catch (Throwable t) {
+    } catch (ClassCastException e) {
       LOG.error(String.format("To publish data in task, the publisher class (%s) must extend %s",
-          ConfigurationKeys.DATA_PUBLISHER_TYPE, SingleTaskDataPublisher.class.getSimpleName()), t);
+          ConfigurationKeys.DATA_PUBLISHER_TYPE, SingleTaskDataPublisher.class.getSimpleName()), e);
+      this.taskState.setTaskFailureException(e);
+      closer.rethrow(e);
+    } catch(Throwable t) {
+      this.taskState.setTaskFailureException(t);
       throw closer.rethrow(t);
     } finally {
       closer.close();

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobExecutionEventSubmitterTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobExecutionEventSubmitterTest.java
@@ -1,0 +1,58 @@
+package gobblin.runtime;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+
+import java.util.Map;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+import org.mockito.Mockito;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.event.EventSubmitter;
+import gobblin.rest.LauncherTypeEnum;
+
+
+@Test(groups = {"gobblin.runtime"})
+public class JobExecutionEventSubmitterTest {
+
+  private EventSubmitter mockEventSubmitter;
+  private JobExecutionEventSubmitter jobExecutionEventSubmitter;
+
+  @BeforeClass
+  public void setUp() {
+    this.mockEventSubmitter = mock(EventSubmitter.class);
+    this.jobExecutionEventSubmitter = new JobExecutionEventSubmitter(this.mockEventSubmitter);
+  }
+
+  @Test
+  public void testSubmitJobExecutionEvents() {
+    JobState mockJobState = mock(JobState.class, Mockito.RETURNS_SMART_NULLS);
+    when(mockJobState.getState()).thenReturn(JobState.RunningState.SUCCESSFUL);
+    when(mockJobState.getLauncherType()).thenReturn(LauncherTypeEnum.$UNKNOWN);
+    when(mockJobState.getTrackingURL()).thenReturn(Optional.<String> absent());
+
+    TaskState mockTaskState1 = createMockTaskState();
+    TaskState mockTaskState2 = createMockTaskState();
+
+    when(mockJobState.getTaskStates()).thenReturn(Lists.newArrayList(mockTaskState1, mockTaskState2));
+
+    this.jobExecutionEventSubmitter.submitJobExecutionEvents(mockJobState);
+    verify(this.mockEventSubmitter, atLeastOnce()).submit(any(String.class), any(Map.class));
+  }
+
+  private TaskState createMockTaskState() {
+    TaskState taskState = mock(TaskState.class, Mockito.RETURNS_SMART_NULLS);
+    when(taskState.getWorkingState()).thenReturn(WorkUnitState.WorkingState.SUCCESSFUL);
+    when(taskState.getTaskFailureException()).thenReturn(Optional.<String> absent());
+    return taskState;
+  }
+}


### PR DESCRIPTION
* Created a new class called `JobExecutionEventSubmitter` that submits metadata for a given `JobState`
* The events are submitted using a `EventSubmitter`, and are emitted at the end of `AbstractJobLauncher.launchJob`
* The config key `ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY` is updated not just for `Task` failures, but also for task publishing failures

@liyinan926 can you review?