### PR TITLE
MRCompactorAvroKeyDedupJobRunner and schema changes #486

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroCombineFileSplit.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroCombineFileSplit.java
@@ -1,0 +1,76 @@
+package gobblin.compaction.mapreduce.avro;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+
+import org.apache.avro.Schema;
+import org.apache.commons.codec.binary.Base64;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
+
+
+/**
+ * A subclass of {@link org.apache.hadoop.mapreduce.lib.input.CombineFileSplit}. The purpose is to add the input file's
+ * avro schema to a split.
+ *
+ *
+ * @author mwol
+ */
+public class AvroCombineFileSplit extends CombineFileSplit {
+
+  private Schema schema;
+
+  public AvroCombineFileSplit() {
+  }
+
+  public AvroCombineFileSplit(Path[] paths, long[] startOffsets, long[] lengths, String[] locations) {
+    super(paths, startOffsets, lengths, locations);
+  }
+
+  public AvroCombineFileSplit(CombineFileSplit old) throws IOException {
+    super(old);
+  }
+
+  public AvroCombineFileSplit(Path[] paths, long[] startOffsets, long[] lengths, String[] locations, Schema schema) {
+    super(paths, startOffsets, lengths, locations);
+    this.schema = schema;
+  }
+
+  public AvroCombineFileSplit(CombineFileSplit old, Schema schema) throws IOException {
+    this(old);
+    this.schema = schema;
+  }
+
+  public Schema getSchema() {
+    return schema;
+  }
+
+  @Override
+  public void readFields(DataInput in) throws IOException {
+    super.readFields(in);
+    schema = new Schema.Parser().parse(fromBase64(Text.readString(in)));
+  }
+
+  @Override
+  public void write(DataOutput out) throws IOException {
+    super.write(out);
+    Text.writeString(out, toBase64(schema.toString()));
+  }
+
+  @Override
+  public String toString() {
+    return super.toString() + " Schema: " + schema.toString();
+  }
+
+  private static String toBase64(String rawString) {
+    Base64 base64decoder = new Base64();
+    return new String(base64decoder.encode(rawString.getBytes()));
+  }
+
+  private static String fromBase64(String base64String) {
+    Base64 base64decoder = new Base64();
+    return new String(base64decoder.decode(base64String.getBytes()));
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyCombineFileRecordReader.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyCombineFileRecordReader.java
@@ -32,16 +32,19 @@ import org.apache.hadoop.mapreduce.lib.input.FileSplit;
  */
 public class AvroKeyCombineFileRecordReader extends AvroKeyRecordReader<GenericRecord> {
 
-  private final CombineFileSplit split;
+  private final AvroCombineFileSplit split;
   private final Integer idx;
 
   public AvroKeyCombineFileRecordReader(CombineFileSplit split, TaskAttemptContext cx, Integer idx) {
-    this(split, AvroJob.getInputKeySchema(cx.getConfiguration()), idx);
+      this(split,
+          AvroJob.getInputKeySchema(cx.getConfiguration()) != null ?
+              AvroJob.getInputKeySchema(cx.getConfiguration()) : ((AvroCombineFileSplit) split).getSchema(),
+          idx);
   }
 
   private AvroKeyCombineFileRecordReader(CombineFileSplit split, Schema inputKeySchema, Integer idx) {
     super(inputKeySchema);
-    this.split = split;
+    this.split = (AvroCombineFileSplit) split;
     this.idx = idx;
   }
 


### PR DESCRIPTION
A proposal for a solution to https://github.com/linkedin/gobblin/issues/486.
I implemented new class AvroCombineFileSplit which stores the avro schema for each split, determined by the corresponding input file.
I added property "avro.single.input.schema" to keep old behaviour.

What do you think?