### PR TITLE
Gobblin Oozie config files

### DIFF
--- a/gobblin-oozie/src/test/resources/local/gobblin-oozie-example-system.properties
+++ b/gobblin-oozie/src/test/resources/local/gobblin-oozie-example-system.properties
@@ -1,0 +1,40 @@
+# An example system.properties file for Gobblin, useful for when launching Gobblin on Oozie
+
+# Gobblin work dir
+gobblin.work.dir=gobblin-out
+
+# Thread pool settings for the task executor
+taskexecutor.threadpool.size=2
+taskretry.threadpool.coresize=1
+taskretry.threadpool.maxsize=2
+
+# File system URIs
+fs.uri=hdfs:///
+writer.fs.uri=${fs.uri}
+state.store.fs.uri=${fs.uri}
+
+# Writer related configuration properties
+writer.destination.type=HDFS
+writer.output.format=AVRO
+writer.staging.dir=${gobblin.work.dir}/task-staging
+writer.output.dir=${gobblin.work.dir}/task-output
+
+# Data publisher related configuration properties
+data.publisher.type=gobblin.publisher.BaseDataPublisher
+data.publisher.final.dir=${gobblin.work.dir}/job-output
+data.publisher.replace.final.dir=false
+
+# Directory where job/task state files are stored
+state.store.dir=${gobblin.work.dir}/state-store
+
+# Directory where error files from the quality checkers are stored
+qualitychecker.row.err.file=${gobblin.work.dir}/err
+
+# Directory where job locks are stored
+job.lock.enabled=false
+
+# Directory where metrics log files are stored
+metrics.log.dir=${gobblin.work.dir}/metrics
+
+# Interval of task state reporting in milliseconds
+task.status.reportintervalinms=5000

--- a/gobblin-oozie/src/test/resources/local/gobblin-oozie-example-workflow.properties
+++ b/gobblin-oozie/src/test/resources/local/gobblin-oozie-example-workflow.properties
@@ -1,0 +1,12 @@
+# An example job.properties file for launching Gobblin jobs via Oozie
+
+# Set the Name Node URI e.g. hdfs://sandbox.hortonworks.com:8020
+name.node=hdfs://localhost:62705
+
+# Set the Resource Manager URI e.g. sandbox.hortonworks.com:8050
+resource.manager=localhost:54580
+
+nameNode=${name.node}
+jobTracker=${resource.manager}
+
+oozie.wf.application.path=${name.node}/path/to/oozie/workflows

--- a/gobblin-oozie/src/test/resources/local/gobblin-oozie-example-workflow.xml
+++ b/gobblin-oozie/src/test/resources/local/gobblin-oozie-example-workflow.xml
@@ -1,0 +1,26 @@
+<workflow-app name="gobblin-oozie-example-workflow" xmlns="uri:oozie:workflow:0.1">
+	<start to="gobblin-local-job"/>
+	<action name="gobblin-local-job">
+		<java>
+			<job-tracker>${jobTracker}</job-tracker>
+			<name-node>${nameNode}</name-node>
+			<configuration>
+				<property>
+					<name>oozie.launcher.mapreduce.user.classpath.first</name>
+					<value>true</value>
+				</property>
+			</configuration>
+			<main-class>gobblin.runtime.local.CliLocalJobLauncher</main-class>
+			<arg>--jobconfig</arg>
+			<arg>${nameNode}/path/to/jobconfig.properties</arg>
+			<arg>--sysconfig</arg>
+			<arg>${nameNode}/path/to/sysconfig.properties</arg>
+		</java>
+		<ok to="end"/>
+		<error to="fail"/>
+	</action>
+	<kill name="fail">
+		<message>Error Message: ${wf:errorMessage(wf:lastErrorNode())}</message>
+	</kill>
+	<end name="end"/>
+</workflow-app>

--- a/gobblin-runtime/src/main/java/gobblin/runtime/cli/CliOptions.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/cli/CliOptions.java
@@ -21,9 +21,13 @@ import org.apache.commons.cli.HelpFormatter;
 import org.apache.commons.cli.Option;
 import org.apache.commons.cli.Options;
 import org.apache.commons.cli.ParseException;
+
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 
 import gobblin.util.JobConfigurationUtils;
 
@@ -74,10 +78,8 @@ public class CliOptions {
       }
 
       // Load system and job configuration properties
-      Properties sysConfig = ConfigurationConverter
-          .getProperties(new PropertiesConfiguration(cmd.getOptionValue(SYS_CONFIG_OPTION.getLongOpt())));
-      Properties jobConfig = ConfigurationConverter
-          .getProperties(new PropertiesConfiguration(cmd.getOptionValue(JOB_CONFIG_OPTION.getLongOpt())));
+      Properties sysConfig = fileToProperties(cmd.getOptionValue(SYS_CONFIG_OPTION.getLongOpt()));
+      Properties jobConfig = fileToProperties(cmd.getOptionValue(JOB_CONFIG_OPTION.getLongOpt()));
 
       return JobConfigurationUtils.combineSysAndJobProperties(sysConfig, jobConfig);
     } catch (ParseException pe) {
@@ -85,7 +87,6 @@ public class CliOptions {
     } catch (ConfigurationException ce) {
       throw new IOException(ce);
     }
-
   }
 
   /**
@@ -104,4 +105,10 @@ public class CliOptions {
     return options;
   }
 
+  private static Properties fileToProperties(String fileName) throws IOException, ConfigurationException {
+    Path filePath = new Path(fileName);
+    PropertiesConfiguration propsConfig = new PropertiesConfiguration();
+    propsConfig.load(filePath.getFileSystem(new Configuration()).open(filePath));
+    return ConfigurationConverter.getProperties(propsConfig);
+  }
 }


### PR DESCRIPTION
Hackday project: Added example configuration files for running Gobblin on Oozie
* Added a few changes to `CliOptions.java` so that it can read configuration files from hdfs, not just the local filesystem - this is necessary for Oozie, as it reads its configuration files from HDFS
* Added configuration files under `gobblin-oozie/src/test/resources`
* The config files run Gobblin in local mode in a Java process
* `gobblin-oozie-example-system.properties` is an example sysconfig for running Gobblin on Oozie
* `gobblin-oozie-example-workflow.properties` is the job config file that Oozie accepts
* `gobblin-oozie-example-workflow.xml` is the Oozie workflow that launches Gobblin as a Java process

Documentation for these configs and a guide on how to run Gobblin on Oozie is here: https://github.com/linkedin/gobblin/wiki/Gobblin-Schedulers

Tested using the Hortonworks Sandbox on VirtualBox.