### PR TITLE
Add RawDataset and RawDatasetRetentionPolicy

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -17,6 +17,7 @@ dependencies {
   compile project(":gobblin-utility")
 
   compile externalDependency.commonsLang
+  compile externalDependency.commonsLang3
   compile externalDependency.guava
   compile externalDependency.slf4j
   compile externalDependency.log4j

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/RawDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/RawDataset.java
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.dataset;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import gobblin.annotation.Alpha;
+import gobblin.data.management.retention.policy.RawDatasetRetentionPolicy;
+import gobblin.data.management.retention.policy.RetentionPolicy;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.finder.VersionFinder;
+
+
+/**
+ * {@link DatasetBase} for raw data.
+ *
+ * A raw dataset is a dataset with a corresponding refined dataset. A version of a raw dataset is deletable only if
+ * it satisfies certain conditions with the corresponding version of the refined dataset. For example,
+ * the modification time of the raw dataset should be earlier than the modification time of the corresponding
+ * refined dataset.
+ */
+@Alpha
+public class RawDataset extends DatasetBase<DatasetVersion> {
+
+  public static final String DATASET_CLASS = "dataset.class";
+  public static final String DATASET_RETENTION_POLICY_CLASS = "dataset.retention.policy.class";
+
+  private final Path datasetRoot;
+  private final DatasetBase<DatasetVersion> embeddedDataset;
+  private final RawDatasetRetentionPolicy retentionPolicy;
+
+  public RawDataset(FileSystem fs, Properties props, Path datasetRoot) throws IOException {
+    this(fs, props, datasetRoot, LoggerFactory.getLogger(RawDataset.class));
+  }
+
+  public RawDataset(FileSystem fs, Properties props, Path datasetRoot, Logger log) throws IOException {
+    super(fs, props, log);
+    this.datasetRoot = datasetRoot;
+    this.embeddedDataset = getDataset(fs, props, datasetRoot);
+    this.retentionPolicy = getRetentionPolicy(fs);
+  }
+
+  private DatasetBase<DatasetVersion> getDataset(FileSystem fs, Properties props, Path datasetRoot) {
+    try {
+      @SuppressWarnings("unchecked")
+      Class<? extends DatasetBase<DatasetVersion>> clazz =
+          (Class<? extends DatasetBase<DatasetVersion>>) Class.forName(DATASET_CLASS);
+      return ConstructorUtils.invokeConstructor(clazz, fs, props, datasetRoot);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to instantiate dataset", e);
+    }
+  }
+
+  private RawDatasetRetentionPolicy getRetentionPolicy(FileSystem fs) {
+    try {
+      @SuppressWarnings("unchecked")
+      Class<? extends RawDatasetRetentionPolicy> clazz =
+          (Class<? extends RawDatasetRetentionPolicy>) Class.forName(DATASET_RETENTION_POLICY_CLASS);
+      return (RawDatasetRetentionPolicy) ConstructorUtils.invokeConstructor(clazz, fs,
+          getVersionFinder().versionClass(), this.embeddedDataset.getRetentionPolicy());
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException("Failed to instantiate RetentionPolicy", e);
+    }
+  }
+
+  @Override
+  public VersionFinder<? extends DatasetVersion> getVersionFinder() {
+    return this.embeddedDataset.getVersionFinder();
+  }
+
+  @Override
+  public RetentionPolicy<DatasetVersion> getRetentionPolicy() {
+    return this.retentionPolicy;
+  }
+
+  @Override
+  public Path datasetRoot() {
+    return this.datasetRoot;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/RawDatasetRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/RawDatasetRetentionPolicy.java
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.policy;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Lists;
+
+import gobblin.annotation.Alpha;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.util.FileListUtils;
+
+
+/**
+ * An abstract {@link RetentionPolicy} for {@link gobblin.data.management.retention.dataset.RawDataset}.
+ *
+ * This class embeds another {@link RetentionPolicy}. In {@link #listDeletableVersions(List)} it applies the
+ * embedded {@link RetentionPolicy}'s predicate, as well as {@link #listQualifiedRawDatasetVersions(Collection)}.
+ */
+@Alpha
+public abstract class RawDatasetRetentionPolicy implements RetentionPolicy<DatasetVersion> {
+
+  private final FileSystem fs;
+  private final Class<? extends DatasetVersion> versionClass;
+  private final RetentionPolicy<DatasetVersion> embeddedRetentionPolicy;
+
+  public RawDatasetRetentionPolicy(FileSystem fs, Class<? extends DatasetVersion> versionClass,
+      RetentionPolicy<DatasetVersion> retentionPolicy) {
+    this.fs = fs;
+    this.versionClass = versionClass;
+    this.embeddedRetentionPolicy = retentionPolicy;
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return this.versionClass;
+  }
+
+  @Override
+  public Collection<DatasetVersion> listDeletableVersions(List<DatasetVersion> allVersions) {
+    Collection<DatasetVersion> deletableVersions = this.embeddedRetentionPolicy.listDeletableVersions(allVersions);
+    return listQualifiedRawDatasetVersions(deletableVersions);
+  }
+
+  /**
+   * A raw dataset version is qualified to be deleted, iff the corresponding refined paths exist, and the latest
+   * mod time of all files is in the raw dataset is earlier than the latest mod time of all files in the refined paths.
+   */
+  protected Collection<DatasetVersion> listQualifiedRawDatasetVersions(Collection<DatasetVersion> allVersions) {
+    return Lists.newArrayList(Collections2.filter(allVersions, new Predicate<DatasetVersion>() {
+      @Override
+      public boolean apply(DatasetVersion version) {
+        Iterable<Path> refinedDatasetPaths = getRefinedDatasetPaths(version);
+        try {
+          Optional<Long> latestRawDatasetModTime = getLatestModTime(version.getPathsToDelete());
+          Optional<Long> latestRefinedDatasetModTime = getLatestModTime(refinedDatasetPaths);
+          return latestRawDatasetModTime.isPresent() && latestRefinedDatasetModTime.isPresent()
+              && latestRawDatasetModTime.get() <= latestRefinedDatasetModTime.get();
+        } catch (IOException e) {
+          throw new RuntimeException("Failed to get modification time", e);
+        }
+      }
+    }));
+  }
+
+  private Optional<Long> getLatestModTime(Iterable<Path> paths) throws IOException {
+    long latestModTime = Long.MIN_VALUE;
+    for (FileStatus status : FileListUtils.listMostNestedPathRecursively(this.fs, paths)) {
+      latestModTime = Math.max(latestModTime, status.getModificationTime());
+    }
+    return latestModTime == Long.MIN_VALUE ? Optional.<Long> absent() : Optional.of(latestModTime);
+  }
+
+  /**
+   * Get the corresponding refined paths for a raw dataset version. For example, a raw dataset version
+   * can be a file containing un-deduplicated records, whose corresponding refined dataset path is a file
+   * containing the corresponding deduplicated records.
+   */
+  protected abstract Iterable<Path> getRefinedDatasetPaths(DatasetVersion version);
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/RawDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/RawDatasetProfile.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.profile;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import gobblin.annotation.Alpha;
+import gobblin.data.management.dataset.Dataset;
+import gobblin.data.management.retention.dataset.RawDataset;
+import gobblin.data.management.retention.version.DatasetVersion;
+
+
+/**
+ * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for raw datasets.
+ *
+ * <p>
+ *   A raw dataset is a dataset with a corresponding refined dataset.
+ * </p>
+ */
+@Alpha
+public class RawDatasetProfile<T extends DatasetVersion> extends ConfigurableGlobDatasetFinder {
+
+  public RawDatasetProfile(FileSystem fs, Properties props) throws IOException {
+    super(fs, props);
+  }
+
+  @Override
+  public List<String> requiredProperties() {
+    List<String> requiredProperties = super.requiredProperties();
+    requiredProperties.add(RawDataset.DATASET_CLASS);
+    requiredProperties.add(RawDataset.DATASET_RETENTION_POLICY_CLASS);
+    return requiredProperties;
+  }
+
+  @Override
+  public Dataset datasetAtPath(Path path) throws IOException {
+    return new RawDataset(this.fs, this.props, path);
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/FileListUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/FileListUtils.java
@@ -29,13 +29,11 @@ public class FileListUtils {
     }
   };
 
-  public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path)
-      throws FileNotFoundException, IOException {
+  public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path) throws IOException {
     return listFilesRecursively(fs, path, NO_OP_PATH_FILTER);
   }
 
-  public static List<FileStatus> listFilesRecursively(FileSystem fs, Iterable<Path> paths)
-      throws FileNotFoundException, IOException {
+  public static List<FileStatus> listFilesRecursively(FileSystem fs, Iterable<Path> paths) throws IOException {
     List<FileStatus> results = Lists.newArrayList();
     for (Path path : paths) {
       results.addAll(listFilesRecursively(fs, path));
@@ -48,7 +46,7 @@ public class FileListUtils {
    * filter, that is it is only applied to file {@link Path}s.
    */
   public static List<FileStatus> listFilesRecursively(FileSystem fs, Path path, PathFilter fileFilter)
-      throws FileNotFoundException, IOException {
+      throws IOException {
     return listFilesRecursivelyHelper(fs, Lists.<FileStatus> newArrayList(), fs.getFileStatus(path), fileFilter);
   }
 
@@ -68,9 +66,16 @@ public class FileListUtils {
   /**
    * Method to list out all files, or directory if no file exists, under a specified path.
    */
-  public static List<FileStatus> listMostNestedPathRecursively(FileSystem fs, Path path)
-      throws FileNotFoundException, IOException {
+  public static List<FileStatus> listMostNestedPathRecursively(FileSystem fs, Path path) throws IOException {
     return listMostNestedPathRecursively(fs, path, NO_OP_PATH_FILTER);
+  }
+
+  public static List<FileStatus> listMostNestedPathRecursively(FileSystem fs, Iterable<Path> paths) throws IOException {
+    List<FileStatus> results = Lists.newArrayList();
+    for (Path path : paths) {
+      results.addAll(listMostNestedPathRecursively(fs, path));
+    }
+    return results;
   }
 
   /**
@@ -78,14 +83,14 @@ public class FileListUtils {
    * The specified {@link PathFilter} is treated as a file filter, that is it is only applied to file {@link Path}s.
    */
   public static List<FileStatus> listMostNestedPathRecursively(FileSystem fs, Path path, PathFilter fileFilter)
-      throws FileNotFoundException, IOException {
+      throws IOException {
     return listMostNestedPathRecursivelyHelper(fs, Lists.<FileStatus> newArrayList(), fs.getFileStatus(path),
         fileFilter);
   }
 
   @SuppressWarnings("deprecation")
   private static List<FileStatus> listMostNestedPathRecursivelyHelper(FileSystem fs, List<FileStatus> files,
-      FileStatus fileStatus, PathFilter fileFilter) throws FileNotFoundException, IOException {
+      FileStatus fileStatus, PathFilter fileFilter) throws IOException {
     if (fileStatus.isDir()) {
       FileStatus[] curFileStatus = fs.listStatus(fileStatus.getPath());
       if (ArrayUtils.isEmpty(curFileStatus)) {


### PR DESCRIPTION
A `RawDataset` is a dataset with a corresponding refined dataset (e.g., raw dataset = tracking hourly, refined dataset = tracking daily). A version of a raw dataset is deletable only if it satisfies certain conditions with the corresponding version of the refined dataset. For example, the modification time of the raw dataset should be earlier than the modification time of the corresponding refined dataset.

A `RawDatasetRetentionPolicy` embeds another `RetentionPolicy`. In `listDeletableVersions(List)` it applies the embedded `RetentionPolicy`'s predicate, as well as `listQualifiedRawDatasetVersions(Collection)`.