### PR TITLE
Fixing bug with GobblinMetricsRegistry.getOrDefault

### DIFF
--- a/gobblin-core/src/main/java/gobblin/instrumented/Instrumented.java
+++ b/gobblin-core/src/main/java/gobblin/instrumented/Instrumented.java
@@ -126,16 +126,18 @@ public class Instrumented implements Instrumentable, Closeable {
 
     List<Tag<?>> generatedTags = Lists.newArrayList();
     if (construct != null) {
-      generatedTags.add(new Tag<String>("construct", construct.toString()));
+      generatedTags.add(new Tag<>("construct", construct.toString()));
     }
     if (!klazz.isAnonymousClass()) {
-      generatedTags.add(new Tag<String>("class", klazz.getCanonicalName()));
+      generatedTags.add(new Tag<>("class", klazz.getCanonicalName()));
     }
 
-    GobblinMetrics gobblinMetrics;
-    MetricContext.Builder builder = state.contains(METRIC_CONTEXT_NAME_KEY) &&
-        (gobblinMetrics = GobblinMetricsRegistry.getInstance().get(state.getProp(METRIC_CONTEXT_NAME_KEY))) != null ?
-        gobblinMetrics.getMetricContext().childBuilder(klazz.getCanonicalName() + "." + randomId) :
+    Optional<GobblinMetrics> gobblinMetrics = state.contains(METRIC_CONTEXT_NAME_KEY) ?
+        GobblinMetricsRegistry.getInstance().get(state.getProp(METRIC_CONTEXT_NAME_KEY)) :
+        Optional.<GobblinMetrics>absent();
+
+    MetricContext.Builder builder = gobblinMetrics.isPresent() ?
+        gobblinMetrics.get().getMetricContext().childBuilder(klazz.getCanonicalName() + "." + randomId) :
         MetricContext.builder(klazz.getCanonicalName() + "." + randomId);
     return builder.
         addTags(generatedTags).

--- a/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
@@ -692,7 +692,10 @@ public class MetricContext extends MetricRegistry implements ReportableContext, 
       try {
         return buildStrict();
       } catch (NameConflictException nce) {
-        this.name = this.name + "_" + UUID.randomUUID().toString();
+        String uuid = UUID.randomUUID().toString();
+        LOG.warn("MetricContext with specified name already exists, appending UUID to the given name: " + uuid);
+
+        this.name = this.name + "_" + uuid;
         try {
           return buildStrict();
         } catch (NameConflictException nce2) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/JobMetrics.java
@@ -13,6 +13,7 @@
 package gobblin.runtime.util;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import com.google.common.collect.Lists;
 
@@ -70,8 +71,12 @@ public class JobMetrics extends GobblinMetrics {
    * @param parentContext is the parent {@link MetricContext}
    * @return a {@link JobMetrics} instance
    */
-  public static JobMetrics get(JobState jobState, MetricContext parentContext) {
-    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new JobMetrics(jobState, parentContext));
+  public static JobMetrics get(final JobState jobState, final MetricContext parentContext) {
+    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new Callable<GobblinMetrics>() {
+      @Override public GobblinMetrics call() throws Exception {
+        return new JobMetrics(jobState, parentContext);
+      }
+    });
   }
 
   /**
@@ -80,8 +85,12 @@ public class JobMetrics extends GobblinMetrics {
    * @param jobState the given {@link JobState} instance
    * @return a {@link JobMetrics} instance
    */
-  public static JobMetrics get(JobState jobState) {
-    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new JobMetrics(jobState));
+  public static JobMetrics get(final JobState jobState) {
+    return (JobMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(jobState), new Callable<GobblinMetrics>() {
+      @Override public GobblinMetrics call() throws Exception {
+        return new JobMetrics(jobState);
+      }
+    });
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
@@ -13,6 +13,7 @@
 package gobblin.runtime.util;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import com.google.common.collect.Lists;
 
@@ -43,8 +44,12 @@ public class TaskMetrics extends GobblinMetrics {
    * @param taskState the given {@link TaskState} instance
    * @return a {@link TaskMetrics} instance
    */
-  public static TaskMetrics get(TaskState taskState) {
-    return (TaskMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(taskState), new TaskMetrics(taskState));
+  public static TaskMetrics get(final TaskState taskState) {
+    return (TaskMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(taskState), new Callable<GobblinMetrics>() {
+      @Override public GobblinMetrics call() throws Exception {
+        return new TaskMetrics(taskState);
+      }
+    });
   }
 
   /**

--- a/gobblin-yarn/src/main/java/gobblin/yarn/ContainerMetrics.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/ContainerMetrics.java
@@ -13,6 +13,7 @@
 package gobblin.yarn;
 
 import java.util.List;
+import java.util.concurrent.Callable;
 
 import org.apache.hadoop.yarn.api.records.ContainerId;
 
@@ -46,9 +47,13 @@ public class ContainerMetrics extends GobblinMetrics {
    * @param containerId the {@link ContainerId} of the container
    * @return a {@link ContainerMetrics} instance
    */
-  public static ContainerMetrics get(State containerState, String applicationName, ContainerId containerId) {
-    return (ContainerMetrics) GOBBLIN_METRICS_REGISTRY
-        .getOrDefault(name(containerId), new ContainerMetrics(containerState, applicationName, containerId));
+  public static ContainerMetrics get(final State containerState, final String applicationName,
+      final ContainerId containerId) {
+    return (ContainerMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(containerId), new Callable<GobblinMetrics>() {
+      @Override public GobblinMetrics call() throws Exception {
+        return new ContainerMetrics(containerState, applicationName, containerId);
+      }
+    });
   }
 
   private static String name(ContainerId containerId) {


### PR DESCRIPTION
While doing some testing for ETL-3891 I found that a bunch of duplicate `MetricContext`s were being created. The duplicate `MetricContext`s had name conflicts and thus had a `UUID` appended at the end of the name. The reason the duplicates were being created is due to the behavior of the `GobblinMetricsRegistry.getOrDefault()` method as well as the `get()` methods in `GobblinMetrics`, `JobMetrics`, `ContainerMetrics`, and `TaskMetrics`.

The `getOrDefault` behavior would construct the default value regardless of if the `id` already existed in the `GobblinMetricsRegistry` Cache. So basically, each invocation of `GobblinMetrics.get()` caused a new `GobblinMetrics` instance to be created, which in turn created a new `MetricContext`. These duplicate `MetricContext`s have no references so they are GC'ed pretty fast, but since it seems that every `MetricContext` has a `gobblin.metrics.notifications.timer` it still reports a bunch of garbage info.

@liyinan926 and @ibuenros can you review?