### PR TITLE
Adding central repositories block for all subprojects

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@
 // Unless required by applicable law or agreed to in writing, software distributed
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied.
+
 buildscript {
   repositories {
     maven {
@@ -127,23 +128,23 @@ ext.externalDependency = [
   "guava": "com.google.guava:guava:15.0",
   "gson": "com.google.code.gson:gson:2.3.1",
   "findBugs": "com.google.code.findbugs:jsr305:1.3.9",
-  "hadoop": "org.apache.hadoop:hadoop-core:"+hadoopVersion,
-  "hadoopCommon": "org.apache.hadoop:hadoop-common:"+hadoopVersion,
-  "hadoopClientCore": "org.apache.hadoop:hadoop-mapreduce-client-core:"+hadoopVersion,
-  "hadoopClientCommon": "org.apache.hadoop:hadoop-mapreduce-client-common:"+hadoopVersion,
-  "hadoopHdfs": "org.apache.hadoop:hadoop-hdfs:"+hadoopVersion,
-  "hadoopAuth": "org.apache.hadoop:hadoop-auth:"+hadoopVersion,
-  "hadoopYarnApi": "org.apache.hadoop:hadoop-yarn-api:"+hadoopVersion,
-  "hadoopYarnCommon": "org.apache.hadoop:hadoop-yarn-common:"+hadoopVersion,
-  "hadoopYarnClient": "org.apache.hadoop:hadoop-yarn-client:"+hadoopVersion,
-  "hadoopYarnMiniCluster": "org.apache.hadoop:hadoop-minicluster:"+hadoopVersion,
-  "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:"+hadoopVersion,
+  "hadoop": "org.apache.hadoop:hadoop-core:" + hadoopVersion,
+  "hadoopCommon": "org.apache.hadoop:hadoop-common:" + hadoopVersion,
+  "hadoopClientCore": "org.apache.hadoop:hadoop-mapreduce-client-core:" + hadoopVersion,
+  "hadoopClientCommon": "org.apache.hadoop:hadoop-mapreduce-client-common:" + hadoopVersion,
+  "hadoopHdfs": "org.apache.hadoop:hadoop-hdfs:" + hadoopVersion,
+  "hadoopAuth": "org.apache.hadoop:hadoop-auth:" + hadoopVersion,
+  "hadoopYarnApi": "org.apache.hadoop:hadoop-yarn-api:" + hadoopVersion,
+  "hadoopYarnCommon": "org.apache.hadoop:hadoop-yarn-common:" + hadoopVersion,
+  "hadoopYarnClient": "org.apache.hadoop:hadoop-yarn-client:" + hadoopVersion,
+  "hadoopYarnMiniCluster": "org.apache.hadoop:hadoop-minicluster:" + hadoopVersion,
+  "hadoopAnnotations": "org.apache.hadoop:hadoop-annotations:" + hadoopVersion,
   "hadoopAws": "org.apache.hadoop:hadoop-aws:2.6.0",
-  "hiveService": "org.apache.hive:hive-service:"+hiveVersion,
-  "hiveJdbc": "org.apache.hive:hive-jdbc:"+hiveVersion,
-  "hiveMetastore": "org.apache.hive:hive-metastore:"+hiveVersion,
+  "hiveService": "org.apache.hive:hive-service:" + hiveVersion,
+  "hiveJdbc": "org.apache.hive:hive-jdbc:" + hiveVersion,
+  "hiveMetastore": "org.apache.hive:hive-metastore:" + hiveVersion,
   "hiveExec": "org.apache.hive:hive-exec:" + hiveVersion + ":core",
-  "hiveSerDe": "org.apache.hive:hive-serde:"+hiveVersion,
+  "hiveSerDe": "org.apache.hive:hive-serde:" + hiveVersion,
   "httpclient": "org.apache.httpcomponents:httpclient:4.5",
   "httpcore": "org.apache.httpcomponents:httpcore:4.4.1",
   "kafka": "org.apache.kafka:kafka_2.11:0.8.2.1",
@@ -179,8 +180,8 @@ ext.externalDependency = [
   "mockRunnerJdbc":"com.mockrunner:mockrunner-jdbc:1.0.8",
   "xerces":"xerces:xercesImpl:2.11.0",
   "typesafeConfig": "com.typesafe:config:1.2.1",
-  "byteman": "org.jboss.byteman:byteman:"+bytemanVersion,
-  "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:"+bytemanVersion,
+  "byteman": "org.jboss.byteman:byteman:" + bytemanVersion,
+  "bytemanBmunit": "org.jboss.byteman:byteman-bmunit:" + bytemanVersion,
   "bcpgJdk15on": "org.bouncycastle:bcpg-jdk15on:1.52",
   "bcprovJdk15on": "org.bouncycastle:bcprov-jdk15on:1.52",
   "calciteCore": "org.apache.calcite:calcite-core:1.2.0-incubating",
@@ -192,16 +193,16 @@ ext.externalDependency = [
   "joptSimple": "net.sf.jopt-simple:jopt-simple:4.9",
   "protobuf": "com.google.protobuf:protobuf-java:2.6.1",
   "pegasus" : [
-    "data" : "com.linkedin.pegasus:data:"+pegasusVersion,
-    "generator" : "com.linkedin.pegasus:generator:"+pegasusVersion,
-    "restliClient" : "com.linkedin.pegasus:restli-client:"+pegasusVersion,
-    "restliServer" : "com.linkedin.pegasus:restli-server:"+pegasusVersion,
-    "restliTools" : "com.linkedin.pegasus:restli-tools:"+pegasusVersion,
-    "pegasusCommon" : "com.linkedin.pegasus:pegasus-common:"+pegasusVersion,
-    "restliCommon" : "com.linkedin.pegasus:restli-common:"+pegasusVersion,
-    "r2" : "com.linkedin.pegasus:r2:"+pegasusVersion,
-    "d2" : "com.linkedin.pegasus:d2:"+pegasusVersion,
-    "restliNettyStandalone" : "com.linkedin.pegasus:restli-netty-standalone:"+pegasusVersion
+    "data" : "com.linkedin.pegasus:data:" + pegasusVersion,
+    "generator" : "com.linkedin.pegasus:generator:" + pegasusVersion,
+    "restliClient" : "com.linkedin.pegasus:restli-client:" + pegasusVersion,
+    "restliServer" : "com.linkedin.pegasus:restli-server:" + pegasusVersion,
+    "restliTools" : "com.linkedin.pegasus:restli-tools:" + pegasusVersion,
+    "pegasusCommon" : "com.linkedin.pegasus:pegasus-common:" + pegasusVersion,
+    "restliCommon" : "com.linkedin.pegasus:restli-common:" + pegasusVersion,
+    "r2" : "com.linkedin.pegasus:r2:" + pegasusVersion,
+    "d2" : "com.linkedin.pegasus:d2:" + pegasusVersion,
+    "restliNettyStandalone" : "com.linkedin.pegasus:restli-netty-standalone:" + pegasusVersion
   ]
 ];
 
@@ -242,7 +243,7 @@ permalink: /javadoc/${version}/
   }
 }
 
-//Javadoc initialization for subprojects
+// Javadoc initialization for subprojects
 ext.javadocVersion = null != project.version ? project.version.toString() : "latest"
 if (ext.javadocVersion.indexOf('-') > 0) {
   // Remove any "-" addons from the version
@@ -272,205 +273,215 @@ subprojects {
 }
 
 subprojects {
-plugins.withType(JavaPlugin) {
-  plugins.apply('idea')
-  plugins.apply('eclipse')
-  plugins.apply('maven')
-// Disabling the FindBugs plugin for now because FindBugs 2.x is not compatible with Java8
-//  apply plugin: 'findbugs'
-
-  sourceCompatibility = JavaVersion.VERSION_1_7
-
-
-/*  findbugs {
-    ignoreFailures = true
-    effort = "max"
-    excludeFilter = file(rootProject.projectDir.path + "/ligradle/findbugs/findbugsExclude.xml")
-  }
-*/
-  test {
-    if (project.hasProperty("printTestOutput")) {
-      testLogging.showStandardStreams = true
-    }
-  }
-
-  configurations {
-    compile
-    dependencies {
-      if (project.hasProperty('useHadoop2')) {
-        compile externalDependency.hadoopCommon
-        compile externalDependency.hadoopClientCore
-        compile externalDependency.hadoopAnnotations
-        if (project.name.equals('gobblin-runtime') || project.name.equals('gobblin-test')) {
-          compile externalDependency.hadoopClientCommon
-        }
-      } else {
-        compile externalDependency.hadoop
-      }
-      compile(externalDependency.guava) {
-        force = true
-      }
-
-      // Required to add JDK's tool jar, which is required to run byteman tests.
-      compile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
-    }
-  }
-
-  if (isDefaultEnvironment) {
-    task sourcesJar(type: Jar, dependsOn: classes) {
-      from sourceSets.main.allSource
-      classifier = 'sources'
-    }
-    task javadocJar(type: Jar) {
-      from javadoc
-      classifier = 'javadoc'
-    }
-    artifacts { archives sourcesJar, javadocJar }
-  }
-
-  // Publishing of maven artifacts for subprojects
-  if (rootProject.ext.publishToMaven) {
-    plugins.apply('maven')
-    if (rootProject.ext.signArtifacts) {
-      plugins.apply('signing')
-    }
-
-    project.version = rootProject.version
-    project.group = rootProject.group
-
-    uploadArchives {
-      repositories {
-        mavenDeployer {
-          beforeDeployment { MavenDeployment deployment ->
-            if (rootProject.ext.signArtifacts) {
-              signing.signPom(deployment)
-            }
-          }
-
-          repository(url: rootProject.artifactRepository) {
-            authentication(userName: ossrhUsername, password: ossrhPassword)
-          }
-
-          snapshotRepository(url: rootProject.artifactSnapshotRepository) {
-            authentication(userName: ossrhUsername, password: ossrhPassword)
-          }
-
-          pom.project {
-            name "${project.name}"
-            packaging 'jar'
-            // optionally artifactId can be defined here
-            description 'Gobblin Ingestion Framework'
-            url 'https://github.com/linkedin/gobblin/'
-
-            scm {
-              connection 'scm:git:git@github.com:linkedin/gobblin.git'
-              developerConnection 'scm:git:git@github.com:linkedin/gobblin.git'
-              url 'git@github.com:linkedin/gobblin.git'
-            }
-
-            licenses {
-              license {
-                name 'The Apache License, Version 2.0'
-                url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
-              }
-            }
-
-            developers {
-              developer {
-                name 'Abhishek Tiwari'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Chavdar Botev'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Issac Buenrostro'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Min Tu'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Narasimha Veeramreddy'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Pradhan Cadabam'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Sahil Takiar'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Shirshanka Das'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Yinan Li'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Ying Dai'
-                organization 'LinkedIn'
-              }
-              developer {
-                name 'Ziyang Liu'
-                organization 'LinkedIn'
-              }
-            }
-          }
-        }
-      }
-    }
-
-    if (rootProject.ext.signArtifacts) {
-      signing {
-        sign configurations.archives
-      }
-    }
-  }
-
-  // Configure the IDEA plugin to (1) add the codegen as source dirs and (2) work around
-  // an apparent bug in the plugin which doesn't set the outputDir/testOutputDir as documented
-  idea.project {
-    ext.languageLevel = JavaVersion.VERSION_1_7
-  }
-  idea.module {
-    // Gradle docs claim the two settings below are the default, but
-    // the actual defaults appear to be "out/production/$MODULE_NAME"
-    // and "out/test/$MODULE_NAME". Changing it so IDEA and gradle share
-    // the class output directory.
-
-    outputDir = sourceSets.main.output.classesDir
-    testOutputDir = sourceSets.test.output.classesDir
-  }
-
-  // Add standard javadoc repositories so we can reference classes in them using @link
-  tasks.javadoc.options.links "http://typesafehub.github.io/config/latest/api/",
-                              "https://docs.oracle.com/javase/7/docs/api/",
-                              "http://docs.guava-libraries.googlecode.com/git-history/v15.0/javadoc/",
-                              "http://hadoop.apache.org/docs/r${rootProject.ext.hadoopVersion}/api/",
-                              "https://hive.apache.org/javadocs/r${rootProject.ext.hiveVersion}/api/",
-                              "http://avro.apache.org/docs/${avroVersion}/api/java/",
-                              "https://dropwizard.github.io/metrics/${dropwizardMetricsVersion}/apidocs/"
-  rootProject.ext.javadocPackages.each {
-    tasks.javadoc.options.linksOffline "http://linkedin.github.io/gobblin/javadoc/${javadocVersion}/${it}/",
-                                       "${rootProject.buildDir}/${it}/docs/javadoc/" 
-  }
-
-  afterEvaluate {
-    // add the standard pegasus dependencies wherever the plugin is used
-    if (project.plugins.hasPlugin('pegasus')) {
-      dependencies {
-        dataTemplateCompile externalDependency.pegasus.data
-        restClientCompile externalDependency.pegasus.restliClient,externalDependency.pegasus.restliCommon,externalDependency.pegasus.restliTools
-      }
+  repositories {
+    mavenCentral()
+    maven {
+      url "http://conjars.org/repo"
     }
   }
 }
+
+subprojects {
+  plugins.withType(JavaPlugin) {
+    plugins.apply('idea')
+    plugins.apply('eclipse')
+    plugins.apply('maven')
+    // Disabling the FindBugs plugin for now because FindBugs 2.x is not compatible with Java8
+    //  apply plugin: 'findbugs'
+
+    sourceCompatibility = JavaVersion.VERSION_1_7
+
+    /*
+    findbugs {
+      ignoreFailures = true
+      effort = "max"
+      excludeFilter = file(rootProject.projectDir.path + "/ligradle/findbugs/findbugsExclude.xml")
+    }
+    */
+
+    test {
+      if (project.hasProperty("printTestOutput")) {
+        testLogging.showStandardStreams = true
+      }
+    }
+
+    configurations {
+      compile
+      dependencies {
+        if (project.hasProperty('useHadoop2')) {
+          compile externalDependency.hadoopCommon
+          compile externalDependency.hadoopClientCore
+          compile externalDependency.hadoopAnnotations
+          if (project.name.equals('gobblin-runtime') || project.name.equals('gobblin-test')) {
+            compile externalDependency.hadoopClientCommon
+          }
+        } else {
+          compile externalDependency.hadoop
+        }
+        compile(externalDependency.guava) {
+          force = true
+        }
+
+        // Required to add JDK's tool jar, which is required to run byteman tests.
+        compile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
+      }
+    }
+
+    if (isDefaultEnvironment) {
+      task sourcesJar(type: Jar, dependsOn: classes) {
+        from sourceSets.main.allSource
+        classifier = 'sources'
+      }
+      task javadocJar(type: Jar) {
+        from javadoc
+        classifier = 'javadoc'
+      }
+      artifacts { archives sourcesJar, javadocJar }
+    }
+
+    // Publishing of maven artifacts for subprojects
+    if (rootProject.ext.publishToMaven) {
+      plugins.apply('maven')
+      if (rootProject.ext.signArtifacts) {
+        plugins.apply('signing')
+      }
+
+      project.version = rootProject.version
+      project.group = rootProject.group
+
+      uploadArchives {
+        repositories {
+          mavenDeployer {
+            beforeDeployment { MavenDeployment deployment ->
+              if (rootProject.ext.signArtifacts) {
+                signing.signPom(deployment)
+              }
+            }
+
+            repository(url: rootProject.artifactRepository) {
+              authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            snapshotRepository(url: rootProject.artifactSnapshotRepository) {
+              authentication(userName: ossrhUsername, password: ossrhPassword)
+            }
+
+            pom.project {
+              name "${project.name}"
+              packaging 'jar'
+              // optionally artifactId can be defined here
+              description 'Gobblin Ingestion Framework'
+              url 'https://github.com/linkedin/gobblin/'
+
+              scm {
+                connection 'scm:git:git@github.com:linkedin/gobblin.git'
+                developerConnection 'scm:git:git@github.com:linkedin/gobblin.git'
+                url 'git@github.com:linkedin/gobblin.git'
+              }
+
+              licenses {
+                license {
+                  name 'The Apache License, Version 2.0'
+                  url 'http://www.apache.org/licenses/LICENSE-2.0.txt'
+                }
+              }
+
+              developers {
+                developer {
+                  name 'Abhishek Tiwari'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Chavdar Botev'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Issac Buenrostro'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Min Tu'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Narasimha Veeramreddy'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Pradhan Cadabam'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Sahil Takiar'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Shirshanka Das'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Yinan Li'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Ying Dai'
+                  organization 'LinkedIn'
+                }
+                developer {
+                  name 'Ziyang Liu'
+                  organization 'LinkedIn'
+                }
+              }
+            }
+          }
+        }
+      }
+
+      if (rootProject.ext.signArtifacts) {
+        signing {
+          sign configurations.archives
+        }
+      }
+    }
+
+    // Configure the IDEA plugin to (1) add the codegen as source dirs and (2) work around
+    // an apparent bug in the plugin which doesn't set the outputDir/testOutputDir as documented
+    idea.project {
+      ext.languageLevel = JavaVersion.VERSION_1_7
+    }
+    idea.module {
+      // Gradle docs claim the two settings below are the default, but
+      // the actual defaults appear to be "out/production/$MODULE_NAME"
+      // and "out/test/$MODULE_NAME". Changing it so IDEA and gradle share
+      // the class output directory.
+
+      outputDir = sourceSets.main.output.classesDir
+      testOutputDir = sourceSets.test.output.classesDir
+    }
+
+    // Add standard javadoc repositories so we can reference classes in them using @link
+    tasks.javadoc.options.links "http://typesafehub.github.io/config/latest/api/",
+                                "https://docs.oracle.com/javase/7/docs/api/",
+                                "http://docs.guava-libraries.googlecode.com/git-history/v15.0/javadoc/",
+                                "http://hadoop.apache.org/docs/r${rootProject.ext.hadoopVersion}/api/",
+                                "https://hive.apache.org/javadocs/r${rootProject.ext.hiveVersion}/api/",
+                                "http://avro.apache.org/docs/${avroVersion}/api/java/",
+                                "https://dropwizard.github.io/metrics/${dropwizardMetricsVersion}/apidocs/"
+    rootProject.ext.javadocPackages.each {
+      tasks.javadoc.options.linksOffline "http://linkedin.github.io/gobblin/javadoc/${javadocVersion}/${it}/",
+                                         "${rootProject.buildDir}/${it}/docs/javadoc/" 
+    }
+
+    afterEvaluate {
+      // add the standard pegasus dependencies wherever the plugin is used
+      if (project.plugins.hasPlugin('pegasus')) {
+        dependencies {
+          dataTemplateCompile externalDependency.pegasus.data
+          restClientCompile externalDependency.pegasus.restliClient,externalDependency.pegasus.restliCommon,externalDependency.pegasus.restliTools
+        }
+      }
+    }
+  }
 }
 
 //Turn off javadoc lint for Java 8+

--- a/gobblin-azkaban/build.gradle
+++ b/gobblin-azkaban/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-compaction")

--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -11,13 +11,6 @@
 apply plugin: 'java'
 apply plugin: 'eclipse'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-utility")

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-utility")

--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-core")

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(':gobblin-azkaban')
   compile project(':gobblin-api')

--- a/gobblin-example/build.gradle
+++ b/gobblin-example/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
     compile project(":gobblin-api")
     compile project(":gobblin-core")

--- a/gobblin-metastore/build.gradle
+++ b/gobblin-metastore/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
     compile project(":gobblin-api")
     compile project(path: ':gobblin-rest-service:gobblin-rest-api', configuration: 'restClient')

--- a/gobblin-metrics/build.gradle
+++ b/gobblin-metrics/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 /** TODO: Re-enable avro auto-compile once Java 1.7 is fully supported by users.
 buildscript {
   repositories {

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-core")

--- a/gobblin-salesforce/build.gradle
+++ b/gobblin-salesforce/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
     compile project(":gobblin-api")
     compile project(":gobblin-core")

--- a/gobblin-scheduler/build.gradle
+++ b/gobblin-scheduler/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-runtime")

--- a/gobblin-test-harness/build.gradle
+++ b/gobblin-test-harness/build.gradle
@@ -10,13 +10,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   testCompile project(":gobblin-api")
   testCompile project(":gobblin-core")

--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -11,13 +11,6 @@
 
 apply plugin: 'java'
 
-repositories {
-  mavenCentral()
-  maven {
-    url "http://conjars.org/repo"
-  }
-}
-
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-core")


### PR DESCRIPTION
Added a central repositories block for all subprojects in the master `build.gradle` file. Fixed a few formatting issues in the master `build.gradle` file.