### PR TITLE
Making ScheduledReporter ThreadPool daemon threads, fixed bugs in CliLocalJobLauncher

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/CliLocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/CliLocalJobLauncher.java
@@ -28,16 +28,11 @@ public class CliLocalJobLauncher {
   private static final Logger LOG = LoggerFactory.getLogger(CliLocalJobLauncher.class);
 
   public static void main(String[] args) throws Exception {
+    Properties jobProperties = CliOptions.parseArgs(CliLocalJobLauncher.class, args);
 
-    try {
-
-      Properties jobProperties = CliOptions.parseArgs(CliLocalJobLauncher.class, args);
-      LOG.debug(String.format("Running job with properties:%n%s", jobProperties));
-      new LocalJobLauncher(jobProperties).launchJob(null);
-
-    } catch (Exception exception) {
-      throw new RuntimeException(exception);
+    LOG.debug(String.format("Running job with properties:%n%s", jobProperties));
+    try (LocalJobLauncher localJobLauncher = new LocalJobLauncher(jobProperties)) {
+      localJobLauncher.launchJob(null);
     }
   }
-
 }

--- a/gobblin-utility/src/main/java/gobblin/util/ExecutorsUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ExecutorsUtils.java
@@ -75,7 +75,24 @@ public class ExecutorsUtils {
    * @return a new {@link java.util.concurrent.ThreadFactory}
    */
   public static ThreadFactory newThreadFactory(Optional<Logger> logger, Optional<String> nameFormat) {
-    ThreadFactoryBuilder builder = new ThreadFactoryBuilder();
+    return newThreadFactory(new ThreadFactoryBuilder(), logger, nameFormat);
+  }
+
+  /**
+   * Get a new {@link ThreadFactory} that uses a {@link LoggingUncaughtExceptionHandler}
+   * to handle uncaught exceptions, uses the given thread name format, and produces daemon threads.
+   *
+   * @param logger an {@link Optional} wrapping the {@link Logger} that the
+   *               {@link LoggingUncaughtExceptionHandler} uses to log uncaught exceptions thrown in threads
+   * @param nameFormat an {@link Optional} wrapping a thread naming format
+   * @return a new {@link ThreadFactory}
+   */
+  public static ThreadFactory newDaemonThreadFactory(Optional<Logger> logger, Optional<String> nameFormat) {
+    return newThreadFactory(new ThreadFactoryBuilder().setDaemon(true), logger, nameFormat);
+  }
+
+  private static ThreadFactory newThreadFactory(ThreadFactoryBuilder builder, Optional<Logger> logger,
+      Optional<String> nameFormat) {
     if (nameFormat.isPresent()) {
       builder.setNameFormat(nameFormat.get());
     }


### PR DESCRIPTION
* Created a new method `ExecutorUtils.newDaemonThreadFactory` that produces daemon threads
* Fixed bug in `CliLocalJobLauncher` where `LocalJobLauncher` wasn't being closed, causing a few other thread pools to not be shut down
* Fix to `ScheduledReporter.stopImpl` so that when the shutdown hook is invoked, the thread pool is first shutdown, and then one last invocation of `report()` is done
* Test locally, `RootMetricContext`'s `shutdownHook` is invoked, and the process terminates gracefully

@ibuenros and @pcadabam can you review?