### PR TITLE
Limit typesafe config conversion to metrics keys

### DIFF
--- a/gobblin-metrics/build.gradle
+++ b/gobblin-metrics/build.gradle
@@ -33,6 +33,7 @@ apply plugin: "com.commercehub.gradle.plugin.avro"
 
 dependencies {
   compile project(":gobblin-utility")
+  compile project(":gobblin-api")
 
   compile externalDependency.guava
   compile externalDependency.metricsCore

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaAvroReporter.java
@@ -12,19 +12,19 @@
 
 package gobblin.metrics.kafka;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import com.google.common.base.Optional;
-
-import com.typesafe.config.Config;
-
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.MetricReport;
 import gobblin.metrics.reporter.util.AvroBinarySerializer;
 import gobblin.metrics.reporter.util.AvroSerializer;
 import gobblin.metrics.reporter.util.SchemaRegistryVersionWriter;
 import gobblin.metrics.reporter.util.SchemaVersionWriter;
 import gobblin.util.ConfigUtils;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
 
 
 /**
@@ -89,7 +89,7 @@ public class KafkaAvroReporter extends KafkaReporter {
     public KafkaAvroReporter build(String brokers, String topic, Properties props) throws IOException {
       this.brokers = brokers;
       this.topic = topic;
-      return new KafkaAvroReporter(this, ConfigUtils.propertiesToConfig(props));
+      return new KafkaAvroReporter(this, ConfigUtils.propertiesToConfig(props, Optional.of(ConfigurationKeys.METRICS_CONFIGURATIONS_PREFIX)));
     }
   }
 }

--- a/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/kafka/KafkaReporter.java
@@ -12,14 +12,7 @@
 
 package gobblin.metrics.kafka;
 
-import java.io.IOException;
-import java.util.Properties;
-
-import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
-
-import com.typesafe.config.Config;
-
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.MetricReport;
 import gobblin.metrics.reporter.MetricReportReporter;
 import gobblin.metrics.reporter.util.AvroJsonSerializer;
@@ -27,6 +20,13 @@ import gobblin.metrics.reporter.util.AvroSerializer;
 import gobblin.metrics.reporter.util.FixedSchemaVersionWriter;
 import gobblin.metrics.reporter.util.SchemaVersionWriter;
 import gobblin.util.ConfigUtils;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
 
 
 /**
@@ -109,7 +109,7 @@ public class KafkaReporter extends MetricReportReporter {
       this.brokers = brokers;
       this.topic = topic;
 
-      return new KafkaReporter(this, ConfigUtils.propertiesToConfig(props));
+      return new KafkaReporter(this, ConfigUtils.propertiesToConfig(props, Optional.of(ConfigurationKeys.METRICS_CONFIGURATIONS_PREFIX)));
     }
   }
 

--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/OutputStreamReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/OutputStreamReporter.java
@@ -41,11 +41,12 @@ import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.Snapshot;
 import com.codahale.metrics.Timer;
-
 import com.google.common.collect.Maps;
 import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
 import com.google.common.io.Closer;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.MetricReport;
 import gobblin.metrics.Tag;
 import gobblin.util.ConfigUtils;
@@ -158,7 +159,7 @@ public class OutputStreamReporter extends MetricReportReporter {
      * @return a {@link OutputStreamReporter}
      */
     public OutputStreamReporter build(Properties props) {
-      return new OutputStreamReporter(this, ConfigUtils.propertiesToConfig(props));
+      return new OutputStreamReporter(this, ConfigUtils.propertiesToConfig(props, Optional.of(ConfigurationKeys.METRICS_CONFIGURATIONS_PREFIX)));
     }
   }
 

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ScheduledReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ScheduledReporterTest.java
@@ -12,6 +12,12 @@
 
 package gobblin.metrics.reporter;
 
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.MetricContext;
+import gobblin.metrics.context.ReportableContext;
+import gobblin.metrics.context.filter.ContextFilterFactory;
+import gobblin.util.ConfigUtils;
+
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -22,15 +28,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
+import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
-
 import com.typesafe.config.Config;
-
-import gobblin.metrics.MetricContext;
-import gobblin.metrics.context.ReportableContext;
-import gobblin.metrics.context.filter.ContextFilterFactory;
-import gobblin.util.ConfigUtils;
 
 
 /**

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -12,16 +12,18 @@
 
 package gobblin.util;
 
+import gobblin.configuration.State;
+
 import java.util.Map;
 import java.util.Properties;
 
-import com.google.common.collect.ImmutableMap;
+import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigValue;
-
-import gobblin.configuration.State;
 
 
 /**
@@ -67,9 +69,28 @@ public class ConfigUtils {
    * @return a {@link Config} instance
    */
   public static Config propertiesToConfig(Properties properties) {
+    return propertiesToConfig(properties, Optional.<String>absent());
+  }
+
+  /**
+   * Convert all the keys that start with a <code>prefix</code> in {@link Properties} to a {@link Config} instance.
+   *
+   * <p>
+   *   This method will throw an exception if (1) the {@link Object#toString()} method of any two keys in the
+   *   {@link Properties} objects returns the same {@link String}, or (2) if any two keys are prefixes of one another,
+   *   see the Java Docs of {@link ConfigFactory#parseMap(Map)} for more details.
+   * </p>
+   *
+   * @param properties the given {@link Properties} instance
+   * @param prefix of keys to be converted
+   * @return a {@link Config} instance
+   */
+  public static Config propertiesToConfig(Properties properties, Optional<String> prefix) {
     ImmutableMap.Builder<String, Object> immutableMapBuilder = ImmutableMap.builder();
     for (Map.Entry<Object, Object> entry : properties.entrySet()) {
-      immutableMapBuilder.put(entry.getKey().toString(), entry.getValue());
+      if (StringUtils.startsWith(entry.getKey().toString(), prefix.or(StringUtils.EMPTY))) {
+        immutableMapBuilder.put(entry.getKey().toString(), entry.getValue());
+      }
     }
     return ConfigFactory.parseMap(immutableMapBuilder.build());
   }

--- a/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
+public class ConfigUtilsTest {
+
+  @Test
+  public void testPropertiesToConfig() {
+
+    Properties properties = new Properties();
+    properties.setProperty("k1.kk1", "v1");
+    properties.setProperty("k1.kk2", "v2");
+    properties.setProperty("k2.kk", "v3");
+
+    Config conf = ConfigUtils.propertiesToConfig(properties);
+    Assert.assertEquals(conf.getString("k1.kk1"), "v1");
+    Assert.assertEquals(conf.getString("k1.kk2"), "v2");
+    Assert.assertEquals(conf.getString("k2.kk"), "v3");
+
+  }
+
+  @Test
+  public void testPropertiesToConfigWithPrefix() {
+
+    Properties properties = new Properties();
+    properties.setProperty("k1.kk1", "v1");
+    properties.setProperty("k1.kk2", "v2");
+    properties.setProperty("k2.kk", "v3");
+
+    Config conf = ConfigUtils.propertiesToConfig(properties, Optional.of("k1"));
+    Assert.assertEquals(conf.getString("k1.kk1"), "v1");
+    Assert.assertEquals(conf.getString("k1.kk2"), "v2");
+    Assert.assertFalse(conf.hasPath("k2.kk"), "Should not contain key k2.kk");
+
+  }
+}


### PR DESCRIPTION
@ibuenros and @sahilTakiar can you please review?
The change limits the conversion of properties to typesafe config only for keys that start with metrics.