### PR TITLE
Migrating KafkaReporter and OutputStreamReporter to MetricReportReporter

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
@@ -311,7 +311,7 @@ public class MRCompactor implements Compactor {
         this.closer.close();
       } finally {
         deleteDependencyJars();
-        gobblinMetrics.stopMetricReporting();
+        gobblinMetrics.stopMetricsReporting();
       }
     }
   }

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -47,7 +47,7 @@ dependencies {
   compile externalDependency.findBugs
   compile externalDependency.mockito
   compile externalDependency.lombok
-
+  compile externalDependency.typesafeConfig
 
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2

--- a/gobblin-core/src/main/java/gobblin/metrics/ConsoleEventReporterFactory.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/ConsoleEventReporterFactory.java
@@ -22,11 +22,12 @@ import gobblin.metrics.reporter.OutputStreamEventReporter;
 
 /**
  * A reporter factory to report event to console.
+ *
  * <p>
- * Set metrics.reporting.custom.builders=gobblin.metrics.ConsoleEventReporterFactory to report event to console
+ *   Set metrics.reporting.custom.builders=gobblin.metrics.ConsoleEventReporterFactory to report event to console
  * </p>
  */
-public class ConsoleEventReporterFactory implements CustomReporterFactory {
+public class ConsoleEventReporterFactory implements CustomCodahaleReporterFactory {
 
   @Override
   public ScheduledReporter newScheduledReporter(MetricRegistry registry, Properties properties) throws IOException {

--- a/gobblin-core/src/main/java/gobblin/metrics/ConsoleReporterFactory.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/ConsoleReporterFactory.java
@@ -11,24 +11,24 @@
  */
 package gobblin.metrics;
 
-import gobblin.metrics.reporter.OutputStreamReporter;
-
 import java.io.IOException;
 import java.util.Properties;
 
-import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.ScheduledReporter;
+import gobblin.metrics.reporter.OutputStreamReporter;
+import gobblin.metrics.reporter.ScheduledReporter;
 
 
 /**
  * A reporter factory to report metrics to console.
- * <p>Set
- * metrics.reporting.custom.builders=gobblin.metrics.ConsoleReporterFactory to report event to console</p>
+ *
+ * <p>
+ *   Set metrics.reporting.custom.builders=gobblin.metrics.ConsoleReporterFactory to report event to console
+ * </p>
  */
 public class ConsoleReporterFactory implements CustomReporterFactory {
 
   @Override
-  public ScheduledReporter newScheduledReporter(MetricRegistry registry, Properties properties) throws IOException {
-    return OutputStreamReporter.forRegistry(registry).build();
+  public ScheduledReporter newScheduledReporter(Properties properties) throws IOException {
+    return OutputStreamReporter.Factory.newBuilder().build(properties);
   }
 }

--- a/gobblin-core/src/main/java/gobblin/metrics/CustomCodahaleReporterFactory.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/CustomCodahaleReporterFactory.java
@@ -15,19 +15,21 @@ package gobblin.metrics;
 import java.io.IOException;
 import java.util.Properties;
 
-import gobblin.metrics.reporter.ScheduledReporter;
+import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.ScheduledReporter;
 
 
 /**
  * BuilderFactory for custom {@link ScheduledReporter}. Implementations should have a parameter-less constructor.
  */
-public interface CustomReporterFactory {
+public interface CustomCodahaleReporterFactory {
 
   /**
-   * Builds and returns a new {@link com.codahale.metrics.ScheduledReporter}.
+   * Builds and returns a new {@link ScheduledReporter}.
    *
+   * @param registry {@link MetricRegistry} for which metrics should be reported.
    * @param properties {@link Properties} used to build the reporter.
    * @return new {@link ScheduledReporter}.
    */
-  public ScheduledReporter newScheduledReporter(Properties properties) throws IOException;
+  public ScheduledReporter newScheduledReporter(MetricRegistry registry, Properties properties) throws IOException;
 }

--- a/gobblin-core/src/main/java/gobblin/metrics/KafkaReportingFormats.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/KafkaReportingFormats.java
@@ -31,21 +31,21 @@ public enum KafkaReportingFormats {
 
   /**
    * Get a {@link gobblin.metrics.kafka.KafkaReporter.Builder} for this reporting format.
-   * @param context {@link gobblin.metrics.MetricContext} that should be reported.
+   *
    * @param properties {@link java.util.Properties} containing information to build reporters.
    * @return {@link gobblin.metrics.kafka.KafkaReporter.Builder}.
    */
-  public KafkaReporter.Builder<?> metricReporterBuilder(MetricContext context, Properties properties) {
+  public KafkaReporter.Builder<?> metricReporterBuilder(Properties properties) {
     switch (this) {
       case AVRO:
-        KafkaAvroReporter.Builder<?> builder = KafkaAvroReporter.forContext(context);
+        KafkaAvroReporter.Builder<?> builder = KafkaAvroReporter.BuilderFactory.newBuilder();
         if (Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY,
             ConfigurationKeys.DEFAULT_METRICS_REPORTING_KAFKA_USE_SCHEMA_REGISTRY))) {
           builder.withSchemaRegistry(new KafkaAvroSchemaRegistry(properties));
         }
         return builder;
       case JSON:
-        return KafkaReporter.forContext(context);
+        return KafkaReporter.BuilderFactory.newBuilder();
       default:
         // This should never happen.
         throw new IllegalArgumentException("KafkaReportingFormat not recognized.");
@@ -74,5 +74,4 @@ public enum KafkaReportingFormats {
         throw new IllegalArgumentException("KafkaReportingFormat not recognized.");
     }
   }
-
 }

--- a/gobblin-core/src/test/java/gobblin/instrumented/InstrumentedTest.java
+++ b/gobblin-core/src/test/java/gobblin/instrumented/InstrumentedTest.java
@@ -49,6 +49,8 @@ public class InstrumentedTest {
     expectedTags.put("class", InstrumentedExtractor.class.getCanonicalName());
     expectedTags.put(MetricContext.METRIC_CONTEXT_ID_TAG_NAME,
         tags.get(MetricContext.METRIC_CONTEXT_ID_TAG_NAME).toString());
+    expectedTags.put(MetricContext.METRIC_CONTEXT_NAME_TAG_NAME,
+        tags.get(MetricContext.METRIC_CONTEXT_NAME_TAG_NAME).toString());
 
     Assert.assertEquals(tags.size(), expectedTags.size());
     for(Map.Entry<String, ?> tag : tags.entrySet()) {

--- a/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/MetricContext.java
@@ -82,6 +82,8 @@ public class MetricContext extends MetricRegistry implements ReportableContext, 
   protected final Closer closer;
 
   public static final String METRIC_CONTEXT_ID_TAG_NAME = "metricContextID";
+  public static final String METRIC_CONTEXT_NAME_TAG_NAME = "metricContextName";
+
   @Getter
   private final InnerMetricContext innerMetricContext;
 
@@ -118,7 +120,7 @@ public class MetricContext extends MetricRegistry implements ReportableContext, 
     this.notificationTimer = new ContextAwareTimer(this, GOBBLIN_METRICS_NOTIFICATIONS_TIMER_NAME);
     register(this.notificationTimer);
 
-    if(!isRoot) {
+    if (!isRoot) {
       RootMetricContext.get().addMetricContext(this);
     }
   }

--- a/gobblin-metrics/src/main/java/gobblin/metrics/context/filter/ContextFilterFactory.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/context/filter/ContextFilterFactory.java
@@ -45,7 +45,7 @@ public class ContextFilterFactory {
    */
   public static ContextFilter createContextFilter(Config config) {
     // For now always return an accept-all context filter.
-    if(config.hasPath(CONTEXT_FILTER_CLASS)) {
+    if (config.hasPath(CONTEXT_FILTER_CLASS)) {
       try {
         return ContextFilter.class.cast(
             ConstructorUtils.invokeConstructor(Class.forName(config.getString(CONTEXT_FILTER_CLASS)), config));
@@ -55,5 +55,4 @@ public class ContextFilterFactory {
     }
     return new AllContextFilter();
   }
-
 }

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
@@ -13,42 +13,39 @@
 package gobblin.metrics.kafka;
 
 import java.io.IOException;
+import java.util.Properties;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import com.codahale.metrics.MetricRegistry;
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
-import gobblin.metrics.MetricContext;
+import com.typesafe.config.Config;
+
 import gobblin.metrics.MetricReport;
 import gobblin.metrics.reporter.MetricReportReporter;
 import gobblin.metrics.reporter.util.AvroJsonSerializer;
 import gobblin.metrics.reporter.util.AvroSerializer;
 import gobblin.metrics.reporter.util.FixedSchemaVersionWriter;
 import gobblin.metrics.reporter.util.SchemaVersionWriter;
+import gobblin.util.ConfigUtils;
 
 
 /**
- * Kafka reporter for Codahale metrics.
+ * Kafka reporter for metrics.
  *
  * @author ibuenros
  */
 public class KafkaReporter extends MetricReportReporter {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(KafkaReporter.class);
-
   protected final AvroSerializer<MetricReport> serializer;
   protected final KafkaPusher kafkaPusher;
 
-  protected KafkaReporter(Builder<?> builder) throws IOException {
-    super(builder);
+  protected KafkaReporter(Builder<?> builder, Config config) throws IOException {
+    super(builder, config);
 
     this.serializer = this.closer.register(
         createSerializer(new FixedSchemaVersionWriter()));
 
-    if(builder.kafkaPusher.isPresent()) {
+    if (builder.kafkaPusher.isPresent()) {
       this.kafkaPusher = builder.kafkaPusher.get();
     } else {
       this.kafkaPusher = this.closer.register(new KafkaPusher(builder.brokers, builder.topic));
@@ -56,65 +53,22 @@ public class KafkaReporter extends MetricReportReporter {
   }
 
   protected AvroSerializer<MetricReport> createSerializer(SchemaVersionWriter schemaVersionWriter) throws IOException {
-    return new AvroJsonSerializer<MetricReport>(MetricReport.SCHEMA$, schemaVersionWriter);
+    return new AvroJsonSerializer<>(MetricReport.SCHEMA$, schemaVersionWriter);
   }
 
   /**
-   * Returns a new {@link KafkaReporter.Builder} for {@link KafkaReporter}.
-   * If the registry is of type {@link gobblin.metrics.MetricContext} tags will NOT be inherited.
-   * To inherit tags, use forContext method.
+   * A static factory class for obtaining new {@link gobblin.metrics.kafka.KafkaReporter.Builder}s
    *
-   * @param registry the registry to report
-   * @return KafkaReporter builder
-   * @deprecated This method is bugged. Use {@link gobblin.metrics.kafka.KafkaReporter.Factory#forRegistry}.
+   * @see {@link gobblin.metrics.kafka.KafkaReporter.Builder}
    */
-  @Deprecated
-  public static Builder<? extends Builder> forRegistry(MetricRegistry registry) {
-    return new BuilderImpl(registry);
-  }
+  public static class BuilderFactory {
 
-  /**
-   * Returns a new {@link KafkaReporter.Builder} for {@link KafkaReporter}.
-   * Will automatically add all Context tags to the reporter.
-   *
-   * @param context the {@link gobblin.metrics.MetricContext} to report
-   * @return KafkaReporter builder
-   * @deprecated This method is bugged. Use {@link gobblin.metrics.kafka.KafkaReporter.Factory#forContext}.
-   */
-  @Deprecated
-  public static Builder<?> forContext(MetricContext context) {
-    return forRegistry(context);
-  }
-
-  public static class Factory {
-    /**
-     * Returns a new {@link KafkaReporter.Builder} for {@link KafkaReporter}.
-     * If the registry is of type {@link gobblin.metrics.MetricContext} tags will NOT be inherited.
-     * To inherit tags, use forContext method.
-     *
-     * @param registry the registry to report
-     * @return KafkaReporter builder
-     */
-    public static BuilderImpl forRegistry(MetricRegistry registry) {
-      return new BuilderImpl(registry);
-    }
-
-    /**
-     * Returns a new {@link KafkaReporter.Builder} for {@link KafkaReporter}.
-     * Will automatically add all Context tags to the reporter.
-     *
-     * @param context the {@link gobblin.metrics.MetricContext} to report
-     * @return KafkaReporter builder
-     */
-    public static BuilderImpl forContext(MetricContext context) {
-      return forRegistry(context);
+    public static BuilderImpl newBuilder() {
+      return new BuilderImpl();
     }
   }
 
   public static class BuilderImpl extends Builder<BuilderImpl> {
-    private BuilderImpl(MetricRegistry registry) {
-      super(registry);
-    }
 
     @Override
     protected BuilderImpl self() {
@@ -123,17 +77,16 @@ public class KafkaReporter extends MetricReportReporter {
   }
 
   /**
-   * Builder for {@link KafkaReporter}.
-   * Defaults to no filter, reporting rates in seconds and times in milliseconds.
+   * Builder for {@link KafkaReporter}. Defaults to no filter, reporting rates in seconds and times in milliseconds.
    */
   public static abstract class Builder<T extends MetricReportReporter.Builder<T>>
       extends MetricReportReporter.Builder<T> {
+
     protected String brokers;
     protected String topic;
     protected Optional<KafkaPusher> kafkaPusher;
 
-    protected Builder(MetricRegistry registry) {
-      super(registry);
+    protected Builder() {
       this.kafkaPusher = Optional.absent();
     }
 
@@ -152,17 +105,16 @@ public class KafkaReporter extends MetricReportReporter {
      * @param topic topic to send metrics to
      * @return KafkaReporter
      */
-    public KafkaReporter build(String brokers, String topic) throws IOException {
+    public KafkaReporter build(String brokers, String topic, Properties props) throws IOException {
       this.brokers = brokers;
       this.topic = topic;
-      return new KafkaReporter(this);
-    }
 
+      return new KafkaReporter(this, ConfigUtils.propertiesToConfig(props));
+    }
   }
 
   @Override
   protected void emitReport(MetricReport report) {
     this.kafkaPusher.pushMessages(Lists.newArrayList(this.serializer.serializeRecord(report)));
   }
-
 }

--- a/gobblin-metrics/src/test/java/gobblin/metrics/MetricContextTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/MetricContextTest.java
@@ -73,7 +73,7 @@ public class MetricContextTest {
     Assert.assertEquals(this.context.getName(), contextName);
     Assert.assertTrue(this.context.getParent().isPresent());
     Assert.assertEquals(this.context.getParent().get(), RootMetricContext.get());
-    Assert.assertEquals(this.context.getTags().size(), 2); // uuid tag gets added automatically
+    Assert.assertEquals(this.context.getTags().size(), 3); // uuid and name tag gets added automatically
     Assert.assertEquals(this.context.getTags().get(0).getKey(), JOB_ID_KEY);
     Assert.assertEquals(this.context.getTags().get(0).getValue(), JOB_ID_PREFIX + 0);
     // Second tag should be uuid
@@ -90,12 +90,13 @@ public class MetricContextTest {
     Assert.assertEquals(this.childContext.getName(), CHILD_CONTEXT_NAME);
     Assert.assertTrue(this.childContext.getParent().isPresent());
     Assert.assertEquals(this.childContext.getParent().get(), this.context);
-    Assert.assertEquals(this.childContext.getTags().size(), 3);
+    Assert.assertEquals(this.childContext.getTags().size(), 4);
     Assert.assertEquals(this.childContext.getTags().get(0).getKey(), JOB_ID_KEY);
     Assert.assertEquals(this.childContext.getTags().get(0).getValue(), JOB_ID_PREFIX + 0);
     Assert.assertEquals(this.childContext.getTags().get(1).getKey(), MetricContext.METRIC_CONTEXT_ID_TAG_NAME);
-    Assert.assertEquals(this.childContext.getTags().get(2).getKey(), TASK_ID_KEY);
-    Assert.assertEquals(this.childContext.getTags().get(2).getValue(), TASK_ID_PREFIX + 0);
+    Assert.assertEquals(this.childContext.getTags().get(2).getKey(), MetricContext.METRIC_CONTEXT_NAME_TAG_NAME);
+    Assert.assertEquals(this.childContext.getTags().get(3).getKey(), TASK_ID_KEY);
+    Assert.assertEquals(this.childContext.getTags().get(3).getValue(), TASK_ID_PREFIX + 0);
   }
 
   @Test(dependsOnMethods = "testChildContext")

--- a/gobblin-metrics/src/test/java/gobblin/metrics/RootMetricContextTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/RootMetricContextTest.java
@@ -12,18 +12,19 @@
 
 package gobblin.metrics;
 
-import junit.framework.Assert;
-import lombok.AllArgsConstructor;
-
 import java.lang.ref.WeakReference;
 import java.util.UUID;
 
+import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Predicate;
+
 import com.typesafe.config.ConfigFactory;
+
+import lombok.AllArgsConstructor;
 
 import gobblin.metrics.callback.NotificationStore;
 import gobblin.metrics.notification.MetricContextCleanupNotification;
@@ -37,25 +38,27 @@ import gobblin.metrics.reporter.ContextStoreReporter;
  */
 public class RootMetricContextTest {
 
-  @BeforeMethod public void setUp() throws Exception {
-
+  @BeforeMethod
+  public void setUp() throws Exception {
     System.gc();
     RootMetricContext.get().clearNotificationTargets();
   }
 
-  @AfterMethod public void tearDown() throws Exception {
+  @AfterMethod
+  public void tearDown() throws Exception {
     System.gc();
     RootMetricContext.get().clearNotificationTargets();
   }
 
-  @Test public void testGet() throws Exception {
-
+  @Test
+  public void testGet() throws Exception {
     Assert.assertNotNull(RootMetricContext.get());
     Assert.assertEquals(RootMetricContext.get(), RootMetricContext.get());
     Assert.assertEquals(RootMetricContext.get().getName(), RootMetricContext.ROOT_METRIC_CONTEXT);
   }
 
-  @Test public void testMetricContextLifecycle() throws Exception {
+  @Test
+  public void testMetricContextLifecycle() throws Exception {
 
     String name = UUID.randomUUID().toString();
     NotificationStore store = new NotificationStore(new ContextNamePredicate(name));
@@ -156,7 +159,6 @@ public class RootMetricContextTest {
     ensureGarbageCollected(innerMetricContextWeakReference);
 
     RootMetricContext.get().removeReporter(reporter);
-
   }
 
   private void ensureGarbageCollected(WeakReference<?> weakReference) {
@@ -181,14 +183,16 @@ public class RootMetricContextTest {
 
   @AllArgsConstructor
   private class ContextNamePredicate implements Predicate<Notification> {
+
     private final String name;
 
-    @Override public boolean apply(Notification input) {
-      if(input instanceof NewMetricContextNotification &&
+    @Override
+    public boolean apply(Notification input) {
+      if (input instanceof NewMetricContextNotification &&
           ((NewMetricContextNotification) input).getInnerMetricContext().getName().equals(this.name)) {
         return true;
       }
-      if(input instanceof MetricContextCleanupNotification &&
+      if (input instanceof MetricContextCleanupNotification &&
           ((MetricContextCleanupNotification) input).getMetricContext().getName().equals(this.name)) {
         return true;
       }

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ContextStoreReporter.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ContextStoreReporter.java
@@ -12,8 +12,6 @@
 
 package gobblin.metrics.reporter;
 
-import lombok.Getter;
-
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -24,9 +22,13 @@ import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Histogram;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.Timer;
+
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+
 import com.typesafe.config.Config;
+
+import lombok.Getter;
 
 import gobblin.metrics.context.ReportableContext;
 
@@ -44,11 +46,13 @@ public class ContextStoreReporter extends ScheduledReporter {
     this.reportedContexts = Lists.newArrayList();
   }
 
-  @Override protected void report(ReportableContext context) {
+  @Override
+  protected void report(ReportableContext context) {
     this.reportedContexts.add(context);
   }
 
-  @Override public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+  @Override
+  public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
       SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers,
       Map<String, Object> tags) {
     // Noop

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaAvroEventReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaAvroEventReporterTest.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.metrics.kafka;
+package gobblin.metrics.reporter;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -21,6 +21,9 @@ import org.testng.annotations.Test;
 import gobblin.metrics.GobblinTrackingEvent;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.reporter.util.EventUtils;
+import gobblin.metrics.kafka.KafkaAvroEventReporter;
+import gobblin.metrics.kafka.KafkaEventReporter;
+import gobblin.metrics.kafka.KafkaPusher;
 
 
 @Test(groups = {"gobblin.metrics"})

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaAvroReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaAvroReporterTest.java
@@ -10,8 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-
-package gobblin.metrics.kafka;
+package gobblin.metrics.reporter;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -19,11 +18,11 @@ import java.util.Iterator;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import com.codahale.metrics.MetricRegistry;
-
-import gobblin.metrics.MetricContext;
 import gobblin.metrics.MetricReport;
 import gobblin.metrics.reporter.util.MetricReportUtils;
+import gobblin.metrics.kafka.KafkaAvroReporter;
+import gobblin.metrics.kafka.KafkaPusher;
+import gobblin.metrics.kafka.KafkaReporter;
 
 
 /**
@@ -45,13 +44,13 @@ public class KafkaAvroReporterTest extends KafkaReporterTest {
   }
 
   @Override
-  public KafkaReporter.Builder<? extends KafkaReporter.Builder> getBuilder(MetricRegistry registry, KafkaPusher pusher) {
-    return KafkaAvroReporter.Factory.forRegistry(registry).withKafkaPusher(pusher);
+  public KafkaReporter.Builder<? extends KafkaReporter.Builder> getBuilder(KafkaPusher pusher) {
+    return KafkaAvroReporter.BuilderFactory.newBuilder().withKafkaPusher(pusher);
   }
 
   @Override
-  public KafkaReporter.Builder<? extends KafkaReporter.Builder> getBuilderFromContext(MetricContext context, KafkaPusher pusher) {
-    return KafkaAvroReporter.Factory.forContext(context).withKafkaPusher(pusher);
+  public KafkaReporter.Builder<? extends KafkaReporter.Builder> getBuilderFromContext(KafkaPusher pusher) {
+    return KafkaAvroReporter.BuilderFactory.newBuilder().withKafkaPusher(pusher);
   }
 
   @Override

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaEventReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaEventReporterTest.java
@@ -10,23 +10,23 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.metrics.kafka;
+package gobblin.metrics.reporter;
 
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.Map;
 
 import org.testng.Assert;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.AfterSuite;
 import org.testng.annotations.Test;
 
-import com.beust.jcommander.internal.Maps;
+import com.google.common.collect.Maps;
 
 import gobblin.metrics.GobblinTrackingEvent;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.Tag;
 import gobblin.metrics.reporter.util.EventUtils;
+import gobblin.metrics.kafka.KafkaEventReporter;
+import gobblin.metrics.kafka.KafkaPusher;
 
 
 @Test(groups = {"gobblin.metrics"})
@@ -79,7 +79,7 @@ public class KafkaEventReporterTest {
     GobblinTrackingEvent retrievedEvent = nextEvent(pusher.messageIterator());
     Assert.assertEquals(retrievedEvent.getNamespace(), namespace);
     Assert.assertEquals(retrievedEvent.getName(), eventName);
-    Assert.assertEquals(retrievedEvent.getMetadata().size(), 3);
+    Assert.assertEquals(retrievedEvent.getMetadata().size(), 4);
 
   }
 
@@ -126,7 +126,7 @@ public class KafkaEventReporterTest {
     GobblinTrackingEvent retrievedEvent = nextEvent(pusher.messageIterator());
     Assert.assertEquals(retrievedEvent.getNamespace(), namespace);
     Assert.assertEquals(retrievedEvent.getName(), eventName);
-    Assert.assertEquals(retrievedEvent.getMetadata().size(), 3);
+    Assert.assertEquals(retrievedEvent.getMetadata().size(), 4);
     Assert.assertEquals(retrievedEvent.getMetadata().get(tag1), metadataValue1);
     Assert.assertEquals(retrievedEvent.getMetadata().get(tag2), value2);
   }
@@ -142,17 +142,4 @@ public class KafkaEventReporterTest {
     Assert.assertTrue(it.hasNext());
     return EventUtils.deserializeReportFromJson(new GobblinTrackingEvent(), it.next());
   }
-
-  @AfterClass
-  public void after() {
-    try {
-    } catch(Exception e) {
-    }
-  }
-
-  @AfterSuite
-  public void afterSuite() {
-
-  }
-
 }

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaPusherTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaPusherTest.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.metrics.kafka;
+package gobblin.metrics.reporter;
 
 import java.io.IOException;
 
@@ -20,6 +20,8 @@ import org.testng.annotations.AfterSuite;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
+
+import gobblin.metrics.kafka.KafkaPusher;
 
 
 /**

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaTestBase.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/KafkaTestBase.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.metrics.kafka;
+package gobblin.metrics.reporter;
 
 import java.io.Closeable;
 import java.io.IOException;

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/MockKafkaPusher.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/MockKafkaPusher.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.metrics.kafka;
+package gobblin.metrics.reporter;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -20,6 +20,9 @@ import java.util.Queue;
 import com.google.common.collect.Queues;
 
 import kafka.producer.ProducerConfig;
+
+import gobblin.metrics.kafka.KafkaPusher;
+import gobblin.metrics.kafka.ProducerCloseable;
 
 
 /**

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/PrefixContextFilter.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/PrefixContextFilter.java
@@ -14,8 +14,9 @@ package gobblin.metrics.reporter;
 
 import java.util.Set;
 
-import com.beust.jcommander.internal.Sets;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.Sets;
+
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ScheduledReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ScheduledReporterTest.java
@@ -12,24 +12,25 @@
 
 package gobblin.metrics.reporter;
 
-import javax.annotation.Nullable;
+import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
-import org.joda.time.format.PeriodFormatter;
-import org.joda.time.format.PeriodFormatterBuilder;
+import javax.annotation.Nullable;
+
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
+
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.context.ReportableContext;
 import gobblin.metrics.context.filter.ContextFilterFactory;
+import gobblin.util.ConfigUtils;
 
 
 /**
@@ -53,7 +54,6 @@ public class ScheduledReporterTest {
     } catch (RuntimeException re) {
       // fail unless exception is thrown
     }
-
   }
 
   @Test
@@ -69,8 +69,9 @@ public class ScheduledReporterTest {
     MetricContext context1 = MetricContext.builder(context1Name).build();
 
     // Set up config for reporter
-    Config config = ConfigFactory.empty();
-    config = ScheduledReporter.setReportingInterval(config, reportingIntervalMillis, TimeUnit.MILLISECONDS);
+    Properties props = new Properties();
+    ScheduledReporter.setReportingInterval(props, reportingIntervalMillis, TimeUnit.MILLISECONDS);
+    Config config = ConfigUtils.propertiesToConfig(props);
     config = PrefixContextFilter.setPrefixString(config, ScheduledReporterTest.class.getSimpleName());
     config = ContextFilterFactory.setContextFilterClass(config, PrefixContextFilter.class);
 
@@ -154,7 +155,6 @@ public class ScheduledReporterTest {
 
     // Test close method
     reporter.close();
-
   }
 
   private Set<String> getContextNames(ContextStoreReporter reporter) {
@@ -165,5 +165,4 @@ public class ScheduledReporterTest {
           }
         }));
   }
-
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -296,8 +296,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
 
     // Stop metrics reporting
     if (this.jobContext.getJobMetricsOptional().isPresent()) {
-      this.jobContext.getJobMetricsOptional().get().triggerMetricReporting();
-      this.jobContext.getJobMetricsOptional().get().stopMetricReporting();
+      this.jobContext.getJobMetricsOptional().get().stopMetricsReporting();
       JobMetrics.remove(jobState);
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -580,8 +580,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
       } finally {
         if (this.jobMetrics.isPresent()) {
           try {
-            this.jobMetrics.get().triggerMetricReporting();
-            this.jobMetrics.get().stopMetricReporting();
+            this.jobMetrics.get().stopMetricsReporting();
           } finally {
             JobMetrics.remove(this.jobMetrics.get().getName());
           }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/util/JobMetricsTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/util/JobMetricsTest.java
@@ -45,19 +45,22 @@ public class JobMetricsTest {
     List<Tag<?>> tags = jobMetrics.getMetricContext().getTags();
     Map<String, ?> tagMap = jobMetrics.getMetricContext().getTagMap();
     String contextId = tagMap.get(MetricContext.METRIC_CONTEXT_ID_TAG_NAME).toString();
+    String contextName = tagMap.get(MetricContext.METRIC_CONTEXT_NAME_TAG_NAME).toString();
 
-    Assert.assertEquals(tagMap.size(), 3);
+    Assert.assertEquals(tagMap.size(), 4);
     Assert.assertEquals(tagMap.get("jobId"), jobId);
     Assert.assertEquals(tagMap.get("jobName"), jobName);
     Assert.assertEquals(tagMap.get(MetricContext.METRIC_CONTEXT_ID_TAG_NAME), contextId);
+    Assert.assertEquals(tagMap.get(MetricContext.METRIC_CONTEXT_NAME_TAG_NAME), contextName);
 
     // should get the original jobMetrics, can check by the id
     JobMetrics jobMetrics1 = JobMetrics.get(jobName + "_", jobId);
     Assert.assertNotNull(jobMetrics1.getMetricContext());
 
     tagMap = jobMetrics1.getMetricContext().getTagMap();
-    Assert.assertEquals(tags.size(), 3);
+    Assert.assertEquals(tags.size(), 4);
     Assert.assertEquals(tagMap.get(MetricContext.METRIC_CONTEXT_ID_TAG_NAME), contextId);
+    Assert.assertEquals(tagMap.get(MetricContext.METRIC_CONTEXT_NAME_TAG_NAME), contextName);
 
     // remove original jobMetrics, should create a new one
     GobblinMetricsRegistry.getInstance().remove(jobMetrics.getId());
@@ -65,8 +68,9 @@ public class JobMetricsTest {
     Assert.assertNotNull(jobMetrics2.getMetricContext());
 
     tagMap = jobMetrics2.getMetricContext().getTagMap();
-    Assert.assertEquals(tags.size(), 3);
+    Assert.assertEquals(tags.size(), 4);
     Assert.assertNotEquals(tagMap.get(MetricContext.METRIC_CONTEXT_ID_TAG_NAME), contextId);
+    Assert.assertNotEquals(tagMap.get(MetricContext.METRIC_CONTEXT_NAME_TAG_NAME), contextName);
   }
 
   @Test

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   compile externalDependency.guice
   compile externalDependency.bcpgJdk15on
   compile externalDependency.bcprovJdk15on
+  compile externalDependency.typesafeConfig
 
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.avroMapredH2

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.util.Map;
+import java.util.Properties;
+
+import com.google.common.collect.ImmutableMap;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValue;
+
+import gobblin.configuration.State;
+
+
+/**
+ * Utility class for dealing with {@link Config} objects.
+ */
+public class ConfigUtils {
+
+  /**
+   * Convert a given {@link Config} instance to a {@link Properties} instance.
+   *
+   * @param config the given {@link Config} instance
+   * @return a {@link Properties} instance
+   */
+  public static Properties configToProperties(Config config) {
+    Properties properties = new Properties();
+    for (Map.Entry<String, ConfigValue> entry : config.entrySet()) {
+      properties.setProperty(entry.getKey(), config.getString(entry.getKey()));
+    }
+
+    return properties;
+  }
+
+  /**
+   * Convert a given {@link Config} to a {@link State} instance.
+   *
+   * @param config the given {@link Config} instance
+   * @return a {@link State} instance
+   */
+  public static State configToState(Config config) {
+    return new State(configToProperties(config));
+  }
+
+  /**
+   * Convert a given {@link Properties} to a {@link Config} instance.
+   *
+   * <p>
+   *   This method will throw an exception if (1) the {@link Object#toString()} method of any two keys in the
+   *   {@link Properties} objects returns the same {@link String}, or (2) if any two keys are prefixes of one another,
+   *   see the Java Docs of {@link ConfigFactory#parseMap(Map)} for more details.
+   * </p>
+   *
+   * @param properties the given {@link Properties} instance
+   * @return a {@link Config} instance
+   */
+  public static Config propertiesToConfig(Properties properties) {
+    ImmutableMap.Builder<String, Object> immutableMapBuilder = ImmutableMap.builder();
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      immutableMapBuilder.put(entry.getKey().toString(), entry.getValue());
+    }
+    return ConfigFactory.parseMap(immutableMapBuilder.build());
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -80,6 +80,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.ConfigUtils;
 import gobblin.yarn.event.ApplicationMasterShutdownRequest;
 import gobblin.yarn.event.DelegationTokenUpdatedEvent;
 
@@ -258,7 +259,7 @@ public class GobblinApplicationMaster extends GobblinYarnLogSource {
   private GobblinHelixJobScheduler buildGobblinHelixJobScheduler(Config config, Path appWorkDir,
       Map<String, String> eventMetadata)
       throws Exception {
-    Properties properties = YarnHelixUtils.configToProperties(config);
+    Properties properties = ConfigUtils.configToProperties(config);
     return new GobblinHelixJobScheduler(properties, this.helixManager, this.eventBus, appWorkDir, eventMetadata);
   }
 

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
@@ -77,6 +77,7 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskStateTracker;
+import gobblin.util.ConfigUtils;
 import gobblin.yarn.event.DelegationTokenUpdatedEvent;
 
 
@@ -152,7 +153,7 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
         .getZKHelixManager(config.getString(GobblinYarnConfigurationKeys.HELIX_CLUSTER_NAME_KEY), helixInstanceName,
             InstanceType.PARTICIPANT, zkConnectionString);
 
-    Properties properties = YarnHelixUtils.configToProperties(config);
+    Properties properties = ConfigUtils.configToProperties(config);
 
     TaskExecutor taskExecutor = new TaskExecutor(properties);
     TaskStateTracker taskStateTracker = new GobblinHelixTaskStateTracker(properties, this.helixManager);
@@ -175,7 +176,7 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
     if (GobblinMetrics.isEnabled(properties)) {
       this.containerMetrics =
-          Optional.of(ContainerMetrics.get(YarnHelixUtils.configToState(this.config), applicationName, containerId));
+          Optional.of(ContainerMetrics.get(ConfigUtils.configToState(this.config), applicationName, containerId));
     } else {
       this.containerMetrics = Optional.absent();
     }
@@ -210,7 +211,7 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
     this.jmxReporter.start();
     if (this.containerMetrics.isPresent()) {
       this.containerMetrics.get()
-          .startMetricReportingWithFileSuffix(YarnHelixUtils.configToState(this.config), this.containerId.toString());
+          .startMetricReportingWithFileSuffix(ConfigUtils.configToState(this.config), this.containerId.toString());
     }
 
     this.serviceManager.startAsync();
@@ -229,8 +230,7 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
     // Stop metric reporting
     this.jmxReporter.stop();
     if (this.containerMetrics.isPresent()) {
-      this.containerMetrics.get().triggerMetricReporting();
-      this.containerMetrics.get().stopMetricReporting();
+      this.containerMetrics.get().stopMetricsReporting();
     }
 
     try {

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -80,6 +80,7 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.rest.JobExecutionInfoServer;
+import gobblin.util.ConfigUtils;
 import gobblin.util.ExecutorsUtils;
 import gobblin.util.io.StreamUtils;
 import gobblin.util.logs.LogCopier;
@@ -241,7 +242,7 @@ public class GobblinYarnAppLauncher {
         YarnHelixUtils.getAppWorkDirPath(this.fs, this.applicationName, this.applicationId.get().toString())));
     if (config.getBoolean(ConfigurationKeys.JOB_EXECINFO_SERVER_ENABLED_KEY)) {
       LOGGER.info("Starting the job execution info server since it is enabled");
-      services.add(new JobExecutionInfoServer(YarnHelixUtils.configToProperties(config)));
+      services.add(new JobExecutionInfoServer(ConfigUtils.configToProperties(config)));
     }
 
     this.serviceManager = Optional.of(new ServiceManager(services));

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnHelixUtils.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnHelixUtils.java
@@ -117,31 +117,6 @@ public class YarnHelixUtils {
   }
 
   /**
-   * Convert a given {@link Config} instance to a {@link Properties} instance.
-   *
-   * @param config the given {@link Config} instance
-   * @return a {@link Properties} instance
-   */
-  public static Properties configToProperties(Config config) {
-    Properties properties = new Properties();
-    for (Map.Entry<String, ConfigValue> entry : config.entrySet()) {
-      properties.setProperty(entry.getKey(), config.getString(entry.getKey()));
-    }
-
-    return properties;
-  }
-
-  /**
-   * Convert a given {@link Config} to a {@link State} instance.
-   *
-   * @param config the given {@link Config} instance
-   * @return a {@link State} instance
-   */
-  public static State configToState(Config config) {
-    return new State(configToProperties(config));
-  }
-
-  /**
    * Write a {@link Token} to a given file.
    *
    * @param token the token to write

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
@@ -44,6 +44,7 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.runtime.FsDatasetStateStore;
 import gobblin.runtime.JobException;
 import gobblin.runtime.JobState;
+import gobblin.util.ConfigUtils;
 
 
 /**
@@ -105,7 +106,7 @@ public class GobblinHelixJobLauncherTest {
             zkConnectingString);
     this.helixManager.connect();
 
-    Properties properties = YarnHelixUtils.configToProperties(config);
+    Properties properties = ConfigUtils.configToProperties(config);
 
     this.localFs = FileSystem.getLocal(new Configuration());
 

--- a/gobblin-yarn/src/test/java/gobblin/yarn/YarnHelixUtilsTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/YarnHelixUtilsTest.java
@@ -30,6 +30,8 @@ import org.testng.annotations.Test;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import gobblin.util.ConfigUtils;
+
 
 /**
  * Unit tests for {@link YarnHelixUtils}.
@@ -66,7 +68,7 @@ public class YarnHelixUtilsTest {
     Assert.assertTrue(config.getBoolean("k4"));
     Assert.assertEquals(config.getLong("k5"), 10000);
 
-    Properties properties = YarnHelixUtils.configToProperties(config);
+    Properties properties = ConfigUtils.configToProperties(config);
     Assert.assertEquals(properties.getProperty("k1"), "v1");
     Assert.assertEquals(properties.getProperty("k2"), "v1");
     Assert.assertEquals(properties.getProperty("k3"), "1000");


### PR DESCRIPTION
A majority of these changes are just refactoring / reformatting related. Very little logic has changed, with a number of exceptions:

* Added a shutdown hook to `RootMetricContext` that closes the `RootMetricContext` and stops all reporters
* Modified the `ScheduledReporter.stopImpl` method to invoke `report` one last time before shutting down
* Remove all uses of TypeSafe's `Config` and replaced it with `Properties`
* Added a new default tag called `metricContextName` which prints the name of the `MetricContext` as one of the `Tag`s
* Modified `GobblinMetrics.buildCustomMetricReporters`
    * There are now two factories for custom reporters: `CustomCodahaleReporterFactory` and `CustomReporterFactory`
    * The reason two different factories are necessary is that only metric reporters were migrated to `gobblin.metrics.report.ScheduledReporter`, while `EventSubmitters` still extend `com.codahale.metrics.ScheduledReporter`
* A number of other changes to `GobblinMetrics` to support using both `gobblin.metrics.report.ScheduledReporter` and `com.codahale.metrics.ScheduledReporter`
* Migrated `KafkaReporter` and `OutputStreamReporter` to extend `MetricReportReporter`
* Still don't know why `KafkaReporterTest` and `KafkaAvroReporterTest` are failing, there seems to be some race condition I haven't been able to pinpoint yet
* A number of changes to how `KafkaAvroReporter`s and `KafkaReporter`s are made - mainly due to the fact that they no longer require a `MetricContext` or a `MetricRegistry` to be created
* `GobblinMetrics`, `RootMetricContext` and `ScheduledReporter` are good classes to start with when reviewing this code

@ibuenros can you review?