### PR TITLE
Distcp persists and reuses failed work units.

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
@@ -15,6 +15,8 @@ package gobblin.data.management.copy;
 import gobblin.data.management.partition.File;
 import gobblin.data.management.copy.PreserveAttributes.Option;
 import gobblin.util.PathUtils;
+import gobblin.util.guid.Guid;
+import gobblin.util.guid.HasGuid;
 
 import java.io.IOException;
 import java.util.List;
@@ -53,7 +55,7 @@ import com.google.gson.reflect.TypeToken;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @EqualsAndHashCode
 @Builder(builderClassName = "Builder", builderMethodName = "_hiddenBuilder")
-public class CopyableFile implements File {
+public class CopyableFile implements File, HasGuid {
 
   private static final Gson GSON = new Gson();
 
@@ -226,6 +228,18 @@ public class CopyableFile implements File {
   @Override
   public FileStatus getFileStatus() {
     return this.origin;
+  }
+
+  /**
+   * Generates a replicable guid to uniquely identify the origin of this {@link CopyableFile}.
+   * @return a guid uniquely identifying the origin file.
+   */
+  public Guid guid() throws IOException {
+    StringBuilder uniqueString = new StringBuilder();
+    uniqueString.append(getFileStatus().getModificationTime());
+    uniqueString.append(getFileStatus().getLen());
+    uniqueString.append(getFileStatus().getPath());
+    return Guid.fromStrings(uniqueString.toString());
   }
 
   /**

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DecryptConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DecryptConverter.java
@@ -12,6 +12,8 @@
 
 package gobblin.data.management.copy.converter;
 
+import javax.annotation.Nullable;
+
 import gobblin.configuration.WorkUnitState;
 import gobblin.converter.Converter;
 import gobblin.converter.DataConversionException;
@@ -26,15 +28,20 @@ import gobblin.util.GPGFileDecrypter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.security.NoSuchProviderException;
+import java.util.List;
 
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 
 
 /**
  * {@link Converter} that decrypts an {@link InputStream}. Uses utilities in {@link GPGFileDecrypter} to do the actual
  * decryption. It also converts the destination file name by removing .gpg extensions.
  */
-public class DecryptConverter extends Converter<String, String, FileAwareInputStream, FileAwareInputStream> {
+public class DecryptConverter extends DistcpConverter {
 
   private static final String DECRYPTION_PASSPHRASE_KEY = "converter.decrypt.passphrase";
   private static final String GPG_EXTENSION = ".gpg";
@@ -48,34 +55,20 @@ public class DecryptConverter extends Converter<String, String, FileAwareInputSt
     return super.init(workUnit);
   }
 
-  @Override
-  public String convertSchema(String inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
-    return inputSchema;
+  @Override public Function<FSDataInputStream, FSDataInputStream> inputStreamTransformation() {
+    return new Function<FSDataInputStream, FSDataInputStream>() {
+      @Nullable @Override public FSDataInputStream apply(FSDataInputStream input) {
+        try {
+          return GPGFileDecrypter.decryptFile(input, passphrase);
+        } catch (NoSuchProviderException | IOException exception) {
+          throw new RuntimeException(exception);
+        }
+      }
+    };
   }
 
-  @Override
-  public Iterable<FileAwareInputStream> convertRecord(String outputSchema, FileAwareInputStream fileAwareInputStream,
-      WorkUnitState workUnit) throws DataConversionException {
-
-    try {
-      removeExtensionAtDestination(fileAwareInputStream.getFile());
-      FileAwareInputStream decryptedFileAwareInputStream =
-          new FileAwareInputStream(fileAwareInputStream.getFile(), GPGFileDecrypter.decryptFile(
-              fileAwareInputStream.getInputStream(), passphrase));
-      return new SingleRecordIterable<FileAwareInputStream>(decryptedFileAwareInputStream);
-    } catch (IOException e) {
-      throw new DataConversionException(e);
-    } catch (NoSuchProviderException e) {
-      throw new DataConversionException(e);
-    }
+  @Override public List<String> extensionsToRemove() {
+    return Lists.newArrayList(GPG_EXTENSION);
   }
 
-  /**
-   * Remove {@value #GPG_EXTENSION} from {@link CopyableFile#getDestination()} and
-   * {@link CopyableFile#getRelativeDestination()}
-   */
-  private void removeExtensionAtDestination(CopyableFile file) {
-    file.setDestination(PathUtils.removeExtension(file.getDestination(), GPG_EXTENSION));
-    file.setRelativeDestination(PathUtils.removeExtension(file.getRelativeDestination(), GPG_EXTENSION));
-  }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DistcpConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DistcpConverter.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.converter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import com.google.common.base.Function;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.converter.SingleRecordIterable;
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.copy.FileAwareInputStream;
+import gobblin.util.PathUtils;
+
+
+/**
+ * Abstract class for distcp {@link Converter}. Simply transforms the {@link InputStream} in the
+ * {@link FileAwareInputStream}, and possibly modifies extensions of the output file.
+ */
+public abstract class DistcpConverter extends Converter<String, String, FileAwareInputStream, FileAwareInputStream> {
+
+  @Override
+  public Converter<String, String, FileAwareInputStream, FileAwareInputStream> init(WorkUnitState workUnit) {
+    return super.init(workUnit);
+  }
+
+  /**
+   * @return A {@link Function} that transforms the {@link FSDataInputStream} in the {@link FileAwareInputStream}.
+   */
+  public abstract Function<FSDataInputStream, FSDataInputStream> inputStreamTransformation();
+
+  /**
+   * @return A list of extensions that should be removed from the output file name, which will be applied in order.
+   *        For example, if this method returns ["gz", "tar", "tgz"] then "file.tar.gz" becomes "file".
+   */
+  public List<String> extensionsToRemove() {
+    return new ArrayList<>();
+  }
+
+  /**
+   * TODO: actually use this method and add the extensions.
+   * @return A list of extensions that should be added to the output file name, to be applied in order.
+   *        For example, if this method returns ["tar", "gz"] then "file" becomes "file.tar.gz".
+   */
+  public List<String> extensionsToAdd() {
+    return new ArrayList<>();
+  }
+
+  /**
+   * Identity schema converter.
+   */
+  @Override
+  public String convertSchema(String inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
+    return inputSchema;
+  }
+
+  /**
+   * Applies the transformation in {@link #inputStreamTransformation} to the {@link FSDataInputStream} in the
+   * {@link FileAwareInputStream}.
+   */
+  @Override
+  public Iterable<FileAwareInputStream> convertRecord(String outputSchema, FileAwareInputStream fileAwareInputStream,
+      WorkUnitState workUnit) throws DataConversionException {
+
+    modifyExtensionAtDestination(fileAwareInputStream.getFile());
+    try {
+      FSDataInputStream newInputStream = inputStreamTransformation().apply(fileAwareInputStream.getInputStream());
+      return new SingleRecordIterable<>(new FileAwareInputStream(fileAwareInputStream.getFile(), newInputStream));
+    } catch (RuntimeException re) {
+      throw new DataConversionException(re);
+    }
+  }
+
+  private void modifyExtensionAtDestination(CopyableFile file) {
+    if (extensionsToRemove().size() > 0) {
+      file.setDestination(PathUtils.removeExtension(file.getDestination(), extensionsToRemove().toArray(new String[0])));
+      file.setRelativeDestination(PathUtils.removeExtension(file.getRelativeDestination(),
+          extensionsToRemove().toArray(new String[0])));
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/UnGzipConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/UnGzipConverter.java
@@ -12,19 +12,20 @@
 
 package gobblin.data.management.copy.converter;
 
-import gobblin.configuration.WorkUnitState;
+import javax.annotation.Nullable;
+
 import gobblin.converter.Converter;
-import gobblin.converter.DataConversionException;
-import gobblin.converter.SchemaConversionException;
-import gobblin.converter.SingleRecordIterable;
-import gobblin.data.management.copy.CopyableFile;
-import gobblin.data.management.copy.FileAwareInputStream;
-import gobblin.util.PathUtils;
 import gobblin.util.io.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
+
+import org.apache.hadoop.fs.FSDataInputStream;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
 
 
 /**
@@ -33,43 +34,25 @@ import java.util.zip.GZIPInputStream;
  * {@link InputStream} from source is compressed.
  * It also converts the destination file name by removing tar and gz extensions.
  */
-public class UnGzipConverter extends Converter<String, String, FileAwareInputStream, FileAwareInputStream> {
+public class UnGzipConverter extends DistcpConverter {
 
   private static final String TAR_EXTENSION = ".tar";
   private static final String GZ_EXTENSION = ".gz";
   private static final String TGZ_EXTENSION = ".tgz";
 
-  @Override
-  public String convertSchema(String inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
-    return inputSchema;
+  @Override public Function<FSDataInputStream, FSDataInputStream> inputStreamTransformation() {
+    return new Function<FSDataInputStream, FSDataInputStream>() {
+      @Nullable @Override public FSDataInputStream apply(FSDataInputStream input) {
+        try {
+          return StreamUtils.convertStream(new GZIPInputStream(input));
+        } catch (IOException ioe) {
+          throw new RuntimeException(ioe);
+        }
+      }
+    };
   }
 
-  @Override
-  public Iterable<FileAwareInputStream> convertRecord(String outputSchema, FileAwareInputStream fileAwareInputStream,
-      WorkUnitState workUnit) throws DataConversionException {
-    removeExtensionAtDestination(fileAwareInputStream.getFile());
-
-    return convertInputStream(outputSchema, fileAwareInputStream, workUnit);
-  }
-
-  static Iterable<FileAwareInputStream> convertInputStream(String outputSchema,
-      FileAwareInputStream fileAwareInputStream, WorkUnitState workUnit) throws DataConversionException {
-    try {
-      return new SingleRecordIterable<FileAwareInputStream>(new FileAwareInputStream(fileAwareInputStream.getFile(),
-          StreamUtils.convertStream(new GZIPInputStream(fileAwareInputStream.getInputStream()))));
-
-    } catch (IOException e) {
-      throw new DataConversionException(String.format("Failed to convert %s ", fileAwareInputStream.getFile()
-          .getOrigin().getPath()), e);
-    }
-  }
-
-  /**
-   * Remove {@value #TAR_EXTENSION} and {@value #GZ_EXTENSION} from {@link CopyableFile#getDestination()} and
-   * {@link CopyableFile#getRelativeDestination()}
-   */
-  private void removeExtensionAtDestination(CopyableFile file) {
-    file.setDestination(PathUtils.removeExtension(file.getDestination(), TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION));
-    file.setRelativeDestination(PathUtils.removeExtension(file.getRelativeDestination(), TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION));
+  @Override public List<String> extensionsToRemove() {
+    return Lists.newArrayList(TAR_EXTENSION, GZ_EXTENSION, TGZ_EXTENSION);
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/recovery/RecoveryHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/recovery/RecoveryHelper.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.recovery;
+
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.security.UserGroupInformation;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+
+import gobblin.configuration.State;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.util.guid.Guid;
+
+
+/**
+ * Helper class for distcp work unit recovery.
+ */
+@Slf4j
+public class RecoveryHelper {
+
+  public static final String PERSIST_DIR_KEY = "distcp.persist.dir";
+
+  private final FileSystem fs;
+  private final Optional<Path> persistDir;
+
+  public RecoveryHelper(FileSystem fs, State state) throws IOException {
+    this.fs = fs;
+    this.persistDir = getPersistDir(state);
+  }
+
+  /**
+   * Get the persist directory for this job.
+   * @param state {@link State} containing job information.
+   * @return A {@link Path} used as persist directory for this job. Note this path is user-specific for security reasons.
+   * @throws java.io.IOException
+   */
+  public static Optional<Path> getPersistDir(State state) throws IOException {
+    if (state.contains(PERSIST_DIR_KEY)) {
+      return Optional.of(new Path(state.getProp(PERSIST_DIR_KEY),
+          UserGroupInformation.getCurrentUser().getShortUserName()));
+    } else {
+      return Optional.absent();
+    }
+  }
+
+  /**
+   * Moves a copied path into a persistent location managed by gobblin-distcp. This method is used when an already
+   * copied file cannot be successfully published. In future runs, instead of re-copying the file, distcp will use the
+   * persisted file.
+   *
+   * @param state {@link State} containing job information.
+   * @param file {@link CopyableFile} from which input {@link Path} originated.
+   * @param path {@link Path} to persist.
+   * @return true if persist was successful.
+   * @throws IOException
+   */
+  public boolean persistFile(State state, CopyableFile file, Path path) throws IOException {
+
+    if (!this.persistDir.isPresent()) {
+      return false;
+    }
+
+    String guid = computeGuid(state, file);
+    StringBuilder nameBuilder = new StringBuilder(guid);
+    nameBuilder.append("_");
+    nameBuilder.append(shortenPathName(file.getOrigin().getPath(), 250 - nameBuilder.length()));
+
+    if (!this.fs.exists(this.persistDir.get())) {
+      this.fs.mkdirs(this.persistDir.get(), new FsPermission(FsAction.ALL, FsAction.READ, FsAction.NONE));
+    }
+
+    Path targetPath = new Path(persistDir.get(), nameBuilder.toString());
+    log.info(String.format("Persisting file %s with guid %s to location %s.", path, guid, targetPath));
+    return this.fs.rename(path, targetPath);
+  }
+
+  /**
+   * Searches the persist directory to find {@link Path}s matching the input {@link CopyableFile}.
+   * @param state {@link State} containing job information.
+   * @param file {@link CopyableFile} for which persisted {@link Path}s should be found.
+   * @param filter {@link com.google.common.base.Predicate} used to filter found paths.
+   * @return Optionally, a {@link Path} in the {@link FileSystem} that is the desired copy of the {@link CopyableFile}.
+   * @throws IOException
+   */
+  public Optional<FileStatus> findPersistedFile(State state, CopyableFile file, Predicate<FileStatus> filter)
+      throws IOException {
+    if (!this.persistDir.isPresent() || !this.fs.exists(this.persistDir.get())) {
+      return Optional.absent();
+    }
+
+    Path glob = new Path(this.persistDir.get(), computeGuid(state, file) + "_*");
+    for (FileStatus fileStatus : this.fs.globStatus(glob)) {
+      if (filter.apply(fileStatus)) {
+        return Optional.of(fileStatus);
+      }
+    }
+    return Optional.absent();
+  }
+
+  /**
+   * Shorten an absolute path into a sanitized String of length at most bytes. This is useful for including a summary
+   * of an absolute path in a file name.
+   *
+   * <p>
+   *   For example: shortenPathName("/user/gobblin/foo/bar/myFile.txt", 25) will be shortened to "_user_gobbl..._myFile.txt".
+   * </p>
+   *
+   * @param path absolute {@link Path} to shorten.
+   * @param bytes max number of UTF8 bytes that output string can use (note that,
+   *              for now, it is assumed that each character uses exactly one byte).
+   * @return a shortened, sanitized String of length at most bytes.
+   */
+  static String shortenPathName(Path path, int bytes) {
+    String pathString = path.toUri().getPath();
+    String replaced = pathString.replace("/", "_");
+
+    if (replaced.length() <= bytes) {
+      return replaced;
+    }
+
+    int bytesPerHalf = (bytes - 3) / 2;
+    return replaced.substring(0, bytesPerHalf) + "..." + replaced.substring(replaced.length() - bytesPerHalf);
+  }
+
+  private static String computeGuid(State state, CopyableFile file) throws IOException {
+    Optional<Guid> stateGuid = CopySource.getWorkUnitGuid(state);
+    if (stateGuid.isPresent()) {
+      return Guid.combine(file.guid(), stateGuid.get()).toString();
+    } else {
+      throw new IOException("State does not contain a guid.");
+    }
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/converter/DecryptConverterTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/converter/DecryptConverterTest.java
@@ -22,7 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.jasypt.util.text.StrongTextEncryptor;
+import org.jasypt.util.text.BasicTextEncryptor;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -85,8 +85,8 @@ public class DecryptConverterTest {
     String masterPassword = UUID.randomUUID().toString();
     createMasterPwdFile(masterPassword);
     state.setProp(ConfigurationKeys.ENCRYPT_KEY_LOC, this.masterPwdFile.toString());
-    state.setProp(ConfigurationKeys.ENCRYPT_USE_STRONG_ENCRYPTOR, true);
-    StrongTextEncryptor encryptor = new StrongTextEncryptor();
+    state.setProp(ConfigurationKeys.ENCRYPT_USE_STRONG_ENCRYPTOR, false);
+    BasicTextEncryptor encryptor = new BasicTextEncryptor();
     encryptor.setPassword(masterPassword);
     String encrypted = encryptor.encrypt(plainPassphrase);
     state.setProp("converter.decrypt.passphrase", "ENC(" + encrypted + ")");

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/recovery/RecoveryHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/recovery/RecoveryHelperTest.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.recovery;
+
+import junit.framework.Assert;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.io.Files;
+
+import gobblin.configuration.State;
+import gobblin.data.management.copy.CopyConfiguration;
+import gobblin.data.management.copy.CopyContext;
+import gobblin.data.management.copy.CopySource;
+import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.copy.PreserveAttributes;
+import gobblin.util.guid.Guid;
+
+
+public class RecoveryHelperTest {
+
+  private File tmpDir;
+
+  @BeforeMethod public void setUp() throws Exception {
+    this.tmpDir = Files.createTempDir();
+    this.tmpDir.deleteOnExit();
+  }
+
+  @Test public void testGetPersistDir() throws Exception {
+
+    State state = new State();
+
+    Assert.assertFalse(RecoveryHelper.getPersistDir(state).isPresent());
+
+    state.setProp(RecoveryHelper.PERSIST_DIR_KEY, this.tmpDir.getAbsolutePath());
+
+    Assert.assertTrue(RecoveryHelper.getPersistDir(state).isPresent());
+    Assert.assertTrue(RecoveryHelper.getPersistDir(state).get().toUri().getPath().
+        startsWith(this.tmpDir.getAbsolutePath()));
+
+  }
+
+  @Test public void testPersistFile() throws Exception {
+
+    String content = "contents";
+
+    File stagingDir = Files.createTempDir();
+    stagingDir.deleteOnExit();
+
+    File file = new File(stagingDir, "file");
+    OutputStream os = new FileOutputStream(file);
+    IOUtils.write(content, os);
+    os.close();
+
+    Assert.assertEquals(stagingDir.listFiles().length, 1);
+
+    State state = new State();
+    state.setProp(RecoveryHelper.PERSIST_DIR_KEY, this.tmpDir.getAbsolutePath());
+
+    File recoveryDir = new File(RecoveryHelper.getPersistDir(state).get().toUri().getPath());
+
+    FileSystem fs = FileSystem.getLocal(new Configuration());
+
+    CopyableFile copyableFile = CopyableFile.builder(fs,
+        new FileStatus(0, false, 0, 0, 0, new Path("/file")), new Path("/dataset"),
+        new CopyConfiguration(new Path("/target"), PreserveAttributes.fromMnemonicString(""), new CopyContext())).build();
+
+    CopySource.setWorkUnitGuid(state, Guid.fromHasGuid(copyableFile));
+
+    RecoveryHelper recoveryHelper = new RecoveryHelper(FileSystem.getLocal(new Configuration()), state);
+
+    recoveryHelper.persistFile(state, copyableFile, new Path(file.getAbsolutePath()));
+
+    Assert.assertEquals(stagingDir.listFiles().length, 0);
+    Assert.assertEquals(recoveryDir.listFiles().length, 1);
+
+    File fileInRecovery = recoveryDir.listFiles()[0];
+    Assert.assertEquals(IOUtils.readLines(new FileInputStream(fileInRecovery)).get(0), content);
+
+    Optional<FileStatus> fileToRecover =
+        recoveryHelper.findPersistedFile(state, copyableFile, Predicates.<FileStatus>alwaysTrue());
+    Assert.assertTrue(fileToRecover.isPresent());
+    Assert.assertEquals(fileToRecover.get().getPath().toUri().getPath(), fileInRecovery.getAbsolutePath());
+
+    fileToRecover =
+        recoveryHelper.findPersistedFile(state, copyableFile, Predicates.<FileStatus>alwaysFalse());
+    Assert.assertFalse(fileToRecover.isPresent());
+
+  }
+
+  @Test public void testShortenPathName() throws Exception {
+
+    Assert.assertEquals(RecoveryHelper.shortenPathName(new Path("/test"), 10), "_test");
+    Assert.assertEquals(RecoveryHelper.shortenPathName(new Path("/relatively/long/path"), 9), "_re...ath");
+
+  }
+}

--- a/gobblin-example/build.gradle
+++ b/gobblin-example/build.gradle
@@ -13,6 +13,8 @@ apply plugin: 'java'
 dependencies {
     compile project(":gobblin-api")
     compile project(":gobblin-core")
+    compile project(":gobblin-runtime")
+    compile project(":gobblin-data-management")
 
     compile externalDependency.avro
     compile externalDependency.guava

--- a/gobblin-example/src/main/resources/distcp.pull
+++ b/gobblin-example/src/main/resources/distcp.pull
@@ -1,0 +1,35 @@
+# ====================================================================
+# Job configurations (can be changed)
+# ====================================================================
+
+job.name=GobblinDatabaseCopyTest
+job.description=Test Gobblin job for copy
+
+# target location for copy
+data.publisher.final.dir=/tmp/gobblin-copy
+
+gobblin.dataset.profile.class=gobblin.data.management.copy.CopyableGlobDatasetFinder
+gobblin.dataset.pattern=${env:HOME}/gobblin-copy
+
+# ====================================================================
+# Distcp configurations (do not change)
+# ====================================================================
+
+type=hadoopJava
+job.class=gobblin.azkaban.AzkabanJobLauncher
+
+extract.namespace=gobblin.copy
+data.publisher.type=gobblin.data.management.copy.publisher.CopyDataPublisher
+source.class=gobblin.data.management.copy.CopySource
+writer.builder.class=gobblin.data.management.copy.writer.FileAwareInputStreamDataWriterBuilder
+converter.classes=gobblin.converter.IdentityConverter
+
+task.maxretries=0
+workunit.retry.enabled=false
+
+distcp.persist.dir=/tmp/distcp-persist-dir
+
+# state.store.dir=${work.dir}/state-store
+# writer.staging.dir=${work.dir}/taskStaging
+# writer.output.dir=${work.dir}/taskOutput
+# mr.job.root.dir=${work.dir}/working

--- a/gobblin-utility/src/main/java/gobblin/util/guid/Guid.java
+++ b/gobblin-utility/src/main/java/gobblin/util/guid/Guid.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.guid;
+
+import lombok.EqualsAndHashCode;
+
+import java.io.IOException;
+
+import org.apache.commons.codec.DecoderException;
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.codec.digest.DigestUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.ArrayUtils;
+
+import com.google.common.base.Charsets;
+
+
+/**
+ * Class wrapping a byte array representing a guid. A {@link Guid} is intended to uniquely identify objects in a
+ * replicable way.
+ */
+@EqualsAndHashCode
+public class Guid {
+
+  public static final int GUID_LENGTH = 20;
+
+  final byte[] sha;
+
+  /**
+   * Creates a {@link Guid} by computing the sha of the input bytes.
+   */
+  public Guid(byte[] bytes) {
+    this(bytes, false);
+  }
+
+  /**
+   * @param bytes byte array.
+   * @param isSha true if bytes are already a sha.
+   */
+  private Guid(byte[] bytes, boolean isSha) {
+    if (isSha) {
+      this.sha = bytes;
+    } else {
+      this.sha = computeGuid(bytes);
+    }
+  }
+
+  /**
+   * Generate a {@link Guid} for an array of {@link HasGuid}.
+   * @param objs array of {@link HasGuid}.
+   * @return a single {@link Guid} for the array.
+   * @throws IOException
+   */
+  public static Guid fromHasGuid(HasGuid... objs) throws IOException {
+    byte[][] byteArrays = new byte[objs.length][];
+    for (int i = 0; i < objs.length; i++) {
+      byteArrays[i] = objs[i].guid().sha;
+    }
+    return fromByteArrays(byteArrays);
+  }
+
+  /**
+   * Generate a {@link Guid} for an array of Strings.
+   * @param strings array of Strings.
+   * @return a single {@link Guid} for the array.
+   * @throws IOException
+   */
+  public static Guid fromStrings(String... strings) throws IOException {
+
+    if (strings == null || strings.length == 0) {
+      throw new IOException("Attempting to compute guid for an empty array.");
+    }
+
+    return new Guid(StringUtils.join(strings).getBytes(Charsets.UTF_8));
+  }
+
+  /**
+   * Generate a {@link Guid} for an array of byte arrays.
+   * @param byteArrays array of byte arrays.
+   * @return a single {@link Guid} for the array.
+   * @throws IOException
+   */
+  public static Guid fromByteArrays(byte[] ... byteArrays) throws IOException {
+    if (byteArrays == null || byteArrays.length == 0) {
+      throw new IOException("Attempting to compute guid for an empty array.");
+    }
+
+    if (byteArrays.length == 1 ) {
+      return new Guid(byteArrays[0]);
+    }
+    byte[] tmp = new byte[0];
+    for (byte[] arr : byteArrays) {
+      tmp = ArrayUtils.addAll(tmp, arr);
+    }
+    return new Guid(tmp);
+  }
+
+  /**
+   * Reverse of {@link #toString}. Deserializes a {@link Guid} from a previously serialized one.
+   * @param str Serialized {@link Guid}.
+   * @return deserialized {@link Guid}.
+   * @throws IOException
+   */
+  public static Guid deserialize(String str) throws IOException {
+    if (str.length() != 2 * GUID_LENGTH) {
+      throw new IOException("String is not an encoded guid.");
+    }
+    try {
+      return new Guid(Hex.decodeHex(str.toCharArray()), true);
+    } catch (DecoderException de) {
+      throw new IOException(de);
+    }
+  }
+
+  /**
+   * Combine multiple {@link Guid}s into a single {@link Guid}.
+   * @throws IOException
+   */
+  public static Guid combine(Guid ... guids) throws IOException {
+    byte[][] byteArrays = new byte[guids.length][];
+    for (int i = 0; i < guids.length; i++) {
+      byteArrays[i] = guids[i].sha;
+    }
+    return fromByteArrays(byteArrays);
+  }
+
+  /**
+   * Creates a new {@link Guid} which is a unique, replicable representation of the pair (this, byteArrays).
+   * @param byteArrays an array of byte arrays.
+   * @return a new {@link Guid}.
+   * @throws IOException
+   */
+  public Guid append(byte[] ... byteArrays) throws IOException {
+    if (byteArrays == null || byteArrays.length == 0) {
+      return this;
+    }
+    return fromByteArrays(ArrayUtils.add(byteArrays, this.sha));
+  }
+
+  /**
+   * Creates a new {@link Guid} which is a unique, replicable representation of the pair (this, guids). Equivalent to
+   * combine(this, guid1, guid2, ...)
+   * @param guids an array of {@link Guid}.
+   * @return a new {@link Guid}.
+   * @throws IOException
+   */
+  public Guid append(Guid... guids) throws IOException {
+    if (guids == null || guids.length == 0) {
+      return this;
+    }
+    return combine(ArrayUtils.add(guids, this));
+  }
+
+  /**
+   * Creates a new {@link Guid} which is a unique, replicable representation of the pair (this, objs).
+   * @param objs an array of {@link HasGuid}.
+   * @return a new {@link Guid}.
+   * @throws IOException
+   */
+  public Guid append(HasGuid ... objs) throws IOException {
+    if (objs == null || objs.length == 0) {
+      return this;
+    }
+    return fromHasGuid(ArrayUtils.add(objs, new SimpleHasGuid(this)));
+  }
+
+  /**
+   * Serializes the guid into a hex string. The original {@link Guid} can be recovered using {@link #deserialize}.
+   */
+  public String toString() {
+    return Hex.encodeHexString(this.sha);
+  }
+
+  private static byte[] computeGuid(byte[] bytes) {
+    return DigestUtils.sha(bytes);
+  }
+
+  static class SimpleHasGuid implements HasGuid {
+    private final Guid guid;
+
+    public SimpleHasGuid(Guid guid) {
+      this.guid = guid;
+    }
+
+    @Override public Guid guid() throws IOException {
+      return this.guid;
+    }
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/util/guid/HasGuid.java
+++ b/gobblin-utility/src/main/java/gobblin/util/guid/HasGuid.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.guid;
+
+import java.io.IOException;
+
+
+/**
+ * Represents an object for which we can compute a unique, replicable {@link Guid}.
+ */
+public interface HasGuid {
+
+  /**
+   * @return the {@link Guid} for this object.
+   * @throws IOException
+   */
+  public Guid guid() throws IOException;
+
+}

--- a/gobblin-utility/src/test/java/gobblin/util/guid/GuidTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/guid/GuidTest.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.guid;
+
+import java.io.IOException;
+import java.util.Random;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class GuidTest {
+
+  @Test
+  public void testLength() {
+    Assert.assertEquals(new Guid(new byte[0]).sha.length, Guid.GUID_LENGTH);
+  }
+
+  // Obviously not an extensive test, but better than nothing.
+  @Test
+  public void testUniqueReplicable() {
+    Random random = new Random();
+
+    byte[] b = new byte[10];
+    random.nextBytes(b);
+
+    Assert.assertEquals(new Guid(b), new Guid(b));
+
+    byte[] other = new byte[10];
+    for (int i = 0; i < 1000; i++) {
+      random.nextBytes(other);
+      Assert.assertNotEquals(new Guid(b), new Guid(other));
+    }
+  }
+
+  @Test
+  public void testSerDe() throws Exception {
+    Random random = new Random();
+
+    byte[] b = new byte[10];
+    random.nextBytes(b);
+
+    Guid guid = new Guid(b);
+
+    Assert.assertEquals(guid.toString().length(), 2 * Guid.GUID_LENGTH);
+
+    Assert.assertEquals(guid, Guid.deserialize(guid.toString()));
+  }
+
+  @Test
+  public void testFromHasGuid() throws IOException {
+    Random random = new Random();
+
+    byte[] b = new byte[10];
+    random.nextBytes(b);
+
+    Guid guid = new Guid(b);
+
+    HasGuid hasGuid = new Guid.SimpleHasGuid(guid);
+
+    Assert.assertEquals(hasGuid.guid(), guid);
+
+
+  }
+
+}


### PR DESCRIPTION
This PR adds a feature to Gobblin distcp to persist and recover late-failing work units (e.g. can't set permissions).

Change summary:
* Added a guid to `CopyableFile`.
* `CopySource` adds a work unit guid to each work unit.
* `FileAwareInputStream` catches late failures and persists work units. To do this, it moves copied files to a persistent location, identified by guid and a shortened version of their original path. Furthermore, for each work unit, the writer will search the persistent location for matching files, if one is found, it is recovered instead of doing the copy.
* Created `DistcpConverter` as a superclass for all distcp converters.