### PR TITLE
Some refactoring around GobblinYarnAppLauncherTest

### DIFF
--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -206,7 +206,6 @@ public class GobblinYarnAppLauncher {
     this.yarnConfiguration.set("fs.automatic.close", "false");
     this.yarnClient = YarnClient.createYarnClient();
     this.yarnClient.init(this.yarnConfiguration);
-    this.yarnClient.start();
 
     this.fs = config.hasPath(ConfigurationKeys.FS_URI_KEY) ?
         FileSystem.get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), this.yarnConfiguration) :
@@ -244,6 +243,8 @@ public class GobblinYarnAppLauncher {
     LOGGER.info("Created Helix cluster " + clusterName);
 
     connectHelixManager();
+
+    startYarnClient();
 
     this.applicationId = getApplicationId();
 
@@ -301,7 +302,7 @@ public class GobblinYarnAppLauncher {
 
       ExecutorsUtils.shutdownExecutorService(this.applicationStatusMonitor, Optional.of(LOGGER), 5, TimeUnit.MINUTES);
 
-      this.yarnClient.stop();
+      stopYarnClient();
 
       disconnectHelixManager();
     } finally {
@@ -392,6 +393,16 @@ public class GobblinYarnAppLauncher {
     if (this.helixManager.isConnected()) {
       this.helixManager.disconnect();
     }
+  }
+
+  @VisibleForTesting
+  void startYarnClient() {
+    this.yarnClient.start();
+  }
+
+  @VisibleForTesting
+  void stopYarnClient() {
+    this.yarnClient.stop();
   }
 
   private Optional<ApplicationId> getApplicationId() throws YarnException, IOException {

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -119,11 +119,10 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
    * has some issue that causes the {@link YarnClient} not be able to connect and submit the Gobblin Yarn
    * application successfully. This works fine on local machine though. So disabling this and the test
    * below that depends on it on Travis-CI.
-   *
-   * @throws Exception
    */
   @Test(groups = { "disabledOnTravis" }, dependsOnMethods = "testCreateHelixCluster")
   public void testSetupAndSubmitApplication() throws Exception {
+    this.gobblinYarnAppLauncher.startYarnClient();
     this.applicationId = this.gobblinYarnAppLauncher.setupAndSubmitApplication();
   }
 
@@ -135,7 +134,6 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
 
   @Test(dependsOnMethods = "testCreateHelixCluster")
   public void testSendShutdownRequest() throws Exception {
-    Logger log = LoggerFactory.getLogger("testSendShutdownRequest");
     this.helixManager.connect();
     this.helixManager.getMessagingService().registerMessageHandlerFactory(Message.MessageType.SHUTDOWN.toString(),
         new TestShutdownMessageHandlerFactory(this));
@@ -143,12 +141,14 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     this.gobblinYarnAppLauncher.connectHelixManager();
     this.gobblinYarnAppLauncher.sendShutdownRequest();
 
-    Assert.assertEquals(this.curatorFramework.checkExists().forPath(
-        String.format("/%s/CONTROLLER/MESSAGES", GobblinYarnAppLauncherTest.class.getSimpleName())).getVersion(), 0);
+    Assert.assertEquals(this.curatorFramework.checkExists()
+        .forPath(String.format("/%s/CONTROLLER/MESSAGES", GobblinYarnAppLauncherTest.class.getSimpleName()))
+        .getVersion(), 0);
     YarnSecurityManagerTest.GetControllerMessageNumFunc getCtrlMessageNum =
-        new YarnSecurityManagerTest.GetControllerMessageNumFunc(
-            GobblinYarnAppLauncherTest.class.getSimpleName(), this.curatorFramework);
-    AssertWithBackoff assertWithBackoff = AssertWithBackoff.create().logger(log).timeoutMs(20000);
+        new YarnSecurityManagerTest.GetControllerMessageNumFunc(GobblinYarnAppLauncherTest.class.getSimpleName(),
+            this.curatorFramework);
+    AssertWithBackoff assertWithBackoff =
+        AssertWithBackoff.create().logger(LoggerFactory.getLogger("testSendShutdownRequest")).timeoutMs(20000);
     assertWithBackoff.assertEquals(getCtrlMessageNum, 1, "1 controller message queued");
 
     // Give Helix sometime to handle the message
@@ -158,6 +158,8 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
   @AfterClass
   public void tearDown() throws IOException, TimeoutException {
     try {
+      this.gobblinYarnAppLauncher.stopYarnClient();
+
       if (this.helixManager.isConnected()) {
         this.helixManager.disconnect();
       }


### PR DESCRIPTION
Made the `YarnClient` inside `GobblinYarnAppLauncher` visible to testing so `GobblinYarnAppLauncher` can explicitly start and stop the `YarnClient` inside `GobblinYarnAppLauncher`. 

Signed-off-by: Yinan Li <liyinan926@gmail.com>