### PR TITLE
Improvements for Javadoc generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -231,7 +231,7 @@ permalink: /javadoc/${version}/
 //Javadoc initialization for subprojects
 ext.javadocVersion = null != project.version ? project.version : "latest"
 if (ext.javadocVersion.indexOf('-') > 0) {
-  //remove any "-" addons from the version
+  // Remove any "-" addons from the version
   ext.javadocVersion = javadocVersion.substring(0, javadocVersion.indexOf('-'))
 }
 
@@ -252,7 +252,7 @@ subprojects {
     
     rootProject.tasks.javadocTarball.dependsOn project.tasks.javadoc
     if ( rootProject.ext.javadocPackages.contains(project.name)) {
-      def cs = rootProject.tasks.javadocTarball.into(project.name){from(fileTree(dir: "${project.buildDir}/docs/javadoc/"))}
+      rootProject.tasks.javadocTarball.into(project.name){from(fileTree(dir: "${project.buildDir}/docs/javadoc/"))}
     } 
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ idea.project {
 }
 
 ext.build_script_dir = "${projectDir.path}/build_script"
-
+ext.javadocPackages = new ArrayList<String>()
 ext.isDefaultEnvironment = !project.hasProperty('overrideBuildEnvironment')
 
 File getEnvironmentScript()
@@ -203,6 +203,29 @@ task wrapper(type: Wrapper) { gradleVersion = '1.12' }
 
 import javax.tools.ToolProvider
 
+task javadocTarball(type: Tar) {
+  baseName = "gobblin-javadoc-all"
+  destinationDir = new File(project.buildDir, baseName)
+  compression = Compression.GZIP
+  extension = 'tgz'
+  description = "Generates a tar-ball with all javadocs to ${destinationDir}/${archiveName}"
+}
+
+javadocTarball << {
+  def indexFile = new File(destinationDir, "index.md")
+  def version = null != project.version ? project.version : "latest"
+  indexFile << """----
+layout: page
+title: Gobblin Javadoc packages ${version}
+permalink: /javadoc/${version}/
+----
+
+"""
+  rootProject.ext.javadocPackages.each {
+    indexFile << "* [${it}](${it})\n"
+  }
+}
+
 subprojects {
 plugins.withType(JavaPlugin) {
   plugins.apply('idea')
@@ -216,6 +239,13 @@ plugins.withType(JavaPlugin) {
   //Sometimes generating javadocs can lead to OOM. This may needs to be increased.
   javadoc {
     options.JFlags = ["-Xmx256m"]
+  }
+  
+  rootProject.tasks.javadocTarball.dependsOn project.tasks.javadoc
+  def javadocRoot = "${project.buildDir}/docs/javadoc"
+  if ( file(javadocRoot).exists()) {
+    def cs = rootProject.tasks.javadocTarball.into(project.name){from(fileTree(dir: javadocRoot))}
+    rootProject.ext.javadocPackages += project.name
   }
 
 /*  findbugs {
@@ -401,3 +431,4 @@ if (JavaVersion.current().isJava8Compatible()) {
     }
   }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -72,29 +72,32 @@ println "project.version=" + project.version
 
 if (!project.hasProperty('hadoopVersion')) {
   if (project.hasProperty('useHadoop2')) {
-    hadoopVersion = '2.3.0'
+    ext.hadoopVersion = '2.3.0'
   } else {
-    hadoopVersion = '1.2.1'
+    ext.hadoopVersion = '1.2.1'
   }
 }
 
 if (!project.hasProperty('hiveVersion')) {
-  hiveVersion = '1.2.1'
+  ext.hiveVersion = '1.2.1'
 }
 
 if (!project.hasProperty('pegasusVersion')) {
-  pegasusVersion = '1.15.9'
+  ext.pegasusVersion = '1.15.9'
 }
 
 if (!project.hasProperty('bytemanVersion')) {
-  bytemanVersion = '2.2.1'
+  ext.bytemanVersion = '2.2.1'
 }
+
+ext.avroVersion = '1.7.7'
+ext.dropwizardMetricsVersion = '3.1.0'
 
 ext.externalDependency = [
   "antlrRuntime": "org.antlr:antlr-runtime:3.5.2",
-  "avro": "org.apache.avro:avro:1.7.7",
-  "avroMapredH1": "org.apache.avro:avro-mapred:1.7.7:hadoop1",
-  "avroMapredH2": "org.apache.avro:avro-mapred:1.7.7:hadoop2",
+  "avro": "org.apache.avro:avro:" + avroVersion,
+  "avroMapredH1": "org.apache.avro:avro-mapred:" + avroVersion + ":hadoop1",
+  "avroMapredH2": "org.apache.avro:avro-mapred:" + avroVersion + ":hadoop2",
   "commonsCli": "commons-cli:commons-cli:1.3.1",
   "commonsCodec": "commons-codec:commons-codec:1.10",
   "commonsDbcp": "commons-dbcp:commons-dbcp:1.4",
@@ -143,9 +146,9 @@ ext.externalDependency = [
   "log4jextras": "log4j:apache-log4j-extras:1.2.17",
   "slf4jLog4j": "org.slf4j:slf4j-log4j12:1.7.12",
   "jodaTime": "joda-time:joda-time:2.9",
-  "metricsCore": "io.dropwizard.metrics:metrics-core:3.1.0",
-  "metricsJvm": "io.dropwizard.metrics:metrics-jvm:3.1.0",
-  "metricsGraphite": "io.dropwizard.metrics:metrics-graphite:3.1.0",
+  "metricsCore": "io.dropwizard.metrics:metrics-core:" + dropwizardMetricsVersion,
+  "metricsJvm": "io.dropwizard.metrics:metrics-jvm:" + dropwizardMetricsVersion,
+  "metricsGraphite": "io.dropwizard.metrics:metrics-graphite:" + dropwizardMetricsVersion,
   "jsch": "com.jcraft:jsch:0.1.53",
   "jdo2": "javax.jdo:jdo2-api:2.1",
   "azkaban": "com.linkedin.azkaban:azkaban:2.5.0",
@@ -229,7 +232,7 @@ permalink: /javadoc/${version}/
 ext.javadocVersion = null != project.version ? project.version : "latest"
 if (ext.javadocVersion.indexOf('-') > 0) {
   //remove any "-" addons from the version
-  ext.javadocVersion = ext.javadocVersion.substring(0, ext.javadocVersion.indexOf('-'))
+  ext.javadocVersion = javadocVersion.substring(0, javadocVersion.indexOf('-'))
 }
 
 ext.javadocPackages = new HashSet<String>()
@@ -238,8 +241,6 @@ subprojects.each{Project pr ->
     rootProject.ext.javadocPackages += pr.name
   }
 }
-ext.javadocLinks = ext.javadocPackages.collect{"http://linkedin.github.io/gobblin/javadoc/${ext.javadocVersion}/${it}/"}
-//println "GOBBLIN_LINKS=" + ext.javadocLinks
 
 subprojects {
   plugins.withType(JavaPlugin) {
@@ -429,8 +430,15 @@ plugins.withType(JavaPlugin) {
   // Add standard javadoc repositories so we can reference classes in them using @link
   tasks.javadoc.options.links "http://typesafehub.github.io/config/latest/api/",
                               "https://docs.oracle.com/javase/7/docs/api/",
-                              "http://docs.guava-libraries.googlecode.com/git-history/v15.0/javadoc/"
-  rootProject.ext.javadocLinks.each{tasks.javadoc.options.links it}
+                              "http://docs.guava-libraries.googlecode.com/git-history/v15.0/javadoc/",
+                              "http://hadoop.apache.org/docs/r${rootProject.ext.hadoopVersion}/api/",
+                              "https://hive.apache.org/javadocs/r${rootProject.ext.hiveVersion}/api/",
+                              "http://avro.apache.org/docs/${avroVersion}/api/java/",
+                              "https://dropwizard.github.io/metrics/${dropwizardMetricsVersion}/apidocs/"
+  rootProject.ext.javadocPackages.each {
+    tasks.javadoc.options.linksOffline "http://linkedin.github.io/gobblin/javadoc/${javadocVersion}/${it}/",
+                                       "${rootProject.buildDir}/${it}/docs/javadoc/" 
+  }
 
   afterEvaluate {
     // add the standard pegasus dependencies wherever the plugin is used

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,6 @@ idea.project {
 }
 
 ext.build_script_dir = "${projectDir.path}/build_script"
-ext.javadocPackages = new ArrayList<String>()
 ext.isDefaultEnvironment = !project.hasProperty('overrideBuildEnvironment')
 
 File getEnvironmentScript()
@@ -213,7 +212,7 @@ task javadocTarball(type: Tar) {
 
 javadocTarball << {
   def indexFile = new File(destinationDir, "index.md")
-  def version = null != project.version ? project.version : "latest"
+  def version = rootProject.ext.javadocVersion
   indexFile << """----
 layout: page
 title: Gobblin Javadoc packages ${version}
@@ -226,6 +225,38 @@ permalink: /javadoc/${version}/
   }
 }
 
+//Javadoc initialization for subprojects
+ext.javadocVersion = null != project.version ? project.version : "latest"
+if (ext.javadocVersion.indexOf('-') > 0) {
+  //remove any "-" addons from the version
+  ext.javadocVersion = ext.javadocVersion.substring(0, ext.javadocVersion.indexOf('-'))
+}
+
+ext.javadocPackages = new HashSet<String>()
+subprojects.each{Project pr -> 
+  if (file(pr.projectDir.absolutePath + "/src/main/java").exists()) {
+    rootProject.ext.javadocPackages += pr.name
+  }
+}
+ext.javadocLinks = ext.javadocPackages.collect{"http://linkedin.github.io/gobblin/javadoc/${ext.javadocVersion}/${it}/"}
+//println "GOBBLIN_LINKS=" + ext.javadocLinks
+
+subprojects {
+  plugins.withType(JavaPlugin) {
+ 
+    //Sometimes generating javadocs can lead to OOM. This may needs to be increased.
+    javadoc {
+      options.JFlags = ["-Xmx256m"]
+    }
+    
+    rootProject.tasks.javadocTarball.dependsOn project.tasks.javadoc
+    if ( rootProject.ext.javadocPackages.contains(project.name)) {
+      def cs = rootProject.tasks.javadocTarball.into(project.name){from(fileTree(dir: "${project.buildDir}/docs/javadoc/"))}
+    } 
+  }
+}
+
+
 subprojects {
 plugins.withType(JavaPlugin) {
   plugins.apply('idea')
@@ -236,17 +267,6 @@ plugins.withType(JavaPlugin) {
 
   sourceCompatibility = JavaVersion.VERSION_1_7
 
-  //Sometimes generating javadocs can lead to OOM. This may needs to be increased.
-  javadoc {
-    options.JFlags = ["-Xmx256m"]
-  }
-  
-  rootProject.tasks.javadocTarball.dependsOn project.tasks.javadoc
-  def javadocRoot = "${project.buildDir}/docs/javadoc"
-  if ( file(javadocRoot).exists()) {
-    def cs = rootProject.tasks.javadocTarball.into(project.name){from(fileTree(dir: javadocRoot))}
-    rootProject.ext.javadocPackages += project.name
-  }
 
 /*  findbugs {
     ignoreFailures = true
@@ -410,6 +430,7 @@ plugins.withType(JavaPlugin) {
   tasks.javadoc.options.links "http://typesafehub.github.io/config/latest/api/",
                               "https://docs.oracle.com/javase/7/docs/api/",
                               "http://docs.guava-libraries.googlecode.com/git-history/v15.0/javadoc/"
+  rootProject.ext.javadocLinks.each{tasks.javadoc.options.links it}
 
   afterEvaluate {
     // add the standard pegasus dependencies wherever the plugin is used


### PR DESCRIPTION
Change:
1. Added a new task javadocTarball that will create a full tarbal with all javadocs under build/gobblin-javadocs-all
2. Added logic to add links to online Gobblin javadocs so @link references to other projects can work

@liyinan926 @sahilTakiar can you review?