### PR TITLE
Unit tests for Gobblin Yarn part II

### DIFF
--- a/gobblin-core/src/main/java/gobblin/fork/IdentityForkOperator.java
+++ b/gobblin-core/src/main/java/gobblin/fork/IdentityForkOperator.java
@@ -12,12 +12,12 @@
 
 package gobblin.fork;
 
-import gobblin.configuration.ConfigurationKeys;
 import java.io.IOException;
 import java.util.List;
 
 import com.google.common.collect.Lists;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
 
 
@@ -46,24 +46,22 @@ public class IdentityForkOperator<S, D> implements ForkOperator<S, D> {
 
   @Override
   public List<Boolean> forkSchema(WorkUnitState workUnitState, S input) {
-
-    schemas.clear();
+    this.schemas.clear();
     for (int i = 0; i < getBranches(workUnitState); i++) {
-      schemas.add(Boolean.TRUE);
+      this.schemas.add(Boolean.TRUE);
     }
 
-    return schemas;
+    return this.schemas;
   }
 
   @Override
   public List<Boolean> forkDataRecord(WorkUnitState workUnitState, D input) {
-
-    records.clear();
+    this.records.clear();
     for (int i = 0; i < getBranches(workUnitState); i++) {
-      records.add(Boolean.TRUE);
+      this.records.add(Boolean.TRUE);
     }
 
-    return records;
+    return this.records;
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -145,7 +145,7 @@ public class Fork implements Closeable, Runnable, FinalState {
         .collectStats()
         .build();
 
-    this.forkState = new AtomicReference<ForkState>(ForkState.PENDING);
+    this.forkState = new AtomicReference<>(ForkState.PENDING);
 
     /**
      * Create a {@link GobblinMetrics} for this {@link Fork} instance so that all new {@link MetricContext}s returned by
@@ -165,20 +165,9 @@ public class Fork implements Closeable, Runnable, FinalState {
     try {
       processRecords();
       compareAndSetForkState(ForkState.RUNNING, ForkState.SUCCEEDED);
-    } catch (IOException ioe) {
-      this.forkState.set(ForkState.FAILED);
-      this.logger.error(
-          String.format("Fork %d of task %s failed to process data records", this.index, this.taskId), ioe);
-      Throwables.propagate(ioe);
-    } catch (DataConversionException dce) {
-      this.forkState.set(ForkState.FAILED);
-      this.logger.error(
-          String.format("Fork %d of task %s failed to convert data records", this.index, this.taskId), dce);
-      Throwables.propagate(dce);
     } catch (Throwable t) {
       this.forkState.set(ForkState.FAILED);
       this.logger.error(String.format("Fork %d of task %s failed to process data records", this.index, this.taskId), t);
-      Throwables.propagate(t);
     } finally {
       // Clear the queue and count down so the parent task knows this fork is done (succeeded or failed)
       this.recordQueue.clear();
@@ -342,7 +331,7 @@ public class Fork implements Closeable, Runnable, FinalState {
    * @return the number of records written by this {@link Fork}
    */
   long getRecordsWritten() {
-    return this.writer.isPresent() ? this.writer.get().recordsWritten() : 0l;
+    return this.writer.isPresent() ? this.writer.get().recordsWritten() : 0L;
   }
 
   /**
@@ -373,7 +362,7 @@ public class Fork implements Closeable, Runnable, FinalState {
         .withBranches(this.branches)
         .forBranch(this.index);
 
-    return new PartitionedDataWriter<Object, Object>(builder, this.taskContext.getTaskState());
+    return new PartitionedDataWriter<>(builder, this.taskContext.getTaskState());
   }
 
   private void buildWriterIfNotPresent() throws IOException {
@@ -434,8 +423,8 @@ public class Fork implements Closeable, Runnable, FinalState {
       this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, this.writer.get().recordsWritten());
       this.taskState.setProp(writerRecordsWrittenKey, this.writer.get().recordsWritten());
     } else {
-      this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, 0l);
-      this.taskState.setProp(writerRecordsWrittenKey, 0l);
+      this.forkTaskState.setProp(ConfigurationKeys.WRITER_ROWS_WRITTEN, 0L);
+      this.taskState.setProp(writerRecordsWrittenKey, 0L);
     }
 
     if (schema.isPresent()) {
@@ -509,7 +498,7 @@ public class Fork implements Closeable, Runnable, FinalState {
    * index and the branch name.
    */
   private static List<Tag<?>> getForkMetricsTags(State state, int index) {
-    return ImmutableList.<Tag<?>>of(new Tag<String>(FORK_METRICS_BRANCH_NAME_KEY, getForkMetricsId(state, index)));
+    return ImmutableList.<Tag<?>>of(new Tag<>(FORK_METRICS_BRANCH_NAME_KEY, getForkMetricsId(state, index)));
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -520,9 +520,9 @@ public class Task implements Runnable {
 
   /**
    * Get the final state of each construct used by this task and add it to the {@link gobblin.runtime.TaskState}.
-   * @param extractor {@link gobblin.instrumented.extractor.InstrumentedExtractorBase} used by this task.
-   * @param converter {@link gobblin.converter.Converter} used by this task.
-   * @param rowChecker 
+   * @param extractor the {@link gobblin.instrumented.extractor.InstrumentedExtractorBase} used by this task.
+   * @param converter the {@link gobblin.converter.Converter} used by this task.
+   * @param rowChecker the {@link RowLevelPolicyChecker} used by this task.
    */
   private void addConstructsFinalStateToTaskState(InstrumentedExtractorBase<?, ?> extractor,
       Converter<?, ?, ?, ?> converter, RowLevelPolicyChecker rowChecker) {

--- a/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
@@ -246,7 +246,7 @@ public class ParallelRunner implements Closeable {
     } catch (InterruptedException ie) {
       throw new IOException(ie);
     } catch (ExecutionException ee) {
-      throw new IOException(ee);
+      throw new IOException(ee.getCause());
     } finally {
       ExecutorsUtils.shutdownExecutorService(this.executor, Optional.of(LOGGER));
     }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -231,9 +231,9 @@ public class GobblinYarnAppLauncher {
     }, 0, this.appReportIntervalMinutes, TimeUnit.MINUTES);
 
     List<Service> services = Lists.newArrayList();
-    if (config.hasPath(GobblinYarnConfigurationKeys.KEYTAB_FILE_PATH)) {
+    if (this.config.hasPath(GobblinYarnConfigurationKeys.KEYTAB_FILE_PATH)) {
       LOGGER.info("Adding YarnAppSecurityManager since login is keytab based");
-      services.add(new YarnAppSecurityManager(config, this.helixManager, this.fs));
+      services.add(buildYarnAppSecurityManager());
     }
     services.add(buildLogCopier(
         new Path(this.sinkLogRootDir, this.applicationName + Path.SEPARATOR + this.applicationId.get().toString()),
@@ -602,6 +602,12 @@ public class GobblinYarnAppLauncher {
     }
 
     return logRootDir;
+  }
+
+  private YarnAppSecurityManager buildYarnAppSecurityManager() throws IOException {
+    Path tokenFilePath = new Path(this.fs.getHomeDirectory(), this.applicationName + Path.SEPARATOR +
+        GobblinYarnConfigurationKeys.TOKEN_FILE_NAME);
+    return new YarnAppSecurityManager(this.config, this.helixManager, this.fs, tokenFilePath);
   }
 
   @VisibleForTesting

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinApplicationMasterTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinApplicationMasterTest.java
@@ -38,6 +38,13 @@ import gobblin.yarn.event.ApplicationMasterShutdownRequest;
 /**
  * Unit tests for {@link GobblinApplicationMaster}.
  *
+ * <p>
+ *   This class uses a {@link TestingServer} as an embedded ZooKeeper server for testing. The Curator
+ *   framework is used to provide a ZooKeeper client. This class also uses the {@link HelixManager} to
+ *   act as a testing Helix participant to receive the container (running the {@link GobblinWorkUnitRunner})
+ *   shutdown request message.
+ * </p>
+ *
  * @author ynli
  */
 @Test(groups = { "gobblin.yarn" })

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
@@ -15,14 +15,10 @@ package gobblin.yarn;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
 import org.apache.avro.Schema;
-import org.apache.avro.file.DataFileReader;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -142,22 +138,7 @@ public class GobblinHelixJobLauncherTest {
     Assert.assertTrue(this.jobOutputFile.exists());
 
     Schema schema = new Schema.Parser().parse(TestHelper.SOURCE_SCHEMA);
-
-    try (DataFileReader<GenericRecord> reader =
-        new DataFileReader<>(this.jobOutputFile, new GenericDatumReader<GenericRecord>(schema))) {
-      Iterator<GenericRecord> iterator = reader.iterator();
-
-      GenericRecord record = iterator.next();
-      Assert.assertEquals(record.get("name").toString(), "Alyssa");
-
-      record = iterator.next();
-      Assert.assertEquals(record.get("name").toString(), "Ben");
-
-      record = iterator.next();
-      Assert.assertEquals(record.get("name").toString(), "Charlie");
-
-      Assert.assertFalse(iterator.hasNext());
-    }
+    TestHelper.assertGenericRecords(this.jobOutputFile, schema);
 
     List<JobState.DatasetState> datasetStates = this.fsDatasetStateStore.getAll(this.jobName,
         FsDatasetStateStore.CURRENT_DATASET_STATE_FILE_SUFFIX + FsDatasetStateStore.DATASET_STATE_STORE_TABLE_SUFFIX);

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
@@ -49,6 +49,15 @@ import gobblin.runtime.JobState;
 /**
  * Unit tests for {@link GobblinHelixJobLauncher}.
  *
+ * <p>
+ *   This class uses a {@link TestingServer} as an embedded ZooKeeper server for testing. This class
+ *   also uses the {@link HelixManager} to act as a testing Helix controller to be passed into the
+ *   {@link GobblinHelixJobLauncher} instance. A {@link GobblinWorkUnitRunner} is also used to run
+ *   the single task of the test job. A {@link FsDatasetStateStore} is used to check the state store
+ *   after the job is done. The test job writes everything to the local file system as returned by
+ *   {@link FileSystem#getLocal(Configuration)}.
+ * </p>
+ *
  * @author ynli
  */
 @Test(groups = { "gobblin.yarn" })

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixTaskTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixTaskTest.java
@@ -14,14 +14,10 @@ package gobblin.yarn;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.Iterator;
 import java.util.Map;
 import java.util.Properties;
 
 import org.apache.avro.Schema;
-import org.apache.avro.file.DataFileReader;
-import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -131,22 +127,7 @@ public class GobblinHelixTaskTest {
     Assert.assertTrue(outputAvroFile.exists());
 
     Schema schema = new Schema.Parser().parse(TestHelper.SOURCE_SCHEMA);
-
-    try (DataFileReader<GenericRecord> reader =
-        new DataFileReader<>(outputAvroFile, new GenericDatumReader<GenericRecord>(schema))) {
-      Iterator<GenericRecord> iterator = reader.iterator();
-
-      GenericRecord record = iterator.next();
-      Assert.assertEquals(record.get("name").toString(), "Alyssa");
-
-      record = iterator.next();
-      Assert.assertEquals(record.get("name").toString(), "Ben");
-
-      record = iterator.next();
-      Assert.assertEquals(record.get("name").toString(), "Charlie");
-
-      Assert.assertFalse(iterator.hasNext());
-    }
+    TestHelper.assertGenericRecords(outputAvroFile, schema);
   }
 
   @AfterClass

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixTaskTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixTaskTest.java
@@ -49,17 +49,30 @@ import gobblin.writer.WriterOutputFormat;
 /**
  * Unit tests for {@link GobblinHelixTask}.
  *
+ * <p>
+ *   This class uses a mocked {@link HelixManager} to control the behavior of certain method for testing.
+ *   A {@link TaskExecutor} is used to run the test task and a {@link GobblinHelixTaskStateTracker} is
+ *   also used as being required by {@link GobblinHelixTaskFactory}. The test task writes everything to
+ *   the local file system as returned by {@link FileSystem#getLocal(Configuration)}.
+ * </p>
+ *
  * @author ynli
  */
 @Test(groups = { "gobblin.yarn" })
 public class GobblinHelixTaskTest {
 
   private TaskExecutor taskExecutor;
+
   private GobblinHelixTaskStateTracker taskStateTracker;
+
   private GobblinHelixTask gobblinHelixTask;
+
   private HelixManager helixManager;
+
   private FileSystem localFs;
+
   private Path appWorkDir;
+
   private Path taskOutputDir;
 
   @BeforeClass

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinWorkUnitRunnerTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinWorkUnitRunnerTest.java
@@ -33,6 +33,11 @@ import com.typesafe.config.ConfigFactory;
 /**
  * Unit tests for {@link GobblinWorkUnitRunner}.
  *
+ * <p>
+ *   This class uses a {@link TestingServer} as an embedded ZooKeeper server for testing. A
+ *   {@link GobblinApplicationMaster} instance is used to send the test shutdown request message.
+ * </p>
+ *
  * @author ynli
  */
 @Test(groups = { "gobblin.yarn" })

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -42,6 +42,14 @@ import com.google.common.io.Closer;
 /**
  * Unit tests for {@link GobblinYarnAppLauncher}.
  *
+ * <p>
+ *   This class uses a {@link TestingServer} as an embedded ZooKeeper server for testing. The Curator
+ *   framework is used to provide a ZooKeeper client. This class also uses the {@link HelixManager} to
+ *   act as a testing Helix controller to receive the ApplicationMaster shutdown request message. It
+ *   also starts a {@link MiniYARNCluster} so submission of a Gobblin Yarn application can be tested.
+ *   A {@link YarnClient} is used to work with the {@link MiniYARNCluster}.
+ * </p>
+ *
  * @author ynli
  */
 @Test(groups = { "gobblin.yarn" })

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -151,9 +151,8 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
       if (this.helixManager.isConnected()) {
         this.helixManager.disconnect();
       }
+
       this.gobblinYarnAppLauncher.disconnectHelixManager();
-    } catch (Throwable t) {
-      Assert.fail();
     } finally {
       this.closer.close();
     }

--- a/gobblin-yarn/src/test/java/gobblin/yarn/TestHelper.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/TestHelper.java
@@ -14,6 +14,13 @@ package gobblin.yarn;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Iterator;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.testng.Assert;
 
 import com.google.common.io.Files;
 
@@ -56,5 +63,23 @@ public class TestHelper {
   static void createSourceJsonFile(File sourceJsonFile) throws IOException {
     Files.createParentDirs(sourceJsonFile);
     Files.write(SOURCE_JSON_DOCS, sourceJsonFile, ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
+  }
+
+  static void assertGenericRecords(File outputAvroFile, Schema schema) throws IOException {
+    try (DataFileReader<GenericRecord> reader =
+        new DataFileReader<>(outputAvroFile, new GenericDatumReader<GenericRecord>(schema))) {
+      Iterator<GenericRecord> iterator = reader.iterator();
+
+      GenericRecord record = iterator.next();
+      Assert.assertEquals(record.get("name").toString(), "Alyssa");
+
+      record = iterator.next();
+      Assert.assertEquals(record.get("name").toString(), "Ben");
+
+      record = iterator.next();
+      Assert.assertEquals(record.get("name").toString(), "Charlie");
+
+      Assert.assertFalse(iterator.hasNext());
+    }
   }
 }

--- a/gobblin-yarn/src/test/java/gobblin/yarn/YarnSecurityManagerTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/YarnSecurityManagerTest.java
@@ -1,0 +1,184 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.yarn;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collection;
+
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hdfs.HdfsConfiguration;
+import org.apache.hadoop.hdfs.MiniDFSCluster;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.hadoop.security.token.Token;
+import org.apache.helix.HelixManager;
+import org.apache.helix.HelixManagerFactory;
+import org.apache.helix.InstanceType;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.eventbus.EventBus;
+import com.google.common.io.Closer;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+
+/**
+ * Unit tests for {@link YarnAppSecurityManager} and {@link YarnContainerSecurityManager}.
+ *
+ * <p>
+ *   This class tests {@link YarnAppSecurityManager} and {@link YarnContainerSecurityManager} together
+ *   as it is more convenient to test both here where all dependencies are setup between the two.
+ * </p>
+ *
+ * @author ynli
+ */
+@Test(groups = { "gobblin.yarn" })
+public class YarnSecurityManagerTest {
+
+  private static final int TEST_ZK_PORT = 3185;
+
+  private CuratorFramework curatorFramework;
+
+  private HelixManager helixManager;
+
+  private MiniDFSCluster miniDFSCluster;
+
+  private Configuration dfsConfig;
+  private FileSystem fs;
+  private Path miniHDFSBaseDir;
+  private Path tokenFilePath;
+  private Token<?> token;
+
+  private YarnAppSecurityManager yarnAppSecurityManager;
+  private YarnContainerSecurityManager yarnContainerSecurityManager;
+
+  private final Closer closer = Closer.create();
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    TestingServer testingZKServer = this.closer.register(new TestingServer(TEST_ZK_PORT));
+
+    this.curatorFramework = this.closer.register(
+        CuratorFrameworkFactory.newClient(testingZKServer.getConnectString(), new RetryOneTime(2000)));
+    this.curatorFramework.start();
+
+    URL url = YarnSecurityManagerTest.class.getClassLoader().getResource(
+        YarnSecurityManagerTest.class.getSimpleName() + ".conf");
+    Assert.assertNotNull(url, "Could not find resource " + url);
+
+    Config config = ConfigFactory.parseURL(url).resolve();
+
+    String zkConnectingString = config.getString(GobblinYarnConfigurationKeys.ZK_CONNECTION_STRING_KEY);
+    String helixClusterName = config.getString(GobblinYarnConfigurationKeys.HELIX_CLUSTER_NAME_KEY);
+
+    YarnHelixUtils.createGobblinYarnHelixCluster(zkConnectingString, helixClusterName);
+
+    this.helixManager = HelixManagerFactory.getZKHelixManager(
+        helixClusterName, TestHelper.TEST_HELIX_INSTANCE_NAME, InstanceType.SPECTATOR, zkConnectingString);
+    this.helixManager.connect();
+
+    this.miniHDFSBaseDir = new Path(YarnSecurityManagerTest.class.getSimpleName());
+    this.dfsConfig = getTestConfiguration(this.miniHDFSBaseDir);
+    dfsConfig.set(MiniDFSCluster.HDFS_MINIDFS_BASEDIR, this.miniHDFSBaseDir.toUri().toString());
+    MiniDFSCluster.Builder builder = new MiniDFSCluster.Builder(dfsConfig);
+    this.miniDFSCluster = builder.numDataNodes(1).build();
+
+    this.fs = Mockito.spy(this.closer.register(this.miniDFSCluster.getFileSystem()));
+
+    this.token = new Token<>();
+    this.token.setKind(new Text("test"));
+    this.token.setService(new Text("test"));
+    Mockito.<Token<?>>when(this.fs.getDelegationToken(UserGroupInformation.getLoginUser().getShortUserName()))
+        .thenReturn(this.token);
+
+    this.tokenFilePath = new Path(this.fs.getHomeDirectory(), GobblinYarnConfigurationKeys.TOKEN_FILE_NAME);
+    this.yarnAppSecurityManager = new YarnAppSecurityManager(config, this.helixManager, this.fs, this.tokenFilePath);
+    this.yarnContainerSecurityManager = new YarnContainerSecurityManager(config, this.fs, new EventBus());
+  }
+
+  @Test
+  public void testGetNewDelegationTokenForLoginUser() throws IOException {
+    this.yarnAppSecurityManager.getNewDelegationTokenForLoginUser();
+  }
+
+  @Test(dependsOnMethods = "testGetNewDelegationTokenForLoginUser")
+  public void testWriteDelegationTokenToFile() throws IOException {
+    this.yarnAppSecurityManager.writeDelegationTokenToFile();
+    Assert.assertTrue(this.fs.exists(this.tokenFilePath));
+    assertToken(YarnHelixUtils.readTokensFromFile(this.tokenFilePath, this.dfsConfig));
+  }
+
+  @Test
+  public void testSendTokenFileUpdatedMessage() throws Exception {
+    this.yarnAppSecurityManager.sendTokenFileUpdatedMessage(InstanceType.CONTROLLER);
+    Assert.assertEquals(this.curatorFramework.checkExists().forPath(
+        String.format("/%s/CONTROLLER/MESSAGES", YarnSecurityManagerTest.class.getSimpleName())).getVersion(), 0);
+    Thread.sleep(500);
+    Assert.assertEquals(this.curatorFramework.getChildren().forPath(String.format("/%s/CONTROLLER/MESSAGES",
+        YarnSecurityManagerTest.class.getSimpleName())).size(), 1);
+  }
+
+  @Test(dependsOnMethods = "testWriteDelegationTokenToFile")
+  public void testYarnContainerSecurityManager() throws IOException {
+    Collection<Token<?>> tokens = this.yarnContainerSecurityManager.readDelegationTokens(this.tokenFilePath);
+    assertToken(tokens);
+    this.yarnContainerSecurityManager.addDelegationTokens(tokens);
+    assertToken(UserGroupInformation.getCurrentUser().getTokens());
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    try {
+      if (this.helixManager.isConnected()) {
+        this.helixManager.disconnect();
+      }
+      try {
+        FileSystem.getLocal(this.dfsConfig).delete(this.miniHDFSBaseDir, true);
+      } finally {
+        this.miniDFSCluster.shutdown(true);
+      }
+    } catch (Throwable t) {
+      throw this.closer.rethrow(t);
+    } finally {
+      this.closer.close();
+    }
+  }
+
+  private void assertToken(Collection<Token<?>> tokens) {
+    Assert.assertEquals(tokens.size(), 1);
+    Token<?> token = tokens.iterator().next();
+    Assert.assertEquals(token, this.token);
+  }
+
+  private HdfsConfiguration getTestConfiguration(Path miniHDFSBaseDir) {
+    HdfsConfiguration hdfsConfiguration = new HdfsConfiguration(false);
+
+    hdfsConfiguration.set("dfs.namenode.name.dir", miniHDFSBaseDir.toString());
+    hdfsConfiguration.set("dfs.namenode.edits.dir", miniHDFSBaseDir.toString());
+    hdfsConfiguration.setLong("dfs.namenode.fs-limits.min-block-size", 0L);
+
+    return hdfsConfiguration;
+  }
+}

--- a/gobblin-yarn/src/test/resources/YarnSecurityManagerTest.conf
+++ b/gobblin-yarn/src/test/resources/YarnSecurityManagerTest.conf
@@ -1,0 +1,21 @@
+#
+# Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+
+include "reference"
+
+# Yarn/Helix configuration properties
+gobblin.yarn.helix.cluster.name=YarnSecurityManagerTest
+gobblin.yarn.app.name=YarnSecurityManagerTest
+gobblin.yarn.work.dir=YarnSecurityManagerTest
+gobblin.yarn.zk.connection.string="localhost:3185"
+gobblin.yarn.login.interval.minutes=60
+gobblin.yarn.token.renew.interval.minutes=30


### PR DESCRIPTION
This is the part II of unit tests for Gobblin Yarn. Part II additionally covers `YarnAppSecurityManager` and `YarnContainerSecurityManager`. Currently the only Yarn-dependent class that has no coverage is `YarnService`. Since `YarnService` runs in the `GobblinApplicationMaster` that is supposed to be launched by Yarn without user interference, I'm still trying to figure out a way of running it manually. This PR also addresses the left-over review comments from PR #501.  

Signed-off-by: Yinan Li <liyinan926@gmail.com>