### PR TITLE
Moved logic in RecursiveCopyableDataset to a CopyableDataset builder.

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -36,6 +36,7 @@ dependencies {
   compile externalDependency.commonsCompress
   compile externalDependency.commonsIo
   compile externalDependency.gson
+  compile externalDependency.commonsCodec
 
   testCompile externalDependency.calciteCore
   testCompile externalDependency.calciteAvatica

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy;
+
+import lombok.Data;
+
+import org.apache.hadoop.fs.Path;
+
+
+/**
+ * Configuration for Gobblin distcp jobs.
+ */
+@Data
+public class CopyConfiguration {
+
+  /**
+   * Directory where dataset should be replicated.
+   * This directory corresponds to the {@link CopyableDataset#datasetRoot} in the new location.
+   */
+  private final Path targetRoot;
+  /**
+   * Preserve options passed by the user.
+   */
+  private final PreserveAttributes preserve;
+  /**
+   * {@link CopyContext} for this job.
+   */
+  private final CopyContext copyContext;
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy;
+
+import lombok.Getter;
+
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+
+/**
+ * Context that can hold global objects required in a single copy job.
+ */
+public class CopyContext {
+
+  /**
+   * Cache for {@link OwnerAndPermission} for various paths in {@link org.apache.hadoop.fs.FileSystem}s. Used to reduce
+   * the number of calls to {@link org.apache.hadoop.fs.FileSystem#getFileStatus} when replicating attributes. Keys
+   * should be fully qualified paths in case multiple {@link org.apache.hadoop.fs.FileSystem}s are in use.
+   */
+  @Getter
+  private final Cache<Path, OwnerAndPermission> ownerAndPermissionCache;
+
+  public CopyContext() {
+    this.ownerAndPermissionCache = CacheBuilder.newBuilder().build();
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
@@ -37,15 +37,21 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
+
+import javax.annotation.Nullable;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 
 
 /**
@@ -59,6 +65,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
   private static final String COPY_PREFIX = "gobblin.copy";
   public static final String SERIALIZED_COPYABLE_FILES = COPY_PREFIX + ".serialized.copyable.files";
   public static final String SERIALIZED_COPYABLE_DATASET = COPY_PREFIX + ".serialized.copyable.datasets";
+  public static final String PRESERVE_ATTRIBUTES_KEY = COPY_PREFIX + ".preserved.attributes";
 
   /**
    * <ul>
@@ -81,6 +88,8 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
   public List<WorkUnit> getWorkunits(SourceState state) {
 
     List<WorkUnit> workUnits = Lists.newArrayList();
+    CopyContext copyContext = new CopyContext();
+
     try {
 
       DatasetFinder<CopyableDataset> datasetFinder =
@@ -93,8 +102,11 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
 
         Path targetRoot = getTargetRoot(state, datasetFinder, copyableDataset);
 
-        Collection<Partition<CopyableFile>> partitions =
-            copyableDataset.partitionFiles(copyableDataset.getCopyableFiles(targetFs, targetRoot));
+        CopyConfiguration copyConfiguration = new CopyConfiguration(targetRoot,
+            PreserveAttributes.fromMnemonicString(state.getProp(PRESERVE_ATTRIBUTES_KEY)), copyContext);
+
+        Collection<CopyableFile> files = copyableDataset.getCopyableFiles(targetFs, copyConfiguration);
+        Collection<Partition<CopyableFile>> partitions = partitionCopyableFiles(files);
 
         for (Partition<CopyableFile> partition : partitions) {
           Extract extract = new Extract(Extract.TableType.SNAPSHOT_ONLY, COPY_PREFIX, partition.getName());
@@ -106,7 +118,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
             GobblinMetrics.addCustomTagToState(workUnit, new Tag<String>(
                 CopyEventSubmitterHelper.DATASET_ROOT_METADATA_NAME, copyableDataset.datasetRoot().toString()));
             workUnit.setProp(SlaEventKeys.DATASET_URN_KEY, copyableDataset.datasetRoot().toString());
-            workUnit.setProp(SlaEventKeys.PARTITION_KEY, partition.getName());
+            workUnit.setProp(SlaEventKeys.PARTITION_KEY, copyableFile.getPartition());
             workUnit.setProp(SlaEventKeys.ORIGIN_TS_IN_MILLI_SECS_KEY, copyableFile.getFileStatus().getModificationTime());
             workUnits.add(workUnit);
           }
@@ -187,4 +199,21 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
   public static CopyableDatasetMetadata deserializeCopyableDataset(State state) throws IOException {
     return CopyableDatasetMetadata.deserialize(state.getProp(SERIALIZED_COPYABLE_DATASET));
   }
+
+  private Collection<Partition<CopyableFile>> partitionCopyableFiles(Collection<CopyableFile> files) {
+    Map<String, Partition.Builder<CopyableFile>> partitionBuildersMaps = Maps.newHashMap();
+    for (CopyableFile file : files) {
+      if (!partitionBuildersMaps.containsKey(file.getPartition())) {
+        partitionBuildersMaps.put(file.getPartition(), new Partition.Builder<CopyableFile>(file.getPartition()));
+      }
+      partitionBuildersMaps.get(file.getPartition()).add(file);
+    }
+    return Lists.newArrayList(Iterables.transform(partitionBuildersMaps.values(),
+        new Function<Partition.Builder<CopyableFile>, Partition<CopyableFile>>() {
+          @Nullable @Override public Partition<CopyableFile> apply(Partition.Builder<CopyableFile> input) {
+            return input.build();
+          }
+        }));
+  }
+
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
@@ -118,7 +118,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
             GobblinMetrics.addCustomTagToState(workUnit, new Tag<String>(
                 CopyEventSubmitterHelper.DATASET_ROOT_METADATA_NAME, copyableDataset.datasetRoot().toString()));
             workUnit.setProp(SlaEventKeys.DATASET_URN_KEY, copyableDataset.datasetRoot().toString());
-            workUnit.setProp(SlaEventKeys.PARTITION_KEY, copyableFile.getPartition());
+            workUnit.setProp(SlaEventKeys.PARTITION_KEY, copyableFile.getFileSet());
             workUnit.setProp(SlaEventKeys.ORIGIN_TS_IN_MILLI_SECS_KEY, copyableFile.getFileStatus().getModificationTime());
             workUnits.add(workUnit);
           }
@@ -203,10 +203,10 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
   private Collection<Partition<CopyableFile>> partitionCopyableFiles(Collection<CopyableFile> files) {
     Map<String, Partition.Builder<CopyableFile>> partitionBuildersMaps = Maps.newHashMap();
     for (CopyableFile file : files) {
-      if (!partitionBuildersMaps.containsKey(file.getPartition())) {
-        partitionBuildersMaps.put(file.getPartition(), new Partition.Builder<CopyableFile>(file.getPartition()));
+      if (!partitionBuildersMaps.containsKey(file.getFileSet())) {
+        partitionBuildersMaps.put(file.getFileSet(), new Partition.Builder<CopyableFile>(file.getFileSet()));
       }
-      partitionBuildersMaps.get(file.getPartition()).add(file);
+      partitionBuildersMaps.get(file.getFileSet()).add(file);
     }
     return Lists.newArrayList(Iterables.transform(partitionBuildersMaps.values(),
         new Function<Partition.Builder<CopyableFile>, Partition<CopyableFile>>() {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDataset.java
@@ -13,26 +13,34 @@
 package gobblin.data.management.copy;
 
 import gobblin.data.management.dataset.Dataset;
-import gobblin.data.management.partition.PartitionableDataset;
 
 import java.io.IOException;
-import java.util.List;
+import java.util.Collection;
 
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
 
 
 /**
  * {@link Dataset} that supports finding {@link CopyableFile}s.
  */
-public interface CopyableDataset extends PartitionableDataset<CopyableFile> {
+public interface CopyableDataset extends Dataset {
 
   /**
    * Find all {@link CopyableFile}s in this dataset.
    *
+   * <p>
+   *   This method should return a collection of {@link CopyableFile}, each describing one file that should be copied
+   *   to the target. The returned collection should contain exactly one {@link CopyableFile} per file that should
+   *   be copied. Directories are created automatically, the returned collection should not include any directories.
+   *   See {@link CopyableFile} for explanation of the information contained in the {@link CopyableFile}s.
+   * </p>
+   *
+   * @param targetFs target {@link FileSystem} where copied files will be placed.
+   * @param configuration {@link CopyConfiguration} for this job. See {@link CopyConfiguration}.
    * @return List of {@link CopyableFile}s in this dataset.
    * @throws IOException
    */
-  public List<CopyableFile> getCopyableFiles(FileSystem targetFs, Path targetRoot) throws IOException;
+  public Collection<CopyableFile> getCopyableFiles(FileSystem targetFs, CopyConfiguration configuration) throws
+      IOException;
 
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDatasetMetadata.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDatasetMetadata.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.ToString;
 
 import org.apache.hadoop.fs.Path;
 
@@ -28,6 +29,7 @@ import com.google.gson.Gson;
  * The class is a data object and does not carry any functionality
  */
 @EqualsAndHashCode(callSuper=false)
+@ToString
 public class CopyableDatasetMetadata {
 
   public CopyableDatasetMetadata(CopyableDataset copyableDataset, Path datasetTargetRoot) {
@@ -59,4 +61,5 @@ public class CopyableDatasetMetadata {
   public static CopyableDatasetMetadata deserialize(String serialized) throws IOException {
     return GSON.fromJson(serialized, CopyableDatasetMetadata.class);
   }
+
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
@@ -90,11 +90,11 @@ public class CopyableFile implements File {
   /** Attributes to be preserved. */
   private PreserveAttributes preserve;
   /**
-   * Partition this file belongs to. {@link CopyableFile}s in the same partition and originating from the same
+   * File set this file belongs to. {@link CopyableFile}s in the same fileSet and originating from the same
    * {@link CopyableDataset} will be treated as a unit: they will be published nearly atomically, and a notification
-   * will be emitted for each partition when it is published.
+   * will be emitted for each fileSet when it is published.
    */
-  private String partition;
+  private String fileSet;
 
   /**
    * Get a {@link CopyableFile.Builder}.
@@ -160,7 +160,7 @@ public class CopyableFile implements File {
      *       allowing Gobblin distcp to use defaults for the target {@link FileSystem}.
      *   * {@link CopyableFile#checksum}: the checksum of the origin {@link FileStatus} obtained using the origin
      *       {@link FileSystem}.
-     *   * {@link CopyableFile#partition}: equal to the origin dataset root path.
+     *   * {@link CopyableFile#fileSet}: equal to the origin dataset root path.
      * </p>
      *
      * @return A {@link CopyableFile}.
@@ -183,12 +183,12 @@ public class CopyableFile implements File {
         FileChecksum checksumTmp = this.originFs.getFileChecksum(origin.getPath());
         this.checksum = checksumTmp == null ? new byte[0] : checksumTmp.getBytes();
       }
-      if (this.partition == null) {
-        this.partition = this.rootPath.toString();
+      if (this.fileSet == null) {
+        this.fileSet = this.rootPath.toString();
       }
 
       return new CopyableFile(origin, destination, relativeDestination, destinationOwnerAndPermission,
-          ancestorsOwnerAndPermission, null, preserve, partition);
+          ancestorsOwnerAndPermission, null, preserve, fileSet);
     }
 
     private List<OwnerAndPermission> replicateOwnerAndPermission(final FileSystem originFs, final Path path,
@@ -275,16 +275,16 @@ public class CopyableFile implements File {
   }
 
   /**
-   * Get a {@link DatasetAndPartition} instance for the dataset and partition this {@link CopyableFile} belongs to.
+   * Get a {@link DatasetAndPartition} instance for the dataset and fileSet this {@link CopyableFile} belongs to.
    * @param metadata {@link CopyableDatasetMetadata} for the dataset this {@link CopyableFile} belongs to.
    * @return an instance of {@link DatasetAndPartition}
    */
   public DatasetAndPartition getDatasetAndPartition(CopyableDatasetMetadata metadata) {
-    return new DatasetAndPartition(metadata, getPartition());
+    return new DatasetAndPartition(metadata, getFileSet());
   }
 
   /**
-   * Uniquely identifies a partition by also including the dataset metadata.
+   * Uniquely identifies a fileSet by also including the dataset metadata.
    */
   @Data
   @EqualsAndHashCode

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/PreserveAttributes.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/PreserveAttributes.java
@@ -89,14 +89,15 @@ public class PreserveAttributes {
    */
   public static PreserveAttributes fromMnemonicString(String s) {
 
+    if (Strings.isNullOrEmpty(s)) {
+      return new PreserveAttributes(0);
+    }
+
     s = s.toLowerCase();
 
     Preconditions.checkArgument(ATTRIBUTES_REGEXP.matcher(s).matches(), "Invalid %s string %s, must be of the form %s.",
         PreserveAttributes.class.getSimpleName(), s, ATTRIBUTES_REGEXP.pattern());
 
-    if (Strings.isNullOrEmpty(s)) {
-      return new PreserveAttributes(0);
-    }
     int value = 0;
     for (Option option : Option.values()) {
       if (s.indexOf(option.token) >= 0) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/PreserveAttributes.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/PreserveAttributes.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+import com.google.common.base.Strings;
+
+
+/**
+* Configuration for preserving attributes in Gobblin distcp jobs.
+*/
+@AllArgsConstructor
+@EqualsAndHashCode
+public class PreserveAttributes {
+
+  /**
+   * Attributes that can be preserved.
+   */
+  public static enum Option {
+    REPLICATION('r'),
+    BLOCK_SIZE('b'),
+    OWNER('u'),
+    GROUP('g'),
+    PERMISSION('p');
+
+    private final char token;
+
+    Option(char token) {
+      this.token = token;
+    }
+  }
+
+  private int options;
+
+  /**
+   * @return true if attribute should be preserved.
+   */
+  public boolean preserve(Option option) {
+    return 0 < (this.options & (1 << option.ordinal()));
+  }
+
+  /**
+   * Converts this instance of {@link PreserveAttributes} into a String that can be converted to an equivalent
+   * {@link PreserveAttributes} using {@link PreserveAttributes#fromMnemonicString}. See the latter for more
+   * information.
+   * @return a String that can be converted to an equivalent {@link PreserveAttributes} using
+   *         {@link PreserveAttributes#fromMnemonicString}
+   */
+  public String toMnemonicString() {
+    int value = options;
+    StringBuilder mnemonicString = new StringBuilder();
+    for(Option option : Option.values()) {
+      if(value % 2  == 1) {
+        mnemonicString.append(option.token);
+      }
+      value >>= 1;
+    }
+    return mnemonicString.toString();
+  }
+
+  /**
+   * Parse {@link PreserveAttributes} from a string of the form \[rbugp]*\:
+   * * r -> preserve replication
+   * * b -> preserve block size
+   * * u -> preserve owner
+   * * g -> preserve group
+   * * p -> preserve permissions
+   * Characters not in this character set will be ignored.
+   *
+   * @param s String of the form \[rbugp]*\
+   * @return Parsed {@link PreserveAttributes}
+   */
+  public static PreserveAttributes fromMnemonicString(String s) {
+    if (Strings.isNullOrEmpty(s)) {
+      return new PreserveAttributes(0);
+    }
+    int value = 0;
+    for (Option option : Option.values()) {
+      if (s.indexOf(option.token) >= 0) {
+        value |= 1 << option.ordinal();
+      }
+    }
+    return new PreserveAttributes(value);
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/PreserveAttributes.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/PreserveAttributes.java
@@ -15,6 +15,9 @@ package gobblin.data.management.copy;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 
+import java.util.regex.Pattern;
+
+import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
 
 
@@ -24,6 +27,8 @@ import com.google.common.base.Strings;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class PreserveAttributes {
+
+  public static final Pattern ATTRIBUTES_REGEXP = getAllowedRegexp();
 
   /**
    * Attributes that can be preserved.
@@ -83,6 +88,12 @@ public class PreserveAttributes {
    * @return Parsed {@link PreserveAttributes}
    */
   public static PreserveAttributes fromMnemonicString(String s) {
+
+    s = s.toLowerCase();
+
+    Preconditions.checkArgument(ATTRIBUTES_REGEXP.matcher(s).matches(), "Invalid %s string %s, must be of the form %s.",
+        PreserveAttributes.class.getSimpleName(), s, ATTRIBUTES_REGEXP.pattern());
+
     if (Strings.isNullOrEmpty(s)) {
       return new PreserveAttributes(0);
     }
@@ -93,5 +104,14 @@ public class PreserveAttributes {
       }
     }
     return new PreserveAttributes(value);
+  }
+
+  private static Pattern getAllowedRegexp() {
+    StringBuilder builder = new StringBuilder("[");
+    for(Option option : Option.values()) {
+      builder.append(option.token);
+    }
+    builder.append("]*");
+    return Pattern.compile(builder.toString());
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/SinglePartitionCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/SinglePartitionCopyableDataset.java
@@ -13,26 +13,32 @@
 package gobblin.data.management.copy;
 
 import gobblin.data.management.partition.Partition;
+import gobblin.data.management.partition.PartitionableDataset;
 
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 /**
  * An implementation of {@link CopyableDataset} that partitions all files into a single partition
  */
-public abstract class SinglePartitionCopyableDataset implements CopyableDataset {
-  @SuppressWarnings("unchecked")
-  @Override
-  public Collection<Partition<CopyableFile>> partitionFiles(Collection<? extends CopyableFile> files) {
+public abstract class SinglePartitionCopyableDataset implements CopyableDataset, PartitionableDataset<CopyableFile> {
 
+  public static Collection<Partition<CopyableFile>> singlePartition(Collection<? extends CopyableFile> files,
+      String name) {
     List<CopyableFile> copyableFiles = Lists.newArrayListWithCapacity(files.size());
     for (CopyableFile file : files) {
       copyableFiles.add(file);
     }
-    return Lists.newArrayList(new Partition.Builder<CopyableFile>(datasetRoot().toString()).add(copyableFiles).build());
+    return ImmutableList.of(new Partition.Builder<CopyableFile>(name).add(copyableFiles).build());
+  }
 
+  @SuppressWarnings("unchecked")
+  @Override
+  public Collection<Partition<CopyableFile>> partitionFiles(Collection<? extends CopyableFile> files) {
+    return singlePartition(files, datasetRoot().toString());
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/SinglePartitionCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/SinglePartitionCopyableDataset.java
@@ -22,7 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
 /**
- * An implementation of {@link CopyableDataset} that partitions all files into a single partition
+ * An implementation of {@link CopyableDataset} that partitions all files into a single fileSet
  */
 public abstract class SinglePartitionCopyableDataset implements CopyableDataset, PartitionableDataset<CopyableFile> {
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 
@@ -86,15 +87,15 @@ public class CopyDataPublisher extends DataPublisher {
      * This mapping is used to set WorkingState of all {@link WorkUnitState}s to {@link
      * WorkUnitState.WorkingState#COMMITTED} after a {@link CopyableDataset} is successfully published
      */
-    Multimap<CopyableDatasetMetadata, WorkUnitState> datasets = getDatasetRoots(states);
+    Multimap<CopyableFile.DatasetAndPartition, WorkUnitState> datasets = getDatasetRoots(states);
 
     boolean allDatasetsPublished = true;
-    for (CopyableDatasetMetadata copyableDataset : datasets.keySet()) {
+    for (CopyableFile.DatasetAndPartition datasetAndPartition : datasets.keySet()) {
       try {
-        this.publishDataset(copyableDataset, datasets.get(copyableDataset));
+        this.publishDataset(datasetAndPartition, datasets.get(datasetAndPartition));
       } catch (Throwable e) {
-        CopyEventSubmitterHelper.submitFailedDatasetPublish(eventSubmitter, copyableDataset);
-        log.error("Failed to publish " + copyableDataset.getDatasetTargetRoot(), e);
+        CopyEventSubmitterHelper.submitFailedDatasetPublish(eventSubmitter, datasetAndPartition);
+        log.error("Failed to publish " + datasetAndPartition.getDataset().getDatasetTargetRoot(), e);
         allDatasetsPublished = false;
       }
     }
@@ -109,16 +110,16 @@ public class CopyDataPublisher extends DataPublisher {
    * {@link CopyableDataset}. This mapping is used to set WorkingState of all {@link WorkUnitState}s to
    * {@link WorkUnitState.WorkingState#COMMITTED} after a {@link CopyableDataset} is successfully published.
    */
-  private Multimap<CopyableDatasetMetadata, WorkUnitState> getDatasetRoots(Collection<? extends WorkUnitState> states)
+  private Multimap<CopyableFile.DatasetAndPartition, WorkUnitState> getDatasetRoots(Collection<? extends WorkUnitState> states)
       throws IOException {
-    Multimap<CopyableDatasetMetadata, WorkUnitState> datasetRoots = ArrayListMultimap.create();
+    Multimap<CopyableFile.DatasetAndPartition, WorkUnitState> datasetRoots = ArrayListMultimap.create();
 
     for (WorkUnitState workUnitState : states) {
-      CopyableDatasetMetadata copyableDataset =
-          CopyableDatasetMetadata.deserialize(workUnitState.getProp(CopySource.SERIALIZED_COPYABLE_DATASET));
+      CopyableFile file = CopySource.deserializeCopyableFiles(workUnitState).get(0);
+      CopyableFile.DatasetAndPartition datasetAndPartition = file.getDatasetAndPartition(
+          CopyableDatasetMetadata.deserialize(workUnitState.getProp(CopySource.SERIALIZED_COPYABLE_DATASET)));
 
-      datasetRoots.put(copyableDataset, workUnitState);
-
+      datasetRoots.put(datasetAndPartition, workUnitState);
     }
     return datasetRoots;
   }
@@ -127,14 +128,22 @@ public class CopyDataPublisher extends DataPublisher {
    * Publish data for a {@link CopyableDataset}.
    *
    */
-  private void publishDataset(CopyableDatasetMetadata copyableDataset, Collection<WorkUnitState> datasetWorkUnitStates)
+  private void publishDataset(CopyableFile.DatasetAndPartition datasetAndPartition,
+      Collection<WorkUnitState> datasetWorkUnitStates)
       throws IOException {
 
-    Path datasetWriterOutputPath = new Path(writerOutputDir, PathUtils.withoutLeadingSeparator(copyableDataset.getDatasetTargetRoot()));
+    Preconditions.checkArgument(!datasetWorkUnitStates.isEmpty(),
+        "publishDataset received an empty collection work units. This is an error in code.");
 
-    log.info(String.format("Publishing dataset from %s to %s", datasetWriterOutputPath, copyableDataset.getDatasetTargetRoot()));
+    CopyableDatasetMetadata metadata = CopyableDatasetMetadata.deserialize(
+        datasetWorkUnitStates.iterator().next().getProp(CopySource.SERIALIZED_COPYABLE_DATASET));
+    Path datasetWriterOutputPath = new Path(new Path(writerOutputDir, datasetAndPartition.identifier()),
+        PathUtils.withoutLeadingSeparator(metadata.getDatasetTargetRoot()));
 
-    HadoopUtils.renameRecursively(fs, datasetWriterOutputPath, copyableDataset.getDatasetTargetRoot());
+    log.info(String
+        .format("Publishing dataset from %s to %s", datasetWriterOutputPath, metadata.getDatasetTargetRoot()));
+
+    HadoopUtils.renameRecursively(fs, datasetWriterOutputPath, metadata.getDatasetTargetRoot());
 
     fs.delete(datasetWriterOutputPath, true);
 
@@ -145,7 +154,7 @@ public class CopyDataPublisher extends DataPublisher {
       }
     }
 
-    CopyEventSubmitterHelper.submitSuccessfulDatasetPublish(eventSubmitter, copyableDataset);
+    CopyEventSubmitterHelper.submitSuccessfulDatasetPublish(eventSubmitter, datasetAndPartition);
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
@@ -82,10 +82,9 @@ public class TarArchiveInputStreamDataWriter extends FileAwareInputStreamDataWri
 
         // the API tarEntry.getName() is misleading, it is actually the path of the tarEntry in the tar file
         String newTarEntryPath = tarEntry.getName().replace(tarEntryRootName, fileDestinationPath.getName());
-        Path tarEntryDestinationPath =
-            PathUtils.withoutLeadingSeparator(new Path(fileDestinationPath.getParent(), newTarEntryPath));
 
-        Path tarEntryStagingPath = new Path(this.stagingDir, tarEntryDestinationPath);
+        Path tarEntryStagingPath = new Path(getStagingFilePath(fileAwareInputStream.getFile()).getParent()
+            , newTarEntryPath);
 
         log.info("Unarchiving at " + tarEntryStagingPath);
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/dataset/DummyDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/dataset/DummyDataset.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.dataset;
+
+import lombok.RequiredArgsConstructor;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.ImmutableList;
+
+import gobblin.data.management.copy.CopyConfiguration;
+import gobblin.data.management.copy.CopyableDataset;
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+
+
+/**
+ * Dummy {@link Dataset} that does nothing.
+ */
+@RequiredArgsConstructor
+public class DummyDataset implements CopyableDataset, CleanableDataset {
+
+  private final Path datasetRoot;
+
+  @Override public void clean() throws IOException {
+    // Do nothing
+  }
+
+  @Override public Collection<CopyableFile> getCopyableFiles(FileSystem targetFs, CopyConfiguration configuration)
+      throws IOException {
+    return ImmutableList.of();
+  }
+
+  @Override public Path datasetRoot() {
+    return this.datasetRoot;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/partition/Partition.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/partition/Partition.java
@@ -37,7 +37,7 @@ public class Partition<T extends File> {
     private final List<T> files;
 
     public Builder(String name) {
-      if(name == null) {
+      if (name == null) {
         throw new RuntimeException("Name cannot be null.");
       }
       this.name = name;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigurableGlobDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigurableGlobDatasetFinder.java
@@ -113,7 +113,7 @@ public abstract class ConfigurableGlobDatasetFinder<T extends Dataset> implement
         continue;
       }
       LOG.info("Found dataset at " + fileStatus.getPath());
-      datasets.add(datasetAtPath(fileStatus.getPath()));
+      datasets.add(datasetAtPath(PathUtils.getPathWithoutSchemeAndAuthority(fileStatus.getPath())));
     }
     return datasets;
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileTest.java
@@ -33,7 +33,7 @@ public class CopyableFileTest {
         new CopyableFile(new FileStatus(10, false, 12, 100, 12345, new Path("/path")), new Path("/destination"),
             new Path("/relative"), new OwnerAndPermission("owner", "group", FsPermission.getDefault()),
             Lists.newArrayList(new OwnerAndPermission("owner2", "group2", FsPermission.getDefault())),
-            "checksum".getBytes());
+            "checksum".getBytes(), PreserveAttributes.fromMnemonicString(""), "");
 
     String s = CopyableFile.serialize(copyableFile);
     CopyableFile de = CopyableFile.deserialize(s);
@@ -47,7 +47,7 @@ public class CopyableFileTest {
     CopyableFile copyableFile =
         new CopyableFile(null, null, new Path("/relative"), new OwnerAndPermission("owner", "group",
             FsPermission.getDefault()), Lists.newArrayList(new OwnerAndPermission(null, "group2", FsPermission
-            .getDefault())), "checksum".getBytes());
+            .getDefault())), "checksum".getBytes(), PreserveAttributes.fromMnemonicString(""), "");
 
     String serialized = CopyableFile.serialize(copyableFile);
     CopyableFile deserialized = CopyableFile.deserialize(serialized);

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileUtils.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileUtils.java
@@ -31,7 +31,8 @@ public class CopyableFileUtils {
 
     FileStatus status = new FileStatus(0l, false, 0, 0l, 0l, new Path(resourcePath));
 
-    return new CopyableFile(status, new Path(getRandomPath()), new Path(getRandomPath()), null, null, null);
+    return new CopyableFile(status, new Path(getRandomPath()), new Path(getRandomPath()), null, null, null,
+        PreserveAttributes.fromMnemonicString(""), "");
   }
 
   public static CopyableFile getTestCopyableFile() {
@@ -74,7 +75,8 @@ public class CopyableFileUtils {
 
     Path destinationRelativePath = new Path(relativePath);
 
-    return new CopyableFile(status, new Path(destinationPath), destinationRelativePath, ownerAndPermission, null, null);
+    return new CopyableFile(status, new Path(destinationPath), destinationRelativePath, ownerAndPermission, null, null,
+        PreserveAttributes.fromMnemonicString(""), "");
   }
 
   private static String getRandomPath() {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/PreserveAttributesTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/PreserveAttributesTest.java
@@ -40,7 +40,7 @@ public class PreserveAttributesTest {
     tests.put("rbugp", Sets.newHashSet(Option.REPLICATION, Option.OWNER, Option.BLOCK_SIZE, Option.GROUP,
         Option.PERMISSION));
     tests.put("rrr", Sets.newHashSet(Option.REPLICATION));
-    tests.put("rrbx", Sets.newHashSet(Option.REPLICATION, Option.BLOCK_SIZE));
+    tests.put("rrb", Sets.newHashSet(Option.REPLICATION, Option.BLOCK_SIZE));
     tests.put("", Sets.<Option>newHashSet());
 
     for(Map.Entry<String, Set<PreserveAttributes.Option>> entry : tests.entrySet()) {
@@ -49,6 +49,32 @@ public class PreserveAttributesTest {
         Assert.assertEquals(preserve.preserve(option), entry.getValue().contains(option));
       }
       Assert.assertEquals(preserve, PreserveAttributes.fromMnemonicString(preserve.toMnemonicString()));
+    }
+
+  }
+
+  @Test
+  public void testInvalidStrings() {
+
+    try {
+      PreserveAttributes.fromMnemonicString("x");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      // Expect exception
+    }
+
+    try {
+      PreserveAttributes.fromMnemonicString("rx");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      // Expect exception
+    }
+
+    try {
+      PreserveAttributes.fromMnemonicString("ugq");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      // Expect exception
     }
 
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/PreserveAttributesTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/PreserveAttributesTest.java
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy;
+
+import gobblin.data.management.copy.PreserveAttributes.Option;
+
+import junit.framework.Assert;
+
+import java.util.Map;
+import java.util.Set;
+
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+
+public class PreserveAttributesTest {
+
+  @Test
+  public void test() {
+
+    Map<String, Set<PreserveAttributes.Option>> tests = Maps.newHashMap();
+    tests.put("r", Sets.newHashSet(Option.REPLICATION));
+    tests.put("b", Sets.newHashSet(Option.BLOCK_SIZE));
+    tests.put("u", Sets.newHashSet(Option.OWNER));
+    tests.put("g", Sets.newHashSet(Option.GROUP));
+    tests.put("p", Sets.newHashSet(Option.PERMISSION));
+    tests.put("ru", Sets.newHashSet(Option.REPLICATION, Option.OWNER));
+    tests.put("rbugp", Sets.newHashSet(Option.REPLICATION, Option.OWNER, Option.BLOCK_SIZE, Option.GROUP,
+        Option.PERMISSION));
+    tests.put("rrr", Sets.newHashSet(Option.REPLICATION));
+    tests.put("rrbx", Sets.newHashSet(Option.REPLICATION, Option.BLOCK_SIZE));
+    tests.put("", Sets.<Option>newHashSet());
+
+    for(Map.Entry<String, Set<PreserveAttributes.Option>> entry : tests.entrySet()) {
+      PreserveAttributes preserve = PreserveAttributes.fromMnemonicString(entry.getKey());
+      for(Option option : Option.values()) {
+        Assert.assertEquals(preserve.preserve(option), entry.getValue().contains(option));
+      }
+      Assert.assertEquals(preserve, PreserveAttributes.fromMnemonicString(preserve.toMnemonicString()));
+    }
+
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
@@ -14,6 +14,7 @@ package gobblin.data.management.copy;
 
 import gobblin.util.PathUtils;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -41,7 +42,9 @@ public class RecursiveCopyableDatasetTest {
 
     RecursiveCopyableDataset dataset = new RecursiveCopyableDataset(FileSystem.getLocal(new Configuration()), new Path(baseDir), properties);
 
-    List<CopyableFile> files = dataset.getCopyableFiles(FileSystem.getLocal(new Configuration()), new Path(destinationDir));
+    CopyConfiguration copyConfiguration = new CopyConfiguration(new Path(destinationDir),
+        PreserveAttributes.fromMnemonicString("ugp"), new CopyContext());
+    Collection<CopyableFile> files = dataset.getCopyableFiles(FileSystem.getLocal(new Configuration()), copyConfiguration);
 
     Assert.assertEquals(files.size(), 3);
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyablePartitionableDataset.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyablePartitionableDataset.java
@@ -27,9 +27,9 @@ public class TestCopyablePartitionableDataset extends TestCopyableDataset {
   @Override protected void modifyCopyableFile(CopyableFile.Builder builder, FileStatus origin) {
     super.modifyCopyableFile(builder, origin);
     if (Integer.parseInt(origin.getPath().getName()) < THRESHOLD) {
-      builder.partition(BELOW);
+      builder.fileSet(BELOW);
     } else {
-      builder.partition(ABOVE);
+      builder.fileSet(ABOVE);
     }
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyablePartitionableDataset.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyablePartitionableDataset.java
@@ -12,42 +12,25 @@
 
 package gobblin.data.management.copy;
 
-import gobblin.data.management.partition.Partition;
-import gobblin.data.management.partition.PartitionableDataset;
-
-import java.util.Collection;
-
-import com.google.common.collect.Lists;
-
+import org.apache.hadoop.fs.FileStatus;
 
 /**
  * Partitionable dataset that partitions files depending on whether their name, parsed as an integer, is above or below
  * a threshold.
  */
-public class TestCopyablePartitionableDataset extends TestCopyableDataset implements PartitionableDataset<CopyableFile> {
+public class TestCopyablePartitionableDataset extends TestCopyableDataset {
 
   public static final String BELOW = "below";
   public static final String ABOVE = "above";
   public static final int THRESHOLD = TestCopyableDataset.FILE_COUNT / 2;
 
-  @Override
-  public Collection<Partition<CopyableFile>> partitionFiles(Collection<? extends CopyableFile> files) {
-    Partition.Builder<CopyableFile> belowThreshold = new Partition.Builder<CopyableFile>(BELOW);
-    Partition.Builder<CopyableFile> aboveThreshold = new Partition.Builder<CopyableFile>(ABOVE);
-
-    for (CopyableFile file : files) {
-      if (Integer.parseInt(file.getOrigin().getPath().getName()) < THRESHOLD) {
-        belowThreshold.add(file);
-      } else {
-        aboveThreshold.add(file);
-      }
+  @Override protected void modifyCopyableFile(CopyableFile.Builder builder, FileStatus origin) {
+    super.modifyCopyableFile(builder, origin);
+    if (Integer.parseInt(origin.getPath().getName()) < THRESHOLD) {
+      builder.partition(BELOW);
+    } else {
+      builder.partition(ABOVE);
     }
-
-    return Lists.newArrayList(belowThreshold.build(), aboveThreshold.build());
   }
 
-  @Override
-  public Class<?> fileClass() {
-    return CopyableFile.class;
-  }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/extractor/InputStreamExtractorTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/extractor/InputStreamExtractorTest.java
@@ -11,9 +11,13 @@
  */
 package gobblin.data.management.copy.extractor;
 
+import gobblin.data.management.copy.CopyConfiguration;
+import gobblin.data.management.copy.CopyContext;
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.FileAwareInputStream;
+import gobblin.data.management.copy.PreserveAttributes;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -50,9 +54,10 @@ public class InputStreamExtractorTest {
     Assert.assertEquals(IOUtils.toString(fileAwareInputStream.getInputStream()), "second");
   }
 
-  private CopyableFile getTestCopyableFile(String resourcePath) {
+  private CopyableFile getTestCopyableFile(String resourcePath) throws IOException {
     String filePath = getClass().getClassLoader().getResource(resourcePath).getFile();
     FileStatus status = new FileStatus(0l, false, 0, 0l, 0l, new Path(filePath));
-    return new CopyableFile(status, null, null, null, null, null);
+    return CopyableFile.builder(FileSystem.getLocal(new Configuration()), status, new Path("/"),
+        new CopyConfiguration(new Path("/"), PreserveAttributes.fromMnemonicString(""), new CopyContext())).build();
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterTest.java
@@ -13,10 +13,13 @@ package gobblin.data.management.copy.writer;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableDatasetMetadata;
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.CopyableFileUtils;
 import gobblin.data.management.copy.FileAwareInputStream;
 import gobblin.data.management.copy.OwnerAndPermission;
+import gobblin.data.management.copy.TestCopyableDataset;
 import gobblin.util.io.StreamUtils;
 
 import java.io.FileInputStream;
@@ -56,6 +59,9 @@ public class FileAwareInputStreamDataWriterTest {
     state.setProp(ConfigurationKeys.WRITER_STAGING_DIR, new Path(testTempPath, "staging").toString());
     state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, new Path(testTempPath, "output").toString());
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH, RandomStringUtils.randomAlphabetic(5));
+    CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")),
+        new Path("/"));
+    CopySource.serializeCopyableDataset(state, metadata);
 
     FileStatus status = fs.getFileStatus(testTempPath);
 
@@ -69,7 +75,8 @@ public class FileAwareInputStreamDataWriterTest {
     FileAwareInputStream fileAwareInputStream = new FileAwareInputStream(cf, StreamUtils.convertStream(IOUtils.toInputStream(streamString)));
     dataWriter.write(fileAwareInputStream);
     dataWriter.commit();
-    Path writtenFilePath = new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR), cf.getDestination());
+    Path writtenFilePath = new Path(new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
+        cf.getDatasetAndPartition(metadata).identifier()), cf.getDestination());
     Assert.assertEquals(IOUtils.toString(new FileInputStream(writtenFilePath.toString())), streamString);
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriterTest.java
@@ -13,10 +13,13 @@ package gobblin.data.management.copy.writer;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableDatasetMetadata;
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.CopyableFileUtils;
 import gobblin.data.management.copy.FileAwareInputStream;
 import gobblin.data.management.copy.OwnerAndPermission;
+import gobblin.data.management.copy.TestCopyableDataset;
 import gobblin.data.management.copy.converter.UnGzipConverter;
 import gobblin.util.PathUtils;
 
@@ -70,6 +73,9 @@ public class TarArchiveInputStreamDataWriterTest {
     state.setProp(ConfigurationKeys.WRITER_STAGING_DIR, new Path(testTempPath, "staging").toString());
     state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, new Path(testTempPath, "output").toString());
     state.setProp(ConfigurationKeys.WRITER_FILE_PATH, "writer_file_path_" + RandomStringUtils.randomAlphabetic(5));
+    CopyableDatasetMetadata metadata = new CopyableDatasetMetadata(new TestCopyableDataset(new Path("/source")),
+        new Path("/"));
+    CopySource.serializeCopyableDataset(state, metadata);
 
     TarArchiveInputStreamDataWriter dataWriter = new TarArchiveInputStreamDataWriter(state, 1, 0);
     FileAwareInputStream fileAwareInputStream = getCompressedInputStream(filePath, newFileName);
@@ -81,7 +87,8 @@ public class TarArchiveInputStreamDataWriterTest {
 
     // Path at which the writer writes text.txt
     Path taskOutputFilePath =
-        new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
+        new Path(new Path(state.getProp(ConfigurationKeys.WRITER_OUTPUT_DIR),
+            fileAwareInputStream.getFile().getDatasetAndPartition(metadata).identifier()),
             PathUtils.withoutLeadingSeparator(unArchivedFilePath));
 
     Assert.assertEquals(IOUtils.toString(new FileInputStream(taskOutputFilePath.toString())).trim(),


### PR DESCRIPTION
This PR creates a CopyableFile builder to reuse logic in different CopyableDatasets and fixes some bugs with copy operations.