### PR TITLE
Fixing dangling MetricContext creation in ForkOperator

### DIFF
--- a/gobblin-core/src/main/java/gobblin/instrumented/fork/InstrumentedForkOperatorDecorator.java
+++ b/gobblin-core/src/main/java/gobblin/instrumented/fork/InstrumentedForkOperatorDecorator.java
@@ -14,6 +14,8 @@ package gobblin.instrumented.fork;
 
 import java.util.List;
 
+import com.google.common.base.Optional;
+
 import gobblin.configuration.WorkUnitState;
 import gobblin.fork.ForkOperator;
 import gobblin.instrumented.Instrumented;
@@ -33,6 +35,7 @@ public class InstrumentedForkOperatorDecorator<S, D> extends InstrumentedForkOpe
   private boolean isEmbeddedInstrumented;
 
   public InstrumentedForkOperatorDecorator(ForkOperator<S, D> forkOperator) {
+    super(Optional.<Class<?>>of(DecoratorUtils.resolveUnderlyingObject(forkOperator).getClass()));
     this.embeddedForkOperator = this.closer.register(forkOperator);
     this.isEmbeddedInstrumented = Instrumented.isLineageInstrumented(forkOperator);
   }

--- a/gobblin-scheduler/src/test/java/gobblin/scheduler/JobConfigFileMonitorTest.java
+++ b/gobblin-scheduler/src/test/java/gobblin/scheduler/JobConfigFileMonitorTest.java
@@ -77,7 +77,7 @@ public class JobConfigFileMonitorTest {
   public void testAddNewJobConfigFile()
       throws Exception {
     final Logger log = LoggerFactory.getLogger("testAddNewJobConfigFile");
-    AssertWithBackoff assertWithBackoff = AssertWithBackoff.create().logger(log).timeoutMs(5000);
+    AssertWithBackoff assertWithBackoff = AssertWithBackoff.create().logger(log).timeoutMs(7500);
     assertWithBackoff.assertEquals(new GetNumScheduledJobs(), 3, "3 scheduled jobs");
 
     // Create a new job configuration file by making a copy of an existing
@@ -111,7 +111,7 @@ public class JobConfigFileMonitorTest {
     jobProps.setProperty(ConfigurationKeys.JOB_COMMIT_POLICY_KEY, "partial");
     jobProps.store(new FileWriter(this.newJobConfigFile), null);
 
-    AssertWithBackoff.create().logger(log).timeoutMs(5000)
+    AssertWithBackoff.create().logger(log).timeoutMs(7500)
         .assertEquals(new GetNumScheduledJobs(), 4, "4 scheduled jobs");
 
     Set<String> jobNames = Sets.newHashSet(this.jobScheduler.getScheduledJobs());
@@ -136,7 +136,7 @@ public class JobConfigFileMonitorTest {
     jobProps.store(new FileWriter(this.newJobConfigFile), null);
 
 
-    AssertWithBackoff.create().logger(log).timeoutMs(5000)
+    AssertWithBackoff.create().logger(log).timeoutMs(7500)
         .assertEquals(new GetNumScheduledJobs(), 3, "3 scheduled jobs");
 
     Set<String> jobNames = Sets.newHashSet(this.jobScheduler.getScheduledJobs());


### PR DESCRIPTION
The class `InstrumentedForkOperatorBase` would create a new `MetricContext` in its default constructor, but it would make it with no parent (the correct parent should get the `Task` level `MetricContext`). Then during the `init()` method it would create a new `MetricContext` (this time with the correct parent). The first `MetricContext` would be GC'ed quite quickly as it has no references, but it causes some duplicate reporting so it's best to remove it.

@ibuenros can you review