### PR TITLE
Increase the size of the property_value column in the history store from TEXT to MEDIUMTEXT

### DIFF
--- a/gobblin-metastore/src/main/resources/gobblin_job_history_store.sql
+++ b/gobblin-metastore/src/main/resources/gobblin_job_history_store.sql
@@ -21,7 +21,7 @@ CREATE TABLE IF NOT EXISTS gobblin_job_executions (
 	launched_tasks INT,
 	completed_tasks INT,
 	launcher_type ENUM('LOCAL', 'MAPREDUCE', 'YARN'),
-  tracking_url VARCHAR(512),
+	tracking_url VARCHAR(512),
 	created_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	last_modified_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (job_id),
@@ -91,29 +91,29 @@ CREATE TABLE IF NOT EXISTS gobblin_task_metrics (
 );
 
 CREATE TABLE IF NOT EXISTS gobblin_job_properties (
-  property_id BIGINT(21) NOT NULL AUTO_INCREMENT,
-  job_id VARCHAR(128) NOT NULL,
-  property_key VARCHAR(128) NOT NULL,
-  property_value TEXT NOT NULL,
+	property_id BIGINT(21) NOT NULL AUTO_INCREMENT,
+	job_id VARCHAR(128) NOT NULL,
+	property_key VARCHAR(128) NOT NULL,
+	property_value MEDIUMTEXT NOT NULL,
 	created_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	last_modified_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (property_id),
 	FOREIGN KEY (job_id)
-  REFERENCES gobblin_job_executions(job_id)
-  ON DELETE CASCADE,
-  INDEX (property_key)
+	REFERENCES gobblin_job_executions(job_id)
+	ON DELETE CASCADE,
+	INDEX (property_key)
 );
 
 CREATE TABLE IF NOT EXISTS gobblin_task_properties (
 	property_id BIGINT(21) NOT NULL AUTO_INCREMENT,
 	task_id VARCHAR(128) NOT NULL,
-  property_key VARCHAR(128) NOT NULL,
-  property_value TEXT NOT NULL,
+	property_key VARCHAR(128) NOT NULL,
+	property_value MEDIUMTEXT NOT NULL,
 	created_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
 	last_modified_ts TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
 	PRIMARY KEY (property_id),
 	FOREIGN KEY (task_id)
-  REFERENCES gobblin_task_executions(task_id)
-  ON DELETE CASCADE,
-  INDEX (property_key)
+	REFERENCES gobblin_task_executions(task_id)
+	ON DELETE CASCADE,
+	INDEX (property_key)
 );


### PR DESCRIPTION
Certain properties such as `source.filebased.fs.snapshot` can be too large to fit in a TEXT column.