### PR TITLE
Fixed gobblin yarn job config path

### DIFF
--- a/conf/yarn/application.conf
+++ b/conf/yarn/application.conf
@@ -10,7 +10,7 @@ gobblin.yarn.conf.path=<directory where Gobblin on Yarn related configuration fi
 gobblin.yarn.lib.jars.dir=<directory where Gobblin on Yarn lib jars are located>
 gobblin.yarn.app.master.files.local=${gobblin.yarn.conf.dir}"/log4j-yarn.properties,"${gobblin.yarn.conf.dir}"/application.conf,"${gobblin.yarn.conf.dir}"/reference.conf"
 gobblin.yarn.container.files.local=${gobblin.yarn.app.master.files.local}
-gobblin.yarn.job.conf.package.path=<path where Gobblin job configuration file package is located>
+gobblin.yarn.job.conf.path=<path where Gobblin job configuration file package is located>
 gobblin.yarn.logs.sink.root.dir=<root sink directory for aggregated application/container logs stored on the launcher side>
 
 # File system URIs


### PR DESCRIPTION
Fixed config file to account for recent change in property name of gobblin.yarn.job.conf.package.path to gobblin.yarn.job.conf.path