### PR TITLE
Remove xerces dependencies in gobblin-core:test

### DIFF
--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -61,10 +61,16 @@ dependencies {
   testCompile externalDependency.jhyde
   testCompile externalDependency.testng
   testCompile externalDependency.mockRunnerJdbc
-  testRuntime externalDependency.xerces
 }
 
-configurations { compile { transitive = false } }
+configurations {
+  compile { transitive = false }
+  // Remove xerces dependencies because of versioning issues. Standard JRE implementation should
+  // work. See also http://stackoverflow.com/questions/11677572/dealing-with-xerces-hell-in-java-maven
+  // HADOOP-5254 and MAPREDUCE-5664
+  all*.exclude group: 'xml-apis'
+  all*.exclude group: 'xerces'
+}
 
 test {
   useTestNG () { excludeGroups 'ignore' }


### PR DESCRIPTION
Remove xerces dependencies in gobblin-core:test due to failures in Gradle 2.10

@liyinan926  can you review

Tests pass with this change:

    :gobblin-core:testClasses
    :gobblin-core:test

    BUILD SUCCESSFUL
