### PR TITLE
Adding yarn name and app id to job life cycle events

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java
@@ -57,6 +57,11 @@ public class EventSubmitter {
       return this;
     }
 
+    public Builder addMetadata(Map<String, String> additionalMetadata) {
+      this.metadata.putAll(additionalMetadata);
+      return this;
+    }
+
     public EventSubmitter build() {
       return new EventSubmitter(this);
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -28,6 +28,7 @@ import com.google.common.base.CaseFormat;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
@@ -38,6 +39,7 @@ import gobblin.metastore.StateStore;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.GobblinMetricsRegistry;
 import gobblin.metrics.MetricContext;
+import gobblin.metrics.Tag;
 import gobblin.metrics.event.EventNames;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.metrics.event.TimingEvent;
@@ -99,7 +101,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   // A list of JobListeners that will be injected into the user provided JobListener
   private final List<JobListener> mandatoryJobListeners = Lists.newArrayList();
 
-  public AbstractJobLauncher(Properties jobProps) throws Exception {
+  public AbstractJobLauncher(Properties jobProps, Map<String, String> eventMetadata) throws Exception {
     Preconditions.checkArgument(jobProps.containsKey(ConfigurationKeys.JOB_NAME_KEY),
         "A job must have a job name specified by job.name");
 
@@ -120,7 +122,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           }
         });
 
-    this.eventSubmitter = new EventSubmitter.Builder(this.runtimeMetricContext, "gobblin.runtime").build();
+    this.eventSubmitter =
+        new EventSubmitter.Builder(this.runtimeMetricContext, "gobblin.runtime").addMetadata(eventMetadata).build();
 
     JobExecutionEventSubmitter jobExecutionEventSubmitter = new JobExecutionEventSubmitter(this.eventSubmitter);
     this.mandatoryJobListeners.add(new JobExecutionEventSubmitterListener(jobExecutionEventSubmitter));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobExecutionEventSubmitter.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobExecutionEventSubmitter.java
@@ -82,6 +82,7 @@ public class JobExecutionEventSubmitter {
     ImmutableMap.Builder<String, String> jobMetadataBuilder = new ImmutableMap.Builder<String, String>();
     jobMetadataBuilder.put(JOB_ID, jobState.getJobId());
     jobMetadataBuilder.put(JOB_NAME, jobState.getJobName());
+    jobMetadataBuilder.put(JOB_TRACKING_URL, jobState.getTrackingURL().or(UNKNOWN_VALUE));
     Map<String, String> jobMetadata = jobMetadataBuilder.build();
 
     // Submit event for each TaskState

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -22,14 +22,15 @@ import java.util.concurrent.TimeoutException;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ServiceManager;
 
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.WorkUnitState;
 import gobblin.metrics.event.TimingEvent;
 import gobblin.runtime.AbstractJobLauncher;
 import gobblin.runtime.FileBasedJobLock;
@@ -61,7 +62,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   private volatile CountDownLatch countDownLatch;
 
   public LocalJobLauncher(Properties jobProps) throws Exception {
-    super(jobProps);
+    super(jobProps, ImmutableMap.<String, String> of());
 
     TimingEvent jobLocalSetupTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.JOB_LOCAL_SETUP);
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.NLineInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -122,7 +123,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   }
 
   public MRJobLauncher(Properties jobProps, Configuration conf) throws Exception {
-    super(jobProps);
+    super(jobProps, ImmutableMap.<String, String> of());
 
     this.conf = conf;
     // Put job configuration properties into the Hadoop configuration so they are available in the mappers

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
@@ -34,8 +34,6 @@ public class JobMetrics extends GobblinMetrics {
 
   protected final String jobName;
 
-  private static final Configuration HADOOP_CONFIGURATION = new Configuration();
-
   protected JobMetrics(JobState job) {
     super(name(job), null, tagsForJob(job));
     this.jobName = job.getJobName();

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJob.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJob.java
@@ -12,6 +12,7 @@
 
 package gobblin.yarn;
 
+import java.util.Map;
 import java.util.Properties;
 
 import org.apache.hadoop.fs.Path;
@@ -43,9 +44,10 @@ public class GobblinHelixJob implements Job {
     JobListener jobListener = (JobListener) dataMap.get(JobScheduler.JOB_LISTENER_KEY);
     HelixManager helixManager = (HelixManager) dataMap.get(GobblinHelixJobScheduler.HELIX_MANAGER_KEY);
     Path appWorkDir = (Path) dataMap.get(GobblinHelixJobScheduler.APPLICATION_WORK_DIR_KEY);
+    Map<String, String> eventMetadata = (Map<String, String>) dataMap.get(GobblinHelixJobScheduler.EVENT_METADATA);
 
     try {
-      JobLauncher jobLauncher = new GobblinHelixJobLauncher(jobProps, helixManager, appWorkDir);
+      JobLauncher jobLauncher = new GobblinHelixJobLauncher(jobProps, helixManager, appWorkDir, eventMetadata);
       jobScheduler.runJob(jobProps, jobListener, jobLauncher);
     } catch (Throwable t) {
       throw new JobExecutionException(t);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.io.Text;
+
 import org.apache.helix.HelixManager;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobQueue;
@@ -31,6 +32,7 @@ import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskUtil;
 import org.apache.helix.task.WorkflowContext;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,8 +100,10 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   private volatile boolean jobSubmitted = false;
   private volatile boolean jobComplete = false;
 
-  public GobblinHelixJobLauncher(Properties jobProps, HelixManager helixManager, Path appWorkDir) throws Exception {
-    super(jobProps);
+  public GobblinHelixJobLauncher(Properties jobProps, HelixManager helixManager, Path appWorkDir,
+      Map<String, String> eventMetadata)
+      throws Exception {
+    super(jobProps, eventMetadata);
 
     this.helixManager = helixManager;
     this.helixTaskDriver = new TaskDriver(this.helixManager);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.yarn.client.api.YarnClientApplication;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.Records;
+
 import org.apache.helix.Criteria;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -60,6 +61,7 @@ import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.Message;
 import org.apache.helix.tools.ClusterSetup;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -305,8 +307,7 @@ public class GobblinYarnAppLauncher {
       LOGGER.info("Gobblin Yarn application finished with final status: " +
           applicationReport.getFinalApplicationStatus().toString());
       if (applicationReport.getFinalApplicationStatus() == FinalApplicationStatus.FAILED) {
-        LOGGER.error(
-            "Gobblin Yarn application failed for the following reason: " + applicationReport.getDiagnostics());
+        LOGGER.error("Gobblin Yarn application failed for the following reason: " + applicationReport.getDiagnostics());
       }
 
       try {
@@ -403,6 +404,12 @@ public class GobblinYarnAppLauncher {
     // Submit the application
     LOGGER.info("Submitting application " + applicationId);
     this.yarnClient.submitApplication(appSubmissionContext);
+
+    LOGGER.info("Application successfully submitted and accepted");
+    ApplicationReport applicationReport = this.yarnClient.getApplicationReport(applicationId);
+    LOGGER.info("Application Name: " + applicationReport.getName());
+    LOGGER.info("Application Tracking URL: " + applicationReport.getTrackingUrl());
+    LOGGER.info("Application User: " + applicationReport.getUser() + " Queue: " + applicationReport.getQueue());
 
     return applicationId;
   }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnEventNames.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnEventNames.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.yarn;
+
+/**
+ * YARN specific metadata keys to be used with an {@link gobblin.metrics.event.EventSubmitter}.
+ */
+public class GobblinYarnEventNames {
+
+  public static final String YARN_APPLICATION_NAME = "yarnApplicationName";
+  public static final String YARN_APPLICATION_ID = "yarnApplicationId";
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
@@ -113,7 +113,7 @@ public class YarnService extends AbstractIdleService {
 
   private final Object allContainersStopped = new Object();
 
-  private volatile Optional<Resource> maxResourceCapacity =Optional.absent();
+  private volatile Optional<Resource> maxResourceCapacity = Optional.absent();
 
   public YarnService(Config config, String applicationName, ApplicationId applicationId, FileSystem fs,
       EventBus eventBus) throws Exception {


### PR DESCRIPTION
* Added feature so that the YARN application name and application id are submitted in YARN job life cycle events (job failed, task failed, etc.). This was done by modifying the constructor of `AbstractJobLauncher` so that it can take in additional metadata that is specific to any of its sub-classes
* A few other code formatting / cleanup changes.
* Tested on Nertz

@liyinan926 can you review?