### PR TITLE
Make it possible for RowLevelErrFileWriter to write to HDFS

### DIFF
--- a/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
+++ b/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelPolicyChecker.java
@@ -16,26 +16,33 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Strings;
 import com.google.common.io.Closer;
 
 import gobblin.configuration.State;
 import gobblin.util.FinalState;
+import gobblin.util.HadoopUtils;
 
 
 public class RowLevelPolicyChecker implements Closeable, FinalState {
 
   private final List<RowLevelPolicy> list;
+  private final String stateId;
+  private final FileSystem fs;
   private boolean errFileOpen;
   private final Closer closer;
   private RowLevelErrFileWriter writer;
 
-  public RowLevelPolicyChecker(List<RowLevelPolicy> list) {
+  public RowLevelPolicyChecker(List<RowLevelPolicy> list, String stateId, FileSystem fs) throws IOException {
     this.list = list;
+    this.stateId = stateId;
+    this.fs = fs;
     this.errFileOpen = false;
     this.closer = Closer.create();
-    this.writer = this.closer.register(new RowLevelErrFileWriter());
+    this.writer = this.closer.register(new RowLevelErrFileWriter(this.fs));
   }
 
   public boolean executePolicies(Object record, RowLevelPolicyCheckResults results) throws IOException {
@@ -48,7 +55,7 @@ public class RowLevelPolicyChecker implements Closeable, FinalState {
           throw new RuntimeException("RowLevelPolicy " + p + " failed on record " + record);
         } else if (p.getType().equals(RowLevelPolicy.Type.ERR_FILE)) {
           if (!errFileOpen) {
-            this.writer.open(new Path(p.getErrFileLocation(), p.toString().replaceAll("\\.", "-") + ".err"));
+            this.writer.open(getErrFilePath(p));
             this.writer.write(record);
           } else {
             this.writer.write(record);
@@ -59,6 +66,15 @@ public class RowLevelPolicyChecker implements Closeable, FinalState {
       }
     }
     return true;
+  }
+
+  private Path getErrFilePath(RowLevelPolicy policy) {
+    String errFileName = HadoopUtils.sanitizePath(policy.toString(), "-");
+    if (!Strings.isNullOrEmpty(this.stateId)) {
+      errFileName += "-" + this.stateId;
+    }
+    errFileName += ".err";
+    return new Path(policy.getErrFileLocation(), errFileName);
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelPolicyCheckerBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/qualitychecker/row/RowLevelPolicyCheckerBuilder.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Lists;
 
 import gobblin.configuration.State;
 import gobblin.util.ForkOperatorUtils;
+import gobblin.util.WriterUtils;
 
 
 public class RowLevelPolicyCheckerBuilder {
@@ -78,6 +79,6 @@ public class RowLevelPolicyCheckerBuilder {
 
   public RowLevelPolicyChecker build()
       throws Exception {
-    return new RowLevelPolicyChecker(createPolicyList());
+    return new RowLevelPolicyChecker(createPolicyList(), this.state.getId(), WriterUtils.getWriterFS(this.state, 1, 0));
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/AvroUtils.java
@@ -69,7 +69,6 @@ public class AvroUtils {
   private static final String FIELD_LOCATION_DELIMITER = ".";
 
   private static final String AVRO_SUFFIX = ".avro";
-  public static final String HDFS_ILLEGAL_TOKEN_REGEX = "[\\s:\\\\]";
 
   /**
    * Given a GenericRecord, this method will return the schema of the field specified by the path parameter. The
@@ -458,8 +457,8 @@ public class AvroUtils {
     }
     List<String> tokens = Lists.newArrayList();
     for (Schema.Field field : record.getSchema().getFields()) {
-      String sanitizedName = field.name().replaceAll(HDFS_ILLEGAL_TOKEN_REGEX, "_");
-      String sanitizedValue = record.get(field.name()).toString().replaceAll(HDFS_ILLEGAL_TOKEN_REGEX, "_");
+      String sanitizedName = HadoopUtils.sanitizePath(field.name(), "_");
+      String sanitizedValue = HadoopUtils.sanitizePath(record.get(field.name()).toString(), "_");
       if (replacePathSeparators) {
         sanitizedName = sanitizedName.replaceAll(Path.SEPARATOR, "_");
         sanitizedValue = sanitizedValue.replaceAll(Path.SEPARATOR, "_");

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.ReflectionUtils;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.io.BaseEncoding;
 import com.google.common.io.Closer;
@@ -48,6 +49,8 @@ import com.google.common.io.Closer;
  */
 @Slf4j
 public class HadoopUtils {
+
+  public static final String HDFS_ILLEGAL_TOKEN_REGEX = "[\\s:\\\\]";
 
   public static Configuration newConfiguration() {
     Configuration conf = new Configuration();
@@ -414,5 +417,24 @@ public class HadoopUtils {
     short mode = props.getPropAsShortWithRadix(propName, defaultPermission.toShort(),
         ConfigurationKeys.PERMISSION_PARSING_RADIX);
     return new FsPermission(mode);
+  }
+
+  /**
+   * Remove illegal HDFS path characters from the given path. Illegal characters will be replaced
+   * with the given substitute.
+   */
+  public static String sanitizePath(String path, String substitute) {
+    Preconditions.checkArgument(substitute.replaceAll(HDFS_ILLEGAL_TOKEN_REGEX, "").equals(substitute),
+        "substitute contains illegal characters: " + substitute);
+
+    return path.replaceAll(HDFS_ILLEGAL_TOKEN_REGEX, substitute);
+  }
+
+  /**
+   * Remove illegal HDFS path characters from the given path. Illegal characters will be replaced
+   * with the given substitute.
+   */
+  public static Path sanitizePath(Path path, String substitute) {
+    return new Path(sanitizePath(path.toString(), substitute));
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/HadoopUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/HadoopUtilsTest.java
@@ -136,4 +136,16 @@ public class HadoopUtilsTest {
     Assert.assertTrue(fs.exists(new Path(hadoopUtilsTestDir, "testSafeRename/a/b/c/e/t4.txt")));
 
   }
+
+  @Test
+  public void testSanitizePath() throws Exception {
+    Assert.assertEquals(HadoopUtils.sanitizePath("/A:B/::C:::D\\", "abc"), "/AabcB/abcabcCabcabcabcDabc");
+    Assert.assertEquals(HadoopUtils.sanitizePath(":\\:\\/", ""), "/");
+    try {
+      HadoopUtils.sanitizePath("/A:B/::C:::D\\", "a:b");
+      throw new RuntimeException();
+    } catch (RuntimeException e) {
+      Assert.assertTrue(e.getMessage().contains("substitute contains illegal characters"));
+    }
+  }
 }


### PR DESCRIPTION
This PR fixes two issues:
1. Originally `RowLevelErrFileWriter` can only write to local FS.
2. Originally multiple tasks write the error records into the same err file. Now task id is added to the err file name to avoid this.