### PR TITLE
Add support to delete data on source after copy

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/DeletingCopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/DeletingCopyDataPublisher.java
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy.publisher;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.configuration.WorkUnitState.WorkingState;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.copy.publisher.CopyDataPublisher;
+import gobblin.util.HadoopUtils;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Collection;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
+
+/**
+ * A {@link CopyDataPublisher} that deletes files on the source fileSystem for all the {@link WorkUnitState}s that are
+ * successfully committed/published
+ */
+@Slf4j
+public class DeletingCopyDataPublisher extends CopyDataPublisher {
+
+  private final FileSystem sourceFs;
+
+  public DeletingCopyDataPublisher(State state) throws IOException {
+    super(state);
+    Configuration conf = HadoopUtils.getConfFromState(state);
+    String uri = state.getProp(ConfigurationKeys.SOURCE_FILEBASED_FS_URI, ConfigurationKeys.LOCAL_FS_URI);
+    this.sourceFs = FileSystem.get(URI.create(uri), conf);
+  }
+
+  @Override
+  public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
+    super.publishData(states);
+    for (WorkUnitState state : states) {
+      if (state.getWorkingState() == WorkingState.COMMITTED) {
+        try {
+          deleteFilesOnSource(state);
+        } catch (Throwable t) {
+          log.warn(
+              String.format("Failed to delete one or more files on source in %s",
+                  state.getProp(CopySource.SERIALIZED_COPYABLE_FILES)), t);
+        }
+      } else {
+        log.info(String.format("Not deleting files %s on source fileSystem as the workunit state is %s.",
+            state.getProp(CopySource.SERIALIZED_COPYABLE_FILES), state.getWorkingState()));
+      }
+    }
+  }
+
+  private void deleteFilesOnSource(WorkUnitState state) throws IOException {
+    List<CopyableFile> copyableFiles = CopySource.deserializeCopyableFiles(state);
+    for (CopyableFile copyableFile : copyableFiles) {
+      if (this.sourceFs.exists(copyableFile.getOrigin().getPath())) {
+        log.info(String.format("Deleting %s on source fileSystem.", copyableFile.getOrigin().getPath()));
+        if (!this.sourceFs.delete(copyableFile.getOrigin().getPath(), true)) {
+          throw new IOException("Delete failed for " + copyableFile.getOrigin().getPath());
+        }
+      }
+    }
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileUtils.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileUtils.java
@@ -11,15 +11,28 @@
  */
 package gobblin.data.management.copy;
 
+import java.io.IOException;
+
 import org.apache.commons.lang.RandomStringUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+
 /**
- * Utils class to generate dummy {@link CopyableFile}s for testing.
- * Random strings are generated for null paths.
+ * Utils class to generate dummy {@link CopyableFile}s for testing. Random strings are generated for null paths.
  */
 public class CopyableFileUtils {
+
+  public static CopyableFile createTestCopyableFile(String resourcePath) throws IOException {
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+    fs.create(new Path(resourcePath));
+
+    FileStatus status = new FileStatus(0l, false, 0, 0l, 0l, new Path(resourcePath));
+
+    return new CopyableFile(status, new Path(getRandomPath()), new Path(getRandomPath()), null, null, null);
+  }
 
   public static CopyableFile getTestCopyableFile() {
     return getTestCopyableFile(null, null);

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyableDataset.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyableDataset.java
@@ -34,13 +34,26 @@ public class TestCopyableDataset extends SinglePartitionCopyableDataset {
   public static final OwnerAndPermission OWNER_AND_PERMISSION = new OwnerAndPermission("owner", "group",
       FsPermission.getDefault());
 
+  private Path datasetRoot;
+  private Path datasetTargetRoot;
+  public TestCopyableDataset(Path datasetRoot, Path datasetTargetRoot) {
+    this.datasetRoot = datasetRoot;
+    this.datasetTargetRoot = datasetTargetRoot;
+  }
+
+
+  public TestCopyableDataset() {
+    this.datasetRoot = new Path(ORIGIN_PREFIX);
+    this.datasetTargetRoot = new Path(DESTINATION_PREFIX);
+  }
+
   @Override
   public List<CopyableFile> getCopyableFiles() throws IOException {
     List<CopyableFile> files = Lists.newArrayList();
 
     for (int i = 0; i < FILE_COUNT; i++) {
-      files.add(new CopyableFile(new FileStatus(10, false, 0, 0, 0, new Path(ORIGIN_PREFIX, Integer.toString(i))),
-          new Path(DESTINATION_PREFIX, Integer.toString(i)), new Path(RELATIVE_PREFIX, Integer.toString(i)),
+      files.add(new CopyableFile(new FileStatus(10, false, 0, 0, 0, new Path(datasetRoot, Integer.toString(i))),
+          new Path(datasetTargetRoot, Integer.toString(i)), new Path(RELATIVE_PREFIX, Integer.toString(i)),
           OWNER_AND_PERMISSION, Lists.newArrayList(OWNER_AND_PERMISSION), "checksum".getBytes()));
     }
 
@@ -49,11 +62,11 @@ public class TestCopyableDataset extends SinglePartitionCopyableDataset {
 
   @Override
   public Path datasetRoot() {
-    return new Path(ORIGIN_PREFIX);
+    return datasetRoot;
   }
 
   @Override
   public Path datasetTargetRoot() {
-    return new Path(DESTINATION_PREFIX);
+    return datasetTargetRoot;
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/publisher/CopyDataPublisherTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/publisher/CopyDataPublisherTest.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy.publisher;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableDataset;
+import gobblin.data.management.copy.TestCopyableDataset;
+import gobblin.data.management.util.PathUtils;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.io.Closer;
+
+
+/*
+ *
+ *  Test cases covered
+ * - Single dataset multiple files/workunits
+ * - Single dataset multiple files/workunits few workunits failed
+ * - Two datasets multiple files
+ * - Two datasets one of them failed to publish
+ * - datasets with overlapping dataset roots
+ *
+ */
+@Slf4j
+public class CopyDataPublisherTest {
+
+  private static final Closer closer = Closer.create();
+
+  private FileSystem fs;
+  private Path testClassTempPath;
+
+  @Test
+  public void testPublishSingleDataset() throws Exception {
+
+    State state = getTestState("testPublishSingleDataset");
+
+    Path testMethodTempPath = new Path(testClassTempPath, "testPublishSingleDataset");
+
+    CopyDataPublisher copyDataPublisher = closer.register(new CopyDataPublisher(state));
+
+
+    TestDatasetManager datasetManager =
+        new TestDatasetManager(testMethodTempPath, state, "datasetTargetPath",
+            ImmutableList.of("a/b, a/c, d/e"));
+
+    datasetManager.createDatasetFiles();
+
+    datasetManager.verifyDoesntExist();
+
+    copyDataPublisher.publishData(datasetManager.getWorkUnitStates());
+
+    datasetManager.verifyExists();
+
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPublishMultipleDatasets() throws Exception {
+
+    State state = getTestState("testPublishMultipleDatasets");
+
+    Path testMethodTempPath = new Path(testClassTempPath, "testPublishMultipleDatasets");
+
+    CopyDataPublisher copyDataPublisher = closer.register(new CopyDataPublisher(state));
+
+    TestDatasetManager dataset1Manager =
+        new TestDatasetManager(testMethodTempPath, state, "dataset1TargetPath",
+            ImmutableList.of("a/b, a/c, d/e"));
+
+    dataset1Manager.createDatasetFiles();
+
+    TestDatasetManager dataset2Manager =
+        new TestDatasetManager(testMethodTempPath, state, "dataset2TargetPath",
+            ImmutableList.of("a/b, a/c, d/e"));
+
+    dataset2Manager.createDatasetFiles();
+
+    dataset1Manager.verifyDoesntExist();
+
+    dataset2Manager.verifyDoesntExist();
+
+    copyDataPublisher.publishData(combine(dataset1Manager.getWorkUnitStates(), dataset2Manager.getWorkUnitStates()));
+
+    dataset1Manager.verifyExists();
+
+    dataset2Manager.verifyExists();
+
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPublishOverlappingDatasets() throws Exception {
+
+    State state = getTestState("testPublishOverlappingDatasets");
+
+    Path testMethodTempPath = new Path(testClassTempPath, "testPublishOverlappingDatasets");
+
+    CopyDataPublisher copyDataPublisher = closer.register(new CopyDataPublisher(state));
+
+    TestDatasetManager dataset1Manager =
+        new TestDatasetManager(testMethodTempPath, state, "datasetTargetPath", ImmutableList.of("a/b"));
+
+    dataset1Manager.createDatasetFiles();
+
+    TestDatasetManager dataset2Manager =
+        new TestDatasetManager(testMethodTempPath, state, "datasetTargetPath/subDir",
+            ImmutableList.of("a/c, d/e"));
+
+    dataset2Manager.createDatasetFiles();
+
+    dataset1Manager.verifyDoesntExist();
+
+    dataset2Manager.verifyDoesntExist();
+
+    copyDataPublisher.publishData(combine(dataset1Manager.getWorkUnitStates(), dataset2Manager.getWorkUnitStates()));
+
+    dataset1Manager.verifyExists();
+
+    dataset2Manager.verifyExists();
+
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testPublishDatasetFailure() throws Exception {
+
+    State state = getTestState("testPublishDatasetFailure");
+
+    Path testMethodTempPath = new Path(testClassTempPath, "testPublishDatasetFailure");
+
+    CopyDataPublisher copyDataPublisher = closer.register(new CopyDataPublisher(state));
+
+    TestDatasetManager successDatasetManager =
+        new TestDatasetManager(testMethodTempPath, state, "successTargetPath", ImmutableList.of("a/b"));
+
+    successDatasetManager.createDatasetFiles();
+
+    TestDatasetManager failedDatasetManager =
+        new TestDatasetManager(testMethodTempPath, state, "failedTargetPath", ImmutableList.of("c/d"));
+
+    successDatasetManager.verifyDoesntExist();
+
+    failedDatasetManager.verifyDoesntExist();
+
+    copyDataPublisher.publishData(combine(successDatasetManager.getWorkUnitStates(),
+        failedDatasetManager.getWorkUnitStates()));
+
+    successDatasetManager.verifyExists();
+
+    failedDatasetManager.verifyDoesntExist();
+
+  }
+
+  @BeforeClass
+  public void setup() throws Exception {
+    fs = FileSystem.getLocal(new Configuration());
+    testClassTempPath = new Path(this.getClass().getClassLoader().getResource("").getFile(), "CopyDataPublisherTest");
+    fs.delete(testClassTempPath, true);
+    log.info("Created a temp directory for CopyDataPublisherTest at " + testClassTempPath);
+    fs.mkdirs(testClassTempPath);
+  }
+
+  private static Collection<? extends WorkUnitState> combine(List<WorkUnitState>... workUnitStateLists) {
+    List<WorkUnitState> wus = Lists.newArrayList();
+    for (List<WorkUnitState> workUnitStates : workUnitStateLists) {
+      wus.addAll(workUnitStates);
+    }
+
+    return wus;
+  }
+
+  private State getTestState(String testMethodName) {
+    return getTestState(testMethodName, testClassTempPath);
+  }
+
+  public static State getTestState(String testMethodName, Path testClassTempPath) {
+
+    Path testMethodPath = new Path(testClassTempPath, testMethodName);
+    State state = new State();
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, new Path(testMethodPath, "task-output"));
+    state.setProp(ConfigurationKeys.WRITER_STAGING_DIR, new Path(testMethodPath, "task-staging"));
+    state.setProp(ConfigurationKeys.JOB_ID_KEY, "jobid");
+
+    return state;
+  }
+
+  public static class TestDatasetManager {
+
+    private CopyableDataset copyableDataset;
+    private List<String> relativeFilePaths;
+    private Path writerOutputPath;
+    private FileSystem fs;
+
+    private void createDatasetFiles() throws IOException {
+      // Create writer output files
+      Path datasetWriterOutputPath =
+          new Path(writerOutputPath, PathUtils.withoutLeadingSeparator(copyableDataset.datasetTargetRoot()));
+      for (String path : relativeFilePaths) {
+        Path pathToCreate = new Path(datasetWriterOutputPath, path);
+        fs.mkdirs(pathToCreate.getParent());
+        fs.create(pathToCreate);
+      }
+    }
+
+    public TestDatasetManager(Path testMethodTempPath, State state, String datasetTargetPath, List<String> relativeFilePaths)
+        throws IOException {
+
+      this.fs = FileSystem.getLocal(new Configuration());
+      this.copyableDataset =
+          new TestCopyableDataset(new Path("origin"), new Path(testMethodTempPath, datasetTargetPath));
+      this.relativeFilePaths = relativeFilePaths;
+      this.writerOutputPath = new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR));
+
+      fs.mkdirs(testMethodTempPath);
+      log.info("Created a temp directory for test at " + testMethodTempPath);
+
+    }
+
+    List<WorkUnitState> getWorkUnitStates() throws IOException {
+      List<WorkUnitState> workUnitStates =
+          Lists.newArrayList(new WorkUnitState(), new WorkUnitState(), new WorkUnitState());
+      for (WorkUnitState wus : workUnitStates) {
+        CopySource.serializeCopyableDataset(wus, copyableDataset);
+      }
+      return workUnitStates;
+    }
+
+    void verifyExists() throws IOException {
+      for (String fileRelativePath : relativeFilePaths) {
+        Path filePublishPath = new Path(copyableDataset.datasetTargetRoot(), fileRelativePath);
+        Assert.assertEquals(fs.exists(filePublishPath), true);
+      }
+    }
+
+    void verifyDoesntExist() throws IOException {
+      for (String fileRelativePath : relativeFilePaths) {
+        Path filePublishPath = new Path(copyableDataset.datasetTargetRoot(), fileRelativePath);
+        Assert.assertEquals(fs.exists(filePublishPath), false);
+      }
+    }
+  }
+
+  @AfterClass
+  public void cleanup() {
+    try {
+      closer.close();
+      fs.delete(testClassTempPath, true);
+    } catch (IOException e) {
+      log.warn(e.getMessage());
+    }
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/publisher/DeletingCopyDataPublisherTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/publisher/DeletingCopyDataPublisherTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy.publisher;
+
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.configuration.WorkUnitState.WorkingState;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableDataset;
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.copy.CopyableFileUtils;
+import gobblin.data.management.copy.TestCopyableDataset;
+
+import java.io.IOException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.io.Closer;
+
+
+@Slf4j
+public class DeletingCopyDataPublisherTest {
+
+  @Test
+  public void testDeleteOnSource() throws Exception {
+
+    State state = getTestState("testDeleteOnSource");
+
+    Path testMethodTempPath = new Path(testClassTempPath, "testDeleteOnSource");
+
+    DeletingCopyDataPublisher copyDataPublisher = closer.register(new DeletingCopyDataPublisher(state));
+
+    WorkUnitState wus = new WorkUnitState();
+
+    CopyableDataset copyableDataset = new TestCopyableDataset(new Path("origin"), new Path(testMethodTempPath, "testdataset"));
+
+    CopyableFile cf = CopyableFileUtils.createTestCopyableFile(new Path(testMethodTempPath, "test.txt").toString());
+
+    CopySource.serializeCopyableDataset(wus, copyableDataset);
+
+    CopySource.serializeCopyableFiles(wus, ImmutableList.of(cf));
+
+    Assert.assertTrue(fs.exists(new Path(testMethodTempPath, "test.txt")));
+
+    wus.setWorkingState(WorkingState.SUCCESSFUL);
+
+    copyDataPublisher.publishData(ImmutableList.of(wus));
+
+    Assert.assertFalse(fs.exists(new Path(testMethodTempPath, "test.txt")));
+
+  }
+
+  private static final Closer closer = Closer.create();
+
+  private FileSystem fs;
+  private Path testClassTempPath;
+
+  @BeforeClass
+  public void setup() throws Exception {
+    fs = FileSystem.getLocal(new Configuration());
+    testClassTempPath =
+        new Path(this.getClass().getClassLoader().getResource("").getFile(), "DeletingCopyDataPublisherTest");
+    fs.delete(testClassTempPath, true);
+    log.info("Created a temp directory for CopyDataPublisherTest at " + testClassTempPath);
+    fs.mkdirs(testClassTempPath);
+  }
+
+  @AfterClass
+  public void cleanup() {
+    try {
+      closer.close();
+      fs.delete(testClassTempPath, true);
+    } catch (IOException e) {
+      log.warn(e.getMessage());
+    }
+  }
+
+  private State getTestState(String testMethodName) {
+    return CopyDataPublisherTest.getTestState(testMethodName, testClassTempPath);
+  }
+
+}


### PR DESCRIPTION
@liyinan926 can you review?
Changes -
1. If a dataset publish fails, the job should not fail. It should publish other datasets
2. Add a publisher that deletes data on source after successful publish
3. Add unit tests for CopyDataPublisher and DeletingCopyDataPublisher