### PR TITLE
Address gradle error in determining javadoc version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -242,7 +242,7 @@ permalink: /javadoc/${version}/
 }
 
 //Javadoc initialization for subprojects
-ext.javadocVersion = null != project.version ? project.version : "latest"
+ext.javadocVersion = null != project.version ? project.version.toString() : "latest"
 if (ext.javadocVersion.indexOf('-') > 0) {
   // Remove any "-" addons from the version
   ext.javadocVersion = javadocVersion.substring(0, javadocVersion.indexOf('-'))


### PR DESCRIPTION
Error is :

* Where:
Build file '/export/home/tester/hudson/data/workspace/etl-infra-gobblin-proxy-code-quality/gobblin-proxy_trunk/gobblin-github/build.gradle' line: 246

* What went wrong:
A problem occurred evaluating root project 'gobblin-github'.
> No signature of method: com.linkedin.ligradle.product.SimpleVersion.indexOf() is applicable for argument types: (java.lang.String) values: [-]
  Possible solutions: findIndexOf(groovy.lang.Closure)
