### PR TITLE
Adding Hadoop cluster Tags to gobblin-yarn metrics

### DIFF
--- a/gobblin-azkaban/build.gradle
+++ b/gobblin-azkaban/build.gradle
@@ -35,6 +35,8 @@ dependencies {
   compile externalDependency.guava
   compile externalDependency.commonsLang
   compile externalDependency.jodaTime
+  compile externalDependency.lombok
+  compile externalDependency.slf4j
   if (project.hasProperty('useHadoop2')) {
     compile externalDependency.typesafeConfig
     compile externalDependency.hadoopYarnApi

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanCompactionJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanCompactionJobLauncher.java
@@ -15,11 +15,14 @@ package gobblin.azkaban;
 import gobblin.compaction.Compactor;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.log4j.Logger;
 
 import azkaban.jobExecutor.AbstractJob;
+
+import gobblin.metrics.Tag;
 
 
 /**
@@ -47,7 +50,8 @@ public class AzkabanCompactionJobLauncher extends AbstractJob {
   private Compactor getCompactor() {
     try {
       Class<? extends Compactor> compactorClass = getCompactorClass();
-      Compactor compactor = compactorClass.getDeclaredConstructor(Properties.class).newInstance(this.properties);
+      Compactor compactor = compactorClass.getDeclaredConstructor(Properties.class, List.class)
+          .newInstance(this.properties, Tag.fromMap(AzkabanTags.getAzkabanTags()));
       return compactor;
     } catch (Exception e) {
       throw new RuntimeException("Failed to instantiate compactor", e);
@@ -56,7 +60,6 @@ public class AzkabanCompactionJobLauncher extends AbstractJob {
 
   @Override
   public void run() throws Exception {
-
     this.compactor.compact();
   }
 
@@ -71,5 +74,4 @@ public class AzkabanCompactionJobLauncher extends AbstractJob {
   public void cancel() throws IOException {
     this.compactor.cancel();
   }
-
 }

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
@@ -35,7 +35,6 @@ import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobLauncherFactory;
 import gobblin.runtime.JobListener;
 import gobblin.runtime.util.JobMetrics;
-import gobblin.util.TagUtils;
 import gobblin.util.TimeRangeChecker;
 
 
@@ -94,7 +93,7 @@ public class AzkabanJobLauncher extends AbstractJob {
     }
 
     List<Tag<?>> tags = Lists.newArrayList();
-    tags.addAll(Tag.fromMap(TagUtils.getRuntimeTags()));
+    tags.addAll(Tag.fromMap(AzkabanTags.getAzkabanTags()));
     JobMetrics.addCustomTagsToProperties(this.props, tags);
 
     // If the job launcher type is not specified in the job configuration,

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanTags.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanTags.java
@@ -1,4 +1,4 @@
-package gobblin.util;
+package gobblin.azkaban;
 
 import java.util.Map;
 
@@ -10,12 +10,12 @@ import org.apache.hadoop.conf.Configuration;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
+
 /**
- * Utility class to build commonly used tags
- *
+ * Utility class for collecting metadata specific to a Azkaban runtime environment.
  */
 @Slf4j
-public class TagUtils {
+public class AzkabanTags {
 
   public static final ImmutableMap<String, String> PROPERTIES_TO_TAGS_MAP = new ImmutableMap.Builder<String, String>()
       .put("azkaban.flow.projectname", "azkabanProjectName")
@@ -23,26 +23,23 @@ public class TagUtils {
       .put("azkaban.job.id", "azkabanJobId")
       .put("azkaban.flow.execid", "azkabanExecId").build();
 
-  public static final String CLUSTER_IDENTIFIER_TAG_NAME = "clusterIdentifier";
-
   /**
-   * Uses {@link #getRuntimeTags(Configuration)} with default Hadoop {@link Configuration}
+   * Uses {@link #getAzkabanTags(Configuration)} with default Hadoop {@link Configuration}
    */
-  public static Map<String, String> getRuntimeTags() {
-    return getRuntimeTags(new Configuration());
+  public static Map<String, String> getAzkabanTags() {
+    return getAzkabanTags(new Configuration());
   }
 
   /**
-   * Gets all useful runtime properties required by metrics as a {@link Map}.
-   *
-   * @see ClustersNames
+   * Gets all useful Azkaban runtime properties required by metrics as a {@link Map}.
    *
    * @param conf Hadoop Configuration that contains the properties. Keys of {@link #PROPERTIES_TO_TAGS_MAP} lists out
-   *          all the properties to look for in {@link Configuration}.
+   * all the properties to look for in {@link Configuration}.
+   *
    * @return a {@link Map} with keys as property names (name mapping in {@link #PROPERTIES_TO_TAGS_MAP}) and the value
-   *         of the property from {@link Configuration}
+   * of the property from {@link Configuration}
    */
-  public static Map<String, String> getRuntimeTags(Configuration conf) {
+  public static Map<String, String> getAzkabanTags(Configuration conf) {
     Map<String, String> tagMap = Maps.newHashMap();
 
     for (Map.Entry<String, String> entry : PROPERTIES_TO_TAGS_MAP.entrySet()) {
@@ -52,10 +49,6 @@ public class TagUtils {
         log.warn(String.format("No config value found for config %s. Metrics will not have tag %s", entry.getKey(),
             entry.getValue()));
       }
-    }
-    String clusterIdentifierTag = ClustersNames.getInstance().getClusterName();
-    if (StringUtils.isNotBlank(clusterIdentifierTag)) {
-      tagMap.put(CLUSTER_IDENTIFIER_TAG_NAME, clusterIdentifierTag);
     }
     return tagMap;
   }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
@@ -32,6 +32,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Pattern;
 
 import org.apache.commons.lang.StringUtils;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -39,6 +40,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.mapreduce.Job;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,6 +48,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
@@ -70,7 +73,7 @@ import gobblin.metrics.event.sla.SlaEventSubmitter;
 import gobblin.util.DatasetFilterUtils;
 import gobblin.util.ExecutorsUtils;
 import gobblin.util.HadoopUtils;
-import gobblin.util.TagUtils;
+import gobblin.util.ClusterNameTags;
 import gobblin.util.recordcount.CompactionRecordCountProvider;
 import gobblin.util.recordcount.IngestionRecordCountProvider;
 
@@ -210,6 +213,7 @@ public class MRCompactor implements Compactor {
   private static final Map<Dataset, Job> RUNNING_MR_JOBS = Maps.newConcurrentMap();
 
   private final State state;
+  private final List<? extends Tag<?>> tags;
   private final Configuration conf;
   private final String tmpOutputDir;
   private final FileSystem fs;
@@ -227,9 +231,10 @@ public class MRCompactor implements Compactor {
   private final boolean shouldVerifDataCompl;
   private final boolean shouldPublishDataIfCannotVerifyCompl;
 
-  public MRCompactor(Properties props) throws IOException {
+  public MRCompactor(Properties props, List<? extends Tag<?>> tags) throws IOException {
     this.state = new State();
-    state.addAll(props);
+    this.state.addAll(props);
+    this.tags = tags;
     this.conf = HadoopUtils.getConfFromState(state);
     this.tmpOutputDir = getTmpOutputDir();
     this.fs = getFileSystem();
@@ -286,10 +291,12 @@ public class MRCompactor implements Compactor {
   }
 
   private GobblinMetrics initializeMetrics() {
-    List<Tag<?>> tags = Lists.newArrayList();
-    tags.addAll(Tag.fromMap(TagUtils.getRuntimeTags()));
-    GobblinMetrics gobblinMetrics = GobblinMetrics.get(state.getProp(ConfigurationKeys.JOB_NAME_KEY), null, tags);
-    gobblinMetrics.startMetricReporting(state.getProperties());
+    ImmutableList.Builder<Tag<?>> tags = ImmutableList.builder();
+    tags.addAll(this.tags);
+    tags.addAll(Tag.fromMap(ClusterNameTags.getClusterNameTags()));
+    GobblinMetrics gobblinMetrics =
+        GobblinMetrics.get(this.state.getProp(ConfigurationKeys.JOB_NAME_KEY), null, tags.build());
+    gobblinMetrics.startMetricReporting(this.state.getProperties());
     return gobblinMetrics;
   }
 

--- a/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-core/src/main/java/gobblin/metrics/GobblinMetrics.java
@@ -140,6 +140,22 @@ public class GobblinMetrics {
   }
 
   /**
+   * Add a {@link List} of {@link Tag}s to a {@link gobblin.configuration.State} with key {@link #METRICS_STATE_CUSTOM_TAGS}.
+   *
+   * <p>
+   *   {@link gobblin.metrics.Tag}s under this key can later be parsed using the method {@link #getCustomTagsFromState}.
+   * </p>
+   *
+   * @param state {@link gobblin.configuration.State} state to add the tag to.
+   * @param tags list of {@link Tag}s to add.
+   */
+  public static void addCustomTagToState(State state, List<? extends Tag<?>> tags) {
+    for (Tag<?> tag : tags) {
+      state.appendToListProp(METRICS_STATE_CUSTOM_TAGS, tag.toString());
+    }
+  }
+
+  /**
    * Add a {@link Tag} to a {@link gobblin.configuration.State} with key {@link #METRICS_STATE_CUSTOM_TAGS}.
    *
    * <p>

--- a/gobblin-metrics/src/main/java/gobblin/metrics/Tag.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/Tag.java
@@ -16,7 +16,12 @@ import java.util.AbstractMap;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
+import com.google.common.base.Function;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 
 
@@ -46,7 +51,7 @@ public class Tag<T> extends AbstractMap.SimpleEntry<String, T> {
   public static Tag<String> fromString(String tagKeyValue) {
     List<String> splitKeyValue = Splitter.on(KEY_VALUE_SEPARATOR).limit(2).omitEmptyStrings().splitToList(tagKeyValue);
     if(splitKeyValue.size() == 2) {
-      return new Tag<String>(splitKeyValue.get(0), splitKeyValue.get(1));
+      return new Tag<>(splitKeyValue.get(0), splitKeyValue.get(1));
     } else {
       return null;
     }
@@ -60,12 +65,64 @@ public class Tag<T> extends AbstractMap.SimpleEntry<String, T> {
     super(entry);
   }
 
+  /**
+   * Converts a {@link Map} of key, value pairs to a {@link List} of {@link Tag}s. Each key, value pair will be used to
+   * create a new {@link Tag}.
+   *
+   * @param tagsMap a {@link Map} of key, value pairs that should be converted into {@link Tag}s
+   *
+   * @return a {@link List} of {@link Tag}s
+   */
   public static <T> List<Tag<T>> fromMap(Map<? extends String, T> tagsMap) {
-    List<Tag<T>> tags = Lists.newArrayList();
-    for(Map.Entry<? extends String, T> entry : tagsMap.entrySet()) {
-      tags.add(new Tag<T>(entry));
+    ImmutableList.Builder<Tag<T>> tagsBuilder = ImmutableList.builder();
+    for (Map.Entry<? extends String, T> entry : tagsMap.entrySet()) {
+      tagsBuilder.add(new Tag<>(entry));
     }
-    return tags;
+    return tagsBuilder.build();
+  }
+
+  /**
+   * Converts a {@link List} of {@link Tag}s to a {@link Map} of key, value pairs.
+   *
+   * @param tags a {@link List} of {@link Tag}s that should be converted to key, value pairs
+   *
+   * @return a {@link Map} of key, value pairs
+   */
+  public static <T> Map<? extends String, T> toMap(List<Tag<T>> tags) {
+    ImmutableMap.Builder<String, T> tagsMapBuilder = ImmutableMap.builder();
+    for (Tag<T> tag : tags) {
+      tagsMapBuilder.put(tag.getKey(), tag.getValue());
+    }
+    return tagsMapBuilder.build();
+  }
+
+  /**
+   * Converts a {@link List} of wildcard {@link Tag}s to a {@link List} of {@link String} {@link Tag}s.
+   *
+   * @param tags a {@link List} of {@link Tag}s that should be converted to {@link Tag}s with value of type {@link String}
+   *
+   * @return a {@link List} of {@link Tag}s
+   *
+   * @see {@link #tagValueToString(Tag)}
+   */
+  public static List<Tag<String>> tagValuesToString(List<? extends Tag<?>> tags) {
+    return Lists.transform(tags, new Function<Tag<?>, Tag<String>>() {
+      @Nullable @Override public Tag<String> apply(Tag<?> input) {
+        return Tag.tagValueToString(input);
+      }
+    });
+  }
+
+  /**
+   * Converts a wildcard {@link Tag} to a {@link String} {@link Tag}. This method uses the {@link Object#toString()}
+   * method to convert the wildcard type to a {@link String}.
+   *
+   * @param tag a {@link Tag} that should be converted to a {@link Tag} with value of type {@link String}
+   *
+   * @return a {@link Tag} with a {@link String} value
+   */
+  public static Tag<String> tagValueToString(Tag<?> tag) {
+    return new Tag<>(tag.getKey(), tag.getValue().toString());
   }
 
   @Override

--- a/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java
@@ -57,7 +57,7 @@ public class EventSubmitter {
       return this;
     }
 
-    public Builder addMetadata(Map<String, String> additionalMetadata) {
+    public Builder addMetadata(Map<? extends String, ? extends String> additionalMetadata) {
       this.metadata.putAll(additionalMetadata);
       return this;
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -28,6 +28,7 @@ import com.google.common.base.CaseFormat;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.EventBus;
@@ -39,12 +40,14 @@ import gobblin.metastore.StateStore;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.GobblinMetricsRegistry;
 import gobblin.metrics.MetricContext;
+import gobblin.metrics.Tag;
 import gobblin.metrics.event.EventNames;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.metrics.event.TimingEvent;
 import gobblin.runtime.util.JobMetrics;
 import gobblin.runtime.util.TimingEventNames;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.ClusterNameTags;
 import gobblin.util.ExecutorsUtils;
 import gobblin.util.JobLauncherUtils;
 import gobblin.util.ParallelRunner;
@@ -103,7 +106,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
   // A list of JobListeners that will be injected into the user provided JobListener
   private final List<JobListener> mandatoryJobListeners = Lists.newArrayList();
 
-  public AbstractJobLauncher(Properties jobProps, Map<String, String> eventMetadata) throws Exception {
+  public AbstractJobLauncher(Properties jobProps, List<? extends Tag<?>> metadataTags) throws Exception {
     Preconditions.checkArgument(jobProps.containsKey(ConfigurationKeys.JOB_NAME_KEY),
         "A job must have a job name specified by job.name");
 
@@ -125,8 +128,11 @@ public abstract class AbstractJobLauncher implements JobLauncher {
           }
         });
 
-    this.eventSubmitter =
-        new EventSubmitter.Builder(this.runtimeMetricContext, "gobblin.runtime").addMetadata(eventMetadata).build();
+    metadataTags = addClusterNameTags(metadataTags);
+    this.eventSubmitter = buildEventSubmitter(metadataTags);
+
+    // Add all custom tags to the JobState so that tags are added to any new TaskState created
+    JobMetrics.addCustomTagToState(this.jobContext.getJobState(), metadataTags);
 
     JobExecutionEventSubmitter jobExecutionEventSubmitter = new JobExecutionEventSubmitter(this.eventSubmitter);
     this.mandatoryJobListeners.add(new JobExecutionEventSubmitterListener(jobExecutionEventSubmitter));
@@ -505,6 +511,25 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     List<JobListener> jobListeners = Lists.newArrayList(this.mandatoryJobListeners);
     jobListeners.add(jobListener);
     return JobListeners.parallelJobListener(jobListeners);
+  }
+
+  /**
+   * Takes a {@link List} of {@link Tag}s and returns a new {@link List} with the original {@link Tag}s as well as any
+   * additional {@link Tag}s returned by {@link ClusterNameTags#getClusterNameTags()}.
+   *
+   * @see {@link ClusterNameTags}
+   */
+  private List<Tag<?>> addClusterNameTags(List<? extends Tag<?>> tags) {
+    return ImmutableList.<Tag<?>>builder().addAll(tags).addAll(Tag.fromMap(ClusterNameTags.getClusterNameTags()))
+        .build();
+  }
+
+  /**
+   * Build the {@link EventSubmitter} for this class.
+   */
+  private EventSubmitter buildEventSubmitter(List<? extends Tag<?>> tags) {
+    return new EventSubmitter.Builder(this.runtimeMetricContext, "gobblin.runtime")
+        .addMetadata(Tag.toMap(Tag.tagValuesToString(tags))).build();
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -26,11 +26,12 @@ import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ServiceManager;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.Tag;
 import gobblin.metrics.event.TimingEvent;
 import gobblin.runtime.AbstractJobLauncher;
 import gobblin.runtime.FileBasedJobLock;
@@ -63,7 +64,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   private volatile CountDownLatch countDownLatch;
 
   public LocalJobLauncher(Properties jobProps) throws Exception {
-    super(jobProps, ImmutableMap.<String, String> of());
+    super(jobProps, ImmutableList.<Tag<?>>of());
 
     TimingEvent jobLocalSetupTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.JOB_LOCAL_SETUP);
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -46,6 +46,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
@@ -55,6 +56,7 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
 import gobblin.metrics.GobblinMetrics;
+import gobblin.metrics.Tag;
 import gobblin.metrics.event.TimingEvent;
 import gobblin.password.PasswordManager;
 import gobblin.runtime.AbstractJobLauncher;
@@ -125,7 +127,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   }
 
   public MRJobLauncher(Properties jobProps, Configuration conf) throws Exception {
-    super(jobProps, ImmutableMap.<String, String>of());
+    super(jobProps, ImmutableList.<Tag<?>>of());
 
     this.conf = conf;
     // Put job configuration properties into the Hadoop configuration so they are available in the mappers

--- a/gobblin-utility/src/main/java/gobblin/util/ClusterNameTags.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ClusterNameTags.java
@@ -1,0 +1,45 @@
+package gobblin.util;
+
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+
+
+/**
+ * Utility class for collecting metadata specific to the current Hadoop cluster.
+ *
+ * @see {@link ClustersNames}
+ */
+public class ClusterNameTags {
+
+  public static final String CLUSTER_IDENTIFIER_TAG_NAME = "clusterIdentifier";
+
+  /**
+   * Uses {@link #getClusterNameTags(Configuration)} with default Hadoop {@link Configuration}.
+   *
+   * @return a {@link Map} of key, value pairs containing the cluster metadata
+   */
+  public static Map<String, String> getClusterNameTags() {
+    return getClusterNameTags(new Configuration());
+  }
+
+  /**
+   * Gets all useful Hadoop cluster metrics.
+   *
+   * @param conf a Hadoop {@link Configuration} to collect the metadata from
+   *
+   * @return a {@link Map} of key, value pairs containing the cluster metadata
+   */
+  public static Map<String, String> getClusterNameTags(Configuration conf) {
+    ImmutableMap.Builder<String, String> tagMap = ImmutableMap.builder();
+
+    String clusterIdentifierTag = ClustersNames.getInstance().getClusterName(conf);
+    if (!Strings.isNullOrEmpty(clusterIdentifierTag)) {
+      tagMap.put(CLUSTER_IDENTIFIER_TAG_NAME, clusterIdentifierTag);
+    }
+    return tagMap.build();
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -80,6 +80,8 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.Tag;
+import gobblin.util.ClusterNameTags;
 import gobblin.util.ConfigUtils;
 import gobblin.yarn.event.ApplicationMasterShutdownRequest;
 import gobblin.yarn.event.DelegationTokenUpdatedEvent;
@@ -139,15 +141,14 @@ public class GobblinApplicationMaster extends GobblinYarnLogSource {
     FileSystem fs = buildFileSystem(config);
     Path appWorkDir = YarnHelixUtils.getAppWorkDirPath(fs, applicationName, applicationId);
 
-    Map<String, String> eventMetadata = getEventSubmitterMetadata(applicationName, applicationId);
-
     List<Service> services = Lists.newArrayList();
 
     if (isLogSourcePresent()) {
       services.add(buildLogCopier(containerId, fs, appWorkDir));
     }
+
     services.add(buildYarnService(config, applicationName, applicationId, yarnConfiguration, fs));
-    services.add(buildGobblinHelixJobScheduler(config, appWorkDir, eventMetadata));
+    services.add(buildGobblinHelixJobScheduler(config, appWorkDir, getMetadataTags(applicationName, applicationId)));
     services.add(buildJobConfigurationManager(config));
 
     if (UserGroupInformation.isSecurityEnabled()) {
@@ -217,11 +218,12 @@ public class GobblinApplicationMaster extends GobblinYarnLogSource {
   }
 
   /**
-   * Get additional metadata required for the {@link gobblin.metrics.event.EventSubmitter}.
+   * Get additional {@link Tag}s required for any type of reporting.
    */
-  private Map<String, String> getEventSubmitterMetadata(String applicationName, String applicationId) {
-    return new ImmutableMap.Builder<String, String>().put(GobblinYarnEventNames.YARN_APPLICATION_NAME, applicationName)
-        .put(GobblinYarnEventNames.YARN_APPLICATION_ID, applicationId).build();
+  private List<? extends Tag<?>> getMetadataTags(String applicationName, String applicationId) {
+    return Tag.fromMap(
+        new ImmutableMap.Builder<String, Object>().put(GobblinYarnEventNames.YARN_APPLICATION_NAME, applicationName)
+            .put(GobblinYarnEventNames.YARN_APPLICATION_ID, applicationId).build());
   }
 
   /**
@@ -257,10 +259,10 @@ public class GobblinApplicationMaster extends GobblinYarnLogSource {
    * Build the {@link GobblinHelixJobScheduler} for the Application Master.
    */
   private GobblinHelixJobScheduler buildGobblinHelixJobScheduler(Config config, Path appWorkDir,
-      Map<String, String> eventMetadata)
+      List<? extends Tag<?>> metadataTags)
       throws Exception {
     Properties properties = ConfigUtils.configToProperties(config);
-    return new GobblinHelixJobScheduler(properties, this.helixManager, this.eventBus, appWorkDir, eventMetadata);
+    return new GobblinHelixJobScheduler(properties, this.helixManager, this.eventBus, appWorkDir, metadataTags);
   }
 
   /**

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJob.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJob.java
@@ -12,17 +12,19 @@
 
 package gobblin.yarn;
 
-import java.util.Map;
+import java.util.List;
 import java.util.Properties;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.helix.HelixManager;
+
 import org.quartz.Job;
 import org.quartz.JobDataMap;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 
+import gobblin.metrics.Tag;
 import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobListener;
 import gobblin.scheduler.JobScheduler;
@@ -46,7 +48,7 @@ public class GobblinHelixJob implements Job {
     HelixManager helixManager = (HelixManager) dataMap.get(GobblinHelixJobScheduler.HELIX_MANAGER_KEY);
     Path appWorkDir = (Path) dataMap.get(GobblinHelixJobScheduler.APPLICATION_WORK_DIR_KEY);
     @SuppressWarnings("unchecked")
-    Map<String, String> eventMetadata = (Map<String, String>) dataMap.get(GobblinHelixJobScheduler.EVENT_METADATA);
+    List<? extends Tag<?>> eventMetadata = (List<? extends Tag<?>>) dataMap.get(GobblinHelixJobScheduler.METADATA_TAGS);
     FileSystem fs = (FileSystem) dataMap.get(GobblinHelixJobScheduler.FILE_SYSTEM);
 
     try {

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobLauncher.java
@@ -34,6 +34,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.collect.Maps;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.Tag;
 import gobblin.metrics.event.TimingEvent;
 import gobblin.rest.LauncherTypeEnum;
 import gobblin.runtime.AbstractJobLauncher;
@@ -99,9 +100,9 @@ public class GobblinHelixJobLauncher extends AbstractJobLauncher {
   private volatile boolean jobComplete = false;
 
   public GobblinHelixJobLauncher(Properties jobProps, HelixManager helixManager, FileSystem fs, Path appWorkDir,
-      Map<String, String> eventMetadata)
+      List<? extends Tag<?>> metadataTags)
       throws Exception {
-    super(jobProps, eventMetadata);
+    super(jobProps, metadataTags);
 
     this.helixManager = helixManager;
     this.helixTaskDriver = new TaskDriver(this.helixManager);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobScheduler.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixJobScheduler.java
@@ -13,6 +13,7 @@
 package gobblin.yarn;
 
 import java.net.URI;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 
@@ -29,6 +30,7 @@ import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.Tag;
 import gobblin.runtime.JobException;
 import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobListener;
@@ -48,25 +50,25 @@ public class GobblinHelixJobScheduler extends JobScheduler {
 
   static final String HELIX_MANAGER_KEY = "helixManager";
   static final String APPLICATION_WORK_DIR_KEY = "applicationWorkDir";
-  static final String EVENT_METADATA = "eventMetadata";
+  static final String METADATA_TAGS = "metadataTags";
   static final String FILE_SYSTEM = "fileSystem";
 
   private final Properties properties;
   private final HelixManager helixManager;
   private final EventBus eventBus;
   private final Path appWorkDir;
-  private final Map<String, String> eventMetadata;
+  private final List<? extends Tag<?>> metadataTags;
   private final FileSystem fs;
 
   public GobblinHelixJobScheduler(Properties properties, HelixManager helixManager, EventBus eventBus,
-      Path appWorkDir, Map<String, String> eventMetadata) throws Exception {
+      Path appWorkDir, List<? extends Tag<?>> metadataTags) throws Exception {
     super(properties);
     this.properties = properties;
     this.helixManager = helixManager;
     this.eventBus = eventBus;
 
     this.appWorkDir = appWorkDir;
-    this.eventMetadata = eventMetadata;
+    this.metadataTags = metadataTags;
 
     URI fsUri = URI.create(properties.getProperty(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
     this.fs = FileSystem.get(fsUri, new Configuration());
@@ -83,7 +85,7 @@ public class GobblinHelixJobScheduler extends JobScheduler {
     Map<String, Object> additionalJobDataMap = Maps.newHashMap();
     additionalJobDataMap.put(HELIX_MANAGER_KEY, this.helixManager);
     additionalJobDataMap.put(APPLICATION_WORK_DIR_KEY, this.appWorkDir);
-    additionalJobDataMap.put(EVENT_METADATA, this.eventMetadata);
+    additionalJobDataMap.put(METADATA_TAGS, this.metadataTags);
     additionalJobDataMap.put(FILE_SYSTEM, this.fs);
 
     try {
@@ -105,7 +107,7 @@ public class GobblinHelixJobScheduler extends JobScheduler {
 
   private GobblinHelixJobLauncher buildGobblinHelixJobLauncher(Properties jobProps)
       throws Exception {
-    return new GobblinHelixJobLauncher(jobProps, this.helixManager, this.fs, this.appWorkDir, this.eventMetadata);
+    return new GobblinHelixJobLauncher(jobProps, this.helixManager, this.fs, this.appWorkDir, this.metadataTags);
   }
 
   @SuppressWarnings("unused")

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
@@ -12,6 +12,7 @@
 
 package gobblin.yarn;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +27,7 @@ import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -78,6 +80,7 @@ import gobblin.metrics.GobblinMetrics;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskStateTracker;
 import gobblin.util.ConfigUtils;
+import gobblin.util.HadoopUtils;
 import gobblin.yarn.event.DelegationTokenUpdatedEvent;
 
 
@@ -142,9 +145,8 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
     ApplicationAttemptId applicationAttemptId = this.containerId.getApplicationAttemptId();
     String applicationId = applicationAttemptId.getApplicationId().toString();
 
-    FileSystem fs = config.hasPath(ConfigurationKeys.FS_URI_KEY) ?
-        FileSystem.get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), new Configuration()) :
-        FileSystem.get(new Configuration());
+    Configuration conf = HadoopUtils.newConfiguration();
+    FileSystem fs = buildFileSystem(this.config, conf);
 
     String zkConnectionString = config.getString(GobblinYarnConfigurationKeys.ZK_CONNECTION_STRING_KEY);
     LOGGER.info("Using ZooKeeper connection string: " + zkConnectionString);
@@ -174,12 +176,7 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
 
     this.serviceManager = new ServiceManager(services);
 
-    if (GobblinMetrics.isEnabled(properties)) {
-      this.containerMetrics =
-          Optional.of(ContainerMetrics.get(ConfigUtils.configToState(this.config), applicationName, containerId));
-    } else {
-      this.containerMetrics = Optional.absent();
-    }
+    this.containerMetrics = buildContainerMetrics(this.config, properties, applicationName, containerId);
 
     // Register task factory for the Helix task state model
     Map<String, TaskFactory> taskFactoryMap = Maps.newHashMap();
@@ -295,6 +292,21 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
   private void registerMetricSetWithPrefix(String prefix, MetricSet metricSet) {
     for (Map.Entry<String, Metric> entry : metricSet.getMetrics().entrySet()) {
       this.metricRegistry.register(MetricRegistry.name(prefix, entry.getKey()), entry.getValue());
+    }
+  }
+
+  private FileSystem buildFileSystem(Config config, Configuration conf) throws IOException {
+    return config.hasPath(ConfigurationKeys.FS_URI_KEY) ?
+        FileSystem.get(URI.create(config.getString(ConfigurationKeys.FS_URI_KEY)), conf) :
+        FileSystem.get(conf);
+  }
+
+  private Optional<ContainerMetrics> buildContainerMetrics(Config config, Properties properties, String applicationName,
+      ContainerId containerId) {
+    if (GobblinMetrics.isEnabled(properties)) {
+      return Optional.of(ContainerMetrics.get(ConfigUtils.configToState(config), applicationName, containerId));
+    } else {
+      return Optional.absent();
     }
   }
 

--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinHelixJobLauncherTest.java
@@ -19,21 +19,25 @@ import java.util.List;
 import java.util.Properties;
 
 import org.apache.avro.Schema;
+
 import org.apache.curator.test.TestingServer;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.util.ConverterUtils;
+
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
+
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 
 import com.typesafe.config.Config;
@@ -41,6 +45,7 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.Tag;
 import gobblin.runtime.FsDatasetStateStore;
 import gobblin.runtime.JobException;
 import gobblin.runtime.JobState;
@@ -125,7 +130,7 @@ public class GobblinHelixJobLauncherTest {
 
     this.gobblinHelixJobLauncher = this.closer.register(
         new GobblinHelixJobLauncher(properties, this.helixManager, this.localFs, this.appWorkDir,
-            ImmutableMap.<String, String>of()));
+            ImmutableList.<Tag<?>>of()));
 
     this.gobblinWorkUnitRunner =
         new GobblinWorkUnitRunner(TestHelper.TEST_APPLICATION_NAME, TestHelper.TEST_HELIX_INSTANCE_NAME,


### PR DESCRIPTION
* Add Hadoop cluster tag to metrics emitted by gobblin-yarn
* Originally Hadoop cluster tags were only added in `AzkabanJobLauncher` so only jobs launched via `AzkabanJobLauncher` had these tags.
* Moved addition of Hadoop cluster tags to `AbstractJobLauncher`
* Separated out Azkaban and Hadoop specific tags