### PR TITLE
Ensure that parallel runner waits for the underlying tasks to finish

### DIFF
--- a/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
@@ -129,6 +129,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
     for (int branchId = 0; branchId < this.numBranches; branchId++) {
       publishSingleTaskData(state, branchId);
     }
+    this.parallelRunnerCloser.close();
   }
 
   /**


### PR DESCRIPTION
Fix for #675 