### PR TITLE
Gobblin-compaction tarball doesn't contain gobblin-compaction.jar

### DIFF
--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -73,7 +73,7 @@ task createCompactionTar(type: Tar) {
   compression = Compression.GZIP
 
   into("gobblin-compaction_lib") { from configurations.runtime }
-  into(".") { from project.rootDir.path + "/build/gobblin-compaction/libs/gobblin-compaction.jar" }
+  into(".") { from "${project.rootDir}/build/${project.name}/libs/${project.name}-${project.version}.jar" }
   into(".") { from project.rootDir.path + "/conf/log4j-compaction.xml" rename ('log4j-compaction.xml', 'log4j.xml')}
 }
 


### PR DESCRIPTION
The `:gobblin-compaction:createCompactionTar` task looks for `gobblin-compaction.jar` instead of the 
versioned jar name.