### PR TITLE
Add schema registry to KafkaAvroExtractor

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
@@ -15,6 +15,7 @@ package gobblin.source.extractor.extract.kafka;
 import java.io.IOException;
 
 import kafka.message.MessageAndOffset;
+import lombok.extern.slf4j.Slf4j;
 
 import org.apache.avro.Schema;
 import org.apache.avro.SchemaBuilder;
@@ -22,12 +23,13 @@ import org.apache.avro.generic.GenericData.Record;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Decoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
 import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.metrics.kafka.SchemaRegistryException;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.util.AvroUtils;
@@ -36,26 +38,52 @@ import gobblin.util.AvroUtils;
 /**
  * An abstract implementation of {@link Extractor} for Kafka, where events are in Avro format.
  *
+ * Subclasses should implement {@link #getRecordSchema(byte[])} and {@link #getDecoder(byte[])}. Additionally, if
+ * schema registry is not used (i.e., property {@link KafkaSchemaRegistry#KAFKA_SCHEMA_REGISTRY_CLASS} is not
+ * specified, method {@link #getExtractorSchema()} should be overriden.
+ *
  * @author ziliu
  */
-public abstract class KafkaAvroExtractor extends KafkaExtractor<Schema, GenericRecord> {
+@Slf4j
+public abstract class KafkaAvroExtractor<K> extends KafkaExtractor<Schema, GenericRecord> {
 
-  private static final Logger LOG = LoggerFactory.getLogger(KafkaAvroExtractor.class);
   private static final Schema DEFAULT_SCHEMA = SchemaBuilder.record("DefaultSchema").fields().name("header")
       .type(SchemaBuilder.record("header").fields().name("time").type("long").withDefault(0).endRecord()).noDefault()
       .endRecord();
 
+  private final Optional<KafkaSchemaRegistry<K, Schema>> schemaRegistry;
   private final Optional<Schema> schema;
   private final Optional<GenericDatumReader<Record>> reader;
 
   public KafkaAvroExtractor(WorkUnitState state) {
     super(state);
+    this.schemaRegistry = state.contains(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_CLASS)
+        ? Optional.of(KafkaSchemaRegistry.<K, Schema> get(state.getProperties()))
+        : Optional.<KafkaSchemaRegistry<K, Schema>> absent();
     this.schema = getExtractorSchema();
     if (this.schema.isPresent()) {
       this.reader = Optional.of(new GenericDatumReader<Record>(this.schema.get()));
     } else {
-      LOG.error(String.format("Cannot find latest schema for topic %s. This topic will be skipped", this.topicName));
+      log.error(String.format("Cannot find latest schema for topic %s. This topic will be skipped", this.topicName));
       this.reader = Optional.absent();
+    }
+  }
+
+  /**
+   * Get the schema to be used by this extractor. All extracted records that have different schemas
+   * will be converted to this schema.
+   */
+  protected Optional<Schema> getExtractorSchema() {
+    return Optional.fromNullable(getLatestSchemaByTopic());
+  }
+
+  private Schema getLatestSchemaByTopic() {
+    Preconditions.checkState(this.schemaRegistry.isPresent());
+    try {
+      return this.schemaRegistry.get().getLatestSchemaByTopic(this.topicName);
+    } catch (SchemaRegistryException e) {
+      log.error(String.format("Cannot find latest schema for topic %s. This topic will be skipped", this.topicName), e);
+      return null;
     }
   }
 
@@ -83,24 +111,18 @@ public abstract class KafkaAvroExtractor extends KafkaExtractor<Schema, GenericR
       record = AvroUtils.convertRecordSchema(record, this.schema.get());
       return record;
     } catch (IOException e) {
-      LOG.error(String.format("Error during decoding record for partition %s: ", this.getCurrentPartition()));
+      log.error(String.format("Error during decoding record for partition %s: ", this.getCurrentPartition()));
       throw e;
     }
   }
 
   /**
-   * Get the schema to be used by this extractor. All extracted records that have different schemas
-   * will be converted to this schema.
-   */
-  protected abstract Optional<Schema> getExtractorSchema();
-
-  /**
-   * Obtain the {@link Schema} of a Kafka record given the payload of the record.
+   * Obtain the Avro {@link Schema} of a Kafka record given the payload of the record.
    */
   protected abstract Schema getRecordSchema(byte[] payload);
 
   /**
-   * Obtain the {@link Decoder} for a Kafka record given the payload of the record.
+   * Obtain the Avro {@link Decoder} for a Kafka record given the payload of the record.
    */
   protected abstract Decoder getDecoder(byte[] payload);
 }

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaSchemaRegistry.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaSchemaRegistry.java
@@ -12,8 +12,28 @@
 
 package gobblin.metrics.kafka;
 
+import java.lang.reflect.InvocationTargetException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.commons.lang.reflect.ConstructorUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.cache.CacheBuilder;
+import com.google.common.cache.CacheLoader;
+import com.google.common.cache.LoadingCache;
+import com.google.common.collect.Maps;
+
+import lombok.extern.slf4j.Slf4j;
+
+
 /**
- * A schema registry interface for Kafka, which supports fetching schema by key, fetching the latest schema
+ * A abstract schema registry class for Kafka, which supports fetching schema by key, fetching the latest schema
  * of a topic, and registering a schema.
  *
  * @param <K> key type
@@ -21,32 +41,160 @@ package gobblin.metrics.kafka;
  *
  * @author ziliu
  */
-public interface KafkaSchemaRegistry<K, S> {
+@Slf4j
+public abstract class KafkaSchemaRegistry<K, S> {
+
+  public static final String KAFKA_SCHEMA_REGISTRY_CLASS = "kafka.schema.registry.class";
+  public static final String KAFKA_SCHEMA_REGISTRY_URL = "kafka.schema.registry.url";
+
+  public static final int GET_SCHEMA_BY_ID_MAX_TIRES = 3;
+  public static final int GET_SCHEMA_BY_ID_MIN_INTERVAL_SECONDS = 1;
+  public static final String KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = "kafka.schema.registry.max.cache.size";
+  public static final String DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE = "1000";
+  public static final String KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN =
+      "kafka.schema.registry.cache.expire.after.write.min";
+  public static final String DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN = "10";
+
+  protected final Properties props;
+
+  // Cache that stores schemas by keys.
+  protected final LoadingCache<K, S> cachedSchemasByKeys;
+
+  protected KafkaSchemaRegistry(Properties props) {
+    this.props = props;
+    int maxCacheSize = Integer.parseInt(
+        props.getProperty(KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE, DEFAULT_KAFKA_SCHEMA_REGISTRY_MAX_CACHE_SIZE));
+    int expireAfterWriteMin = Integer.parseInt(props.getProperty(KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN,
+        DEFAULT_KAFKA_SCHEMA_REGISTRY_CACHE_EXPIRE_AFTER_WRITE_MIN));
+    this.cachedSchemasByKeys = CacheBuilder.newBuilder().maximumSize(maxCacheSize)
+        .expireAfterWrite(expireAfterWriteMin, TimeUnit.MINUTES).build(new KafkaSchemaCacheLoader());
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <K, S> KafkaSchemaRegistry<K, S> get(Properties props) {
+    Preconditions.checkArgument(props.containsKey(KAFKA_SCHEMA_REGISTRY_CLASS),
+        "Missing required property " + KAFKA_SCHEMA_REGISTRY_CLASS);
+    Class<? extends KafkaSchemaRegistry<?, ?>> clazz;
+    try {
+      clazz =
+          (Class<? extends KafkaSchemaRegistry<?, ?>>) Class.forName(props.getProperty(KAFKA_SCHEMA_REGISTRY_CLASS));
+      return (KafkaSchemaRegistry<K, S>) ConstructorUtils.invokeConstructor(clazz, props);
+    } catch (ClassNotFoundException | NoSuchMethodException | IllegalAccessException | InvocationTargetException
+        | InstantiationException e) {
+      log.error("Failed to instantiate " + KafkaSchemaRegistry.class, e);
+      throw Throwables.propagate(e);
+    }
+  }
 
   /**
    * Get schema from schema registry by key.
-   * @throws SchemaRegistryException if the given key doesn't exist in the schema registry.
+   * @throws SchemaRegistryException if failed to get schema by key.
    */
-  public S getSchemaByKey(K key) throws SchemaRegistryException;
+  public S getSchemaByKey(K key) throws SchemaRegistryException {
+    try {
+      return cachedSchemasByKeys.get(key);
+    } catch (ExecutionException e) {
+      throw new SchemaRegistryException(String.format("Schema with key %s cannot be retrieved", key), e);
+    }
+  }
+
+  /**
+   * Fetch schema by key.
+   *
+   * This method is called in {@link #getSchemaByKey(K)} to fetch the schema if the given key does not exist
+   * in the cache.
+   * @throws SchemaRegistryException if failed to fetch schema by key.
+   */
+  protected abstract S fetchSchemaByKey(K key) throws SchemaRegistryException;
 
   /**
    * Get the latest schema of a topic.
-   * @throws SchemaRegistryException if the given topic doesn't exist in the schema registry.
+   * @throws SchemaRegistryException if failed to get schema by topic.
    */
-  public S getLatestSchemaByTopic(String topic) throws SchemaRegistryException;
+  public abstract S getLatestSchemaByTopic(String topic) throws SchemaRegistryException;
 
   /**
    * Register a schema to the schema registry
    * @return the key of the registered schema.
    * @throws SchemaRegistryException if registration failed.
    */
-  public K register(S schema) throws SchemaRegistryException;
+  public abstract K register(S schema) throws SchemaRegistryException;
 
   /**
    * Register a schema to the schema registry under the given name
    * @return the key of the registered schema.
    * @throws SchemaRegistryException if registration failed.
    */
-  public K register(S schema, String name) throws SchemaRegistryException;
+  public abstract K register(S schema, String name) throws SchemaRegistryException;
+
+  private class KafkaSchemaCacheLoader extends CacheLoader<K, S> {
+
+    private final ConcurrentMap<K, FailedFetchHistory> failedFetchHistories;
+
+    private KafkaSchemaCacheLoader() {
+      super();
+      this.failedFetchHistories = Maps.newConcurrentMap();
+    }
+
+    @Override
+    public S load(K key) throws Exception {
+      if (shouldFetchFromSchemaRegistry(key)) {
+        try {
+          return KafkaSchemaRegistry.this.fetchSchemaByKey(key);
+        } catch (SchemaRegistryException e) {
+          addFetchToFailureHistory(key);
+          throw e;
+        }
+      }
+
+      // Throw exception if we've just tried to fetch this id, or if we've tried too many times for this id.
+      throw new SchemaRegistryException(String.format("Schema with key %s cannot be retrieved", key));
+    }
+
+    private void addFetchToFailureHistory(K key) {
+      this.failedFetchHistories.putIfAbsent(key, new FailedFetchHistory(System.nanoTime()));
+      this.failedFetchHistories.get(key).incrementNumOfAttempts();
+      this.failedFetchHistories.get(key).setPreviousAttemptTime(System.nanoTime());
+    }
+
+    private boolean shouldFetchFromSchemaRegistry(K key) {
+      if (!this.failedFetchHistories.containsKey(key)) {
+        return true;
+      }
+      FailedFetchHistory failedFetchHistory = this.failedFetchHistories.get(key);
+      boolean maxTriesNotExceeded = failedFetchHistory.getNumOfAttempts() < GET_SCHEMA_BY_ID_MAX_TIRES;
+      boolean minRetryIntervalSatisfied =
+          System.nanoTime() - failedFetchHistory.getPreviousAttemptTime() >= TimeUnit.SECONDS
+              .toNanos(GET_SCHEMA_BY_ID_MIN_INTERVAL_SECONDS);
+      return maxTriesNotExceeded && minRetryIntervalSatisfied;
+    }
+
+    private class FailedFetchHistory {
+
+      private final AtomicInteger numOfAttempts;
+      private long previousAttemptTime;
+
+      private FailedFetchHistory(long previousAttemptTime) {
+        this.numOfAttempts = new AtomicInteger();
+        this.previousAttemptTime = previousAttemptTime;
+      }
+
+      private int getNumOfAttempts() {
+        return numOfAttempts.get();
+      }
+
+      private long getPreviousAttemptTime() {
+        return previousAttemptTime;
+      }
+
+      private void setPreviousAttemptTime(long previousAttemptTime) {
+        this.previousAttemptTime = previousAttemptTime;
+      }
+
+      private void incrementNumOfAttempts() {
+        this.numOfAttempts.incrementAndGet();
+      }
+    }
+  }
 
 }


### PR DESCRIPTION
1. Added schema registry to `KafkaAvroExtractor`, since people are using Confluent's schema registry. It is not mandatory, and if one doesn't want to use schema registry, she needs to override `getExtractorSchema()` and get the schema in her own way.
2. Changed `KafkaSchemaRegistry` from interface to abstract class, and moved some code over from `KafkaAvroSchemaRegistry` (mainly the loading cache part), which can be reused by other implementations of schema registry.