### PR TITLE
Adding instrumentation to publish to Maven Central

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ apply from: environmentScript
 ext.publishToMaven = project.hasProperty('publishToMaven')
 if (ext.publishToMaven) {
     plugins.apply('maven')
-    //workaround for a bug in gradle's "maven" plugin. See https://discuss.gradle.org/t/error-in-parallel-build/7215/3
+    // Workaround for a bug in gradle's "maven" plugin. See https://discuss.gradle.org/t/error-in-parallel-build/7215/3
     project.setProperty("org.gradle.parallel", "false")
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -23,8 +23,15 @@ File getEnvironmentScript()
 
 apply from: environmentScript
 
+ext.publishToMaven = project.hasProperty('publishToMaven')
+if (ext.publishToMaven) {
+    plugins.apply('maven')
+    //workaround for a bug in gradle's "maven" plugin. See https://discuss.gradle.org/t/error-in-parallel-build/7215/3
+    project.setProperty("org.gradle.parallel", "false")
+}
+
 if (!project.hasProperty('group') || project.group.length() == 0) {
-    project.group = 'gobblin'
+    project.group = 'com.linkedin.gobblin'
 }
 
 if (!project.hasProperty('version') || project.version == 'unspecified') {
@@ -40,6 +47,9 @@ if (!project.hasProperty('version') || project.version == 'unspecified') {
     }
     else {
         project.version = tagStr
+    }
+    if (!project.hasProperty('useHadoop2')) {
+      project.version = project.version + "-hadoop1"
     }
 }
 
@@ -184,6 +194,11 @@ plugins.withType(JavaPlugin) {
 
   sourceCompatibility = JavaVersion.VERSION_1_7
 
+  //Sometimes generating javadocs can lead to OOM. This may needs to be increased.
+  javadoc {
+    options.JFlags = ["-Xmx256m"]
+  }
+
 /*  findbugs {
     ignoreFailures = true
     effort = "max"
@@ -223,7 +238,108 @@ plugins.withType(JavaPlugin) {
       from sourceSets.main.allSource
       classifier = 'sources'
     }
-    artifacts { archives sourcesJar }
+    task javadocJar(type: Jar) {
+      from javadoc
+      classifier = 'javadoc'
+    }
+    artifacts { archives sourcesJar, javadocJar }
+  }
+
+  // Publishing of maven artifacts for subprojects
+  if (rootProject.ext.publishToMaven) {
+    plugins.apply('maven')
+    plugins.apply('signing')
+
+    project.version = rootProject.version
+    project.group = rootProject.group
+
+    uploadArchives {
+      repositories {
+        mavenDeployer {
+          beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
+
+          repository(url: "https://oss.sonatype.org/service/local/staging/deploy/maven2/") {
+            authentication(userName: ossrhUsername, password: ossrhPassword)
+          }
+
+          snapshotRepository(url: "https://oss.sonatype.org/content/repositories/snapshots/") {
+            authentication(userName: ossrhUsername, password: ossrhPassword)
+          }
+
+          pom.project {
+            name "${project.name}"
+            packaging 'jar'
+            // optionally artifactId can be defined here 
+            description 'Gobblin Ingestion Framework'
+            url 'https://github.com/linkedin/gobblin/'
+
+            scm {
+              connection 'scm:git:git@github.com:linkedin/gobblin.git'
+              developerConnection 'scm:git:git@github.com:linkedin/gobblin.git'
+              url 'git@github.com:linkedin/gobblin.git'
+            }
+
+            licenses {
+              license {
+                name 'The Apache License, Version 2.0'
+                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+              }
+            }
+
+            developers {
+              developer {
+                name 'Abhishek Tiwari'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Chavdar Botev'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Issac Buenrostro'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Min Tu'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Narasimha Veeramreddy'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Pradhan Cadabam'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Sahil Takiar'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Shirshanka Das'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Yinan Li'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Ying Dai'
+                organization 'LinkedIn'
+              }
+              developer {
+                name 'Ziyang Liu'
+                organization 'LinkedIn'
+              }
+            }
+          }
+        }
+      }
+    }
+
+    signing {
+      sign configurations.archives
+    }
   }
 
   // Configure the IDEA plugin to (1) add the codegen as source dirs and (2) work around

--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -53,8 +53,10 @@ dependencies {
 }
 
 
-configurations { compile { transitive = true
-  } }
+configurations { 
+    compile { transitive = true } 
+    archives
+}
 
 classification="library"
 
@@ -70,7 +72,10 @@ jar {
 }
 
 task createCompactionTar(type: Tar) {
-  extension = 'tar.gz'
+  //there seems to be a bug in the Gradle signing module where X.tar.gz will generate
+  // a signature X.gz.asc instead of X.tar.gz.asc. Therefore, we have to use the .tgz 
+  // extension
+  extension = 'tgz'
   baseName = project.name
   compression = Compression.GZIP
 

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -51,6 +51,7 @@ configurations {
     compile {
         transitive = true
     }
+    archives
 }
 
 test {
@@ -64,7 +65,10 @@ classification="library"
 
 
 task utilityTar(type: Tar) {
-  extension = 'tar.gz'
+  //there seems to be a bug in the Gradle signing module where X.tar.gz will generate
+  // a signature X.gz.asc instead of X.tar.gz.asc. Therefore, we have to use the .tgz 
+  // extension
+  extension = 'tgz'
   baseName = project.name
   compression = Compression.GZIP
 

--- a/maven-sonatype.sh
+++ b/maven-sonatype.sh
@@ -1,0 +1,87 @@
+#!/bin/bash
+
+script_dir=$(dirname $0)
+script_name=$(basename $0)
+GRADLE="$script_dir/gradlew"
+
+function print_usage() {
+    echo -e "USAGE: $0 [-remote|-local] [-hadoop1] [-noclean] [gradle_args]"
+    echo
+    echo -e "Publishes signed maven artifacts locally ($HOME/.m2/repository) or remotely (Sonatype)."
+    echo -e "By default, Hadoop2 artifacts are generated."
+    echo -e "\t-hadoop1    Generate hadoop1 artifacts"
+    echo -e "\t-local      Publish to local repository"
+    echo -e "\t-noclean    Don't run gradlew clean (useful if re-running)"
+    echo -e "\t-remote     Publish to Sonatype repository"
+    echo
+    echo -e "NOTES:"
+    echo -e "\t1. You need the Gobblin PGP key to sign the artifacts. If you don't have it,"
+    echo -e "\t   talk to another committer to get it. You also need to add the following to"
+    echo -e "\t   your $HOME/.gradle/gradle.properties file:"
+    echo
+    echo -e "signing.keyId=<PGP key hex id>"
+    echo -e "signing.password=<PGP key password>"
+    echo -e "signing.secretKeyRingFile=$HOME/.gnupg/secring.gpg"
+    echo
+    echo -e "\t2. To upload remotely, you'll need a Sonatype account. Visit "
+    echo -e "\t   https://issues.sonatype.org/secure/Signup!default.jspa to set it up. After"
+    echo -e "\t   that add to your $HOME/.gradle/gradle.properties file:"
+    echo
+    echo -e "ossrhUsername=<Sonatype username>"
+    echo -e "ossrhPassword=<Sonatype password>"
+    echo
+    echo -e "\t3. Uploading remotely will upload only to the Sonatype staging directory. Follow "
+    echo -e "     the steps at http://central.sonatype.org/pages/releasing-the-deployment.html to"
+    echo -e "     synchronize with Maven Central."
+    echo -e "\t4. Don't forget to create a gobblin_<version> tag before publishing remotely!"
+    echo -e "\t5. Sometimes build with fail with an error"
+    echo -e "\t   '... Failed to interpolate field: private java.lang.String ...'"
+    echo -e "\t   Just re-run with -noclean"
+}
+
+if [ "$#" -eq 0 ] ; then
+    print_usage
+    exit
+fi
+
+install_target=
+hadoop_version=-PuseHadoop2
+gradle_args=
+noclean=
+
+# Parse command line
+for A in "$@" ; do
+    case "$A" in
+        -local)
+            install_target=install
+            ;;
+        -noclean)
+            noclean="1"
+            ;;
+        -remote)
+            install_target=uploadArchives
+            ;;
+        -hadoop1)
+            hadoop_version=
+            ;;
+        -h|--help|-help)
+            print_usage
+            exit
+            ;;
+        *)
+            gradle_args="$gradle_args $A"
+            ;;
+    esac
+done
+
+if [ -z "${install_target}" ] ; then
+    echo "${script_name}: missing install target"
+    exit 1
+fi
+
+if [ -z "$noclean" ] ; then
+    $GRADLE clean
+fi
+$GRADLE -PpublishToMaven -Porg.gradle.parallel=false -Porg.gradle.daemon=false -xtest $hadoop_version $gradle_args $install_target 2>&1 | tee /tmp/${script_name}.out
+
+


### PR DESCRIPTION
Rework of the Maven Publishing code:

* Switch to using the legacy "maven" plugin instead of the new "maven-publish" due to issues with signing artifacts
* Add support for signing the artifacts
* Use group com.linkedin.gobblin instead of gobblin as per Sonatype requirements
* Add POM metadata as per Sonatype requirements
* Rename gobblin-utility.tar.gz and gobblin-compaction.tar.gz to gobblin-utility.tgz and gobblin-compaction.tgz since the Gradle signing plugin does not work correctly if a file has two extensions
* Add a helper script maven-sonatype.sh with instructions on how to publish the artifacts

@liyinan926 @ibuenros Can you review?