### PR TITLE
Resolve race condition between writer and metric updater

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -89,7 +89,7 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   }
 
   @Override
-  public long bytesWritten() throws IOException {
+  public synchronized long bytesWritten() throws IOException {
     if (!this.fs.exists(this.outputFile)) {
       return 0;
     }

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -57,7 +57,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
   protected final String fileName;
   protected final FileSystem fs;
   protected final Path stagingFile;
-  protected final Path outputFile;
+  protected Path outputFile;
   protected final String allOutputFilesPropName;
   protected final boolean shouldIncludeRecordCountInFileName;
   protected final int bufferSize;
@@ -210,11 +210,12 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
     }
   }
 
-  private String addRecordCountToFileName() throws IOException {
+  private synchronized String addRecordCountToFileName() throws IOException {
     String filePath = getOutputFilePath();
     String filePathWithRecordCount = new IngestionRecordCountProvider().constructFilePath(filePath, recordsWritten());
     LOG.info("Renaming " + filePath + " to " + filePathWithRecordCount);
     HadoopUtils.renamePath(this.fs, new Path(filePath), new Path(filePathWithRecordCount));
+    this.outputFile = new Path(filePathWithRecordCount);
     return filePathWithRecordCount;
   }
 


### PR DESCRIPTION
There is a race condition between `FsDataWriter.addRecordCountToFileName()` and `AvroHdfsDataWriter.bytesWritten()`. Between `if (!this.fs.exists(this.outputFile))` and `return this.fs.getFileStatus(this.outputFile).getLen()`, the output file could be renamed (adding row count to file name). Adding synchronization to resolve this. 

Also, reset `this.outputFile` to new path after renaming.