### PR TITLE
Adding final tag to the last metric report reported

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/MetricReportReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/MetricReportReporter.java
@@ -59,7 +59,9 @@ import gobblin.metrics.Tag;
  */
 public abstract class MetricReportReporter extends ScheduledReporter {
 
-  private final static Logger LOGGER = LoggerFactory.getLogger(MetricReportReporter.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(MetricReportReporter.class);
+
+  private static final String FINAL_TAG_KEY = "finalMetricReport";
 
   @Getter
   private final TimeUnit rateUnit;
@@ -172,6 +174,18 @@ public abstract class MetricReportReporter extends ScheduledReporter {
     }
   }
 
+  @Override
+  protected void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+      SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers,
+      Map<String, Object> tags, boolean isFinal) {
+    if (isFinal) {
+      report(gauges, counters, histograms, meters, timers,
+          ImmutableMap.<String, Object>builder().putAll(tags).put(FINAL_TAG_KEY, Boolean.TRUE).build());
+    } else {
+      report(gauges, counters, histograms, meters, timers, tags);
+    }
+  }
+
   /**
    * Serializes metrics and pushes the byte arrays to Kafka. Uses the serialize* methods in {@link MetricReportReporter}.
    *
@@ -182,7 +196,7 @@ public abstract class MetricReportReporter extends ScheduledReporter {
    * @param timers map of {@link com.codahale.metrics.Timer} to report and their name.
    */
   @Override
-  public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
+  protected void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
       SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters, SortedMap<String, Timer> timers,
       Map<String, Object> tags) {
 

--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/OutputStreamReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/OutputStreamReporter.java
@@ -204,7 +204,7 @@ public class OutputStreamReporter extends MetricReportReporter {
   }
 
   @Override
-  public synchronized void report(SortedMap<String, Gauge> gauges,
+  protected synchronized void report(SortedMap<String, Gauge> gauges,
       SortedMap<String, Counter> counters,
       SortedMap<String, Histogram> histograms,
       SortedMap<String, Meter> meters,

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ContextStoreReporter.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ContextStoreReporter.java
@@ -47,7 +47,7 @@ public class ContextStoreReporter extends ScheduledReporter {
   }
 
   @Override
-  protected void report(ReportableContext context) {
+  protected void report(ReportableContext context, boolean isFinal) {
     this.reportedContexts.add(context);
   }
 


### PR DESCRIPTION
* Adding a tag named `finalMetricReport` that will be set to true on the final metric report reported, this tag will not be present for all other metric reports
* The tag is enabled when a `ScheduledReporter` is stopped or a `MetricContext` is removed
* Implementation is done by introducing a few new methods in `ScheduledReporter`
* Looking at `ScheduledReporter` is the best place to start for this PR

@ibuenros can you review?