### PR TITLE
Fix distribution creation for both install and upload

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -41,6 +41,11 @@ dependencies {
   }
 }
 
+distributionTarballName = 'gobblin-distribution'
+if (tasks.findIndexOf { task -> task.name.equals('uploadArchives') } >= 0) {
+  distributionTarballName = distributionTarballName + '-' + project.version
+}
+
 task build(type: Tar, overwrite: true) {
   extension = 'tar.gz'
   baseName = project.name
@@ -55,9 +60,9 @@ task build(type: Tar, overwrite: true) {
 
   doLast {
     copy {
-      from buildDir.path + '/distributions/gobblin-distribution-' + project.version + '.tar.gz'
+      from buildDir.path + '/distributions/' + distributionTarballName + '.tar.gz'
       into project.rootDir.path
-      rename ('gobblin-distribution-' + project.version + '.tar.gz', 'gobblin-dist.tar.gz')
+      rename (distributionTarballName + '.tar.gz', 'gobblin-dist.tar.gz')
     }
   }
 }


### PR DESCRIPTION
Make the distribution build script detect the `uploadArchives` target so that it can know the correct name for the distribution tarball.

As discovered by @sahilTakiar after #604 was merged, the `install` and `uploadArchives` targets result in differently named tarballs.  Prior to #604, when the `uploadArchives` target was specified the tarball would not be copied to gobblin root.  Post #604, when the `install` target is specified the tarball will not be copied to gobblin root.  This PR makes to work either way.