### PR TITLE
Adding build instrumentation for generation of rest-api-* artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -270,7 +270,6 @@ subprojects {
   }
 }
 
-
 subprojects {
 plugins.withType(JavaPlugin) {
   plugins.apply('idea')

--- a/gobblin-rest-service/gobblin-rest-api/build.gradle
+++ b/gobblin-rest-service/gobblin-rest-api/build.gradle
@@ -19,6 +19,72 @@ dependencies {
     compile externalDependency.pegasus.pegasusCommon
 }
 
+artifacts {
+  archives mainRestClientJar
+  archives mainDataTemplateJar
+} 
+
+ 
+configure(install.repositories.mavenInstaller) {
+  addFilter('gobblin-rest-api-rest-client') {artifact, file ->
+    artifact.name == 'gobblin-rest-api-rest-client'
+  }.artifactId = 'gobblin-rest-api-rest-client'
+
+  addFilter('gobblin-rest-api-data-template') {artifact, file ->
+    artifact.name == 'gobblin-rest-api-data-template'
+  }.artifactId = 'gobblin-rest-api-data-template'
+  // artifact names for 'data-model', 'avro-schema' and 'rest-model' may be added as well if needed
+}
+
+// Configure sources and javadoc jars for the data template library
+def dataTemplateName = project.name + "-data-template"
+
+task dataTemplateSourcesJar(type: Jar, dependsOn: classes) {
+    from sourceSets.mainGeneratedDataTemplate.allSource
+    classifier = 'sources'
+    baseName = dataTemplateName
+}
+
+task dataTemplateJavadoc(type: Javadoc, dependsOn: classes) {
+    source sourceSets.mainGeneratedDataTemplate.allSource
+    classpath = files(sourceSets.mainGeneratedDataTemplate.compileClasspath)
+    destinationDir file("${rootProject.buildDir}/${dataTemplateName}/docs/javadoc")
+}
+//javadoc.dependsOn dataTemplateJavadoc
+
+task dataTemplateJavadocJar(type: Jar, dependsOn: 'dataTemplateJavadoc') {
+    from dataTemplateJavadoc
+    baseName = dataTemplateName
+    classifier = 'javadoc'
+}
+
+
+// Configure sources and javadoc jars for the rest client  library
+def restClientName = project.name + "-rest-client"
+
+task restClientSourcesJar(type: Jar, dependsOn: classes) {
+    from sourceSets.mainGeneratedRest.allSource
+    classifier = 'sources'
+    baseName = restClientName
+}
+
+task restClientJavadoc(type: Javadoc, dependsOn: classes) {
+    source sourceSets.mainGeneratedRest.allSource
+    classpath = files(sourceSets.mainGeneratedRest.compileClasspath)
+    destinationDir file("${rootProject.buildDir}/${restClientName}/docs/javadoc")
+}
+//javadoc.dependsOn dataTemplateJavadoc
+
+task restClientJavadocJar(type: Jar, dependsOn: 'restClientJavadoc') {
+    from restClientJavadoc
+    baseName = restClientName
+    classifier = 'javadoc'
+}
+
+artifacts { 
+    archives dataTemplateSourcesJar, dataTemplateJavadocJar, restClientSourcesJar, restClientJavadocJar 
+}
+
 buildscript {
     repositories {
         mavenCentral()


### PR DESCRIPTION
Generate artifacts (classes, javadoc, sources) for Pegasus-gerated gobblin-rest-api-data-template and gobblin-rest-api-rest-client.