### PR TITLE
Bug fix for publishing to S3

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -229,7 +229,7 @@ public class WriterUtils {
     if (fs.exists(path)) {
       return;
     }
-    if (!fs.exists(path.getParent())) {
+    if (path.getParent() != null && !fs.exists(path.getParent())) {
       mkdirsWithRecursivePermission(fs, path.getParent(), perm);
     }
     if (!fs.mkdirs(path, perm)) {


### PR DESCRIPTION
Bug fix in `WriterUtils.mkdirsWithRecursivePermission` for publishing to file systems where the root directory does not already exist.

@zliu41 can you review?