### PR TITLE
Separate publisher filesystem from writer filesystem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ out/
 **/mainGeneratedDataTemplate
 **/mainGeneratedRest
 gobblin-dist*
+gobblin.tar.gz

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -277,6 +277,7 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_PREFIX = "data.publisher";
   public static final String DATA_PUBLISHER_TYPE = DATA_PUBLISHER_PREFIX + ".type";
   public static final String DEFAULT_DATA_PUBLISHER_TYPE = "gobblin.publisher.BaseDataPublisher";
+  public static final String DATA_PUBLISHER_FILE_SYSTEM_URI = DATA_PUBLISHER_PREFIX + ".fs.uri";
   public static final String DATA_PUBLISHER_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".final.dir";
   public static final String DATA_PUBLISHER_REPLACE_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".replace.final.dir";
   public static final String DATA_PUBLISHER_FINAL_NAME = DATA_PUBLISHER_PREFIX + ".final.name";

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -54,18 +54,19 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
   protected void addWriterOutputToExistingDir(Path writerOutput, Path publisherOutput, WorkUnitState workUnitState,
       int branchId, ParallelRunner parallelRunner) throws IOException {
 
-    for (FileStatus status : FileListUtils.listFilesRecursively(this.fileSystemByBranches.get(branchId),
+    for (FileStatus status : FileListUtils.listFilesRecursively(this.writerFileSystemByBranches.get(branchId),
         writerOutput)) {
       String filePathStr = status.getPath().toString();
       String pathSuffix =
           filePathStr.substring(filePathStr.indexOf(writerOutput.toString()) + writerOutput.toString().length() + 1);
       Path outputPath = new Path(publisherOutput, pathSuffix);
 
-      WriterUtils.mkdirsWithRecursivePermission(this.fileSystemByBranches.get(branchId), outputPath.getParent(),
+      WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId), outputPath.getParent(),
           this.permissions.get(branchId));
 
       LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));
-      parallelRunner.renamePath(status.getPath(), outputPath, Optional.<String> absent());
+      parallelRunner.movePath(status.getPath(), this.publisherFileSystemByBranches.get(branchId),
+          outputPath, Optional.<String> absent());
     }
   }
 }

--- a/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
@@ -186,6 +186,7 @@ public class FsStateStore<T extends State> implements StateStore<T> {
 
     Closer closer = Closer.create();
     try {
+      @SuppressWarnings("deprecation")
       SequenceFile.Reader reader = closer.register(new SequenceFile.Reader(this.fs, tablePath, this.conf));
       try {
         Text key = new Text();
@@ -219,6 +220,7 @@ public class FsStateStore<T extends State> implements StateStore<T> {
 
     Closer closer = Closer.create();
     try {
+      @SuppressWarnings("deprecation")
       SequenceFile.Reader reader = closer.register(new SequenceFile.Reader(this.fs, tablePath, this.conf));
       try {
         Text key = new Text();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/FsDatasetStateStore.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/FsDatasetStateStore.java
@@ -82,6 +82,7 @@ public class FsDatasetStateStore extends FsStateStore<JobState.DatasetState> {
 
     Closer closer = Closer.create();
     try {
+      @SuppressWarnings("deprecation")
       SequenceFile.Reader reader = closer.register(new SequenceFile.Reader(this.fs, tablePath, this.conf));
       // This is necessary for backward compatibility as existing jobs are using the JobState class
       Writable writable = reader.getValueClass() == JobState.class ? new JobState() : new JobState.DatasetState();
@@ -121,6 +122,7 @@ public class FsDatasetStateStore extends FsStateStore<JobState.DatasetState> {
 
     Closer closer = Closer.create();
     try {
+      @SuppressWarnings("deprecation")
       SequenceFile.Reader reader = closer.register(new SequenceFile.Reader(this.fs, tablePath, this.conf));
       // This is necessary for backward compatibility as existing jobs are using the JobState class
       Writable writable = reader.getValueClass() == JobState.class ? new JobState() : new JobState.DatasetState();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -93,9 +93,15 @@ public class JobContext {
     this.jobLockEnabled =
         Boolean.valueOf(jobProps.getProperty(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, Boolean.TRUE.toString()));
 
+    // Add all job configuration properties so they are picked up by Hadoop
+    Configuration conf = new Configuration();
+    for (String key : jobProps.stringPropertyNames()) {
+      conf.set(key, jobProps.getProperty(key));
+    }
+
     String stateStoreFsUri =
         jobProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI);
-    FileSystem stateStoreFs = FileSystem.get(URI.create(stateStoreFsUri), new Configuration());
+    FileSystem stateStoreFs = FileSystem.get(URI.create(stateStoreFsUri), conf);
     String stateStoreRootDir = jobProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY);
     this.datasetStateStore = new FsDatasetStateStore(stateStoreFs, stateStoreRootDir);
 

--- a/gobblin-utility/src/main/java/gobblin/util/ExecutorsUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ExecutorsUtils.java
@@ -105,7 +105,7 @@ public class ExecutorsUtils {
     executorService.shutdown();
 
     if (logger.isPresent()) {
-      logger.get().info("Attempting to shutdown ExecutorSerivce: " + executorService);
+      logger.get().info("Attempting to shutdown ExecutorService: " + executorService);
     }
 
     try {
@@ -133,7 +133,7 @@ public class ExecutorsUtils {
       executorService.shutdownNow();
 
       if (logger.isPresent()) {
-        logger.get().info("Attempting to shutdownNow ExecutorSerivce: " + executorService);
+        logger.get().info("Attempting to shutdownNow ExecutorService: " + executorService);
       }
     }
   }

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -142,6 +142,22 @@ public class HadoopUtils {
     }
   }
 
+  /**
+   * A wrapper around {@link HadoopUtils#renamePath(FileSystem, Path, Path)} and
+   * {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, Configuration)} which will rename the path
+   * if the src and dst filesystems are the same; otherwise, the src file will be moved the the dst filesystem.
+   * An {@link IOException} if {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, Configuration)} returns false.
+   */
+  public static void movePath(FileSystem srcFs, Path src, FileSystem dstFs, Path dst) throws IOException {
+    if (srcFs.getUri().equals(dstFs.getUri())) {
+      renamePath(srcFs, src, dst);
+    } else {
+      if (!FileUtil.copy(srcFs, src, dstFs, dst, true, false, dstFs.getConf())) {
+        throw new IOException(String.format("Failed to move %s to %s", src, dst));
+      }
+    }
+  }
+
   @SuppressWarnings("deprecation")
   private static void walk(List<FileStatus> results, FileSystem fileSystem, Path path) throws IOException {
     for (FileStatus status : fileSystem.listStatus(path)) {

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemUtils.java
@@ -213,6 +213,7 @@ public class ProxiedFileSystemUtils {
     Closer closer = Closer.create();
     try {
       FileSystem localFs = FileSystem.getLocal(new Configuration());
+      @SuppressWarnings("deprecation")
       SequenceFile.Reader tokenReader =
           closer.register(new SequenceFile.Reader(localFs, tokenFilePath, localFs.getConf()));
       Text key = new Text();

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
@@ -128,6 +128,7 @@ public class ProxiedFileSystemWrapper {
     Closer closer = Closer.create();
     try {
       FileSystem localFs = FileSystem.getLocal(new Configuration());
+      @SuppressWarnings("deprecation")
       SequenceFile.Reader tokenReader =
           closer.register(new SequenceFile.Reader(localFs, new Path(authPath), localFs.getConf()));
       Text key = new Text();


### PR DESCRIPTION
Support for publishing data to a different filesystem from where data is written.  The use case of this is writing the files to HDFS, but publishing them to S3.