### PR TITLE
Gobblin_password_encryptor should be included in the tarball

### DIFF
--- a/gobblin-api/src/main/java/gobblin/password/PasswordManager.java
+++ b/gobblin-api/src/main/java/gobblin/password/PasswordManager.java
@@ -173,7 +173,7 @@ public class PasswordManager {
    * provided in the constructor. Otherwise, return the password as is.
    */
   public String readPassword(String password) {
-    if (!this.encryptor.isPresent()) {
+    if (password == null || !this.encryptor.isPresent()) {
       return password;
     }
     Matcher matcher = PASSWORD_PATTERN.matcher(password);

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -36,7 +36,10 @@ task build(type: Tar, overwrite: true) {
   compression = Compression.GZIP
 
   into("conf") { from "../conf/" }
-  into("bin") { from "../bin/" }
+  into("bin") { 
+    from "../bin/" 
+    from project(':gobblin-utility').projectDir.path + '/src/main/bash/gobblin_password_encryptor.sh'
+  }
   into("lib") {
     from configurations.runtime
   }


### PR DESCRIPTION
As all the jars needed by the password encryptor cli tool are in the ```gobblin-dist/lib``` directory,
it's not necessary to build ```gobblin-utility.tar.gz``` manually as suggested in the [documentation]
(https://github.com/linkedin/gobblin/wiki/Working-with-Job-Configuration-Files#password-encryption) .

This patch copies the shell script to gobblin-dist/bin. Also added a null check to the password
decryptor to fix the NPE in case of unset passwords.