### PR TITLE
Fix permissions for directories in distcp.

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
@@ -219,7 +219,7 @@ public class CopyableFile implements File, HasGuid {
       List<OwnerAndPermission> ancestorOwnerAndPermissions = Lists.newArrayList();
       try {
         Path currentPath = PathUtils.getPathWithoutSchemeAndAuthority(path);
-        while (currentPath != null && currentPath.getParent() != null && !currentPath.getParent().equals(rootPathTmp)) {
+        while (currentPath != null && currentPath.getParent() != null) {
           currentPath = currentPath.getParent();
           final Path thisPath = currentPath;
           OwnerAndPermission ownerAndPermission = this.configuration.getCopyContext().getOwnerAndPermissionCache()

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -316,24 +316,25 @@ public class FileAwareInputStreamDataWriter implements DataWriter<FileAwareInput
 
     if (ownerAndPermissionIterator.hasNext()) {
       OwnerAndPermission ownerAndPermission = ownerAndPermissionIterator.next();
+
       if (path.getParent() != null) {
         ensureDirectoryExists(fs, path.getParent(), ownerAndPermissionIterator);
       }
-      if (ownerAndPermission.getFsPermission() == null) {
-        // use default permissions
-        if (!fs.mkdirs(path)) {
-          // fs.mkdirs returns false if path already existed. Do not overwrite permissions
-          return;
-        }
-      } else {
-        if (!fs.mkdirs(path, addExecutePermissionToOwner(ownerAndPermission.getFsPermission()))) {
-          // fs.mkdirs returns false if path already existed. Do not overwrite permissions
-          return;
-        }
+
+      if (!fs.mkdirs(path)) {
+        // fs.mkdirs returns false if path already existed. Do not overwrite permissions
+        return;
       }
+
+      if (ownerAndPermission.getFsPermission() != null) {
+        log.debug("Applying permissions %s to path %s.", ownerAndPermission.getFsPermission(), path);
+        fs.setPermission(path, addExecutePermissionToOwner(ownerAndPermission.getFsPermission()));
+      }
+
       String group = ownerAndPermission.getGroup();
       String owner = ownerAndPermission.getOwner();
       if (group != null || owner != null) {
+        log.debug("Applying owner %s and group %s to path %s.", owner, group, path);
         fs.setOwner(path, owner, group);
       }
     } else {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/CopyableFileTest.java
@@ -94,6 +94,7 @@ public class CopyableFileTest {
         CopyConfiguration.builder().targetRoot(new Path(targetRoot)).preserve(preserveAttributes).build();
 
     CopyableFile copyableFile = CopyableFile.builder(originFS, origin, datasetRoot, copyConfiguration)
+        .ancestorsOwnerAndPermission(Lists.<OwnerAndPermission>newArrayList()) // not testing ancestors
         .build();
 
     // Making sure all fields are populated correctly via CopyableFile builder
@@ -152,7 +153,9 @@ public class CopyableFileTest {
         .origin(origin)
         .preserve(preserveAttributes)
         .relativeDestination(relativePath)
-        .destination(targetPath).build();
+        .destination(targetPath)
+        .ancestorsOwnerAndPermission(Lists.<OwnerAndPermission>newArrayList())
+        .build();
 
     // Verify preserve attribute options
     Assert.assertEquals(copyableFile.getPreserve().toMnemonicString(), preserveAttributes.toMnemonicString());

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
@@ -59,7 +59,7 @@ public class RecursiveCopyableDatasetTest {
       Assert.assertTrue(paths.contains(originRelativePath));
       Assert.assertTrue(paths.contains(targetRelativePath));
       Assert.assertEquals(originRelativePath, targetRelativePath);
-      Assert.assertEquals(copyableFile.getAncestorsOwnerAndPermission().size(), originRelativePath.depth() - 1);
+      Assert.assertEquals(copyableFile.getAncestorsOwnerAndPermission().size(), copyableFile.getOrigin().getPath().depth());
     }
 
   }


### PR DESCRIPTION
Issue:
Permissions were not being set correctly for newly generated directories in distcp. Root cause:
1. fs.mkdirs(Path, FsPermission) is affected by umask.
2. we were only setting permissions up to the dataset root. However, for patterns like `/foo/*/*`, where the dataset would be /foo/bar/dataset, we should also set permissions for /foo/bar and /foo/bar/dataset if these directories are newly created.