### PR TITLE
Fixing task reporting of bytes written

### DIFF
--- a/gobblin-api/src/main/java/gobblin/writer/DataWriter.java
+++ b/gobblin-api/src/main/java/gobblin/writer/DataWriter.java
@@ -60,11 +60,6 @@ public interface DataWriter<D> extends Closeable {
   /**
    * Get the number of bytes written.
    *
-   * <p>
-   *     This method should ONLY be called after {@link DataWriter#commit()}
-   *     is called.
-   * </p>
-   *
    * @return number of bytes written
    */
   public long bytesWritten()

--- a/gobblin-core/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterBase.java
+++ b/gobblin-core/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterBase.java
@@ -16,6 +16,8 @@ package gobblin.instrumented.writer;
 import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import com.codahale.metrics.Meter;
@@ -25,6 +27,8 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.configuration.State;
 import gobblin.instrumented.Instrumentable;
 import gobblin.instrumented.Instrumented;
@@ -32,24 +36,35 @@ import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.MetricNames;
 import gobblin.metrics.Tag;
+import gobblin.util.ExecutorsUtils;
 import gobblin.util.FinalState;
 import gobblin.writer.DataWriter;
 
 
-/**
- * package-private implementation of instrumentation for {@link gobblin.writer.DataWriter}.
- * See {@link gobblin.instrumented.writer.InstrumentedDataWriter} for extensible class.
- */
-abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrumentable, Closeable, FinalState {
+@Slf4j
 
+/**
+ * Package-private implementation of instrumentation for {@link gobblin.writer.DataWriter}.
+ *
+ * @see {@link gobblin.instrumented.writer.InstrumentedDataWriter} for extensible class.
+ */
+abstract class InstrumentedDataWriterBase<D> implements DataWriter<D>, Instrumentable, Closeable, FinalState {
+
+  private final Optional<ScheduledThreadPoolExecutor> writerMetricsUpdater;
   private final boolean instrumentationEnabled;
 
-  protected final Closer closer;
   private MetricContext metricContext;
   private Optional<Meter> recordsInMeter;
-  private Optional<Meter> successfulWriteMeter;
-  private Optional<Meter> exceptionWriteMeter;
+  private Optional<Meter> successfulWritesMeter;
+  private Optional<Meter> failedWritesMeter;
   private Optional<Timer> dataWriterTimer;
+  private Optional<Meter> recordsWrittenMeter;
+  private Optional<Meter> bytesWrittenMeter;
+
+  protected final Closer closer;
+
+  public static final String WRITER_METRICS_UPDATER_INTERVAL = "gobblin.writer.metrics.updater.interval";
+  public static final long DEFAULT_WRITER_METRICS_UPDATER_INTERVAL = 30000;
 
   public InstrumentedDataWriterBase(State state) {
     this(state, Optional.<Class<?>>absent());
@@ -58,16 +73,22 @@ abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrume
   protected InstrumentedDataWriterBase(State state, Optional<Class<?>> classTag) {
     this.closer = Closer.create();
     this.instrumentationEnabled = GobblinMetrics.isEnabled(state);
-    this.metricContext =
-        this.closer.register(Instrumented.getMetricContext(state, classTag.or(this.getClass())));
+    this.metricContext = this.closer.register(Instrumented.getMetricContext(state, classTag.or(this.getClass())));
+
+    if (this.instrumentationEnabled) {
+      this.writerMetricsUpdater = Optional.of(buildWriterMetricsUpdater());
+      scheduleWriterMetricsUpdater(this.writerMetricsUpdater.get(), getWriterMetricsUpdaterInterval(state));
+    } else {
+      this.writerMetricsUpdater = Optional.absent();
+    }
 
     regenerateMetrics();
   }
 
   @Override
   public void switchMetricContext(List<Tag<?>> tags) {
-    this.metricContext = this.closer.register(Instrumented.newContextFromReferenceContext(this.metricContext, tags,
-        Optional.<String>absent()));
+    this.metricContext = this.closer
+        .register(Instrumented.newContextFromReferenceContext(this.metricContext, tags, Optional.<String>absent()));
 
     regenerateMetrics();
   }
@@ -82,17 +103,21 @@ abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrume
    * Generates metrics for the instrumentation of this class.
    */
   protected void regenerateMetrics() {
-    if(isInstrumentationEnabled()) {
+    if (isInstrumentationEnabled()) {
       this.recordsInMeter = Optional.of(this.metricContext.meter(MetricNames.DataWriterMetrics.RECORDS_IN_METER));
-      this.successfulWriteMeter = Optional.of(
-          this.metricContext.meter(MetricNames.DataWriterMetrics.RECORDS_WRITTEN_METER));
-      this.exceptionWriteMeter = Optional.of(
-          this.metricContext.meter(MetricNames.DataWriterMetrics.RECORDS_FAILED_METER));
+      this.successfulWritesMeter =
+          Optional.of(this.metricContext.meter(MetricNames.DataWriterMetrics.SUCCESSFUL_WRITES_METER));
+      this.failedWritesMeter = Optional.of(this.metricContext.meter(MetricNames.DataWriterMetrics.FAILED_WRITES_METER));
+      this.recordsWrittenMeter =
+          Optional.of(this.metricContext.meter(MetricNames.DataWriterMetrics.RECORDS_WRITTEN_METER));
+      this.bytesWrittenMeter = Optional.of(this.metricContext.meter(MetricNames.DataWriterMetrics.BYTES_WRITTEN_METER));
       this.dataWriterTimer = Optional.of(this.metricContext.timer(MetricNames.DataWriterMetrics.WRITE_TIMER));
     } else {
       this.recordsInMeter = Optional.absent();
-      this.successfulWriteMeter = Optional.absent();
-      this.exceptionWriteMeter = Optional.absent();
+      this.successfulWritesMeter = Optional.absent();
+      this.failedWritesMeter = Optional.absent();
+      this.recordsWrittenMeter = Optional.absent();
+      this.bytesWrittenMeter = Optional.absent();
       this.dataWriterTimer = Optional.absent();
     }
   }
@@ -111,7 +136,7 @@ abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrume
   @Override
   public void write(D record)
       throws IOException {
-    if(!isInstrumentationEnabled()) {
+    if (!isInstrumentationEnabled()) {
       writeImpl(record);
       return;
     }
@@ -121,7 +146,7 @@ abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrume
       beforeWrite(record);
       writeImpl(record);
       onSuccessfulWrite(startTimeNanos);
-    } catch(IOException exception) {
+    } catch (IOException exception) {
       onException(exception);
       throw exception;
     }
@@ -141,20 +166,21 @@ abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrume
    */
   public void onSuccessfulWrite(long startTimeNanos) {
     Instrumented.updateTimer(this.dataWriterTimer, System.nanoTime() - startTimeNanos, TimeUnit.NANOSECONDS);
-    Instrumented.markMeter(this.successfulWriteMeter);
+    Instrumented.markMeter(this.successfulWritesMeter);
   }
 
   /** Called after a failed writing of a record.
    * @param exception exception thrown.
    */
   public void onException(Exception exception) {
-    Instrumented.markMeter(this.exceptionWriteMeter);
+    Instrumented.markMeter(this.failedWritesMeter);
   }
 
   /**
    * Subclasses should implement this instead of {@link gobblin.writer.DataWriter#write}
    */
-  public abstract void writeImpl(D record) throws IOException;
+  public abstract void writeImpl(D record)
+      throws IOException;
 
   /**
    * Get final state for this object. By default this returns an empty {@link gobblin.configuration.State}, but
@@ -170,10 +196,84 @@ abstract class InstrumentedDataWriterBase <D> implements DataWriter<D>, Instrume
   public void close()
       throws IOException {
     this.closer.close();
+    if (this.writerMetricsUpdater.isPresent()) {
+      ExecutorsUtils.shutdownExecutorService(this.writerMetricsUpdater.get(), Optional.of(log));
+    }
   }
 
   @Override
   public MetricContext getMetricContext() {
     return this.metricContext;
+  }
+
+  /**
+   * Update the {@link #recordsWrittenMeter} and {@link #bytesWrittenMeter}. This method should be invoked after the
+   * wrapped {@link DataWriter#commit()} is invoked. This ensures that the record-level and byte-level meters are
+   * updated at least once.
+   */
+  @Override
+  public void commit()
+      throws IOException {
+    updateRecordsWrittenMeter();
+    updateBytesWrittenMeter();
+  }
+
+  /**
+   * Update the {@link #recordsWrittenMeter} using the {@link DataWriter#recordsWritten()} method..
+   */
+  private synchronized void updateRecordsWrittenMeter() {
+    if (this.recordsWrittenMeter.isPresent()) {
+      this.recordsWrittenMeter.get().mark(recordsWritten() - this.recordsWrittenMeter.get().getCount());
+    }
+  }
+
+  /**
+   * Update the {@link #bytesWrittenMeter} using the {@link DataWriter#bytesWritten()} method.
+   */
+  private synchronized void updateBytesWrittenMeter() {
+    if (this.bytesWrittenMeter.isPresent()) {
+      try {
+        this.bytesWrittenMeter.get().mark(bytesWritten() - this.bytesWrittenMeter.get().getCount());
+      } catch (IOException e) {
+        log.error("Cannot get bytesWritten for DataWriter, will not update " + this.bytesWrittenMeter.get().toString(),
+            e);
+      }
+    }
+  }
+
+  /**
+   * Build a {@link ScheduledThreadPoolExecutor} that updates record-level and byte-level metrics.
+   */
+  private ScheduledThreadPoolExecutor buildWriterMetricsUpdater() {
+    return new ScheduledThreadPoolExecutor(1,
+        ExecutorsUtils.newThreadFactory(Optional.of(log), Optional.of("WriterMetricsUpdater-%d")));
+  }
+
+  /**
+   * Get the interval that the Writer Metrics Updater should be scheduled on.
+   */
+  private long getWriterMetricsUpdaterInterval(State state) {
+    return state.getPropAsLong(WRITER_METRICS_UPDATER_INTERVAL, DEFAULT_WRITER_METRICS_UPDATER_INTERVAL);
+  }
+
+  /**
+   * Schedule the given {@link ScheduledThreadPoolExecutor} to run at the given interval.
+   */
+  private ScheduledFuture<?> scheduleWriterMetricsUpdater(ScheduledThreadPoolExecutor writerMetricsUpdater,
+      long scheduleInterval) {
+    return writerMetricsUpdater
+        .scheduleAtFixedRate(new WriterMetricsUpdater(), scheduleInterval, scheduleInterval, TimeUnit.MILLISECONDS);
+  }
+
+  /**
+   * An implementation of {@link Runnable} that updates record-level and byte-level metrics.
+   */
+  private class WriterMetricsUpdater implements Runnable {
+
+    @Override
+    public void run() {
+      updateRecordsWrittenMeter();
+      updateBytesWrittenMeter();
+    }
   }
 }

--- a/gobblin-core/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterDecorator.java
+++ b/gobblin-core/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterDecorator.java
@@ -27,9 +27,8 @@ import gobblin.writer.DataWriter;
 
 
 /**
- * Decorator that automatically instruments {@link gobblin.writer.DataWriter}.
- * Handles already instrumented {@link gobblin.instrumented.writer.InstrumentedDataWriter}
- * appropriately to avoid double metric reporting.
+ * Decorator that automatically instruments {@link gobblin.writer.DataWriter}. Handles already instrumented
+ * {@link gobblin.instrumented.writer.InstrumentedDataWriter} appropriately to avoid double metric reporting.
  */
 public class InstrumentedDataWriterDecorator<D> extends InstrumentedDataWriterBase<D> implements Decorator {
 
@@ -44,15 +43,14 @@ public class InstrumentedDataWriterDecorator<D> extends InstrumentedDataWriterBa
 
   @Override
   public MetricContext getMetricContext() {
-    return this.isEmbeddedInstrumented ?
-        ((InstrumentedDataWriterBase)this.embeddedWriter).getMetricContext() :
-        super.getMetricContext();
+    return this.isEmbeddedInstrumented ? ((InstrumentedDataWriterBase) this.embeddedWriter).getMetricContext()
+        : super.getMetricContext();
   }
 
   @Override
   public void write(D record)
       throws IOException {
-    if(this.isEmbeddedInstrumented) {
+    if (this.isEmbeddedInstrumented) {
       writeImpl(record);
     } else {
       super.write(record);
@@ -69,6 +67,7 @@ public class InstrumentedDataWriterDecorator<D> extends InstrumentedDataWriterBa
   public void commit()
       throws IOException {
     this.embeddedWriter.commit();
+    super.commit();
   }
 
   @Override
@@ -90,7 +89,7 @@ public class InstrumentedDataWriterDecorator<D> extends InstrumentedDataWriterBa
 
   @Override
   public State getFinalState() {
-    if(this.embeddedWriter instanceof FinalState) {
+    if (this.embeddedWriter instanceof FinalState) {
       return ((FinalState) this.embeddedWriter).getFinalState();
     } else {
       return super.getFinalState();

--- a/gobblin-core/src/main/java/gobblin/metrics/MetricNames.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/MetricNames.java
@@ -62,13 +62,42 @@ public class MetricNames {
   }
 
   /**
-   * Data writer metrics.
+   * {@link gobblin.writer.DataWriter} metrics.
    */
   public static class DataWriterMetrics {
+
+    /**
+     * A {@link com.codahale.metrics.Meter} measuring the number of records given to a {@link gobblin.writer.DataWriter}.
+     */
     public static final String RECORDS_IN_METER = "gobblin.writer.records.in";
+
+    /**
+     * A {@link com.codahale.metrics.Meter} measuring the number of successful write operations performed by a
+     * {@link gobblin.writer.DataWriter}.
+     */
+    public static final String SUCCESSFUL_WRITES_METER = "gobblin.writer.successful.writes";
+
+    /**
+     * A {@link com.codahale.metrics.Meter} measuring the number of failed write operations performed by a
+     * {@link gobblin.writer.DataWriter}.
+     */
+    public static final String FAILED_WRITES_METER = "gobblin.writer.failed.writes";
+
+    /**
+     * A {@link com.codahale.metrics.Meter} measuring the number records written by a {@link gobblin.writer.DataWriter}
+     * as reported by its {@link gobblin.writer.DataWriter#recordsWritten()} method.
+     */
     public static final String RECORDS_WRITTEN_METER = "gobblin.writer.records.written";
-    public static final String RECORDS_FAILED_METER = "gobblin.writer.records.failed";
-    // Times writing of records.
+
+    /**
+     * A {@link com.codahale.metrics.Meter} measuring the number bytes written by a {@link gobblin.writer.DataWriter} as
+     * reported by its {@link gobblin.writer.DataWriter#bytesWritten()} method.
+     */
+    public static final String BYTES_WRITTEN_METER = "gobblin.writer.bytes.written";
+
+    /**
+     * A {@link com.codahale.metrics.Timer} measuring the time taken for each write operation.
+     */
     public static final String WRITE_TIMER = "gobblin.writer.write.time";
   }
 }

--- a/gobblin-core/src/test/java/gobblin/instrumented/writer/InstrumentedDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/instrumented/writer/InstrumentedDataWriterTest.java
@@ -132,8 +132,8 @@ public class InstrumentedDataWriterTest {
 
     Map<String, Long> metrics = MetricsHelper.dumpMetrics(writer.getMetricContext());
     Assert.assertEquals(metrics.get(MetricNames.DataWriterMetrics.RECORDS_IN_METER), Long.valueOf(1));
-    Assert.assertEquals(metrics.get(MetricNames.DataWriterMetrics.RECORDS_WRITTEN_METER), Long.valueOf(1));
-    Assert.assertEquals(metrics.get(MetricNames.DataWriterMetrics.RECORDS_FAILED_METER), Long.valueOf(0));
+    Assert.assertEquals(metrics.get(MetricNames.DataWriterMetrics.SUCCESSFUL_WRITES_METER), Long.valueOf(1));
+    Assert.assertEquals(metrics.get(MetricNames.DataWriterMetrics.FAILED_WRITES_METER), Long.valueOf(0));
     Assert.assertEquals(metrics.get(MetricNames.DataWriterMetrics.WRITE_TIMER), Long.valueOf(1));
 
     Assert.assertEquals(MetricsHelper.dumpTags(writer.getMetricContext()).get("construct"),

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractTaskStateTracker.java
@@ -85,6 +85,8 @@ public abstract class AbstractTaskStateTracker extends AbstractIdleService imple
 
   /**
    * A base class providing a default implementation for updating task metrics.
+   *
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
    */
   protected class TaskMetricsUpdater implements Runnable {
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -243,10 +243,6 @@ public class Fork implements Closeable, Runnable, FinalState {
 
   /**
    * Update byte-level metrics.
-   *
-   * <p>
-   *     This method is only supposed to be called after the writer commits.
-   * </p>
    */
   public void updateByteMetrics() throws IOException {
     if (this.writer.isPresent()) {
@@ -487,7 +483,8 @@ public class Fork implements Closeable, Runnable, FinalState {
 
     try {
       if (GobblinMetrics.isEnabled(this.taskState.getWorkunit())) {
-        // Update byte-level metrics after the writer commits
+        // Update record-level and byte-level metrics after the writer commits
+        updateRecordMetrics();
         updateByteMetrics();
       }
     } catch (IOException ioe) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -55,9 +55,25 @@ import gobblin.metrics.GobblinMetrics;
 public class TaskState extends WorkUnitState {
 
   // Built-in metric names
+
+  /**
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
+   */
   private static final String RECORDS = "records";
+
+  /**
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
+   */
   private static final String RECORDS_PER_SECOND = "recordsPerSec";
+
+  /**
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
+   */
   private static final String BYTES = "bytes";
+
+  /**
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
+   */
   private static final String BYTES_PER_SECOND = "bytesPerSec";
 
   private String jobId;
@@ -211,13 +227,14 @@ public class TaskState extends WorkUnitState {
    *
    * @param recordsWritten number of records written by the writer
    * @param branchIndex fork branch index
+   *
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
    */
-  public void updateRecordMetrics(long recordsWritten, int branchIndex) {
+  public synchronized void updateRecordMetrics(long recordsWritten, int branchIndex) {
     TaskMetrics metrics = TaskMetrics.get(this);
     String forkBranchId = ForkOperatorUtils.getForkId(this.taskId, branchIndex);
 
-    Counter taskRecordCounter =
-        metrics.getCounter(gobblin.runtime.util.MetricGroup.TASK.name(), forkBranchId, RECORDS);
+    Counter taskRecordCounter = metrics.getCounter(MetricGroup.TASK.name(), forkBranchId, RECORDS);
     long inc = recordsWritten - taskRecordCounter.getCount();
     taskRecordCounter.inc(inc);
     metrics.getMeter(MetricGroup.TASK.name(), forkBranchId, RECORDS_PER_SECOND).mark(inc);
@@ -228,21 +245,21 @@ public class TaskState extends WorkUnitState {
   /**
    * Collect byte-level metrics.
    *
-   * <p>
-   *     This method is only supposed to be called after the writer commits.
-   * </p>
-   *
    * @param bytesWritten number of bytes written by the writer
    * @param branchIndex fork branch index
+   *
+   * @deprecated see {@link gobblin.instrumented.writer.InstrumentedDataWriterBase}.
    */
-  public void updateByteMetrics(long bytesWritten, int branchIndex) {
+  public synchronized void updateByteMetrics(long bytesWritten, int branchIndex) {
     TaskMetrics metrics = TaskMetrics.get(this);
     String forkBranchId = ForkOperatorUtils.getForkId(this.taskId, branchIndex);
 
-    metrics.getCounter(MetricGroup.TASK.name(), forkBranchId, BYTES).inc(bytesWritten);
-    metrics.getMeter(MetricGroup.TASK.name(), forkBranchId, BYTES_PER_SECOND).mark(bytesWritten);
-    metrics.getCounter(MetricGroup.JOB.name(), this.jobId, BYTES).inc(bytesWritten);
-    metrics.getMeter(MetricGroup.JOB.name(), this.jobId, BYTES_PER_SECOND).mark(bytesWritten);
+    Counter taskByteCounter = metrics.getCounter(MetricGroup.TASK.name(), forkBranchId, BYTES);
+    long inc = bytesWritten - taskByteCounter.getCount();
+    taskByteCounter.inc(inc);
+    metrics.getMeter(MetricGroup.TASK.name(), forkBranchId, BYTES_PER_SECOND).mark(inc);
+    metrics.getCounter(MetricGroup.JOB.name(), this.jobId, BYTES).inc(inc);
+    metrics.getMeter(MetricGroup.JOB.name(), this.jobId, BYTES_PER_SECOND).mark(inc);
   }
 
   /**


### PR DESCRIPTION
* Fixing reporting for byte level metrics in `TaskState`.
* Fix applies to `BYTES` and `BYTES_PER_SECOND` metrics. 
* Changed the method `TaskState.updateByteMetrics` to follow the same logic as `TaskState.updateRecordMetrics`.

@liyinan926 and @ibuenros can you review