### PR TITLE
Add inline Hive registration to Gobblin job

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -274,7 +274,14 @@ public class ConfigurationKeys {
    * Configuration properties for the data publisher.
    */
   public static final String DATA_PUBLISHER_PREFIX = "data.publisher";
+
+  /**
+   * @deprecated Use {@link #TASK_DATA_PUBLISHER_TYPE} and {@link #JOB_DATA_PUBLISHER_TYPE}.
+   */
+  @Deprecated
   public static final String DATA_PUBLISHER_TYPE = DATA_PUBLISHER_PREFIX + ".type";
+  public static final String JOB_DATA_PUBLISHER_TYPE = DATA_PUBLISHER_PREFIX + ".job.type";
+  public static final String TASK_DATA_PUBLISHER_TYPE = DATA_PUBLISHER_PREFIX + ".task.type";
   public static final String DEFAULT_DATA_PUBLISHER_TYPE = "gobblin.publisher.BaseDataPublisher";
   public static final String DATA_PUBLISHER_FILE_SYSTEM_URI = DATA_PUBLISHER_PREFIX + ".fs.uri";
   public static final String DATA_PUBLISHER_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".final.dir";
@@ -285,6 +292,7 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_PERMISSIONS = DATA_PUBLISHER_PREFIX + ".permissions";
   public static final String PUBLISH_DATA_AT_JOB_LEVEL = "publish.data.at.job.level";
   public static final boolean DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL = true;
+  public static final String PUBLISHER_DIRS = DATA_PUBLISHER_PREFIX + ".output.dirs";
 
   /**
    * Configuration properties used by the extractor.
@@ -513,10 +521,16 @@ public class ConfigurationKeys {
   public static final String AZKABAN_EXECUTION_DAYS_LIST = "azkaban.execution.days.list";
 
   /**
+   * Hive registration properties
+   */
+  public static final String HIVE_REGISTRATION_POLICY = "hive.registration.policy";
+
+  /**
    * Other configuration properties.
    */
   public static final String GOBBLIN_RUNTIME_DELIVERY_SEMANTICS = "gobblin.runtime.delivery.semantics";
   public static final Charset DEFAULT_CHARSET_ENCODING = Charsets.UTF_8;
   public static final String TEST_HARNESS_LAUNCHER_IMPL = "gobblin.testharness.launcher.impl";
   public static final int PERMISSION_PARSING_RADIX = 8;
+
 }

--- a/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisherWithHiveRegistration.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisherWithHiveRegistration.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.publisher;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+
+
+/**
+ * An extension of {@link BaseDataPublisher} which performs Hive registration after publishing data.
+ *
+ * <p>
+ *   This publisher should generally be used as the job level data publisher, since doing Hive registration
+ *   in tasks may need to create many Hive metastore connections if the number of tasks is large. To publish
+ *   data in tasks and do Hive registration in the driver, one should use
+ *   {@link BaseDataPublisher} as the task level publisher and
+ *   {@link HiveRegistrationPublisher} as the job level publisher.
+ * </p>
+ *
+ * @author ziliu
+ */
+public class BaseDataPublisherWithHiveRegistration extends BaseDataPublisher {
+
+  protected final HiveRegistrationPublisher hivePublisher;
+
+  public BaseDataPublisherWithHiveRegistration(State state) throws IOException {
+    super(state);
+    this.hivePublisher = this.closer.register(new HiveRegistrationPublisher(state));
+  }
+
+  @Override
+  public void publish(Collection<? extends WorkUnitState> states) throws IOException {
+    super.publish(states);
+    this.hivePublisher.publish(states);
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.publisher;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Set;
+
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.Sets;
+import com.google.common.io.Closer;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.hive.HiveRegister;
+import gobblin.hive.policy.HiveRegistrationPolicy;
+import gobblin.hive.policy.HiveRegistrationPolicyBase;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A {@link DataPublisher} that registers the already published data with Hive.
+ *
+ * <p>
+ *   This publisher is not responsible for publishing data, and it relies on another publisher
+ *   to document the published paths in property {@link ConfigurationKeys#PUBLISHER_DIRS}. Thus this publisher
+ *   should generally be used as a job level data publisher, where the task level publisher should be a publisher
+ *   that documents the published paths, such as {@link BaseDataPublisher}.
+ * </p>
+ *
+ * @author ziliu
+ */
+@Slf4j
+public class HiveRegistrationPublisher extends DataPublisher {
+
+  private final Closer closer = Closer.create();
+  private final HiveRegister hiveRegister;
+  private final HiveRegistrationPolicy policy;
+
+  public HiveRegistrationPublisher(State state) throws IOException {
+    super(state);
+    this.hiveRegister = this.closer.register(new HiveRegister(state));
+    this.policy = HiveRegistrationPolicyBase.getPolicy(state);
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.closer.close();
+  }
+
+  @Deprecated
+  @Override
+  public void initialize() throws IOException {
+  }
+
+  @Override
+  public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
+    Set<String> pathsToRegister = getUniquePathsToRegister(states);
+    log.info("Number of paths to be registered in Hive: " + pathsToRegister.size());
+    for (String path : pathsToRegister) {
+      this.hiveRegister.register(this.policy.getHiveSpec(new Path(path)));
+    }
+  }
+
+  private Set<String> getUniquePathsToRegister(Collection<? extends WorkUnitState> states) {
+    Set<String> paths = Sets.newHashSet();
+    for (State state : states) {
+      if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {
+        paths.addAll(state.getPropAsList(ConfigurationKeys.PUBLISHER_DIRS));
+      }
+    }
+    return paths;
+  }
+
+  @Override
+  public void publishMetadata(Collection<? extends WorkUnitState> states) throws IOException {
+    // Nothing to do
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -12,13 +12,10 @@
 
 package gobblin.publisher;
 
-import com.google.common.base.Optional;
 import java.io.IOException;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -23,6 +23,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
 import gobblin.annotation.Alpha;
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.hive.HivePartition;
 import gobblin.hive.spec.HiveSpec;
@@ -39,8 +40,6 @@ import gobblin.hive.spec.SimpleHiveSpec;
  */
 @Alpha
 public abstract class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
-
-  public static final String HIVE_REGISTRATION_POLICY = "hive.registration.policy";
 
   public static final String HIVE_DATABASE_NAME = "hive.database.name";
   public static final String HIVE_DATABASE_REGEX = "hive.database.regex";
@@ -154,9 +153,9 @@ public abstract class HiveRegistrationPolicyBase implements HiveRegistrationPoli
    * takes a {@link State} object.
    */
   public static HiveRegistrationPolicy getPolicy(State props) {
-    Preconditions.checkArgument(props.contains(HIVE_REGISTRATION_POLICY));
+    Preconditions.checkArgument(props.contains(ConfigurationKeys.HIVE_REGISTRATION_POLICY));
 
-    String policyType = props.getProp(HIVE_REGISTRATION_POLICY);
+    String policyType = props.getProp(ConfigurationKeys.HIVE_REGISTRATION_POLICY);
     try {
       return (HiveRegistrationPolicy) ConstructorUtils.invokeConstructor(Class.forName(policyType), props);
     } catch (ReflectiveOperationException e) {

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -13,6 +13,7 @@ apply plugin: 'java'
 dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-core")
+  compile project(":gobblin-hive-registration")
   compile project(":gobblin-metrics")
   compile project(":gobblin-metastore")
   compile project(":gobblin-utility")

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -166,9 +166,8 @@ public class JobContext {
 
     Preconditions.checkState(this.jobState.contains(FsCommitSequenceStore.GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_DIR));
 
-    FileSystem fs = FileSystem.get(
-        URI.create(
-            this.jobState.getProp(FsCommitSequenceStore.GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_FS_URI, ConfigurationKeys.LOCAL_FS_URI)),
+    FileSystem fs = FileSystem.get(URI.create(this.jobState
+        .getProp(FsCommitSequenceStore.GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_FS_URI, ConfigurationKeys.LOCAL_FS_URI)),
         HadoopUtils.getConfFromState(this.jobState));
 
     return Optional.<CommitSequenceStore> of(new FsCommitSequenceStore(fs,
@@ -306,6 +305,7 @@ public class JobContext {
   void storeJobExecutionInfo() {
     if (this.jobHistoryStoreOptional.isPresent()) {
       try {
+        this.logger.info("Writing job execution information to the job history store");
         this.jobHistoryStoreOptional.get().put(this.jobState.toJobExecutionInfo());
       } catch (IOException ioe) {
         this.logger.error("Failed to write job execution information to the job history store: " + ioe, ioe);
@@ -353,17 +353,17 @@ public class JobContext {
       finalizeDatasetStateBeforeCommit(datasetState);
 
       Class<? extends DataPublisher> dataPublisherClass;
-      try(Closer closer = Closer.create()) {
-        dataPublisherClass = (Class<? extends DataPublisher>) Class.forName(
-            datasetState.getProp(ConfigurationKeys.DATA_PUBLISHER_TYPE, ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
+      try (Closer closer = Closer.create()) {
+        dataPublisherClass = getJobDataPublisherClass(datasetState);
         if (!canCommitDataset(datasetState)) {
           this.logger.warn(String.format("Not committing dataset %s of job %s with commit policy %s and state %s",
               datasetUrn, this.jobId, this.jobCommitPolicy, datasetState.getState()));
           allDatasetsCommit = false;
           if (UnpublishedHandling.class.isAssignableFrom(dataPublisherClass)) {
             DataPublisher publisher = closer.register(DataPublisher.getInstance(dataPublisherClass, datasetState));
-            this.logger.info(String.format("Calling publisher to handle unpublished work units for dataset %s of job %s.",
-                datasetUrn, this.jobId));
+            this.logger
+                .info(String.format("Calling publisher to handle unpublished work units for dataset %s of job %s.",
+                    datasetUrn, this.jobId));
             ((UnpublishedHandling) publisher).handleUnpublishedWorkUnits(datasetState.getTaskStatesAsWorkUnitStates());
           }
           continue;
@@ -372,7 +372,7 @@ public class JobContext {
         throw new IOException(roe);
       }
 
-      try(Closer closer = Closer.create()) {
+      try (Closer closer = Closer.create()) {
 
         if (shouldCommitDataInJob) {
           this.logger.info(String.format("Committing dataset %s of job %s with commit policy %s and state %s",
@@ -389,7 +389,8 @@ public class JobContext {
         }
       } catch (ReflectiveOperationException roe) {
         this.logger.error(
-            String.format("Failed to instantiate data publisher for dataset %s of job %s.", datasetUrn, this.jobId), roe);
+            String.format("Failed to instantiate data publisher for dataset %s of job %s.", datasetUrn, this.jobId),
+            roe);
       } catch (IOException ioe) {
         this.logger.error(
             String.format("Failed to commit dataset state for dataset %s of job %s", datasetUrn, this.jobId), ioe);
@@ -420,6 +421,20 @@ public class JobContext {
     }
   }
 
+  @SuppressWarnings("unchecked")
+  private Class<? extends DataPublisher> getJobDataPublisherClass(JobState.DatasetState datasetState)
+      throws ReflectiveOperationException {
+    if (datasetState.contains(ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE)) {
+      return (Class<? extends DataPublisher>) Class
+          .forName(datasetState.getProp(ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE));
+    } else {
+      LOG.warn("Property " + ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE + " not specified");
+      return (Class<? extends DataPublisher>) Class.forName(
+          datasetState.getProp(ConfigurationKeys.DATA_PUBLISHER_TYPE, ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
+    }
+
+  }
+
   /**
    * Whether data should be committed by the job (as opposed to being commited by the tasks).
    * Data should be committed by the job if either {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY} is set to "full",
@@ -430,7 +445,8 @@ public class JobContext {
         JobCommitPolicy.getCommitPolicy(state.getProperties()) == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS;
     boolean publishDataAtJobLevel = state.getPropAsBoolean(ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL,
         ConfigurationKeys.DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL);
-    return jobCommitPolicyIsFull || publishDataAtJobLevel;
+    boolean jobDataPublisherSpecified = state.contains(ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE);
+    return jobCommitPolicyIsFull || publishDataAtJobLevel || jobDataPublisherSpecified;
   }
 
   /**
@@ -477,7 +493,6 @@ public class JobContext {
   /**
    * Commit the output data of a dataset.
    */
-  @SuppressWarnings("unchecked")
   private void commitDataset(JobState.DatasetState datasetState, DataPublisher publisher) throws IOException {
 
     try {


### PR DESCRIPTION
Added a `BaseDataPublisherWithHiveRegistration` which records the paths that need to be registered as a state property. After `JobContext` commits the data, it will retrieve the paths from the state and register them in Hive.