### PR TITLE
Adding configurable MetricFilter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/instrumented/converter/InstrumentedConverterBase.java
+++ b/gobblin-core/src/main/java/gobblin/instrumented/converter/InstrumentedConverterBase.java
@@ -46,7 +46,7 @@ abstract class InstrumentedConverterBase<SI, SO, DI, DO> extends Converter<SI, S
     implements Instrumentable, Closeable {
 
   private boolean instrumentationEnabled = false;
-  private MetricContext metricContext = new MetricContext.Builder(InstrumentedConverterBase.class.getName()).build();
+  private MetricContext metricContext;
   private Optional<Meter> recordsInMeter = Optional.absent();
   private Optional<Meter> recordsOutMeter = Optional.absent();
   private Optional<Meter> recordsExceptionMeter = Optional.absent();

--- a/gobblin-metrics/src/main/java/gobblin/metrics/metric/Metrics.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/metric/Metrics.java
@@ -1,0 +1,30 @@
+package gobblin.metrics.metric;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.Timer;
+
+import lombok.Getter;
+
+
+/**
+ * An {@link Enum} of all {@link com.codahale.metrics.Metric}s.
+ */
+public enum Metrics {
+
+  COUNTER(Counter.class),
+  GAUGE(Gauge.class),
+  HISTOGRAM(Histogram.class),
+  METER(Meter.class),
+  TIMER(Timer.class);
+
+  @Getter
+  private final Class<? extends Metric> metricClass;
+
+  Metrics(Class<? extends Metric> metricClass) {
+    this.metricClass = metricClass;
+  }
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/metric/filter/MetricFilters.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/metric/filter/MetricFilters.java
@@ -1,0 +1,21 @@
+package gobblin.metrics.metric.filter;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+
+
+/**
+ * A utility class for working with {@link MetricFilter}s.
+ *
+ * @see {@link MetricFilter}
+ */
+public class MetricFilters {
+
+  public static MetricFilter and(final MetricFilter metricFilter1, final MetricFilter metricFilter2) {
+    return new MetricFilter() {
+      @Override public boolean matches(String name, Metric metric) {
+        return metricFilter1.matches(name, metric) && metricFilter2.matches(name, metric);
+      }
+    };
+  }
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/metric/filter/MetricNameRegexFilter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/metric/filter/MetricNameRegexFilter.java
@@ -1,0 +1,28 @@
+package gobblin.metrics.metric.filter;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+
+
+/**
+ * Implementation of {@link MetricFilter} that takes in a regex, and {@link #matches(String, Metric)} a {@link Metric}
+ * if the name of the {@link Metric} matches the regex.
+ */
+public class MetricNameRegexFilter implements MetricFilter {
+
+  private final Pattern regex;
+  private final Matcher matcher;
+
+  public MetricNameRegexFilter(String regex) {
+    this.regex = Pattern.compile(regex);
+    this.matcher = this.regex.matcher("");
+  }
+
+  @Override
+  public boolean matches(String name, Metric metric) {
+    return this.matcher.reset(name).matches();
+  }
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/metric/filter/MetricTypeFilter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/metric/filter/MetricTypeFilter.java
@@ -1,0 +1,52 @@
+package gobblin.metrics.metric.filter;
+
+import java.util.List;
+
+import javax.annotation.Nullable;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+
+import com.google.common.base.Function;
+import com.google.common.base.Predicate;
+import com.google.common.base.Splitter;
+import com.google.common.base.Strings;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import gobblin.metrics.metric.Metrics;
+
+
+/**
+ * Implementation of {@link MetricFilter} that takes in a {@link String} containing a comma separated list of
+ * {@link Metrics}. This {@link MetricFilter} {@link #matches(String, Metric)} a {@link Metric} if the given
+ * {@link Metric} has a type in the given list of allowed {@link Metrics}.
+ */
+public class MetricTypeFilter implements MetricFilter {
+
+  private List<Metrics> allowedMetrics;
+
+  public MetricTypeFilter(String allowedMetrics) {
+    if (Strings.isNullOrEmpty(allowedMetrics)) {
+      this.allowedMetrics = Lists.newArrayList(Metrics.values());
+    } else {
+      List<String> allowedMetricsList = Splitter.on(",").trimResults().omitEmptyStrings().splitToList(allowedMetrics);
+      this.allowedMetrics = Lists.transform(allowedMetricsList, new Function<String, Metrics>() {
+        @Nullable @Override public Metrics apply(String input) {
+          return input == null ? null : Metrics.valueOf(input);
+        }
+      });
+    }
+  }
+
+  @Override
+  public boolean matches(String name, Metric metric) {
+    final Class<? extends Metric> metricClass = metric.getClass();
+
+    return Iterables.any(this.allowedMetrics, new Predicate<Metrics>() {
+      @Override public boolean apply(@Nullable Metrics input) {
+        return input != null && input.getMetricClass().isAssignableFrom(metricClass);
+      }
+    });
+  }
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ContextAwareReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ContextAwareReporter.java
@@ -59,8 +59,11 @@ public class ContextAwareReporter implements Reporter, Closeable {
   private final Set<InnerMetricContext> contextsToReport;
   private final ContextFilter contextFilter;
 
+  protected final Config config;
+
   public ContextAwareReporter(String name, Config config) {
     this.name = name;
+    this.config = config;
     this.started = false;
     RootMetricContext.get().addNewReporter(this);
     this.notificationTargetUUID = RootMetricContext.get().addNotificationTarget(new Function<Notification, Void>() {

--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ScheduledReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ScheduledReporter.java
@@ -42,6 +42,9 @@ import lombok.extern.slf4j.Slf4j;
 
 import gobblin.metrics.InnerMetricContext;
 import gobblin.metrics.context.ReportableContext;
+import gobblin.metrics.metric.filter.MetricFilters;
+import gobblin.metrics.metric.filter.MetricNameRegexFilter;
+import gobblin.metrics.metric.filter.MetricTypeFilter;
 import gobblin.util.ExecutorsUtils;
 
 
@@ -61,6 +64,9 @@ public abstract class ScheduledReporter extends ContextAwareReporter {
       appendHours().appendSuffix("H").
       appendMinutes().appendSuffix("M").
       appendSeconds().appendSuffix("S").toFormatter();
+
+  private static final String METRIC_FILTER_NAME_REGEX = "metric.filter.name.regex";
+  private static final String METRIC_FILTER_TYPE_LIST = "metric.filter.type.list";
 
   @VisibleForTesting
   static int parsePeriodToSeconds(String periodStr) {
@@ -88,6 +94,8 @@ public abstract class ScheduledReporter extends ContextAwareReporter {
   }
 
   private final ScheduledExecutorService executor;
+  private final MetricFilter metricFilter;
+
   private Optional<ScheduledFuture> scheduledTask;
   private int reportingPeriodSeconds;
 
@@ -97,6 +105,21 @@ public abstract class ScheduledReporter extends ContextAwareReporter {
         ExecutorsUtils.newDaemonThreadFactory(Optional.of(log), Optional.of("metrics-" + name + "-scheduler")));
     this.reportingPeriodSeconds = parsePeriodToSeconds(
         config.hasPath(REPORTING_INTERVAL) ? config.getString(REPORTING_INTERVAL) : DEFAULT_REPORTING_INTERVAL_PERIOD);
+    this.metricFilter = createMetricFilter(this.config);
+  }
+
+  private MetricFilter createMetricFilter(Config config) {
+    if (config.hasPath(METRIC_FILTER_NAME_REGEX) && config.hasPath(METRIC_FILTER_TYPE_LIST)) {
+      return MetricFilters.and(new MetricNameRegexFilter(config.getString(METRIC_FILTER_NAME_REGEX)),
+          new MetricTypeFilter(config.getString(METRIC_FILTER_TYPE_LIST)));
+    }
+    if (config.hasPath(METRIC_FILTER_NAME_REGEX)) {
+      return new MetricNameRegexFilter(config.getString(METRIC_FILTER_NAME_REGEX));
+    }
+    if (config.hasPath(METRIC_FILTER_TYPE_LIST)) {
+      return new MetricTypeFilter(config.getString(METRIC_FILTER_TYPE_LIST));
+    }
+    return MetricFilter.ALL;
   }
 
   @Override
@@ -169,9 +192,9 @@ public abstract class ScheduledReporter extends ContextAwareReporter {
    * @see {@link #report(ReportableContext)}
    */
   protected void report(ReportableContext context, boolean isFinal) {
-    report(context.getGauges(MetricFilter.ALL), context.getCounters(MetricFilter.ALL),
-        context.getHistograms(MetricFilter.ALL), context.getMeters(MetricFilter.ALL),
-        context.getTimers(MetricFilter.ALL), context.getTagMap(), isFinal);
+    report(context.getGauges(this.metricFilter), context.getCounters(this.metricFilter),
+        context.getHistograms(this.metricFilter), context.getMeters(this.metricFilter),
+        context.getTimers(this.metricFilter), context.getTagMap(), isFinal);
   }
 
   /**

--- a/gobblin-metrics/src/test/java/gobblin/metrics/metric/filter/MetricFiltersTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/metric/filter/MetricFiltersTest.java
@@ -1,0 +1,33 @@
+package gobblin.metrics.metric.filter;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.codahale.metrics.Metric;
+import com.codahale.metrics.MetricFilter;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for {@link MetricFilters}.
+ */
+@Test
+public class MetricFiltersTest {
+
+  @Test
+  public void andTest() {
+    MetricFilter trueMetricFilter = mock(MetricFilter.class);
+    when(trueMetricFilter.matches(any(String.class), any(Metric.class))).thenReturn(true);
+
+    MetricFilter falseMetricFilter = mock(MetricFilter.class);
+    when(falseMetricFilter.matches(any(String.class), any(Metric.class))).thenReturn(false);
+
+    Assert.assertTrue(MetricFilters.and(trueMetricFilter, trueMetricFilter).matches("", mock(Metric.class)));
+    Assert.assertFalse(MetricFilters.and(trueMetricFilter, falseMetricFilter).matches("", mock(Metric.class)));
+    Assert.assertFalse(MetricFilters.and(falseMetricFilter, trueMetricFilter).matches("", mock(Metric.class)));
+    Assert.assertFalse(MetricFilters.and(falseMetricFilter, falseMetricFilter).matches("", mock(Metric.class)));
+  }
+}

--- a/gobblin-metrics/src/test/java/gobblin/metrics/metric/filter/MetricNameRegexFilterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/metric/filter/MetricNameRegexFilterTest.java
@@ -1,0 +1,29 @@
+package gobblin.metrics.metric.filter;
+
+import static org.mockito.Mockito.mock;
+
+import com.codahale.metrics.Metric;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for {@link MetricNameRegexFilter}.
+ */
+@Test
+public class MetricNameRegexFilterTest {
+
+  @Test
+  public void matchesTest() {
+    MetricNameRegexFilter metricNameRegexFilter1 = new MetricNameRegexFilter(".*");
+    Assert.assertTrue(metricNameRegexFilter1.matches("test1", mock(Metric.class)));
+    Assert.assertTrue(metricNameRegexFilter1.matches("test2", mock(Metric.class)));
+    Assert.assertTrue(metricNameRegexFilter1.matches("test3", mock(Metric.class)));
+
+    MetricNameRegexFilter metricNameRegexFilter2 = new MetricNameRegexFilter("test1");
+    Assert.assertTrue(metricNameRegexFilter2.matches("test1", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexFilter2.matches("test2", mock(Metric.class)));
+    Assert.assertFalse(metricNameRegexFilter2.matches("test3", mock(Metric.class)));
+  }
+}

--- a/gobblin-metrics/src/test/java/gobblin/metrics/metric/filter/MetricTypeFilterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/metric/filter/MetricTypeFilterTest.java
@@ -1,0 +1,50 @@
+package gobblin.metrics.metric.filter;
+
+import static org.mockito.Mockito.mock;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Gauge;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Meter;
+import com.codahale.metrics.Timer;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for {@link MetricTypeFilter}.
+ */
+@Test
+public class MetricTypeFilterTest {
+
+  @Test
+  public void matchesTest() {
+    Counter counter = mock(Counter.class);
+    Gauge gauge = mock(Gauge.class);
+    Histogram histogram = mock(Histogram.class);
+    Meter meter = mock(Meter.class);
+    Timer timer = mock(Timer.class);
+
+    MetricTypeFilter noMetricTypeFilter = new MetricTypeFilter(null);
+    Assert.assertTrue(noMetricTypeFilter.matches("", counter));
+    Assert.assertTrue(noMetricTypeFilter.matches("", gauge));
+    Assert.assertTrue(noMetricTypeFilter.matches("", histogram));
+    Assert.assertTrue(noMetricTypeFilter.matches("", meter));
+    Assert.assertTrue(noMetricTypeFilter.matches("", timer));
+
+    MetricTypeFilter counterMetricTypeFilter = new MetricTypeFilter("COUNTER");
+    Assert.assertTrue(counterMetricTypeFilter.matches("", counter));
+    Assert.assertFalse(counterMetricTypeFilter.matches("", gauge));
+    Assert.assertFalse(counterMetricTypeFilter.matches("", histogram));
+    Assert.assertFalse(counterMetricTypeFilter.matches("", meter));
+    Assert.assertFalse(counterMetricTypeFilter.matches("", timer));
+
+    MetricTypeFilter allMetricTypeFilter = new MetricTypeFilter("COUNTER,GAUGE,HISTOGRAM,METER,TIMER");
+    Assert.assertTrue(allMetricTypeFilter.matches("", counter));
+    Assert.assertTrue(allMetricTypeFilter.matches("", gauge));
+    Assert.assertTrue(allMetricTypeFilter.matches("", histogram));
+    Assert.assertTrue(allMetricTypeFilter.matches("", meter));
+    Assert.assertTrue(allMetricTypeFilter.matches("", timer));
+  }
+}


### PR DESCRIPTION
* Added a configuration key for specifying custom `MetricFilter`s
* Added `NotificationTimerFilter` to filter out the reporting of `MetricContext.notificationTimer`
* Fixed a dangling `MetricContext` in `InstrumentedConverterBase`

My original approach was to make the creation of the `notificationTimer` configurable but that turned out to be difficult given the current handling of config keys, so I added the `MetricFilter` for now since it will probably be a useful feature in other scenarios too.

@ibuenros can you review?