### PR TITLE
Changes to decrease reliance on timing in unit tests:

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,9 +60,12 @@ if (!project.hasProperty('artifactSnapshotRepository') || project.artifactSnapsh
 }
 
 if (!project.hasProperty('version') || project.version == 'unspecified') {
+    exec {
+        commandLine 'git', 'fetch', '-t', 'https://github.com/linkedin/gobblin.git', 'master'
+    }
     def versionOut = new ByteArrayOutputStream()
     exec {
-        commandLine 'git', 'describe', '--tags'
+        commandLine 'git', 'describe', '--tags', '--always'
         standardOutput versionOut
     }
     def tagStr = versionOut.toString().trim()

--- a/gobblin-api/build.gradle
+++ b/gobblin-api/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     compile externalDependency.lombok
 
     testCompile externalDependency.testng
+    testCompile externalDependency.log4j
 }
 
 configurations {

--- a/gobblin-api/src/main/java/gobblin/testing/AssertWithBackoff.java
+++ b/gobblin-api/src/main/java/gobblin/testing/AssertWithBackoff.java
@@ -1,0 +1,217 @@
+/*
+ * Copyright (C) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.testing;
+
+import java.util.concurrent.TimeoutException;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+
+/**
+ * A helper class to perform a check for a condition with a back-off. Primary use of this is when a tests
+   * needs for something asynchronous to happen, say a service to start.
+ **/
+public class AssertWithBackoff {
+
+  /** the max time in milliseconds to wait for the condition to become true */
+  private long timemoutMs = 30 * 1000;
+  /** a logger to use for logging waiting, results, etc. */
+  private Logger log = LoggerFactory.getLogger(AssertWithBackoff.class);
+  /** the number to multiple the sleep after condition failure */
+  private Optional<Double> backoffFactor = Optional.<Double>absent();
+  /** the max time to sleep between condition failures; */
+  private Optional<Long> maxSleepMs = Optional.<Long>absent();
+
+  public class EqualsCheck<T> implements Predicate<Void> {
+    private final Predicate<T> eqToExpected;
+    private final String message;
+    private final Function<Void, T> actual;
+
+
+    public EqualsCheck(Function<Void, T> actual, T expected, String message) {
+      this.eqToExpected = Predicates.equalTo(expected);
+      this.message = message;
+      this.actual = actual;
+    }
+
+    @Override
+    public boolean apply(Void input) {
+      T currentValue = this.actual.apply(input);
+      getLogger().debug("checking '" + this.message + "': " + currentValue);
+      return this.eqToExpected.apply(currentValue);
+    }
+
+  }
+
+  /** Creates a new instance */
+  public static AssertWithBackoff create() {
+    return new AssertWithBackoff();
+  }
+
+  /** Set the max time in milliseconds to wait for the condition to become true */
+  public AssertWithBackoff timeoutMs(long assertTimeoutMs) {
+    timemoutMs = assertTimeoutMs;
+    if (!this.maxSleepMs.isPresent()) {
+      this.maxSleepMs = Optional.of(getAutoMaxSleep());
+    }
+    if (!this.backoffFactor.isPresent()) {
+      this.backoffFactor = Optional.of(getAutoBackoffFactor());
+    }
+    return this;
+  }
+
+  /** the max time in milliseconds to wait for the condition to become true */
+  public long getTimeoutMs() {
+    return timemoutMs;
+  }
+
+  /** Set the max time to sleep between condition failures */
+  public AssertWithBackoff maxSleepMs(long maxSleepMs) {
+    this.maxSleepMs = Optional.of(maxSleepMs);
+    return this;
+  }
+
+  /** The max time to sleep between condition failures */
+  public long getMaxSleepMs() {
+    return this.maxSleepMs.or(getAutoMaxSleep());
+  }
+
+  /** Set the number to multiple the sleep after condition failure */
+  public AssertWithBackoff backoffFactor(double backoffFactor) {
+    this.backoffFactor = Optional.of(backoffFactor);
+    return this;
+  }
+
+  /** The number to multiple the sleep after condition failure */
+  public double getBackoffFactor() {
+    return this.backoffFactor.or(getAutoBackoffFactor());
+  }
+
+  /** Set the logger to use for logging waiting, results, etc. */
+  public AssertWithBackoff logger(Logger log) {
+    this.log = log;
+    return this;
+  }
+  /** The logger to use for logging waiting, results, etc. */
+  public Logger getLogger() {
+    return this.log;
+  }
+
+  private long getAutoMaxSleep() {
+    return timemoutMs / 3;
+  }
+
+  private double getAutoBackoffFactor() {
+    return Math.log(getMaxSleepMs()) / Math.log(5);
+  }
+
+  /**
+   * Performs a check for a condition with a back-off. Primary use of this is when a tests
+   * needs for something asynchronous to happen, say a service to start.
+   *
+   * @param condition           the condition to wait for
+   * @param assertTimeoutMs     the max time in milliseconds to wait for the condition to become true
+   * @param message             a message to print while waiting for the condition
+   * @param log                 a logger to use for logging waiting, results
+   * @throws TimeoutException   if the condition did not become true in the specified time budget
+   */
+  public void assertTrue(Predicate<Void> condition, String message)
+      throws TimeoutException, InterruptedException {
+        AssertWithBackoff.assertTrue(condition, getTimeoutMs(), message, getLogger(),
+            getBackoffFactor(), getMaxSleepMs());
+  }
+
+  /**
+   * A convenience method for {@link #assertTrue(Predicate, String)} to keep checking until a
+   * certain value until it becomes equal to an expected value.
+   * @param actual    a function that checks the actual value
+   * @param expected  the expected value
+   * @param message   a debugging message
+   **/
+  public <T>void assertEquals(Function<Void, T> actual, T expected, String message)
+      throws TimeoutException, InterruptedException {
+    assertTrue(new EqualsCheck<T>(actual, expected, message), message);
+  }
+
+  /**
+   * Performs a check for a condition with a back-off. Primary use of this is when a tests
+   * needs for something asynchronous to happen, say a service to start.
+   *
+   * @param condition           the condition to wait for
+   * @param assertTimeoutMs     the max time in milliseconds to wait for the condition to become true
+   * @param message             the message to print while waiting for the condition
+   * @param log                 the logger to use for logging waiting, results
+   * @param backoffFactor       the number to multiple the sleep after condition failure;
+   * @param maxSleepMs          the max time to sleep between condition failures; default is
+   * @throws TimeoutException   if the condition did not become true in the specified time budget
+   * @throws InterrupedException if the assert gets interrupted while waiting for the condition to
+   *                            become true.
+   */
+  public static void assertTrue(
+      Predicate<Void> condition, long assertTimeoutMs, String message,
+      Logger log, double backoffFactor, long maxSleepMs)
+          throws TimeoutException, InterruptedException {
+    long startTimeMs = System.currentTimeMillis();
+    long endTimeMs = startTimeMs + assertTimeoutMs;
+    long currentSleepMs = 0;
+    boolean done = false;
+    try {
+      while (!done && System.currentTimeMillis() < endTimeMs) {
+          done = condition.apply(null);
+          if (!done) {
+            currentSleepMs = computeRetrySleep(currentSleepMs, backoffFactor, maxSleepMs,
+                endTimeMs);
+            log.debug("Condition check for '" + message + "' failed; sleeping for " +
+                      currentSleepMs + "ms");
+            Thread.sleep(currentSleepMs);
+          }
+      }
+      //one last try
+      if (!done && !condition.apply(null)) {
+        throw new TimeoutException("Timeout waiting for condition '" + message + "'.");
+      }
+    } catch (TimeoutException|InterruptedException e) {
+      //pass through
+      throw e;
+    } catch (RuntimeException e) {
+      throw new RuntimeException("Exception checking condition '" + message + "':" + e, e);
+    }
+  }
+
+  /**
+   * Computes a new sleep for a retry of a condition check.
+   *
+   * @param currentSleepMs    the last sleep duration in milliseconds
+   * @param backoffFactor     the factor to multiple currentSleepMs
+   * @param maxSleepMs        the maximum allowed sleep in milliseconds
+   * @param endTimeMs         the end time based on timeout for the condition to become true
+   * @return the new sleep time which will not exceed maxSleepMs and will also not cause to
+   *         overshoot endTimeMs
+   */
+  public static long computeRetrySleep(long currentSleepMs, double backoffFactor, long maxSleepMs,
+                                       long endTimeMs) {
+    long newSleepMs = Math.round(currentSleepMs * backoffFactor);
+    if (newSleepMs <= currentSleepMs) {
+      // Prevent infinite loops
+      newSleepMs = currentSleepMs + 1;
+    }
+    long currentTimeMs = System.currentTimeMillis();
+    newSleepMs = Math.min(Math.min(newSleepMs, maxSleepMs), endTimeMs - currentTimeMs);
+    return newSleepMs;
+  }
+
+}

--- a/gobblin-api/src/test/java/gobblin/testing/AssertWithBackoffTest.java
+++ b/gobblin-api/src/test/java/gobblin/testing/AssertWithBackoffTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.testing;
+
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Predicates;
+
+/** Unit tests for {@link AssertWithBackoff} */
+public class AssertWithBackoffTest {
+
+  @BeforeClass
+  public void setUp() {
+    BasicConfigurator.configure();
+    org.apache.log4j.Logger.getRootLogger().setLevel(Level.ERROR);
+  }
+
+  @Test
+  public void testComputeRetrySleep() {
+    final long infiniteFutureMs = Long.MAX_VALUE;
+    Assert.assertEquals(AssertWithBackoff.computeRetrySleep(0, 2, 100, infiniteFutureMs), 1);
+    Assert.assertEquals(AssertWithBackoff.computeRetrySleep(10, 2, 100, infiniteFutureMs), 20);
+    Assert.assertEquals(AssertWithBackoff.computeRetrySleep(50, 1, 100, infiniteFutureMs), 51);
+    Assert.assertEquals(AssertWithBackoff.computeRetrySleep(50, 3, 100, infiniteFutureMs), 100);
+    Assert.assertEquals(AssertWithBackoff.computeRetrySleep(50, 3, 60, System.currentTimeMillis() + 100), 60);
+    long sleepMs = AssertWithBackoff.computeRetrySleep(50, 3, 1000, System.currentTimeMillis() + 100);
+    Assert.assertTrue(sleepMs <= 100);
+  }
+
+  @Test
+  public void testAssertWithBackoff_conditionTrue() throws Exception {
+    Logger log = LoggerFactory.getLogger("testAssertWithBackoff_conditionTrue");
+    AssertWithBackoff.create().logger(log).timeoutMs(1000)
+        .assertTrue(Predicates.<Void>alwaysTrue(), "should always succeed");
+  }
+
+  @Test
+  public void testAssertWithBackoff_conditionEventuallyTrue() throws Exception {
+    Logger log = LoggerFactory.getLogger("testAssertWithBackoff_conditionEventuallyTrue");
+    setLogjLevelForLogger(log, Level.ERROR);
+    final AtomicInteger cnt = new AtomicInteger();
+    AssertWithBackoff.create().logger(log).timeoutMs(100000).backoffFactor(2.0)
+        .assertEquals(new Function<Void, Integer>() {
+          @Override public Integer apply(Void input) { return cnt.incrementAndGet(); }
+        }, 5, "should eventually succeed");
+  }
+
+  @Test
+  public void testAssertWithBackoff_conditionFalse() throws Exception {
+    Logger log = LoggerFactory.getLogger("testAssertWithBackoff_conditionFalse");
+    setLogjLevelForLogger(log, Level.ERROR);
+    long startTimeMs = System.currentTimeMillis();
+    try {
+      AssertWithBackoff.create().logger(log).timeoutMs(50)
+         .assertTrue(Predicates.<Void>alwaysFalse(), "should timeout");
+      Assert.fail("TimeoutException expected");
+    } catch (TimeoutException e) {
+      //Expected
+    }
+    long durationMs = System.currentTimeMillis() - startTimeMs;
+    log.debug("assert took " + durationMs + "ms");
+    Assert.assertTrue(durationMs >= 50L, Long.toString(durationMs) + ">= 50ms");
+  }
+
+  @Test
+  public void testAssertWithBackoff_RuntimeException() throws Exception {
+    Logger log = LoggerFactory.getLogger("testAssertWithBackoff_RuntimeException");
+    setLogjLevelForLogger(log, Level.ERROR);
+    try {
+      AssertWithBackoff.create().logger(log).timeoutMs(50)
+        .assertTrue(new Predicate<Void>() {
+          @Override public boolean apply(Void input) { throw new RuntimeException("BLAH"); }
+        }, "should throw RuntimeException");
+      Assert.fail("should throw RuntimeException");
+    } catch (RuntimeException e) {
+      Assert.assertTrue(e.getMessage().indexOf("BLAH") > 0, e.getMessage());
+    }
+  }
+
+  public static void setLogjLevelForLogger(Logger log, Level logLevel) {
+    org.apache.log4j.Logger log4jLogger = org.apache.log4j.Logger.getLogger(log.getName());
+    log4jLogger.setLevel(logLevel);
+  }
+
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/FileBasedJobLockTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/FileBasedJobLockTest.java
@@ -14,10 +14,19 @@ package gobblin.runtime;
 
 import java.io.IOException;
 import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.log4j.BasicConfigurator;
+import org.apache.log4j.Level;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -36,8 +45,8 @@ public class FileBasedJobLockTest {
   private Path path;
 
   @BeforeClass
-  public void setUp()
-      throws IOException {
+  public void setUp() throws IOException {
+    BasicConfigurator.configure();
     this.fs = FileSystem.getLocal(new Configuration());
     this.path = new Path("MRJobLockTest");
     if (!this.fs.exists(this.path)) {
@@ -45,46 +54,101 @@ public class FileBasedJobLockTest {
     }
   }
 
-  public void testLocalJobLock()
-      throws Exception {
-    final JobLock lock = new FileBasedJobLock(this.fs, this.path.getName(), "MRJobLockTest");
-    final CountDownLatch latch = new CountDownLatch(2);
+  public void testLocalJobLock() throws Exception {
+    // Set to through or fale to enable debug loggin in the threads
+    final AtomicBoolean debugEnabled = new AtomicBoolean(false);
+
+    final JobLock lock =
+        new FileBasedJobLock(this.fs, this.path.getName(),
+            "MRJobLockTest-" + System.currentTimeMillis());
+    final CountDownLatch numTestsToPass = new CountDownLatch(2);
+
+    final Lock stepsLock = new ReentrantLock();
+    final AtomicBoolean thread1Locked = new AtomicBoolean(false);
+    final AtomicBoolean thread2Locked = new AtomicBoolean(false);
+    final Condition thread1Done = stepsLock.newCondition();
+    final Condition thread2Done = stepsLock.newCondition();
 
     Thread thread1 = new Thread(new Runnable() {
       @Override
       public void run() {
+        final Logger log = LoggerFactory.getLogger("testLocalJobLock.thread1");
+        if (debugEnabled.get()) {
+          org.apache.log4j.Logger.getLogger(log.getName()).setLevel(Level.DEBUG);
+        }
         try {
-          Assert.assertTrue(lock.tryLock());
-          Thread.sleep(2000);
-          lock.unlock();
-          latch.countDown();
+          stepsLock.lock();
+          try {
+            log.debug("Acquire the file lock");
+            Assert.assertTrue(lock.tryLock());
+            thread1Locked.set(true);
+            log.debug("Notify thread2 to check the file lock");
+            thread1Done.signal();
+            log.debug("Wait for thread2 to check the file lock");
+            thread2Done.await();
+            log.debug("Release the file lock");
+            lock.unlock();
+            thread1Locked.set(false);
+            log.debug("Notify and wait for thread2 to acquired the file lock");
+            thread1Done.signal();
+            while (!thread2Locked.get()) thread2Done.await();
+            Assert.assertFalse(lock.tryLock());
+            log.debug("Notify thread2 that we are done with the check");
+            thread1Done.signal();
+          } finally {
+            stepsLock.unlock();
+          }
+
+          numTestsToPass.countDown();
         } catch (Exception e) {
-          // Ignored
+          log.error("error: " + e, e);
         }
       }
-    });
+    }, "testLocalJobLock.thread1");
+    thread1.setDaemon(true);
     thread1.start();
-
-    Thread.sleep(1000);
 
     Thread thread2 = new Thread(new Runnable() {
       @Override
       public void run() {
+        final Logger log = LoggerFactory.getLogger("testLocalJobLock.thread2");
+        if (debugEnabled.get()) {
+          org.apache.log4j.Logger.getLogger(log.getName()).setLevel(Level.DEBUG);
+        }
         try {
-          Assert.assertFalse(lock.tryLock());
-          Thread.sleep(2000);
-          Assert.assertTrue(lock.tryLock());
-          Thread.sleep(1000);
+          stepsLock.lock();
+          try {
+            log.debug("Wait for thread1 to acquire the file lock and verify we can't acquire it.");
+            while (!thread1Locked.get()) thread1Done.await();
+            Assert.assertFalse(lock.tryLock());
+            log.debug("Notify thread1 that we are done with the check.");
+            thread2Done.signal();
+            log.debug("Wait for thread1 to release the file lock and try to acquire it.");
+            while (thread1Locked.get()) thread1Done.await();
+            Assert.assertTrue(lock.tryLock());
+            thread2Locked.set(true);
+            thread2Done.signal();
+            log.debug("Wait for thread1 to check the file lock");
+            thread1Done.await();
+
+            //clean up the file lock
+            lock.unlock();
+          } finally {
+            stepsLock.unlock();
+          }
+
           lock.unlock();
-          latch.countDown();
+          numTestsToPass.countDown();
         } catch (Exception e) {
-          // Ignored
+          log.error("error: " + e, e);
         }
       }
-    });
+    }, "testLocalJobLock.thread2");
+    thread2.setDaemon(true);
     thread2.start();
 
-    latch.await();
+    //Wait for some time for the threads to die.
+    Assert.assertTrue(numTestsToPass.await(30, TimeUnit.SECONDS));
   }
 
   @AfterClass

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -46,6 +46,9 @@ public class LocalJobLauncherTest {
 
   @BeforeClass
   public void startUp() throws Exception {
+    System.setProperty("derby.locks.deadlockTrace", "true");
+    System.setProperty("derby.locks.waitTimeout", "180");
+    System.setProperty("derby.locks.deadlockTimeout", "120");
     this.launcherProps = new Properties();
     this.launcherProps.load(new FileReader("gobblin-test/resource/gobblin.test.properties"));
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -21,10 +21,8 @@ import java.util.Properties;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.fs.Path;
-
 import org.jboss.byteman.contrib.bmunit.BMNGRunner;
 import org.jboss.byteman.contrib.bmunit.BMRule;
-
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -52,6 +50,10 @@ public class MRJobLauncherTest extends BMNGRunner {
 
   @BeforeClass
   public void startUp() throws Exception {
+    System.setProperty("derby.locks.deadlockTrace", "true");
+    System.setProperty("derby.locks.waitTimeout", "180");
+    System.setProperty("derby.locks.deadlockTimeout", "120");
+
     this.launcherProps = new Properties();
     this.launcherProps.load(new FileReader("gobblin-test/resource/gobblin.mr-test.properties"));
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, "true");

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinApplicationMasterTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinApplicationMasterTest.java
@@ -22,15 +22,20 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.model.Message;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
 import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import gobblin.testing.AssertWithBackoff;
 import gobblin.yarn.event.ApplicationMasterShutdownRequest;
 
 
@@ -87,36 +92,61 @@ public class GobblinApplicationMasterTest implements HelixMessageTestBase {
     this.gobblinApplicationMaster.connectHelixManager();
   }
 
+  private static class GetMessageNumFunc implements Function<Void, Integer> {
+    private final CuratorFramework curatorFramework;
+
+    public GetMessageNumFunc(CuratorFramework curatorFramework) {
+      this.curatorFramework = curatorFramework;
+    }
+
+    @Override
+    public Integer apply(Void input) {
+      try {
+        return this.curatorFramework.getChildren().forPath(String
+            .format("/%s/INSTANCES/%s/MESSAGES", GobblinApplicationMasterTest.class.getSimpleName(),
+                TestHelper.TEST_HELIX_INSTANCE_NAME)).size();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+  }
+
   @Test
   public void testSendShutdownRequest() throws Exception {
+    Logger log = LoggerFactory.getLogger("testSendShutdownRequest");
     Closer closer = Closer.create();
     try {
       CuratorFramework curatorFramework = TestHelper.createZkClient(this.testingZKServer, closer);
+      final GetMessageNumFunc getMessageNumFunc = new GetMessageNumFunc(curatorFramework);
+      AssertWithBackoff assertWithBackoff =
+          AssertWithBackoff.create().logger(log).timeoutMs(30000);
+
       this.gobblinApplicationMaster.sendShutdownRequest();
 
       Assert.assertEquals(curatorFramework.checkExists().forPath(String
           .format("/%s/INSTANCES/%s/MESSAGES", GobblinApplicationMasterTest.class.getSimpleName(),
               TestHelper.TEST_HELIX_INSTANCE_NAME)).getVersion(), 0);
-      Thread.sleep(500);
-      Assert.assertEquals(curatorFramework.getChildren().forPath(String
-          .format("/%s/INSTANCES/%s/MESSAGES", GobblinApplicationMasterTest.class.getSimpleName(),
-              TestHelper.TEST_HELIX_INSTANCE_NAME)).size(), 1);
+
+      assertWithBackoff.assertEquals(getMessageNumFunc, 1, "1 message queued");
+
       // Give Helix sometime to handle the message
-      Thread.sleep(2000);
-      Assert.assertEquals(curatorFramework.getChildren().forPath(String
-          .format("/%s/INSTANCES/%s/MESSAGES", GobblinApplicationMasterTest.class.getSimpleName(),
-              TestHelper.TEST_HELIX_INSTANCE_NAME)).size(), 0);
+      assertWithBackoff.assertEquals(getMessageNumFunc, 0, "all messages processed");
     } finally {
       closer.close();
     }
   }
 
   @Test(dependsOnMethods = "testSendShutdownRequest")
-  public void testHandleApplicationMasterShutdownRequest() throws InterruptedException {
+  public void testHandleApplicationMasterShutdownRequest() throws Exception {
+    Logger log = LoggerFactory.getLogger("testSendShutdownRequest");
     this.gobblinApplicationMaster.getEventBus().post(new ApplicationMasterShutdownRequest());
-    // Give the ApplicationMaster some time to shutdown
-    Thread.sleep(1000);
-    Assert.assertFalse(this.gobblinApplicationMaster.isHelixManagerConnected());
+    AssertWithBackoff.create().logger(log).timeoutMs(20000)
+      .assertTrue(new Predicate<Void>() {
+        @Override public boolean apply(Void input) {
+          return !GobblinApplicationMasterTest.this.gobblinApplicationMaster.isHelixManagerConnected();
+        }
+      }, "ApplicationMaster shutdown");
   }
 
   @AfterClass

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -17,8 +17,6 @@ import java.net.URL;
 import java.util.concurrent.TimeoutException;
 
 import org.apache.curator.framework.CuratorFramework;
-import org.apache.curator.framework.CuratorFrameworkFactory;
-import org.apache.curator.retry.RetryOneTime;
 import org.apache.curator.test.TestingServer;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.client.api.YarnClient;
@@ -33,10 +31,9 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import com.google.common.io.Closer;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
-import com.google.common.io.Closer;
 
 
 /**
@@ -83,9 +80,8 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     this.yarnClient.start();
 
     TestingServer testingZKServer = this.closer.register(new TestingServer(TEST_ZK_PORT));
-    this.curatorFramework = this.closer.register(
-        CuratorFrameworkFactory.newClient(testingZKServer.getConnectString(), new RetryOneTime(2000)));
-    this.curatorFramework.start();
+
+    this.curatorFramework = TestHelper.createZkClient(testingZKServer, this.closer);
 
     URL url = GobblinYarnAppLauncherTest.class.getClassLoader().getResource(
         GobblinYarnAppLauncherTest.class.getSimpleName() + ".conf");

--- a/gobblin-yarn/src/test/java/gobblin/yarn/TestHelper.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/TestHelper.java
@@ -15,13 +15,19 @@ package gobblin.yarn;
 import java.io.File;
 import java.io.IOException;
 import java.util.Iterator;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileReader;
 import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.curator.framework.CuratorFramework;
+import org.apache.curator.framework.CuratorFrameworkFactory;
+import org.apache.curator.retry.RetryOneTime;
+import org.apache.curator.test.TestingServer;
 import org.testng.Assert;
 
+import com.google.common.io.Closer;
 import com.google.common.io.Files;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -82,4 +88,17 @@ public class TestHelper {
       Assert.assertFalse(iterator.hasNext());
     }
   }
+
+  public static CuratorFramework createZkClient(TestingServer testingZKServer, Closer closer)
+      throws InterruptedException {
+    CuratorFramework curatorFramework =
+        closer.register(CuratorFrameworkFactory.newClient(testingZKServer.getConnectString(),
+            new RetryOneTime(2000)));
+    curatorFramework.start();
+    if (! curatorFramework.blockUntilConnected(60, TimeUnit.SECONDS)) {
+      throw new RuntimeException("Time out waiting to connect to ZK!");
+    }
+    return curatorFramework;
+  }
+
 }


### PR DESCRIPTION
* Wait to connect to ZK in gobblin.yarn.GobblinYarnAppLauncherTest.setUp()
* Add AssertWithBackoff to retry an assert multiple times
* Refactor tests gobblin-yarn/src/test/java/gobblin/yarn/GobblinApplicationMasterTest.java and gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java to use AssertWithBackoff

This is a squashed version of https://github.com/linkedin/gobblin/pull/523