### PR TITLE
Exactly-once POC

### DIFF
--- a/conf/gobblin-standalone.properties
+++ b/conf/gobblin-standalone.properties
@@ -29,6 +29,9 @@ jobconf.dir=${env:GOBBLIN_JOB_CONFIG_DIR}
 # Directory where job/task state files are stored
 state.store.dir=${env:GOBBLIN_WORK_DIR}/state-store
 
+# Directory where commit sequences are stored
+gobblin.runtime.commit.sequence.store.dir=${env:GOBBLIN_WORK_DIR}/commit-sequence-store
+
 # Directory where error files from the quality checkers are stored
 qualitychecker.row.err.file=${env:GOBBLIN_WORK_DIR}/err
 

--- a/gobblin-api/src/main/java/gobblin/commit/CommitSequence.java
+++ b/gobblin-api/src/main/java/gobblin/commit/CommitSequence.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import java.util.List;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import gobblin.annotation.Alpha;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A sequence of {@link CommitStep}s that should be executed atomically.
+ *
+ * <p>
+ *    Typical pattern for building a {@link CommitSequence} with two {@link CommitStep}s:
+ *
+ *    <pre>
+ *      {@code
+ *        CommitSequence sequence = CommitSequence.newBuilder()
+ *                                  .withJobName(jobName)
+ *                                  .withDatasetUrn(datasetUrn)
+ *
+ *                                  .beginStep(FsRenameCommitStep.Builder.class)
+ *                                  .withProps(props)
+ *                                  .from(srcPath)
+ *                                  .to(dstPath)
+ *                                  .endStep()
+ *
+ *                                  .beginStep(DatasetStateCommitStep.Builder.class)
+ *                                  .withProps(props)
+ *                                  .withDatasetUrn(datasetUrn)
+ *                                  .withDatasetState(datasetState)
+ *                                  .endStep()
+ *
+ *                                  .build();
+ *      }
+ *    </pre>
+ * </p>
+ *
+ * @author ziliu
+ */
+@Alpha
+@Slf4j
+public class CommitSequence {
+
+  @Getter
+  private final String jobName;
+
+  @Getter
+  private final String datasetUrn;
+
+  private final List<CommitStep> steps;
+
+  private CommitSequence(Builder builder) {
+    this.jobName = builder.jobName;
+    this.datasetUrn = builder.datasetUrn;
+    this.steps = ImmutableList.copyOf(builder.steps);
+  }
+
+  public static class Builder {
+
+    private String jobName;
+    private String datasetUrn;
+    private final List<CommitStep> steps = Lists.newArrayList();
+
+    /**
+     * Set the job name for the commit sequence.
+     */
+    public Builder withJobName(String jobName) {
+      this.jobName = jobName;
+      return this;
+    }
+
+    /**
+     * Set the dataset URN for the commit sequence.
+     */
+    public Builder withDatasetUrn(String datasetUrn) {
+      this.datasetUrn = datasetUrn;
+      return this;
+    }
+
+    /**
+     * Build a {@link CommitStep}.
+     *
+     * @param builderClass The builder class for the {@link CommitStep}, which should extend
+     * {@link CommitStepBase.Builder}.
+     * @return An instance of the builder class for the {@link CommitStep}.
+     */
+    public <T extends CommitStepBase.Builder<?>> T beginStep(Class<T> builderClass) {
+      try {
+        //return (T) ConstructorUtils.invokeConstructor(builderClass, this);
+        return (T) builderClass.getDeclaredConstructor(this.getClass()).newInstance(this);
+      } catch (ReflectiveOperationException e) {
+        throw new RuntimeException("Failed to instantiate " + builderClass, e);
+      }
+    }
+
+    /**
+     * Add a {@link CommitStep} to the commit sequence.
+     */
+    public Builder addStep(CommitStep step) {
+      this.steps.add(step);
+      return this;
+    }
+
+    public CommitSequence build() {
+      Preconditions.checkState(!Strings.isNullOrEmpty(this.jobName), "Job name not specified for commit sequence");
+      Preconditions.checkState(!Strings.isNullOrEmpty(this.datasetUrn),
+          "Dataset URN not specified for commit sequence");
+      Preconditions.checkState(!this.steps.isEmpty(), "No commit steps specified for the commit sequence");
+
+      return new CommitSequence(this);
+    }
+
+  }
+
+  /**
+   * Execute the {@link CommitStep}s in the order they are added to the commit sequence.
+   */
+  public void execute() {
+    try {
+      for (CommitStep step : this.steps) {
+        if (!step.isCompleted()) {
+          step.execute();
+        }
+      }
+    } catch (Throwable t) {
+      log.error("Commit failed for dataset " + this.datasetUrn, t);
+      throw Throwables.propagate(t);
+    }
+  }
+
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/commit/CommitSequenceStore.java
+++ b/gobblin-api/src/main/java/gobblin/commit/CommitSequenceStore.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import com.google.common.base.Optional;
+
+import gobblin.annotation.Alpha;
+
+
+/**
+ * A store for {@link CommitSequence}s. A {@link CommitSequence} is identified by job name and dataset URN.
+ *
+ * @author ziliu
+ */
+@Alpha
+public interface CommitSequenceStore {
+
+  /**
+   * Whether a {@link CommitSequence} with the given job name exists in the store.
+   */
+  boolean exists(String jobName) throws IOException;
+
+  /**
+   * Whether a {@link CommitSequence} with the given job name and dataset URN exists in a store.
+   */
+  public boolean exists(String jobName, String datasetUrn) throws IOException;
+
+  /**
+   * delete a given job name from the store along with all {@link CommitSequence}s associated with this job.
+   */
+  public void delete(String jobName) throws IOException;
+
+  /**
+   * delete the {@link CommitSequence} for the given job name and dataset URN.
+   */
+  public void delete(String jobName, String datasetUrn) throws IOException;
+
+  /**
+   * Put a {@link CommitSequence} with the given job name and dataset URN.
+   *
+   * @throws IOException if a {@link CommitSequence} for the given job name and dataset URN exists in the store.
+   */
+  public void put(String jobName, String datasetUrn, CommitSequence commitSequence) throws IOException;
+
+  /**
+   * Get a {@link Collection} of dataset URNs with the given job name.
+   */
+  public Collection<String> get(String jobName) throws IOException;
+
+  /**
+   * Get the {@link CommitSequence} associated with the given job name and dataset URN.
+   */
+  public Optional<CommitSequence> get(String jobName, String datasetUrn) throws IOException;
+
+}

--- a/gobblin-api/src/main/java/gobblin/commit/CommitStep.java
+++ b/gobblin-api/src/main/java/gobblin/commit/CommitStep.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import java.io.IOException;
+
+import gobblin.annotation.Alpha;
+
+
+/**
+ * A step during committing a dataset that should be executed atomically with other steps under exactly-once semantics.
+ * An example is publishing the data files of a dataset, which should be executed atomically with persisting the
+ * dataset state in order to avoid pulling duplicate data.
+ *
+ * @author ziliu
+ */
+@Alpha
+public interface CommitStep {
+
+  /**
+   * Determine whether the commit step has been completed.
+   */
+  public boolean isCompleted() throws IOException;
+
+  /**
+   * Execute the commit step.
+   */
+  public void execute() throws IOException;
+}

--- a/gobblin-api/src/main/java/gobblin/commit/CommitStepBase.java
+++ b/gobblin-api/src/main/java/gobblin/commit/CommitStepBase.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import java.io.IOException;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.annotation.Alpha;
+import gobblin.configuration.State;
+
+
+/**
+ * A base implementation of {@link CommitStep}.
+ *
+ * @author ziliu
+ */
+@Alpha
+public abstract class CommitStepBase implements CommitStep {
+
+  protected final State props;
+
+  protected CommitStepBase(Builder<? extends Builder<?>> builder) {
+    Preconditions.checkNotNull(builder.props);
+    this.props = builder.props;
+  }
+
+  public abstract static class Builder<T extends Builder<?>> {
+    private final Optional<CommitSequence.Builder> commitSequenceBuilder;
+
+    protected State props;
+
+    protected Builder() {
+      this.commitSequenceBuilder = Optional.<CommitSequence.Builder> absent();
+    }
+
+    protected Builder(CommitSequence.Builder commitSequenceBuilder) {
+      Preconditions.checkNotNull(commitSequenceBuilder);
+      this.commitSequenceBuilder = Optional.of(commitSequenceBuilder);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T withProps(State props) {
+      this.props = new State(props.getProperties());
+      return (T) this;
+    }
+
+    public CommitSequence.Builder endStep() throws IOException {
+      Preconditions.checkState(this.commitSequenceBuilder.isPresent());
+      this.commitSequenceBuilder.get().addStep(build());
+      return commitSequenceBuilder.get();
+    }
+
+    public abstract CommitStep build() throws IOException;
+  }
+
+}

--- a/gobblin-api/src/main/java/gobblin/commit/DeliverySemantics.java
+++ b/gobblin-api/src/main/java/gobblin/commit/DeliverySemantics.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import com.google.common.base.Enums;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+
+
+/**
+ * The semantics for data delivery.
+ *
+ * @author ziliu
+ */
+public enum DeliverySemantics {
+
+  /**
+   * Each data record from the source is guaranteed to be delivered at least once.
+   */
+  AT_LEAST_ONCE,
+
+  /**
+   * Each data record from the source is guaranteed to be delievered exactly once.
+   */
+  EXACTLY_ONCE;
+
+  /**
+   * Get the devliery semantics type from {@link ConfigurationKeys#DELIVERY_SEMANTICS}.
+   * The default value is {@link Type#AT_LEAST_ONCE}.
+   */
+  public static DeliverySemantics parse(State state) {
+    String value =
+        state.getProp(ConfigurationKeys.GOBBLIN_RUNTIME_DELIVERY_SEMANTICS, AT_LEAST_ONCE.toString()).toUpperCase();
+    Optional<DeliverySemantics> semantics = Enums.getIfPresent(DeliverySemantics.class, value);
+    Preconditions.checkState(semantics.isPresent(), value + " is not a valid delivery semantics");
+    return semantics.get();
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -403,7 +403,6 @@ public class ConfigurationKeys {
   public static final String TASK_STATE_COLLECTOR_INTERVAL_SECONDS = "task.state.collector.interval.secs";
   public static final int DEFAULT_TASK_STATE_COLLECTOR_INTERVAL_SECONDS = 60;
 
-
   /**
    * Configuration properties for email settings.
    */
@@ -507,6 +506,7 @@ public class ConfigurationKeys {
   /**
    * Other configuration properties.
    */
+  public static final String GOBBLIN_RUNTIME_DELIVERY_SEMANTICS = "gobblin.runtime.delivery.semantics";
   public static final Charset DEFAULT_CHARSET_ENCODING = Charsets.UTF_8;
   public static final String TEST_HARNESS_LAUNCHER_IMPL = "gobblin.testharness.launcher.impl";
   public static final int PERMISSION_PARSING_RADIX = 8;

--- a/gobblin-core/src/main/java/gobblin/commit/FsRenameCommitStep.java
+++ b/gobblin-core/src/main/java/gobblin/commit/FsRenameCommitStep.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.annotation.Alpha;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.HadoopUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A {@link CommitStep} for renaming files within a {@link FileSystem} or between {@link FileSystem}s.
+ *
+ * @author ziliu
+ */
+@Alpha
+@Slf4j
+public class FsRenameCommitStep extends CommitStepBase {
+
+  private final Path srcPath;
+  private final Path dstPath;
+  private final String srcFsUri;
+  private final String dstFsUri;
+  private transient FileSystem srcFs;
+  private transient FileSystem dstFs;
+
+  private FsRenameCommitStep(Builder<? extends Builder<?>> builder) throws IOException {
+    super(builder);
+
+    this.srcPath = builder.srcPath;
+    this.dstPath = builder.dstPath;
+    this.srcFs = builder.srcFs != null ? builder.srcFs
+        : getFileSystem(this.props.getProp(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
+    this.srcFsUri = this.srcFs.getUri().toString();
+    this.dstFs = builder.dstFs != null ? builder.dstFs
+        : getFileSystem(this.props.getProp(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
+    this.dstFsUri = this.dstFs.getUri().toString();
+  }
+
+  public static class Builder<T extends Builder<?>> extends CommitStepBase.Builder<T> {
+
+    public Builder() {
+      super();
+    }
+
+    public Builder(CommitSequence.Builder commitSequenceBuilder) {
+      super(commitSequenceBuilder);
+    }
+
+    private Path srcPath;
+    private Path dstPath;
+    private FileSystem srcFs;
+    private FileSystem dstFs;
+
+    @Override
+    public T withProps(State props) {
+      return (T) super.withProps(props);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T from(Path srcPath) {
+      this.srcPath = srcPath;
+      return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T to(Path dstPath) {
+      this.dstPath = dstPath;
+      return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T withSrcFs(FileSystem srcFs) {
+      this.srcFs = srcFs;
+      return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T withDstFs(FileSystem dstFs) {
+      this.dstFs = dstFs;
+      return (T) this;
+    }
+
+    @Override
+    public CommitStep build() throws IOException {
+      Preconditions.checkNotNull(this.srcPath);
+      Preconditions.checkNotNull(this.dstPath);
+
+      return new FsRenameCommitStep(this);
+    }
+  }
+
+  private FileSystem getFileSystem(String fsUri) throws IOException {
+    return FileSystem.get(URI.create(fsUri), HadoopUtils.getConfFromState(this.props));
+  }
+
+  @Override
+  public boolean isCompleted() throws IOException {
+    if (this.dstFs == null) {
+      this.dstFs = getFileSystem(this.dstFsUri);
+    }
+    return this.dstFs.exists(this.dstPath);
+  }
+
+  @Override
+  public void execute() throws IOException {
+    if (this.srcFs == null) {
+      this.srcFs = getFileSystem(this.srcFsUri);
+    }
+    if (this.dstFs == null) {
+      this.dstFs = getFileSystem(this.dstFsUri);
+    }
+    log.info(String.format("Moving %s to %s", this.srcPath, this.dstPath));
+    HadoopUtils.movePath(this.srcFs, this.srcPath, this.dstFs, this.dstPath);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/publisher/CommitSequencePublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/CommitSequencePublisher.java
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.publisher;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterables;
+
+import gobblin.annotation.Alpha;
+import gobblin.commit.CommitSequence;
+import gobblin.commit.FsRenameCommitStep;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.util.ParallelRunner;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * An implementation of {@link DataPublisher} for exactly-once delivery.
+ *
+ * <p>
+ *   This publisher does not actually publish data, instead it constructs a {@link CommitSequence.Builder}.
+ *   The builder is used by Gobblin runtime to build a {@link CommitSequence}, which is then persisted
+ *   and executed.
+ * </p>
+ *
+ * @author ziliu
+ */
+@Alpha
+@Slf4j
+public class CommitSequencePublisher extends BaseDataPublisher {
+
+  @Getter
+  protected Optional<CommitSequence.Builder> commitSequenceBuilder = Optional.of(new CommitSequence.Builder());
+
+  public CommitSequencePublisher(State state) throws IOException {
+    super(state);
+  }
+
+  @Override
+  public void publish(Collection<? extends WorkUnitState> states) throws IOException {
+    super.publish(states);
+
+    if (!states.isEmpty()) {
+
+      String jobName = Iterables.get(states, 0).getProp(ConfigurationKeys.JOB_NAME_KEY);
+      String datasetUrn =
+          Iterables.get(states, 0).getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN);
+      this.commitSequenceBuilder.get().withJobName(jobName).withDatasetUrn(datasetUrn);
+    } else {
+      log.warn("No workunitstate to publish");
+      this.commitSequenceBuilder = Optional.<CommitSequence.Builder> absent();
+    }
+  }
+
+  /**
+   * This method does not actually move data, but it creates an {@link FsRenameCommitStep}.
+   */
+  @Override
+  protected void movePath(ParallelRunner parallelRunner, Path src, Path dst, int branchId) throws IOException {
+    log.info(String.format("Creating CommitStep for moving %s to %s", src, dst));
+    this.commitSequenceBuilder.get().beginStep(FsRenameCommitStep.Builder.class).withProps(this.state).from(src)
+        .withSrcFs(this.writerFileSystemByBranches.get(branchId)).to(dst)
+        .withDstFs(this.publisherFileSystemByBranches.get(branchId)).endStep();
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -38,8 +38,6 @@ import gobblin.util.WriterUtils;
  */
 public class TimePartitionedDataPublisher extends BaseDataPublisher {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TimePartitionedDataPublisher.class);
-
   public TimePartitionedDataPublisher(State state) throws IOException {
     super(state);
   }
@@ -64,9 +62,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
       WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId), outputPath.getParent(),
           this.permissions.get(branchId));
 
-      LOG.info(String.format("Moving %s to %s", status.getPath(), outputPath));
-      parallelRunner.movePath(status.getPath(), this.publisherFileSystemByBranches.get(branchId),
-          outputPath, Optional.<String> absent());
+      movePath(parallelRunner, status.getPath(), outputPath, branchId);
     }
   }
 }

--- a/gobblin-core/src/test/java/gobblin/commit/FsRenameCommitStepTest.java
+++ b/gobblin-core/src/test/java/gobblin/commit/FsRenameCommitStepTest.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.State;
+
+
+/**
+ * Test for {@link FsRenameCommitStep}.
+ *
+ * @author ziliu
+ */
+@Test(groups = { "gobblin.commit" })
+public class FsRenameCommitStepTest {
+  private static final String ROOT_DIR = "fs-rename-commit-sequence-test";
+
+  private FileSystem fs;
+  private FsRenameCommitStep step;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    this.fs = FileSystem.getLocal(new Configuration());
+    this.fs.delete(new Path(ROOT_DIR), true);
+
+    Path dir1 = new Path(ROOT_DIR, "dir1");
+    Path dir2 = new Path(ROOT_DIR, "dir2");
+
+    this.fs.mkdirs(dir1);
+    this.fs.mkdirs(dir2);
+
+    Path src = new Path(dir1, "file");
+    Path dst = new Path(dir2, "file");
+    this.fs.createNewFile(src);
+
+    this.step =
+        (FsRenameCommitStep) new FsRenameCommitStep.Builder<>().from(src).to(dst).withProps(new State()).build();
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    this.fs.delete(new Path(ROOT_DIR), true);
+  }
+
+  @Test
+  public void testExecute() throws IOException {
+    this.step.execute();
+    Assert.assertTrue(this.fs.exists(new Path(ROOT_DIR, "dir2/file")));
+  }
+}

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -29,6 +29,7 @@ dependencies {
   compile externalDependency.httpclient
   compile externalDependency.httpcore
   compile externalDependency.commonsLang
+  compile externalDependency.commonsLang3
   compile externalDependency.slf4j
   compile externalDependency.commonsCli
   compile externalDependency.gson

--- a/gobblin-runtime/src/main/java/gobblin/runtime/commit/DatasetStateCommitStep.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/commit/DatasetStateCommitStep.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime.commit;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.annotation.Alpha;
+import gobblin.commit.CommitSequence;
+import gobblin.commit.CommitStep;
+import gobblin.commit.CommitStepBase;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.runtime.FsDatasetStateStore;
+import gobblin.runtime.JobState.DatasetState;
+import gobblin.util.HadoopUtils;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * An implementation of {@link CommitStep} for persisting dataset states.
+ *
+ * @author ziliu
+ */
+@Alpha
+@Slf4j
+public class DatasetStateCommitStep extends CommitStepBase {
+
+  private final String datasetUrn;
+  private final DatasetState datasetState;
+  private transient FsDatasetStateStore stateStore;
+
+  private DatasetStateCommitStep(Builder<? extends Builder<?>> builder) {
+    super(builder);
+
+    this.datasetUrn = builder.datasetUrn;
+    this.datasetState = builder.datasetState;
+  }
+
+  public static class Builder<T extends Builder<?>> extends CommitStepBase.Builder<T> {
+    private String datasetUrn;
+    private DatasetState datasetState;
+
+    public Builder() {
+      super();
+    }
+
+    public Builder(CommitSequence.Builder commitSequenceBuilder) {
+      super(commitSequenceBuilder);
+    }
+
+    @SuppressWarnings("unchecked")
+    public T withDatasetUrn(String datasetUrn) {
+      this.datasetUrn = datasetUrn;
+      return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T withDatasetState(DatasetState datasetState) {
+      this.datasetState = datasetState;
+      return (T) this;
+    }
+
+    @Override
+    public CommitStep build() {
+      Preconditions.checkNotNull(this.datasetUrn);
+      Preconditions.checkNotNull(this.datasetState);
+
+      return new DatasetStateCommitStep(this);
+    }
+  }
+
+  @Override
+  public boolean isCompleted() throws IOException {
+    Preconditions.checkNotNull(this.datasetState);
+
+    return this.datasetState
+        .equals(getDatasetStateStore().getLatestDatasetState(this.datasetState.getJobName(), this.datasetUrn));
+  }
+
+  @Override
+  public void execute() throws IOException {
+    log.info("Persisting dataset state for dataset " + this.datasetUrn);
+    getDatasetStateStore().persistDatasetState(this.datasetUrn, this.datasetState);
+  }
+
+  private FsDatasetStateStore getDatasetStateStore() throws IOException {
+    if (this.stateStore == null) {
+      FileSystem fs = FileSystem.get(
+          URI.create(this.props.getProp(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI)),
+          HadoopUtils.getConfFromState(this.props));
+
+      this.stateStore = new FsDatasetStateStore(fs, this.props.getProp(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY));
+    }
+    return this.stateStore;
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/commit/FsCommitSequenceStore.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/commit/FsCommitSequenceStore.java
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime.commit;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Collection;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableList;
+import com.google.gson.Gson;
+
+import gobblin.annotation.Alpha;
+import gobblin.commit.CommitSequence;
+import gobblin.commit.CommitSequenceStore;
+import gobblin.commit.CommitStep;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.HadoopUtils;
+import gobblin.util.filters.HiddenFilter;
+import gobblin.util.io.GsonInterfaceAdapter;
+
+
+/**
+ * An implementation of {@link CommitSequenceStore} backed by a {@link FileSystem}.
+ *
+ * <p>
+ *    This implementation serializes a {@link CommitSequence} along with all its {@link CommitStep}s into a
+ *    JSON string using {@link Gson}. Thus it requires that all {@link CommitStep}s can be serialized
+ *    and deserialized with {@link Gson}.
+ * </p>
+ *
+ * @author ziliu
+ */
+@Alpha
+public class FsCommitSequenceStore implements CommitSequenceStore {
+
+  public static final String GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_FS_URI =
+      "gobblin.runtime.commit.sequence.store.fs.uri";
+  public static final String GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_DIR = "gobblin.runtime.commit.sequence.store.dir";
+
+  private static final String DEFAULT_DATASET_URN = "default_dataset_urn";
+  private static final Gson GSON = GsonInterfaceAdapter.getGson(CommitStep.class);
+
+  private final FileSystem fs;
+  private final Path rootPath;
+
+  public FsCommitSequenceStore(FileSystem fs, Path rootPath) {
+    this.fs = fs;
+    this.rootPath = rootPath;
+  }
+
+  @Override
+  public boolean exists(String jobName) throws IOException {
+    Path jobPath = new Path(this.rootPath, jobName);
+    return this.fs.exists(jobPath);
+  }
+
+  @Override
+  public boolean exists(String jobName, String datasetUrn) throws IOException {
+    Path datasetPath = new Path(new Path(this.rootPath, jobName), sanitizeDatasetUrn(datasetUrn));
+    return this.fs.exists(datasetPath);
+  }
+
+  @Override
+  public void delete(String jobName) throws IOException {
+    Path jobPath = new Path(this.rootPath, jobName);
+    HadoopUtils.deletePathAndEmptyAncestors(this.fs, jobPath, true);
+  }
+
+  @Override
+  public void delete(String jobName, String datasetUrn) throws IOException {
+    Path jobPath = new Path(this.rootPath, jobName);
+    Path datasetPath = new Path(jobPath, sanitizeDatasetUrn(datasetUrn));
+    HadoopUtils.deletePathAndEmptyAncestors(this.fs, datasetPath, true);
+  }
+
+  @Override
+  public void put(String jobName, String datasetUrn, CommitSequence commitSequence) throws IOException {
+    datasetUrn = sanitizeDatasetUrn(datasetUrn);
+    if (exists(jobName, datasetUrn)) {
+      throw new IOException(String.format("CommitSequence already exists for job %s, dataset %s", jobName, datasetUrn));
+    }
+
+    Path jobPath = new Path(this.rootPath, jobName);
+    this.fs.mkdirs(jobPath);
+
+    Path datasetPath = new Path(jobPath, datasetUrn);
+    try (DataOutputStream dos = this.fs.create(datasetPath)) {
+      dos.writeBytes(GSON.toJson(commitSequence));
+    }
+  }
+
+  @Override
+  public Collection<String> get(String jobName) throws IOException {
+    ImmutableList.Builder<String> builder = new ImmutableList.Builder<>();
+    Path jobPath = new Path(this.rootPath, jobName);
+    if (this.fs.exists(jobPath)) {
+      for (FileStatus status : this.fs.listStatus(jobPath, new HiddenFilter())) {
+        builder.add(status.getPath().getName());
+      }
+    }
+    return builder.build();
+  }
+
+  @Override
+  public Optional<CommitSequence> get(String jobName, String datasetUrn) throws IOException {
+    if (!exists(jobName, datasetUrn)) {
+      return Optional.<CommitSequence> absent();
+    }
+
+    Path datasetPath = new Path(new Path(this.rootPath, jobName), sanitizeDatasetUrn(datasetUrn));
+    try (InputStream is = this.fs.open(datasetPath)) {
+      return Optional
+          .of(GSON.fromJson(IOUtils.toString(is, ConfigurationKeys.DEFAULT_CHARSET_ENCODING), CommitSequence.class));
+    }
+  }
+
+  /**
+   * Replace a null or empty dataset URN with {@link #DEFAULT_DATASET_URN}, and replaces illegal HDFS
+   * characters with '_'.
+   */
+  private String sanitizeDatasetUrn(String datasetUrn) {
+    return Strings.isNullOrEmpty(datasetUrn) ? DEFAULT_DATASET_URN : HadoopUtils.sanitizePath(datasetUrn, "_");
+  }
+
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/commit/CommitSequenceTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/commit/CommitSequenceTest.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime.commit;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.commit.CommitSequence;
+import gobblin.commit.FsRenameCommitStep;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.runtime.JobState.DatasetState;
+
+
+/**
+ * Tests for {@link CommitSequence}.
+ *
+ * @author ziliu
+ */
+@Test(groups = { "gobblin.runtime.commit" })
+public class CommitSequenceTest {
+
+  private static final String ROOT_DIR = "commit-sequence-test";
+
+  private FileSystem fs;
+  private CommitSequence sequence;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    this.fs = FileSystem.getLocal(new Configuration());
+
+    this.fs.delete(new Path(ROOT_DIR), true);
+
+    Path storeRootDir = new Path(ROOT_DIR, "store");
+
+    Path dir1 = new Path(ROOT_DIR, "dir1");
+    Path dir2 = new Path(ROOT_DIR, "dir2");
+
+    this.fs.mkdirs(dir1);
+    this.fs.mkdirs(dir2);
+
+    Path src1 = new Path(dir1, "file1");
+    Path src2 = new Path(dir2, "file2");
+    Path dst1 = new Path(dir2, "file1");
+    Path dst2 = new Path(dir1, "file2");
+    this.fs.createNewFile(src1);
+    this.fs.createNewFile(src2);
+
+    DatasetState ds = new DatasetState("job-name", "job-id");
+    ds.setProp("key1", "value1");
+    ds.setProp("key2", "value2");
+
+    State state = new State();
+    state.setProp(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, storeRootDir.toString());
+
+    this.sequence = new CommitSequence.Builder().withJobName("testjob").withDatasetUrn("testurn")
+        .beginStep(FsRenameCommitStep.Builder.class).from(src1).to(dst1).withProps(state).endStep()
+        .beginStep(FsRenameCommitStep.Builder.class).from(src2).to(dst2).withProps(state).endStep()
+        .beginStep(DatasetStateCommitStep.Builder.class).withDatasetUrn("urn").withDatasetState(ds).withProps(state)
+        .endStep().build();
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    this.fs.delete(new Path(ROOT_DIR), true);
+  }
+
+  @Test
+  public void testExecute() throws IOException {
+    this.sequence.execute();
+
+    Assert.assertTrue(this.fs.exists(new Path(ROOT_DIR, "dir1/file2")));
+    Assert.assertTrue(this.fs.exists(new Path(ROOT_DIR, "dir2/file1")));
+    Assert.assertTrue(this.fs.exists(new Path(ROOT_DIR, "store/job-name/urn-job-id.jst")));
+    Assert.assertTrue(this.fs.exists(new Path(ROOT_DIR, "store/job-name/urn-current.jst")));
+  }
+
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/commit/FsCommitSequenceStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/commit/FsCommitSequenceStoreTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime.commit;
+
+import java.io.IOException;
+import java.net.URI;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.gson.Gson;
+
+import gobblin.commit.CommitSequence;
+import gobblin.commit.CommitStep;
+import gobblin.commit.FsRenameCommitStep;
+import gobblin.configuration.State;
+import gobblin.runtime.JobState.DatasetState;
+import gobblin.runtime.commit.DatasetStateCommitStep;
+import gobblin.runtime.commit.FsCommitSequenceStore;
+import gobblin.util.io.GsonInterfaceAdapter;
+
+
+/**
+ * Tests for {@link FsCommitSequenceStore}.
+ *
+ * @author ziliu
+ */
+public class FsCommitSequenceStoreTest {
+
+  private static final Gson GSON = GsonInterfaceAdapter.getGson(CommitStep.class);
+
+  private final String jobName = "test-job";
+  private final String datasetUrn = StringUtils.EMPTY;
+
+  private FsCommitSequenceStore store;
+  private CommitSequence sequence;
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    FileSystem fs = FileSystem.get(URI.create("file:///"), new Configuration());
+    this.store = new FsCommitSequenceStore(fs, new Path("commit-sequence-store-test"));
+
+    State props = new State();
+    props.setId("propsId");
+    props.setProp("prop1", "valueOfProp1");
+    props.setProp("prop2", "valueOfProp2");
+    DatasetState datasetState = new DatasetState();
+
+    datasetState.setDatasetUrn(this.datasetUrn);
+    datasetState.setProp("prop3", "valueOfProp3");
+    datasetState.setProp("prop4", "valueOfProp4");
+    this.sequence = new CommitSequence.Builder().withJobName("testjob").withDatasetUrn("testurn")
+        .beginStep(FsRenameCommitStep.Builder.class).from(new Path("/ab/cd")).to(new Path("/ef/gh")).withProps(props)
+        .endStep().beginStep(DatasetStateCommitStep.Builder.class).withDatasetUrn(datasetUrn)
+        .withDatasetState(datasetState).withProps(props).endStep().build();
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    this.store.delete(this.jobName);
+  }
+
+  @Test
+  public void testPut() throws IOException {
+    tearDown();
+    this.store.put(this.jobName, this.datasetUrn, this.sequence);
+    Assert.assertTrue(this.store.exists(this.jobName, this.datasetUrn));
+
+    try {
+      this.store.put(this.jobName, this.datasetUrn, this.sequence);
+      Assert.fail();
+    } catch (IOException e) {
+      // Expected to catch IOException
+    }
+  }
+
+  @Test(dependsOnMethods = { "testPut" })
+  public void testGet() throws IOException {
+    Optional<CommitSequence> sequence2 = this.store.get(this.jobName, this.datasetUrn);
+    Assert.assertTrue(sequence2.isPresent());
+    Assert.assertEquals(GSON.toJsonTree(sequence2.get()), GSON.toJsonTree(this.sequence));
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/filters/HiddenFilter.java
+++ b/gobblin-utility/src/main/java/gobblin/util/filters/HiddenFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.filters;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+
+/**
+ * A {@link PathFilter} that filters out hidden files (those starting with '_' or '.').
+ */
+public class HiddenFilter implements PathFilter {
+
+  private static final String[] HIDDEN_FILE_PREFIX = { "_", "." };
+
+  @Override
+  public boolean accept(Path path) {
+    String name = path.getName();
+    for (String prefix : HIDDEN_FILE_PREFIX) {
+      if (name.startsWith(prefix)) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/GsonInterfaceAdapter.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/GsonInterfaceAdapter.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.io;
+
+import java.lang.reflect.Type;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonDeserializationContext;
+import com.google.gson.JsonDeserializer;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParseException;
+import com.google.gson.JsonSerializationContext;
+import com.google.gson.JsonSerializer;
+
+
+/**
+ * A {@link Gson} interface adapter that makes it possible to serialize and deserialize an object
+ * with an interface or abstract field with {@link Gson}.
+ *
+ * <p>
+ *    Suppose a class <pre>MyClass</pre> contains an interface field <pre>MyInterface field</pre>. To serialize
+ *    and deserialize a <pre>MyClass</pre> object, do the following:
+ *
+ *    <pre>
+ *          {@code
+ *            MyClass object = new MyClass();
+ *            Gson gson = GsonInterfaceAdapter.getGson(MyInterface.class);
+ *            String json = gson.toJson(object);
+ *            Myclass object2 = gson.fromJson(json, MyClass.class);
+ *          }
+ *    </pre>
+ * </p>
+ *
+ * @author ziliu
+ *
+ * @param <T> The interface or abstract type to be serialized and deserialized with {@link Gson}.
+ */
+public class GsonInterfaceAdapter<T> implements JsonSerializer<T>, JsonDeserializer<T> {
+
+  private static final String OBJECT_TYPE = "object-type";
+  private static final String OBJECT_DATA = "object-data";
+
+  @Override
+  public JsonElement serialize(T object, Type interfaceType, JsonSerializationContext context) {
+    JsonObject wrapper = new JsonObject();
+    wrapper.addProperty(OBJECT_TYPE, object.getClass().getName());
+    wrapper.add(OBJECT_DATA, context.serialize(object));
+    return wrapper;
+  }
+
+  @Override
+  public T deserialize(JsonElement elem, Type interfaceType, JsonDeserializationContext context)
+      throws JsonParseException {
+    JsonObject wrapper = (JsonObject) elem;
+    JsonElement typeName = get(wrapper, OBJECT_TYPE);
+    JsonElement data = get(wrapper, OBJECT_DATA);
+    Type actualType = typeForName(typeName);
+    return context.deserialize(data, actualType);
+  }
+
+  private Type typeForName(JsonElement typeElem) {
+    try {
+      return Class.forName(typeElem.getAsString());
+    } catch (ClassNotFoundException e) {
+      throw new JsonParseException(e);
+    }
+  }
+
+  private JsonElement get(JsonObject wrapper, String memberName) {
+    JsonElement elem = wrapper.get(memberName);
+    Preconditions.checkNotNull(elem);
+    return elem;
+  }
+
+  public static <T> Gson getGson(Class<T> clazz) {
+    return new GsonBuilder().registerTypeAdapter(clazz, new GsonInterfaceAdapter<T>()).create();
+  }
+}


### PR DESCRIPTION
Design: https://github.com/linkedin/gobblin/wiki/Exactly-Once-Support

Summary of changes:

- Exacty once semantics will be used if `delivery.semantics=EXACTLY_ONCE`, and data are published in the job (and not in the tasks).
- Created `CommitStep`, `CommitSequence`, `CommitSequenceStore` and their implementations.
- When exactly-once is used:
 - `JobContext.commit()` will first construct a `CommitSequence`, persist the `CommitSequence` into the `CommitSequenceStore`, then execute the `CommitSequence`. If the `CommitSequence` is executed successfully, it will be deleted from the `CommitSequenceStore`.
 - `DataPublisher` will not actually publish the data, instead, it will create a `CommitSequence`. This is because the data can only be published after the `CommitSequence` has been fully constructed and persisted.
 - Staging data of a job will only be cleaned if all `CommitSequence`s of the job are successfully completed.
 - When launching a job, `AbstractJobLauncher` will check the `CommitSequenceStore` to see whether there are any unfinished `CommitSequences` for the current job. If there are, it will execute those `CommitSequences`. If successful, it will delete them from the `CommitSequenceStore`, cleanup the staging data, and run the new WorkUnits.

The features below are not included in this PR and will be in subsequent PRs:
- Enable exactly-once when publishing data from tasks.
- Generate and execute `CommitSequence`s in containers rather than the driver.
- Isolation between differnet datasets of a job: if the `CommitSequence` of a dataset cannot be executed, this dataset should be blacklisted and it should not affect other datasets.
