### PR TITLE
Add mySql to gobblin-metastore runtime dependency

### DIFF
--- a/gobblin-metastore/build.gradle
+++ b/gobblin-metastore/build.gradle
@@ -29,6 +29,8 @@ dependencies {
     compile externalDependency.guice
     compile externalDependency.javaxInject
     compile externalDependency.jodaTime
+    
+    runtime externalDependency.mysqlConnector
 
     testCompile externalDependency.testng
     testRuntime externalDependency.derby

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -240,6 +240,7 @@ public class GobblinYarnAppLauncher {
         new Path(this.sinkLogRootDir, this.applicationName + Path.SEPARATOR + this.applicationId.get().toString()),
         YarnHelixUtils.getAppWorkDirPath(this.fs, this.applicationName, this.applicationId.get().toString())));
     if (config.getBoolean(ConfigurationKeys.JOB_EXECINFO_SERVER_ENABLED_KEY)) {
+      LOGGER.info("Starting the job execution info server since it is enabled");
       services.add(new JobExecutionInfoServer(YarnHelixUtils.configToProperties(config)));
     }
 


### PR DESCRIPTION
Found the missing dependency when testing `JobExecutionInfoServer`. 
@liyinan926 Can you review?