### PR TITLE
Fix broken Gobblin version resolution ( fixes #662 )

### DIFF
--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -42,8 +42,6 @@ dependencies {
   }
 }
 
-import org.apache.tools.ant.filters.ReplaceTokens
-
 task build(type: Tar, overwrite: true) {
   extension = 'tar.gz'
   baseName = project.name
@@ -53,7 +51,8 @@ task build(type: Tar, overwrite: true) {
   into("bin") { 
     from "../bin/" 
     from project(':gobblin-utility').projectDir.path + '/src/main/bash/gobblin_password_encryptor.sh'
-    filter(ReplaceTokens, tokens:['project.version': '"' + project.version + '"'])
+    filter { String line -> line.replace("GOBBLIN_VERSION=@project.version@", 
+      "GOBBLIN_VERSION="+'"' + project.version + '"') }
   }
   into("lib") {
     from configurations.runtime


### PR DESCRIPTION
ReplaceTokens replaces all occurences of a given token, but this is undesirable
when substituting `@project.version@` as it also replaces the value in the if condition
that checks for this placeholder, thus breaking the script. 