### PR TITLE
Adding Container Metrics for gobblin-yarn

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
@@ -14,7 +14,6 @@ package gobblin.data.management.copy;
 
 import gobblin.data.management.partition.File;
 
-import java.io.IOException;
 import java.util.List;
 
 import lombok.AccessLevel;
@@ -41,15 +40,20 @@ import com.google.gson.reflect.TypeToken;
 @EqualsAndHashCode
 public class CopyableFile implements File {
 
-  private static Gson gson = new Gson();
+  private static final Gson GSON = new Gson();
+
   /** {@link FileStatus} of the existing origin file. */
   private FileStatus origin;
+
   /** Complete destination {@link Path} of the file. Dataset's final publish directory + {@link #relativeDestination} */
   private Path destination;
+
   /** {@link Path} to the file relative to the dataset's final publish directory */
   private Path relativeDestination;
+
   /** Desired {@link OwnerAndPermission} of the destination path. */
   private OwnerAndPermission destinationOwnerAndPermission;
+
   /**
    * Desired {@link OwnerAndPermission} of the ancestor directories of the destination path. The list is ordered from
    * deepest to highest directory.
@@ -65,6 +69,7 @@ public class CopyableFile implements File {
    * </p>
    */
   private List<OwnerAndPermission> ancestorsOwnerAndPermission;
+
   /** Checksum of the origin file. */
   private byte[] checksum;
 
@@ -79,18 +84,18 @@ public class CopyableFile implements File {
    * @param copyableFile to be serialized
    * @return serialized string
    */
-  public static String serialize(CopyableFile copyableFile) throws IOException {
-    return gson.toJson(copyableFile);
+  public static String serialize(CopyableFile copyableFile) {
+    return GSON.toJson(copyableFile);
   }
 
   /**
    * Serialize a {@link List} of {@link CopyableFile}s into a {@link String}.
    *
-   * @param copyableFile to be serialized
+   * @param copyableFiles to be serialized
    * @return serialized string
    */
-  public static String serializeList(List<CopyableFile> copyableFiles) throws IOException {
-    return gson.toJson(copyableFiles, new TypeToken<List<CopyableFile>>(){}.getType());
+  public static String serializeList(List<CopyableFile> copyableFiles) {
+    return GSON.toJson(copyableFiles, new TypeToken<List<CopyableFile>>(){}.getType());
   }
 
   /**
@@ -99,8 +104,8 @@ public class CopyableFile implements File {
    * @param serialized string
    * @return a new instance of {@link CopyableFile}
    */
-  public static CopyableFile deserialize(String serialized) throws IOException {
-    return gson.fromJson(serialized, CopyableFile.class);
+  public static CopyableFile deserialize(String serialized) {
+    return GSON.fromJson(serialized, CopyableFile.class);
   }
 
   /**
@@ -110,7 +115,12 @@ public class CopyableFile implements File {
    * @param serialized string
    * @return a new {@link List} of {@link CopyableFile}s
    */
-  public static List<CopyableFile> deserializeList(String serialized) throws IOException {
-    return gson.fromJson(serialized, new TypeToken<List<CopyableFile>>(){}.getType());
+  public static List<CopyableFile> deserializeList(String serialized) {
+    return GSON.fromJson(serialized, new TypeToken<List<CopyableFile>>(){}.getType());
+  }
+
+  @Override
+  public String toString() {
+    return serialize(this);
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/FileAwareInputStream.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/FileAwareInputStream.java
@@ -29,4 +29,8 @@ public class FileAwareInputStream {
   private CopyableFile file;
   private FSDataInputStream inputStream;
 
+  @Override
+  public String toString() {
+    return this.file.toString();
+  }
 }

--- a/gobblin-metrics/src/main/java/gobblin/metrics/Tagged.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/Tagged.java
@@ -44,8 +44,8 @@ public class Tagged implements Taggable {
 
   @Override
   public void addTag(Tag<?> tag) {
-    Preconditions.checkNotNull(tag);
-    Preconditions.checkNotNull(tag.getValue());
+    Preconditions.checkNotNull(tag, "Cannot add a null Tag");
+    Preconditions.checkNotNull(tag.getValue(), "Cannot add a Tag with a null value. Tag: " + tag);
     this.tags.put(tag.getKey(), tag.getValue());
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
@@ -17,7 +17,6 @@ import java.util.Collections;
 import java.util.List;
 
 import com.google.common.base.Enums;
-import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
-import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
@@ -75,6 +74,7 @@ import gobblin.runtime.util.MetricGroup;
 import gobblin.runtime.util.TimingEventNames;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.HadoopUtils;
 import gobblin.util.JobConfigurationUtils;
 import gobblin.util.JobLauncherUtils;
 import gobblin.util.ParallelRunner;
@@ -558,17 +558,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
       if (Boolean.valueOf(
           configuration.get(ConfigurationKeys.METRICS_ENABLED_KEY, ConfigurationKeys.DEFAULT_METRICS_ENABLED))) {
         this.jobMetrics = Optional.of(JobMetrics.get(this.jobState));
-        String metricFileSuffix =
-            configuration.get(ConfigurationKeys.METRICS_FILE_SUFFIX, ConfigurationKeys.DEFAULT_METRICS_FILE_SUFFIX);
-        // If running in MR mode, all mappers will try to write metrics to the same file, which will fail.
-        // Instead, append the taskAttemptId to each file name.
-        if (Strings.isNullOrEmpty(metricFileSuffix)) {
-          metricFileSuffix = context.getTaskAttemptID().getTaskID().toString();
-        } else {
-          metricFileSuffix += "." + context.getTaskAttemptID().getTaskID().toString();
-        }
-        configuration.set(ConfigurationKeys.METRICS_FILE_SUFFIX, metricFileSuffix);
-        this.jobMetrics.get().startMetricReporting(configuration);
+        this.jobMetrics.get().startMetricReportingWithFileSuffix(HadoopUtils.getStateFromConf(configuration),
+            context.getTaskAttemptID().getTaskID().toString());
       }
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
@@ -14,11 +14,10 @@ package gobblin.runtime.util;
 
 import java.util.List;
 
-import org.apache.hadoop.conf.Configuration;
-
 import com.google.common.collect.Lists;
 
 import gobblin.metrics.GobblinMetrics;
+import gobblin.metrics.MetricContext;
 import gobblin.metrics.Tag;
 import gobblin.runtime.JobState;
 import gobblin.runtime.TaskState;
@@ -35,9 +34,12 @@ public class JobMetrics extends GobblinMetrics {
   protected final String jobName;
 
   protected JobMetrics(JobState job) {
-    super(name(job), null, tagsForJob(job));
-    this.jobName = job.getJobName();
+    this(job, null);
+  }
 
+  protected JobMetrics(JobState job, MetricContext parentContext) {
+    super(name(job), parentContext, tagsForJob(job));
+    this.jobName = job.getJobName();
   }
 
   /**
@@ -59,6 +61,17 @@ public class JobMetrics extends GobblinMetrics {
    */
   public static JobMetrics get(String jobId) {
     return get(null, jobId);
+  }
+
+  /**
+   * Get a new {@link GobblinMetrics} instance for a given job.
+   *
+   * @param jobState the given {@link JobState} instance
+   * @param parentContext is the parent {@link MetricContext}
+   * @return a {@link JobMetrics} instance
+   */
+  public static JobMetrics get(JobState jobState, MetricContext parentContext) {
+    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new JobMetrics(jobState, parentContext));
   }
 
   /**
@@ -93,19 +106,17 @@ public class JobMetrics extends GobblinMetrics {
 
   private static List<Tag<?>> tagsForJob(JobState jobState) {
     List<Tag<?>> tags = Lists.newArrayList();
-    tags.add(new Tag<String>("jobName", jobState.getJobName() == null ? "" : jobState.getJobName()));
-    tags.add(new Tag<String>("jobId", jobState.getJobId()));
+    tags.add(new Tag<>("jobName", jobState.getJobName() == null ? "" : jobState.getJobName()));
+    tags.add(new Tag<>("jobId", jobState.getJobId()));
 
     tags.addAll(getCustomTagsFromState(jobState));
     return tags;
   }
 
   /**
-   * @deprecated
-   * Use {@link ClustersNames#getInstance()#getClusterName()}
+   * @deprecated use {@link ClustersNames#getInstance()#getClusterName()}
    */
   public static String getClusterIdentifierTag() {
     return ClustersNames.getInstance().getClusterName();
   }
-
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
@@ -62,7 +62,7 @@ public class TaskMetrics extends GobblinMetrics {
 
   protected static List<Tag<?>> tagsForTask(TaskState taskState) {
     List<Tag<?>> tags = Lists.newArrayList();
-    tags.add(new Tag<String>("taskId", taskState.getTaskId()));
+    tags.add(new Tag<>("taskId", taskState.getTaskId()));
     tags.addAll(getCustomTagsFromState(taskState));
     return tags;
   }
@@ -71,5 +71,4 @@ public class TaskMetrics extends GobblinMetrics {
     return JobMetrics.get(taskState.getProp(ConfigurationKeys.JOB_NAME_KEY), taskState.getJobId())
         .getMetricContext();
   }
-
 }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/ContainerMetrics.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/ContainerMetrics.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.yarn;
+
+import java.util.List;
+
+import org.apache.hadoop.yarn.api.records.ContainerId;
+
+import com.google.common.collect.ImmutableList;
+
+import gobblin.configuration.State;
+import gobblin.metrics.GobblinMetrics;
+import gobblin.metrics.Tag;
+
+
+/**
+ * Extension of {@link GobblinMetrics} specifically for YARN containers.
+ */
+public class ContainerMetrics extends GobblinMetrics {
+
+  private static final String APPLICATION_NAME = "applicationName";
+  private static final String APPLICATION_ID = "applicationId";
+  private static final String APPLICATION_ATTEMPT_ID = "applicationAttemptId";
+  private static final String CONTAINER_ID = "containerId";
+
+  protected ContainerMetrics(State containerState, String applicationName, ContainerId containerId) {
+    super(name(containerId), null, tagsForContainer(containerState, applicationName, containerId));
+  }
+
+  /**
+   * Get a {@link ContainerMetrics} instance given the {@link State} of a container, the name of the application the
+   * container belongs to, and the {@link ContainerId} of the container.
+   *
+   * @param containerState the {@link State} of the container
+   * @param applicationName a {@link String} representing the name of the application the container belongs to
+   * @param containerId the {@link ContainerId} of the container
+   * @return a {@link ContainerMetrics} instance
+   */
+  public static ContainerMetrics get(State containerState, String applicationName, ContainerId containerId) {
+    return (ContainerMetrics) GOBBLIN_METRICS_REGISTRY
+        .getOrDefault(name(containerId), new ContainerMetrics(containerState, applicationName, containerId));
+  }
+
+  private static String name(ContainerId containerId) {
+    return "gobblin.metrics." + containerId.toString();
+  }
+
+  private static List<Tag<?>> tagsForContainer(State containerState, String applicationName, ContainerId containerId) {
+    ImmutableList.Builder<Tag<?>> tags = new ImmutableList.Builder<>();
+    tags.add(new Tag<>(APPLICATION_NAME, applicationName));
+    tags.add(new Tag<>(APPLICATION_ID, containerId.getApplicationAttemptId().getApplicationId().toString()));
+    tags.add(new Tag<>(APPLICATION_ATTEMPT_ID, containerId.getApplicationAttemptId().getAttemptId()));
+    tags.add(new Tag<>(CONTAINER_ID, containerId.toString()));
+    tags.addAll(getCustomTagsFromState(containerState));
+    return tags.build();
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
@@ -17,13 +17,16 @@ import java.util.List;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskResult;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.Lists;
 
@@ -35,6 +38,7 @@ import gobblin.runtime.JobState;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskState;
 import gobblin.runtime.TaskStateTracker;
+import gobblin.runtime.util.JobMetrics;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.JobLauncherUtils;
@@ -62,6 +66,8 @@ public class GobblinHelixTask implements Task {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GobblinHelixTask.class);
 
+  private final Optional<ContainerMetrics> containerMetrics;
+  private final Optional<JobMetrics> jobMetrics;
   private final TaskExecutor taskExecutor;
   private final TaskStateTracker taskStateTracker;
 
@@ -74,8 +80,11 @@ public class GobblinHelixTask implements Task {
   private final FileSystem fs;
   private final StateStore<TaskState> taskStateStore;
 
-  public GobblinHelixTask(TaskCallbackContext taskCallbackContext, TaskExecutor taskExecutor,
-      TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir) throws IOException {
+  public GobblinHelixTask(TaskCallbackContext taskCallbackContext, Optional<ContainerMetrics> containerMetrics, TaskExecutor taskExecutor,
+      TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir)
+      throws IOException {
+    this.containerMetrics = containerMetrics;
+
     this.taskExecutor = taskExecutor;
     this.taskStateTracker = taskStateTracker;
 
@@ -85,10 +94,18 @@ public class GobblinHelixTask implements Task {
 
     this.fs = fs;
     Path taskStateOutputDir = new Path(appWorkDir, GobblinYarnConfigurationKeys.OUTPUT_TASK_STATE_DIR_NAME);
-    this.taskStateStore = new FsStateStore<TaskState>(this.fs, taskStateOutputDir.toString(), TaskState.class);
+    this.taskStateStore = new FsStateStore<>(this.fs, taskStateOutputDir.toString(), TaskState.class);
 
     Path jobStateFilePath = new Path(appWorkDir, this.jobId + "." + AbstractJobLauncher.JOB_STATE_FILE_NAME);
     SerializationUtils.deserializeState(this.fs, jobStateFilePath, this.jobState);
+
+    if (this.containerMetrics.isPresent()) {
+      // This must be done after the jobState is deserialized from the jobStateFilePath
+      // A reference to jobMetrics is required to ensure it is not evicted from the GobbinMetricsRegistry Cache
+      this.jobMetrics = Optional.of(JobMetrics.get(this.jobState, this.containerMetrics.get().getMetricContext()));
+    } else {
+      this.jobMetrics = Optional.absent();
+    }
   }
 
   @Override
@@ -97,8 +114,9 @@ public class GobblinHelixTask implements Task {
       Path workUnitFilePath =
           new Path(this.taskConfig.getConfigMap().get(GobblinYarnConfigurationKeys.WORK_UNIT_FILE_PATH));
 
-      WorkUnit workUnit = workUnitFilePath.getName().endsWith(AbstractJobLauncher.MULTI_WORK_UNIT_FILE_EXTENSION) ?
-          MultiWorkUnit.createEmpty() : WorkUnit.createEmpty();
+      WorkUnit workUnit =
+          workUnitFilePath.getName().endsWith(AbstractJobLauncher.MULTI_WORK_UNIT_FILE_EXTENSION) ? MultiWorkUnit
+              .createEmpty() : WorkUnit.createEmpty();
       SerializationUtils.deserializeState(this.fs, workUnitFilePath, workUnit);
 
       // The list of individual WorkUnits (flattened) to run
@@ -117,20 +135,21 @@ public class GobblinHelixTask implements Task {
         workUnits.add(workUnit);
       }
 
-      AbstractJobLauncher.runWorkUnits(this.jobId, this.participantId, workUnits, this.taskStateTracker,
-          this.taskExecutor, this.taskStateStore, LOGGER);
-
+      AbstractJobLauncher
+          .runWorkUnits(this.jobId, this.participantId, workUnits, this.taskStateTracker, this.taskExecutor,
+              this.taskStateStore, LOGGER);
       return new TaskResult(TaskResult.Status.COMPLETED, String.format("completed tasks: %d", workUnits.size()));
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();
       return new TaskResult(TaskResult.Status.CANCELED, "");
     } catch (Throwable t) {
+      LOGGER.error("GobblinHelixTask failed due to " + t.getMessage(), t);
       return new TaskResult(TaskResult.Status.ERROR, Throwables.getStackTraceAsString(t));
     }
   }
 
   @Override
   public void cancel() {
-    // TODO: implementation cancellation.
+    // TODO: implement cancellation.
   }
 }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTaskFactory.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTaskFactory.java
@@ -16,12 +16,17 @@ import java.io.IOException;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskFactory;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.codahale.metrics.Counter;
+
+import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 
 import gobblin.runtime.TaskExecutor;
@@ -37,13 +42,27 @@ public class GobblinHelixTaskFactory implements TaskFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GobblinHelixTaskFactory.class);
 
+  private static final String GOBBLIN_YARN_NEW_HELIX_TASK_COUNTER = "gobblin.yarn.new.helix.task";
+
+  private final Optional<ContainerMetrics> containerMetrics;
+
+  /**
+   * A {@link Counter} to count the number of new {@link GobblinHelixTask}s that are created.
+   */
+  private final Optional<Counter> newTasksCounter;
   private final TaskExecutor taskExecutor;
   private final TaskStateTracker taskStateTracker;
   private final FileSystem fs;
   private final Path appWorkDir;
 
-  public GobblinHelixTaskFactory(TaskExecutor taskExecutor, TaskStateTracker taskStateTracker,
-      FileSystem fs, Path appWorkDir) {
+  public GobblinHelixTaskFactory(Optional<ContainerMetrics> containerMetrics, TaskExecutor taskExecutor,
+      TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir) {
+    this.containerMetrics = containerMetrics;
+    if (this.containerMetrics.isPresent()) {
+      this.newTasksCounter = Optional.of(this.containerMetrics.get().getCounter(GOBBLIN_YARN_NEW_HELIX_TASK_COUNTER));
+    } else {
+      this.newTasksCounter = Optional.absent();
+    }
     this.taskExecutor = taskExecutor;
     this.taskStateTracker = taskStateTracker;
     this.fs = fs;
@@ -53,7 +72,11 @@ public class GobblinHelixTaskFactory implements TaskFactory {
   @Override
   public Task createNewTask(TaskCallbackContext context) {
     try {
-      return new GobblinHelixTask(context, this.taskExecutor, this.taskStateTracker, this.fs, this.appWorkDir);
+      if (this.newTasksCounter.isPresent()) {
+        this.newTasksCounter.get().inc();
+      }
+      return new GobblinHelixTask(context, this.containerMetrics, this.taskExecutor, this.taskStateTracker, this.fs,
+          this.appWorkDir);
     } catch (IOException ioe) {
       LOGGER.error("Failed to create a new GobblinHelixTask", ioe);
       throw Throwables.propagate(ioe);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.records.ApplicationAttemptId;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.util.ConverterUtils;
+
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -45,6 +46,7 @@ import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
 import org.apache.helix.task.TaskFactory;
 import org.apache.helix.task.TaskStateModelFactory;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,6 +74,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.GobblinMetrics;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskStateTracker;
 import gobblin.yarn.event.DelegationTokenUpdatedEvent;
@@ -108,6 +111,8 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
   private final String helixInstanceName;
 
+  private final Config config;
+
   private final ContainerId containerId;
 
   private final HelixManager helixManager;
@@ -118,6 +123,8 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
   private final TaskStateModelFactory taskStateModelFactory;
 
+  private final Optional<ContainerMetrics> containerMetrics;
+
   private final MetricRegistry metricRegistry;
 
   private final JmxReporter jmxReporter;
@@ -125,11 +132,12 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
   private volatile boolean stopInProgress = false;
   private volatile boolean isStopped = false;
 
-  public GobblinWorkUnitRunner(String applicationName, String helixInstanceName, ContainerId containerId,
-      Config config, Optional<Path> appWorkDirOptional) throws Exception {
+  public GobblinWorkUnitRunner(String applicationName, String helixInstanceName, ContainerId containerId, Config config,
+      Optional<Path> appWorkDirOptional) throws Exception {
     this.helixInstanceName = helixInstanceName;
-
+    this.config = config;
     this.containerId = containerId;
+
     ApplicationAttemptId applicationAttemptId = this.containerId.getApplicationAttemptId();
     String applicationId = applicationAttemptId.getApplicationId().toString();
 
@@ -140,17 +148,17 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
     String zkConnectionString = config.getString(GobblinYarnConfigurationKeys.ZK_CONNECTION_STRING_KEY);
     LOGGER.info("Using ZooKeeper connection string: " + zkConnectionString);
 
-    this.helixManager = HelixManagerFactory.getZKHelixManager(
-        config.getString(GobblinYarnConfigurationKeys.HELIX_CLUSTER_NAME_KEY), helixInstanceName,
-        InstanceType.PARTICIPANT, zkConnectionString);
+    this.helixManager = HelixManagerFactory
+        .getZKHelixManager(config.getString(GobblinYarnConfigurationKeys.HELIX_CLUSTER_NAME_KEY), helixInstanceName,
+            InstanceType.PARTICIPANT, zkConnectionString);
 
     Properties properties = YarnHelixUtils.configToProperties(config);
 
     TaskExecutor taskExecutor = new TaskExecutor(properties);
     TaskStateTracker taskStateTracker = new GobblinHelixTaskStateTracker(properties, this.helixManager);
 
-    Path appWorkDir = appWorkDirOptional.isPresent() ?
-        appWorkDirOptional.get() : YarnHelixUtils.getAppWorkDirPath(fs, applicationName, applicationId);
+    Path appWorkDir = appWorkDirOptional.isPresent() ? appWorkDirOptional.get() :
+        YarnHelixUtils.getAppWorkDirPath(fs, applicationName, applicationId);
 
     List<Service> services = Lists.newArrayList();
     if (isLogSourcePresent()) {
@@ -165,18 +173,23 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
     this.serviceManager = new ServiceManager(services);
 
+    if (GobblinMetrics.isEnabled(properties)) {
+      this.containerMetrics =
+          Optional.of(ContainerMetrics.get(YarnHelixUtils.configToState(this.config), applicationName, containerId));
+    } else {
+      this.containerMetrics = Optional.absent();
+    }
+
     // Register task factory for the Helix task state model
     Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
     taskFactoryMap.put(GOBBLIN_TASK_FACTORY_NAME,
-        new GobblinHelixTaskFactory(taskExecutor, taskStateTracker, fs, appWorkDir));
+        new GobblinHelixTaskFactory(this.containerMetrics, taskExecutor, taskStateTracker, fs, appWorkDir));
     this.taskStateModelFactory = new TaskStateModelFactory(this.helixManager, taskFactoryMap);
     this.helixManager.getStateMachineEngine().registerStateModelFactory("Task", this.taskStateModelFactory);
 
     this.metricRegistry = new MetricRegistry();
-    this.jmxReporter = JmxReporter.forRegistry(this.metricRegistry)
-        .convertRatesTo(TimeUnit.SECONDS)
-        .convertDurationsTo(TimeUnit.MILLISECONDS)
-        .build();
+    this.jmxReporter = JmxReporter.forRegistry(this.metricRegistry).convertRatesTo(TimeUnit.SECONDS)
+        .convertDurationsTo(TimeUnit.MILLISECONDS).build();
   }
 
   /**
@@ -192,8 +205,13 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
     // Register JVM metrics to collect and report
     registerJvmMetrics();
+
     // Start metric reporting
     this.jmxReporter.start();
+    if (this.containerMetrics.isPresent()) {
+      this.containerMetrics.get()
+          .startMetricReportingWithFileSuffix(YarnHelixUtils.configToState(this.config), this.containerId.toString());
+    }
 
     this.serviceManager.startAsync();
     this.serviceManager.awaitStopped();
@@ -208,10 +226,14 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
     LOGGER.info("Stopping the Gobblin Yarn WorkUnit runner");
 
-    try {
-      // Stop metric reporting
-      this.jmxReporter.stop();
+    // Stop metric reporting
+    this.jmxReporter.stop();
+    if (this.containerMetrics.isPresent()) {
+      this.containerMetrics.get().triggerMetricReporting();
+      this.containerMetrics.get().stopMetricReporting();
+    }
 
+    try {
       // Give the services 5 minutes to stop to ensure that we are responsive to shutdown requests
       this.serviceManager.stopAsync().awaitStopped(5, TimeUnit.MINUTES);
     } catch (TimeoutException te) {
@@ -234,10 +256,11 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
   void connectHelixManager() {
     try {
       this.helixManager.connect();
-      this.helixManager.getMessagingService().registerMessageHandlerFactory(
-          Message.MessageType.SHUTDOWN.toString(), new ParticipantShutdownMessageHandlerFactory());
-      this.helixManager.getMessagingService().registerMessageHandlerFactory(
-          Message.MessageType.USER_DEFINE_MSG.toString(), new ParticipantUserDefinedMessageHandlerFactory());
+      this.helixManager.getMessagingService().registerMessageHandlerFactory(Message.MessageType.SHUTDOWN.toString(),
+          new ParticipantShutdownMessageHandlerFactory());
+      this.helixManager.getMessagingService()
+          .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(),
+              new ParticipantUserDefinedMessageHandlerFactory());
     } catch (Exception e) {
       LOGGER.error("HelixManager failed to connect", e);
       throw Throwables.propagate(e);
@@ -309,9 +332,10 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
       @Override
       public HelixTaskResult handleMessage() throws InterruptedException {
         String messageSubType = this._message.getMsgSubType();
-        Preconditions.checkArgument(
-            messageSubType.equalsIgnoreCase(HelixMessageSubTypes.WORK_UNIT_RUNNER_SHUTDOWN.toString()),
-            String.format("Unknown %s message subtype: %s", Message.MessageType.SHUTDOWN.toString(), messageSubType));
+        Preconditions
+            .checkArgument(messageSubType.equalsIgnoreCase(HelixMessageSubTypes.WORK_UNIT_RUNNER_SHUTDOWN.toString()),
+                String
+                    .format("Unknown %s message subtype: %s", Message.MessageType.SHUTDOWN.toString(), messageSubType));
 
         HelixTaskResult result = new HelixTaskResult();
 
@@ -407,8 +431,8 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
           return helixTaskResult;
         }
 
-        throw new IllegalArgumentException(String.format("Unknown %s message subtype: %s",
-            Message.MessageType.USER_DEFINE_MSG.toString(), messageSubType));
+        throw new IllegalArgumentException(String
+            .format("Unknown %s message subtype: %s", Message.MessageType.USER_DEFINE_MSG.toString(), messageSubType));
       }
 
       @Override
@@ -435,14 +459,14 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
     Options options = buildOptions();
     try {
       CommandLine cmd = new DefaultParser().parse(options, args);
-      if (!cmd.hasOption(GobblinYarnConfigurationKeys.APPLICATION_NAME_OPTION_NAME) ||
-          !cmd.hasOption(GobblinYarnConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME)) {
+      if (!cmd.hasOption(GobblinYarnConfigurationKeys.APPLICATION_NAME_OPTION_NAME) || !cmd
+          .hasOption(GobblinYarnConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME)) {
         printUsage(options);
         System.exit(1);
       }
 
-      Log4jConfigurationHelper.updateLog4jConfiguration(
-          GobblinWorkUnitRunner.class, Log4jConfigurationHelper.LOG4J_CONFIGURATION_FILE_NAME);
+      Log4jConfigurationHelper.updateLog4jConfiguration(GobblinWorkUnitRunner.class,
+          Log4jConfigurationHelper.LOG4J_CONFIGURATION_FILE_NAME);
 
       ContainerId containerId =
           ConverterUtils.toContainerId(System.getenv().get(ApplicationConstants.Environment.CONTAINER_ID.key()));

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnHelixUtils.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnHelixUtils.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.util.Apps;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.hadoop.yarn.util.Records;
+
 import org.apache.helix.manager.zk.ZKHelixManager;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.tools.ClusterSetup;
@@ -43,6 +44,8 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValue;
 
 import com.google.common.collect.Maps;
+
+import gobblin.configuration.State;
 
 
 /**
@@ -126,6 +129,16 @@ public class YarnHelixUtils {
     }
 
     return properties;
+  }
+
+  /**
+   * Convert a given {@link Config} to a {@link State} instance.
+   *
+   * @param config the given {@link Config} instance
+   * @return a {@link State} instance
+   */
+  public static State configToState(Config config) {
+    return new State(configToProperties(config));
   }
 
   /**

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixTaskTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixTaskTest.java
@@ -18,19 +18,24 @@ import java.util.Map;
 import java.util.Properties;
 
 import org.apache.avro.Schema;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
 import org.apache.helix.HelixManager;
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskResult;
+
 import org.mockito.Mockito;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Maps;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -125,7 +130,8 @@ public class GobblinHelixTaskTest {
     Mockito.when(taskCallbackContext.getManager()).thenReturn(this.helixManager);
 
     GobblinHelixTaskFactory gobblinHelixTaskFactory =
-        new GobblinHelixTaskFactory(this.taskExecutor, this.taskStateTracker, this.localFs, this.appWorkDir);
+        new GobblinHelixTaskFactory(Optional.<ContainerMetrics>absent(), this.taskExecutor, this.taskStateTracker,
+            this.localFs, this.appWorkDir);
     this.gobblinHelixTask = (GobblinHelixTask) gobblinHelixTaskFactory.createNewTask(taskCallbackContext);
   }
 


### PR DESCRIPTION
* YARN containers were not reporting any Task Level Metrics (e.g. records extracted, records written, bytes written, etc.) because Metrics Reporting was not enabled in the containers
* Added `ContainerMetrics.java` to handle metrics reporting for each YARN container
* The metrics hierarchy is as follows `ContainerMetrics` -> `JobMetrics` -> `TaskMetrics`
* A `JobMetrics` instance is obtained in each `GobblinHelixTask`
* Unlike `MRJobLauncher` where the `JobMetrics` instance is manually removed from the `GobblinMetricsRegistry`, `GobblinHelixTask` does not remove the `JobMetrics` instance at the end of each task because there may be more tasks in the container that need the `JobMetrics` instance
* Reporting is done on the `ContainerMetrics` instance
* Testing is still in progress

@liyinan926 and @ibuenros can you review?