### PR TITLE
Adding option to exclude hadoop and hive jars from gobblin-dist.tar.gz

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ To build Gobblin against a different version of Hadoop 2, e.g., 2.2.0, run the f
 
 	$ ./gradlew clean build -PuseHadoop2 -PhadoopVersion=2.2.0
 
+For more information on the different build options for Gobblin, check out the [Gobblin Build Options](https://github.com/linkedin/gobblin/wiki/Gobblin-Build-Options) wiki.
 
 ### Running Gobblin
 

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -10,6 +10,17 @@
 
 apply plugin: 'java'
 
+configurations {
+  compile {
+    if (rootProject.hasProperty('excludeHadoopDeps')) {
+      exclude group: "org.apache.hadoop"
+    }
+    if (rootProject.hasProperty('excludeHiveDeps')) {
+      exclude group: "org.apache.hive"
+    }
+  }
+}
+
 dependencies {
   compile project(':gobblin-azkaban')
   compile project(':gobblin-api')


### PR DESCRIPTION
This will help with the following bug that a few people on the google-groups have hit: https://github.com/linkedin/gobblin/wiki/FAQs#how-do-i-fix-unsupportedfilesystemexception-no-abstractfilesystem-for-scheme-null

Also, created this wiki to document all Gradle build options: https://github.com/linkedin/gobblin/wiki/Gobblin-Build-Options

@chavdar can you review?