### PR TITLE
Add CopyableFileFilter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpLightWeightFileSystem.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpLightWeightFileSystem.java
@@ -112,9 +112,6 @@ public class SftpLightWeightFileSystem extends FileSystem {
 
   @Override
   public boolean delete(Path path, boolean recursive) throws IOException {
-    if (!recursive) {
-      throw new UnsupportedOperationException("Non recursive delete is not supported on this file system");
-    }
     return delete(path);
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFileFilter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFileFilter.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy;
+
+import java.util.Collection;
+
+import org.apache.hadoop.fs.FileSystem;
+
+
+/**
+ * A filter that is applied on all the {@link CopyableFile}s found by
+ * {@link CopyableDataset#getCopyableFiles(FileSystem, CopyConfiguration)}.
+ */
+public interface CopyableFileFilter {
+
+  /**
+   * Returns an filtered {@link Collection} of {@link CopyableFile}s. The filtering logic is implemented by the subclass
+   *
+   * @param sourceFs of the copyableFiles
+   * @param targetFs of the copyableFiles
+   * @param copyableFiles to be filtered
+   *
+   * @return a filtered collection of copyableFiles
+   */
+  public Collection<CopyableFile> filter(FileSystem sourceFs, FileSystem targetFs,
+      Collection<CopyableFile> copyableFiles);
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/ReadyCopyableFileFilter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/ReadyCopyableFileFilter.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.ImmutableList;
+
+import gobblin.util.PathUtils;
+
+
+/**
+ * A {@link CopyableFileFilter} that drops a {@link CopyableFile} if another file with "filename.ready" is not found on
+ * the <code>sourceFs<code>
+ */
+@Slf4j
+public class ReadyCopyableFileFilter implements CopyableFileFilter {
+
+  public static final String READY_EXTENSION = ".ready";
+
+  /**
+   * For every {@link CopyableFile} in <code>copyableFiles</code> checks if a {@link CopyableFile#getOrigin()#getPath()}
+   * + .ready files is present on <code>sourceFs</code> {@inheritDoc}
+   *
+   * @see gobblin.data.management.copy.CopyableFileFilter#filter(org.apache.hadoop.fs.FileSystem,
+   *      org.apache.hadoop.fs.FileSystem, java.util.Collection)
+   */
+  @Override
+  public Collection<CopyableFile> filter(FileSystem sourceFs, FileSystem targetFs,
+      Collection<CopyableFile> copyableFiles) {
+    Iterator<CopyableFile> cfIterator = copyableFiles.iterator();
+
+    ImmutableList.Builder<CopyableFile> filtered = ImmutableList.builder();
+
+    while (cfIterator.hasNext()) {
+      CopyableFile cf = cfIterator.next();
+      Path readyFilePath = PathUtils.addExtension(cf.getOrigin().getPath(), READY_EXTENSION);
+      try {
+        if (sourceFs.exists(readyFilePath)) {
+          filtered.add(cf);
+        } else {
+          log.info(String.format("Removing %s as the .ready file is not found", cf.getOrigin().getPath()));
+        }
+      } catch (IOException e) {
+        log.warn(String.format("Removing %s as the .ready file can not be read. Exception %s",
+            cf.getOrigin().getPath(), e.getMessage()));
+      }
+    }
+    return filtered.build();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -43,6 +43,7 @@ public class RecursiveCopyableDataset extends SinglePartitionCopyableDataset {
   private final Properties properties;
   private LoadingCache<Path, OwnerAndPermission> ownerAndPermissionCache;
   private final PathFilter pathFilter;
+  private final CopyableFileFilter copyableFileFilter;
 
   public RecursiveCopyableDataset(final FileSystem fs, Path rootPath, Properties properties) {
 
@@ -58,6 +59,7 @@ public class RecursiveCopyableDataset extends SinglePartitionCopyableDataset {
     });
 
     this.pathFilter = DatasetUtils.instantiatePathFilter(properties);
+    this.copyableFileFilter = DatasetUtils.instantiateCopyableFileFilter(properties);
   }
 
   @Override public Collection<CopyableFile> getCopyableFiles(FileSystem targetFs, CopyConfiguration configuration)
@@ -70,7 +72,7 @@ public class RecursiveCopyableDataset extends SinglePartitionCopyableDataset {
     for (FileStatus file : files) {
       copyableFiles.add(CopyableFile.builder(this.fs, file, this.rootPath, configuration).build());
     }
-    return copyableFiles;
+    return copyableFileFilter.filter(this.fs, targetFs, copyableFiles);
   }
 
   /**

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DecryptConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DecryptConverter.java
@@ -75,7 +75,7 @@ public class DecryptConverter extends Converter<String, String, FileAwareInputSt
    * {@link CopyableFile#getRelativeDestination()}
    */
   private void removeExtensionAtDestination(CopyableFile file) {
-    file.setDestination(PathUtils.removeExtention(file.getDestination(), GPG_EXTENSION));
-    file.setRelativeDestination(PathUtils.removeExtention(file.getRelativeDestination(), GPG_EXTENSION));
+    file.setDestination(PathUtils.removeExtension(file.getDestination(), GPG_EXTENSION));
+    file.setRelativeDestination(PathUtils.removeExtension(file.getRelativeDestination(), GPG_EXTENSION));
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/UnGzipConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/UnGzipConverter.java
@@ -69,7 +69,7 @@ public class UnGzipConverter extends Converter<String, String, FileAwareInputStr
    * {@link CopyableFile#getRelativeDestination()}
    */
   private void removeExtensionAtDestination(CopyableFile file) {
-    file.setDestination(PathUtils.removeExtention(file.getDestination(), TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION));
-    file.setRelativeDestination(PathUtils.removeExtention(file.getRelativeDestination(), TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION));
+    file.setDestination(PathUtils.removeExtension(file.getDestination(), TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION));
+    file.setRelativeDestination(PathUtils.removeExtension(file.getRelativeDestination(), TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION));
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/dataset/DatasetUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/dataset/DatasetUtils.java
@@ -12,15 +12,18 @@
 
 package gobblin.data.management.dataset;
 
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
-
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
 import java.util.Properties;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
+
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.copy.CopyableFileFilter;
+import gobblin.data.management.retention.dataset.finder.DatasetFinder;
 
 
 /**
@@ -31,12 +34,22 @@ public class DatasetUtils {
   public static final String CONFIGURATION_KEY_PREFIX = "gobblin.dataset.";
   public static final String DATASET_PROFILE_CLASS_KEY = CONFIGURATION_KEY_PREFIX + "profile.class";
   private static final String PATH_FILTER_KEY = CONFIGURATION_KEY_PREFIX + "path.filter.class";
+  private static final String COPYABLE_FILE_FILTER_KEY = CONFIGURATION_KEY_PREFIX + "copyable.file.filter.class";
 
-  private static final PathFilter ACCEPT_ALL_FILTER = new PathFilter() {
+  private static final PathFilter ACCEPT_ALL_PATH_FILTER = new PathFilter() {
 
     @Override
     public boolean accept(Path path) {
       return true;
+    }
+  };
+
+  private static final CopyableFileFilter ACCEPT_ALL_COPYABLE_FILE_FILTER = new CopyableFileFilter() {
+    @Override
+    public Collection<CopyableFile> filter(FileSystem sourceFs, FileSystem targetFs,
+        Collection<CopyableFile> copyableFiles) {
+
+      return copyableFiles;
     }
   };
 
@@ -76,15 +89,15 @@ public class DatasetUtils {
 
   /**
    * Instantiate a {@link PathFilter} from the class name at key {@link #PATH_FILTER_KEY} in props passed. If key
-   * {@link #PATH_FILTER_KEY} is not set, a default {@link #ACCEPT_ALL_FILTER} is returned
+   * {@link #PATH_FILTER_KEY} is not set, a default {@link #ACCEPT_ALL_PATH_FILTER} is returned
    *
    * @param props that contain path filter classname at {@link #PATH_FILTER_KEY}
-   * @return a new instance of {@link PathFilter}. If not key is found, returns an {@link #ACCEPT_ALL_FILTER}
+   * @return a new instance of {@link PathFilter}. If not key is found, returns an {@link #ACCEPT_ALL_PATH_FILTER}
    */
   public static PathFilter instantiatePathFilter(Properties props) {
 
     if (!props.containsKey(PATH_FILTER_KEY)) {
-      return ACCEPT_ALL_FILTER;
+      return ACCEPT_ALL_PATH_FILTER;
     }
 
     try {
@@ -95,6 +108,29 @@ public class DatasetUtils {
     } catch (InstantiationException exception) {
       throw new RuntimeException(exception);
     } catch (IllegalAccessException exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  /**
+   * Instantiate a {@link CopyableFileFilter} from the class name at key {@link #COPYABLE_FILE_FILTER_KEY} in props
+   * passed. If key {@link #COPYABLE_FILE_FILTER_KEY} is not set, a default {@link #ACCEPT_ALL_COPYABLE_FILE_FILTER} is
+   * returned
+   *
+   * @param props that contain path filter classname at {@link #COPYABLE_FILE_FILTER_KEY}
+   * @return a new instance of {@link PathFilter}. If not key is found, returns an
+   *         {@link #ACCEPT_ALL_COPYABLE_FILE_FILTER}
+   */
+  public static CopyableFileFilter instantiateCopyableFileFilter(Properties props) {
+
+    if (!props.containsKey(COPYABLE_FILE_FILTER_KEY)) {
+      return ACCEPT_ALL_COPYABLE_FILE_FILTER;
+    }
+
+    try {
+      Class<?> copyableFileFilterClass = Class.forName(props.getProperty(COPYABLE_FILE_FILTER_KEY));
+      return (CopyableFileFilter) copyableFileFilterClass.newInstance();
+    } catch (ClassNotFoundException | InstantiationException | IllegalAccessException exception) {
       throw new RuntimeException(exception);
     }
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/ReadyCopyableFileFilterTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/ReadyCopyableFileFilterTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import gobblin.util.PathUtils;
+
+@Test(groups = {"gobblin.data.management.copy"})
+public class ReadyCopyableFileFilterTest {
+
+  @Test
+  public void testFilter() throws Exception {
+
+    CopyableFileFilter readyFilter = new ReadyCopyableFileFilter();
+
+    List<CopyableFile> copyableFiles = Lists.newArrayList();
+
+    copyableFiles.add(CopyableFileUtils.getTestCopyableFile());
+    copyableFiles.add(CopyableFileUtils.getTestCopyableFile());
+    copyableFiles.add(CopyableFileUtils.getTestCopyableFile());
+
+    FileSystem sourceFs = Mockito.mock(FileSystem.class);
+
+    Mockito.when(sourceFs.exists(PathUtils.addExtension(copyableFiles.get(0).getOrigin().getPath(), ".ready")))
+        .thenReturn(false);
+    Mockito.when(sourceFs.exists(PathUtils.addExtension(copyableFiles.get(1).getOrigin().getPath(), ".ready")))
+        .thenReturn(true);
+    Mockito.when(sourceFs.exists(PathUtils.addExtension(copyableFiles.get(2).getOrigin().getPath(), ".ready")))
+        .thenReturn(false);
+
+    Collection<CopyableFile> filtered = readyFilter.filter(sourceFs, null, copyableFiles);
+
+    Assert.assertEquals(filtered.size(), 1);
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
@@ -12,10 +12,7 @@
 
 package gobblin.data.management.copy;
 
-import gobblin.util.PathUtils;
-
 import java.util.Collection;
-import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
@@ -26,6 +23,8 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.collect.Sets;
+
+import gobblin.util.PathUtils;
 
 
 public class RecursiveCopyableDatasetTest {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/util/PathUtilsTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/util/PathUtilsTest.java
@@ -78,26 +78,43 @@ public class PathUtilsTest {
   @Test
   public void testRemoveExtension() throws Exception {
 
-    Path path = PathUtils.removeExtention(new Path("file.txt"), ".txt");
+    Path path = PathUtils.removeExtension(new Path("file.txt"), ".txt");
     Assert.assertEquals(path, new Path("file"));
 
-    path = PathUtils.removeExtention(new Path("file.txt"), ".abc");
+    path = PathUtils.removeExtension(new Path("file.txt"), ".abc");
     Assert.assertEquals(path, new Path("file.txt"));
 
-    path = PathUtils.removeExtention(new Path("file.txt.gpg"), ".txt", ".gpg");
+    path = PathUtils.removeExtension(new Path("file.txt.gpg"), ".txt", ".gpg");
     Assert.assertEquals(path, new Path("file"));
 
-    path = PathUtils.removeExtention(new Path("file.txt.gpg"), ".gpg", ".txt");
+    path = PathUtils.removeExtension(new Path("file.txt.gpg"), ".gpg", ".txt");
     Assert.assertEquals(path, new Path("file"));
 
-    path = PathUtils.removeExtention(new Path("file.txt.gpg"), ".txt");
+    path = PathUtils.removeExtension(new Path("file.txt.gpg"), ".txt");
     Assert.assertEquals(path, new Path("file.gpg"));
 
-    path = PathUtils.removeExtention(new Path("file.txt.gpg"), ".gpg");
+    path = PathUtils.removeExtension(new Path("file.txt.gpg"), ".gpg");
     Assert.assertEquals(path, new Path("file.txt"));
 
-    path = PathUtils.removeExtention(new Path("file"), ".txt", ".gpg");
+    path = PathUtils.removeExtension(new Path("file"), ".txt", ".gpg");
     Assert.assertEquals(path, new Path("file"));
+
+  }
+
+  @Test
+  public void testAddExtension() throws Exception {
+
+    Path path = PathUtils.addExtension(new Path("file"), ".txt");
+    Assert.assertEquals(path, new Path("file.txt"));
+
+    path = PathUtils.addExtension(new Path("file.txt"), ".abc");
+    Assert.assertEquals(path, new Path("file.txt.abc"));
+
+    path = PathUtils.addExtension(new Path("file.txt.gpg"), ".txt", ".gpg");
+    Assert.assertEquals(path, new Path("file.txt.gpg.txt.gpg"));
+
+    path = PathUtils.addExtension(new Path("file.txt.gpg"), ".tar.gz");
+    Assert.assertEquals(path, new Path("file.txt.gpg.tar.gz"));
 
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PathUtils.java
@@ -18,6 +18,8 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Strings;
+
 
 public class PathUtils {
 
@@ -88,12 +90,37 @@ public class PathUtils {
    *
    * @return a new {@link Path} without <code>extensions</code>
    */
-  public static Path removeExtention(Path path, String...extensions) {
+  public static Path removeExtension(Path path, String...extensions) {
     String pathString = path.toString();
     for (String extension : extensions) {
       pathString = StringUtils.remove(pathString, extension);
     }
 
     return new Path(pathString);
+  }
+
+  /**
+   * Suffix all <code>extensions</code> to <code>path</code>.
+   *
+   * <pre>
+   * PathUtils.addExtension("/tmp/data/file", ".txt")                          = file.txt
+   * PathUtils.addExtension("/tmp/data/file.txt.gpg", ".zip")                  = file.txt.gpg.zip
+   * PathUtils.addExtension("/tmp/data/file.txt", ".tar", ".gz")               = file.txt.tar.gz
+   * PathUtils.addExtension("/tmp/data/file.txt.gpg", ".tar.txt")              = file.txt.gpg.tar.txt
+   * </pre>
+   *
+   * @param path to which the <code>extensions</code> need to be added
+   * @param extensions to be added
+   *
+   * @return a new {@link Path} with <code>extensions</code>
+   */
+  public static Path addExtension(Path path, String...extensions) {
+    StringBuilder pathStringBuilder = new StringBuilder(path.toString());
+    for (String extension : extensions) {
+      if (!Strings.isNullOrEmpty(extension)) {
+        pathStringBuilder.append(extension);
+      }
+    }
+    return new Path(pathStringBuilder.toString());
   }
 }


### PR DESCRIPTION
- Adding functionality to optionally apply a filter on CopyableFiles found by the CopyableDataset. One of the use cases is to filter out all files that do not have a .ready file on the source filesystem.
- Fix some typos
- Fix recursive delete in SftpFileSystem

@ibuenros and @liyinan926 can you review?