### PR TITLE
Support custom output file extensions

### DIFF
--- a/bin/gobblin-mapreduce.sh
+++ b/bin/gobblin-mapreduce.sh
@@ -101,7 +101,7 @@ set_user_jars "$JARS"
 LIBJARS=$USER_JARS$separator$FWDIR_LIB/gobblin-metastore.jar,$FWDIR_LIB/gobblin-metrics.jar,\
 $FWDIR_LIB/gobblin-core.jar,$FWDIR_LIB/gobblin-api.jar,$FWDIR_LIB/gobblin-utility.jar,\
 $FWDIR_LIB/guava-15.0.jar,$FWDIR_LIB/avro-1.7.7.jar,$FWDIR_LIB/metrics-core-3.1.0.jar,\
-$FWDIR_LIB/gson-2.3.1.jar,$FWDIR_LIB/joda-time-2.8.1.jar,$FWDIR_LIB/data-1.15.9.jar
+$FWDIR_LIB/gson-2.3.1.jar,$FWDIR_LIB/joda-time-2.9.jar,$FWDIR_LIB/data-1.15.9.jar
 
 # Add libraries to the Hadoop classpath
 GOBBLIN_DEP_JARS=`echo "$USER_JARS" | tr ',' ':' `

--- a/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
+++ b/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
@@ -12,6 +12,8 @@
 
 package gobblin.writer;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * An enumeration of writer output formats.
  *
@@ -23,7 +25,8 @@ public enum WriterOutputFormat {
   PROTOBUF("protobuf"),
   JSON("json"),
   ORC("orc"),
-  CSV("csv");
+  CSV("csv"),
+  OTHER(StringUtils.EMPTY);
 
   /**
    * Extension specifies the file name extension

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
@@ -13,6 +13,7 @@
 package gobblin.writer;
 
 import org.apache.avro.Schema;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -44,14 +45,19 @@ public abstract class FsDataWriterBuilder<S, D> extends PartitionAwareDataWriter
    */
   public String getFileName(State properties) {
 
-    String fileName = WriterUtils.getWriterFileName(properties, this.branches, this.branch, this.writerId,
-        this.format.getExtension());
+    String extension =
+        this.format.equals(WriterOutputFormat.OTHER) ? getExtension(properties) : this.format.getExtension();
+    String fileName = WriterUtils.getWriterFileName(properties, this.branches, this.branch, this.writerId, extension);
 
     if (this.partition.isPresent()) {
       fileName = getPartitionedFileName(properties, fileName);
     }
 
     return fileName;
+  }
+
+  private String getExtension(State properties) {
+    return properties.getProp(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY, StringUtils.EMPTY);
   }
 
   protected String getPartitionedFileName(State properties, String originalFileName) {

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -22,6 +22,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
@@ -181,9 +182,12 @@ public class WriterUtils {
    */
   public static String getWriterFileName(State state, int numBranches, int branchId, String writerId,
       String formatExtension) {
+    String defaultFileName = Strings.isNullOrEmpty(formatExtension)
+        ? String.format("%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_BASE_NAME, writerId)
+        : String.format("%s.%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_BASE_NAME, writerId, formatExtension);
     return state.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_FILE_NAME, numBranches, branchId),
-        String.format("%s.%s.%s", ConfigurationKeys.DEFAULT_WRITER_FILE_BASE_NAME, writerId, formatExtension));
+        defaultFileName);
   }
 
   /**


### PR DESCRIPTION
If `ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY` doesn't match any `WriterOutputFormat` type, its value will be used as extension.