### PR TITLE
Change hive-exec dependency to core.jar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -142,7 +142,7 @@ ext.externalDependency = [
   "hiveService": "org.apache.hive:hive-service:"+hiveVersion,
   "hiveJdbc": "org.apache.hive:hive-jdbc:"+hiveVersion,
   "hiveMetastore": "org.apache.hive:hive-metastore:"+hiveVersion,
-  "hiveExec": "org.apache.hive:hive-exec:"+hiveVersion,
+  "hiveExec": "org.apache.hive:hive-exec:" + hiveVersion + ":core",
   "hiveSerDe": "org.apache.hive:hive-serde:"+hiveVersion,
   "httpclient": "org.apache.httpcomponents:httpclient:4.5",
   "httpcore": "org.apache.httpcomponents:httpcore:4.4.1",

--- a/gobblin-core/src/main/java/gobblin/instrumented/Instrumented.java
+++ b/gobblin-core/src/main/java/gobblin/instrumented/Instrumented.java
@@ -23,7 +23,7 @@ import java.util.concurrent.TimeUnit;
 
 import javax.annotation.Nonnull;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
@@ -29,7 +29,7 @@ import java.util.Date;
 import java.util.Iterator;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -18,7 +18,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcExtractor.java
@@ -32,7 +32,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.apache.commons.codec.binary.Base64;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/MysqlExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/MysqlExtractor.java
@@ -28,7 +28,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/SqlServerExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/SqlServerExtractor.java
@@ -25,7 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java
@@ -21,7 +21,7 @@ import java.util.regex.Pattern;
 import lombok.Getter;
 import lombok.Setter;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaWrapper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaWrapper.java
@@ -40,7 +40,7 @@ import kafka.javaapi.consumer.SimpleConsumer;
 import kafka.javaapi.message.ByteBufferMessageSet;
 import kafka.message.MessageAndOffset;
 
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.NotImplementedException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpLightWeightFileSystem.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpLightWeightFileSystem.java
@@ -24,7 +24,7 @@ import java.net.URI;
 import java.util.List;
 
 import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.BufferedFSInputStream;
 import org.apache.hadoop.fs.FSDataInputStream;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -18,7 +18,7 @@ import java.util.List;
 
 import gobblin.source.extractor.extract.AbstractSource;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/utils/Utils.java
@@ -22,7 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.codehaus.jackson.JsonNode;
 import org.codehaus.jackson.map.ObjectMapper;
 import org.joda.time.DateTime;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/watermark/WatermarkPredicate.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/watermark/WatermarkPredicate.java
@@ -15,7 +15,7 @@ package gobblin.source.extractor.watermark;
 import gobblin.source.extractor.extract.QueryBasedExtractor;
 import java.util.HashMap;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 
 
 public class WatermarkPredicate {

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -17,7 +17,7 @@ import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
 
-import org.apache.commons.lang.ArrayUtils;
+import org.apache.commons.lang3.ArrayUtils;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;


### PR DESCRIPTION
The original jar is a fat jar that contains dependencies such as commons-lang and Guava, which shadow the intended versions.

This also means that gobblin-core no longer has commons-lang, so changing to commons-lang3.