### PR TITLE
Setting job.launcher.type for YARN jobs

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -327,6 +327,13 @@ public class JobState extends SourceState {
   }
 
   /**
+   * Sets the {@link LauncherTypeEnum} for this {@link JobState}.
+   */
+  public void setJobLauncherType(LauncherTypeEnum jobLauncherType) {
+    this.setProp(ConfigurationKeys.JOB_LAUNCHER_TYPE_KEY, jobLauncherType.name());
+  }
+
+  /**
    * Get the tracking URL for this {@link JobState}.
    */
   public Optional<String> getTrackingURL() {

--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -19,6 +19,7 @@ dependencies {
   compile project(":gobblin-runtime")
   compile project(":gobblin-utility")
   compile project(":gobblin-scheduler")
+  compile project(path: ':gobblin-rest-service:gobblin-rest-api', configuration: 'restClient')
 
   compile externalDependency.avro
   compile externalDependency.commonsConfiguration

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
@@ -40,6 +40,7 @@ import com.google.common.collect.Queues;
 import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.rest.LauncherTypeEnum;
 import gobblin.runtime.AbstractJobLauncher;
 import gobblin.runtime.FileBasedJobLock;
 import gobblin.runtime.JobLauncher;
@@ -112,6 +113,8 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
 
     this.stateSerDeRunnerThreads = Integer.parseInt(jobProps.getProperty(ParallelRunner.PARALLEL_RUNNER_THREADS_KEY,
         Integer.toString(ParallelRunner.DEFAULT_PARALLEL_RUNNER_THREADS)));
+
+    this.jobContext.getJobState().setJobLauncherType(LauncherTypeEnum.YARN);
   }
 
   @Override


### PR DESCRIPTION
Setting the `job.launcher.type` key to `LauncherTypeEnum.YARN` for YARN jobs. This allows us to differentiate between jobs that run on YARN vs. MR vs. Local when consuming events produced by `JobExecutionEventSubmitter`.