### PR TITLE
Check path existance before calling fileSystem.listStatus

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -166,6 +166,11 @@ public class HadoopUtils {
    */
   public static void renameRecursively(FileSystem fileSystem, Path from, Path to) throws IOException {
 
+    // Need this check for hadoop2
+    if (!fileSystem.exists(from)) {
+      return;
+    }
+
     for (FileStatus fromFile : fileSystem.listStatus(from)) {
 
       Path relativeFilePath =


### PR DESCRIPTION
@ibuenros can you review this? This is the fix for failing build on hudson. Hadoop2 freaks out if you call liststatus on a path that does not exist.