### PR TITLE
Reg compacted datasets in Hive

### DIFF
--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanCompactionJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanCompactionJobLauncher.java
@@ -12,16 +12,23 @@
 
 package gobblin.azkaban;
 
-import gobblin.compaction.Compactor;
-
 import java.io.IOException;
-import java.util.List;
 import java.util.Properties;
-
-import org.apache.log4j.Logger;
 
 import azkaban.jobExecutor.AbstractJob;
 
+import com.google.common.base.Optional;
+
+import org.apache.log4j.Logger;
+
+import gobblin.compaction.Compactor;
+import gobblin.compaction.CompactorFactory;
+import gobblin.compaction.CompactorCreationException;
+import gobblin.compaction.listeners.CompactorListener;
+import gobblin.compaction.listeners.CompactorListenerCreationException;
+import gobblin.compaction.listeners.CompactorListenerFactory;
+import gobblin.compaction.ReflectionCompactorFactory;
+import gobblin.compaction.listeners.ReflectionCompactorListenerFactory;
 import gobblin.metrics.Tag;
 
 
@@ -34,9 +41,6 @@ public class AzkabanCompactionJobLauncher extends AbstractJob {
 
   private static final Logger LOG = Logger.getLogger(AzkabanCompactionJobLauncher.class);
 
-  private static final String COMPACTION_COMPACTOR_CLASS = "compaction.compactor.class";
-  private static final String DEFAULT_COMPACTION_COMPACTOR_CLASS = "gobblin.compaction.mapreduce.MRCompactor";
-
   private final Properties properties;
   private final Compactor compactor;
 
@@ -44,30 +48,37 @@ public class AzkabanCompactionJobLauncher extends AbstractJob {
     super(jobId, LOG);
     this.properties = new Properties();
     this.properties.putAll(props);
-    this.compactor = getCompactor();
+    this.compactor = getCompactor(getCompactorFactory(), getCompactorListener(getCompactorListenerFactory()));
   }
 
-  private Compactor getCompactor() {
+  private Compactor getCompactor(CompactorFactory compactorFactory, Optional<CompactorListener> compactorListener) {
     try {
-      Class<? extends Compactor> compactorClass = getCompactorClass();
-      Compactor compactor = compactorClass.getDeclaredConstructor(Properties.class, List.class)
-          .newInstance(this.properties, Tag.fromMap(AzkabanTags.getAzkabanTags()));
-      return compactor;
-    } catch (Exception e) {
-      throw new RuntimeException("Failed to instantiate compactor", e);
+      return compactorFactory
+          .createCompactor(this.properties, Tag.fromMap(AzkabanTags.getAzkabanTags()), compactorListener);
+    } catch (CompactorCreationException e) {
+      throw new RuntimeException("Unable to create compactor", e);
     }
+  }
+
+  protected CompactorFactory getCompactorFactory() {
+    return new ReflectionCompactorFactory();
+  }
+
+  private Optional<CompactorListener> getCompactorListener(CompactorListenerFactory compactorListenerFactory) {
+    try {
+      return compactorListenerFactory.createCompactorListener(this.properties);
+    } catch (CompactorListenerCreationException e) {
+      throw new RuntimeException("Unable to create compactor listener", e);
+    }
+  }
+
+  protected CompactorListenerFactory getCompactorListenerFactory() {
+    return new ReflectionCompactorListenerFactory();
   }
 
   @Override
   public void run() throws Exception {
     this.compactor.compact();
-  }
-
-  @SuppressWarnings("unchecked")
-  private Class<? extends Compactor> getCompactorClass() throws ClassNotFoundException {
-    String compactorClassName =
-        this.properties.getProperty(COMPACTION_COMPACTOR_CLASS, DEFAULT_COMPACTION_COMPACTOR_CLASS);
-    return (Class<? extends Compactor>) Class.forName(compactorClassName);
   }
 
   @Override

--- a/gobblin-compaction/src/main/java/gobblin/compaction/CompactorCreationException.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/CompactorCreationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction;
+
+/**
+ * Throw by {@link CompactorFactory} if there is a problem creating a {@link Compactor}.
+ */
+public class CompactorCreationException extends Exception {
+
+  public CompactorCreationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/CompactorFactory.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/CompactorFactory.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction;
+
+import java.util.List;
+import java.util.Properties;
+
+import com.google.common.base.Optional;
+
+import gobblin.annotation.Alpha;
+import gobblin.compaction.listeners.CompactorListener;
+import gobblin.metrics.Tag;
+
+
+/**
+ * A factory responsible for creating {@link Compactor}s.
+ */
+@Alpha
+public interface CompactorFactory {
+
+    /**
+     * Creates a {@link Compactor}.
+     *
+     * @param properties a {@link Properties} object used to create the {@link Compactor}
+     * @param tags a {@link List} of {@link Tag}s used to create the {@link Compactor}.
+     * @param compactorListener a {@link CompactorListener} used to create the {@link Compactor}.
+     *
+     * @return a {@link Compactor}
+     *
+     * @throws CompactorCreationException if there is a problem creating the {@link Compactor}
+     */
+    public Compactor createCompactor(Properties properties, List<Tag<String>> tags,
+        Optional<CompactorListener> compactorListener) throws CompactorCreationException;
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/ReflectionCompactorFactory.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/ReflectionCompactorFactory.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction;
+
+import java.util.List;
+import java.util.Properties;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import gobblin.compaction.listeners.CompactorListener;
+import gobblin.metrics.Tag;
+
+
+/**
+ * Implementation of {@link CompactorFactory} that creates a {@link Compactor} using reflection.
+ */
+public class ReflectionCompactorFactory implements CompactorFactory {
+
+  @VisibleForTesting
+  static final String COMPACTION_COMPACTOR_CLASS = "compaction.compactor.class";
+  private static final String DEFAULT_COMPACTION_COMPACTOR_CLASS = "gobblin.compaction.mapreduce.MRCompactor";
+
+  @Override
+  public Compactor createCompactor(Properties properties, List<Tag<String>> tags,
+      Optional<CompactorListener> compactorListener) throws CompactorCreationException {
+
+    String compactorClassName = properties.getProperty(COMPACTION_COMPACTOR_CLASS, DEFAULT_COMPACTION_COMPACTOR_CLASS);
+    try {
+      return (Compactor) ConstructorUtils
+          .invokeConstructor(Class.forName(compactorClassName), properties, tags, compactorListener);
+    } catch (ReflectiveOperationException e) {
+      throw new CompactorCreationException(String
+          .format("Unable to create Compactor from key \"%s\" with value \"value\"", COMPACTION_COMPACTOR_CLASS,
+              compactorClassName), e);
+    }
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/registration/HiveRegistrationCompactorListener.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/registration/HiveRegistrationCompactorListener.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.hive.registration;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import gobblin.compaction.listeners.CompactorListener;
+import gobblin.compaction.dataset.Dataset;
+import gobblin.configuration.State;
+import gobblin.hive.HiveRegister;
+import gobblin.hive.policy.HiveRegistrationPolicy;
+import gobblin.hive.policy.HiveRegistrationPolicyBase;
+
+
+public class HiveRegistrationCompactorListener implements CompactorListener {
+
+  private final HiveRegister hiveRegister;
+  private final HiveRegistrationPolicy hiveRegistrationPolicy;
+
+  public HiveRegistrationCompactorListener(Properties properties) throws IOException {
+    State state = new State(properties);
+    this.hiveRegister = new HiveRegister(state);
+    this.hiveRegistrationPolicy = HiveRegistrationPolicyBase.getPolicy(state);
+  }
+
+  @Override
+  public void onDatasetCompactionCompletion(Dataset dataset) throws Exception {
+    this.hiveRegister.register(this.hiveRegistrationPolicy.getHiveSpec(dataset.outputPath()));
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/listeners/CompactorListener.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/listeners/CompactorListener.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.listeners;
+
+import gobblin.annotation.Alpha;
+import gobblin.compaction.Compactor;
+import gobblin.compaction.dataset.Dataset;
+
+
+/**
+ * A listener for a {@link Compactor}.
+ */
+@Alpha
+public interface CompactorListener {
+
+  /**
+   * Invoked after the compaction for a {@link Dataset} has been completed.
+   *
+   * @param dataset the {@link Dataset} whose compaction completed
+   */
+  public void onDatasetCompactionCompletion(Dataset dataset) throws Exception;
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/listeners/CompactorListenerCreationException.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/listeners/CompactorListenerCreationException.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.listeners;
+
+/**
+ * Throw by {@link CompactorListenerFactory} if there is a problem creating a {@link CompactorListener}.
+ */
+public class CompactorListenerCreationException extends Exception {
+
+  public CompactorListenerCreationException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/listeners/CompactorListenerFactory.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/listeners/CompactorListenerFactory.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.listeners;
+
+import java.util.Properties;
+
+import com.google.common.base.Optional;
+
+import gobblin.annotation.Alpha;
+
+
+/**
+ * A factory for creating {@link CompactorListener}s.
+ */
+@Alpha
+public interface CompactorListenerFactory {
+
+  /**
+   * Creates a {@link CompactorListener}, if none are specified returns {@link Optional#absent()}.
+   *
+   * @param properties a {@link Properties} object used to create a {@link CompactorListener}.
+   *
+   * @return {@link Optional#absent()} if no {@link CompactorListener} is present, else returns a {@link CompactorListener}.
+   *
+   * @throws CompactorListenerCreationException if there is a problem creating the {@link CompactorListener}.
+   */
+  public Optional<CompactorListener> createCompactorListener(Properties properties)
+      throws CompactorListenerCreationException;
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/listeners/ReflectionCompactorListenerFactory.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/listeners/ReflectionCompactorListenerFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.listeners;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import gobblin.configuration.State;
+
+
+/**
+ * Implementation of {@link CompactorListenerFactory} that creates a {@link CompactorListener} using reflection. The
+ * config key {@link #COMPACTOR_LISTENERS} is used to specify a comma separated list of compactors to use. These
+ * compactors will be run serially.
+ */
+public class ReflectionCompactorListenerFactory implements CompactorListenerFactory {
+
+  @VisibleForTesting
+  static final String COMPACTOR_LISTENERS = "compactor.listeners";
+
+  @Override
+  public Optional<CompactorListener> createCompactorListener(Properties properties)
+      throws CompactorListenerCreationException {
+    State state = new State(properties);
+
+    if (Strings.isNullOrEmpty(state.getProp(COMPACTOR_LISTENERS))) {
+      return Optional.absent();
+    }
+
+    List<CompactorListener> listeners = new ArrayList<>();
+    for (String listenerClassName : state.getPropAsList(COMPACTOR_LISTENERS)) {
+      try {
+        listeners.add((CompactorListener) ConstructorUtils
+            .invokeConstructor(Class.forName(listenerClassName), properties));
+      } catch (ReflectiveOperationException e) {
+        throw new CompactorListenerCreationException(String
+            .format("Unable to create CompactorListeners from key \"%s\" with value \"value\"", COMPACTOR_LISTENERS,
+                properties.getProperty(COMPACTOR_LISTENERS)), e);
+      }
+    }
+    return Optional.<CompactorListener>of(new SerialCompactorListener(listeners));
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/listeners/SerialCompactorListener.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/listeners/SerialCompactorListener.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.listeners;
+
+import java.util.List;
+
+import lombok.AllArgsConstructor;
+
+import gobblin.compaction.dataset.Dataset;
+
+
+@AllArgsConstructor
+public class SerialCompactorListener implements CompactorListener {
+
+  private final List<CompactorListener> listeners;
+
+  @Override
+  public void onDatasetCompactionCompletion(Dataset dataset) throws Exception {
+    for (CompactorListener compactorListener : this.listeners) {
+      compactorListener.onDatasetCompactionCompletion(dataset);
+    }
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
@@ -58,6 +58,7 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 
 import gobblin.compaction.Compactor;
+import gobblin.compaction.listeners.CompactorListener;
 import gobblin.compaction.dataset.Dataset;
 import gobblin.compaction.dataset.DatasetsFinder;
 import gobblin.compaction.dataset.TimeBasedSubDirDatasetsFinder;
@@ -225,13 +226,15 @@ public class MRCompactor implements Compactor {
   private final Stopwatch stopwatch;
   private final GobblinMetrics gobblinMetrics;
   private final EventSubmitter eventSubmitter;
+  private final Optional<CompactorListener> compactorListener;
 
   private final long dataVerifTimeoutMinutes;
   private final long compactionTimeoutMinutes;
   private final boolean shouldVerifDataCompl;
   private final boolean shouldPublishDataIfCannotVerifyCompl;
 
-  public MRCompactor(Properties props, List<? extends Tag<?>> tags) throws IOException {
+  public MRCompactor(Properties props, List<? extends Tag<?>> tags, Optional<CompactorListener> compactorListener)
+      throws IOException {
     this.state = new State();
     this.state.addAll(props);
     this.tags = tags;
@@ -247,6 +250,7 @@ public class MRCompactor implements Compactor {
     this.eventSubmitter = new EventSubmitter.Builder(
         GobblinMetrics.get(this.state.getProp(ConfigurationKeys.JOB_NAME_KEY)).getMetricContext(),
         MRCompactor.COMPACTION_TRACKING_EVENTS_NAMESPACE).build();
+    this.compactorListener = compactorListener;
 
     this.dataVerifTimeoutMinutes = getDataVerifTimeoutMinutes();
     this.compactionTimeoutMinutes = getCompactionTimeoutMinutes();
@@ -599,7 +603,7 @@ public class MRCompactor implements Compactor {
           allDatasetsCompleted = false;
           // Run compaction for a dataset, if it is not already running or completed
           if (jobRunner == null || jobRunner.status() == ABORTED) {
-            runCompactionForDataset(dataset, dataset.state() == VERIFIED ? true : false);
+            runCompactionForDataset(dataset, dataset.state() == VERIFIED);
           }
         } else if (dataset.state() == GIVEN_UP) {
           if (this.shouldPublishDataIfCannotVerifyCompl) {
@@ -769,9 +773,9 @@ public class MRCompactor implements Compactor {
      */
     @Override
     protected void afterExecute(Runnable r, Throwable t) {
-      Preconditions.checkArgument(r instanceof MRCompactorJobRunner,
-          String.format("Runnable expected to be instance of %s, actual %s", MRCompactorJobRunner.class.getSimpleName(),
-              r.getClass().getSimpleName()));
+      Preconditions.checkArgument(r instanceof MRCompactorJobRunner, String
+              .format("Runnable expected to be instance of %s, actual %s", MRCompactorJobRunner.class.getSimpleName(),
+                  r.getClass().getSimpleName()));
 
       MRCompactorJobRunner jobRunner = (MRCompactorJobRunner) r;
       MRCompactor.this.jobRunnables.remove(jobRunner.getDataset());
@@ -788,6 +792,13 @@ public class MRCompactor implements Compactor {
             // Set the dataset status to COMPACTION_COMPLETE if compaction is successful.
             jobRunner.getDataset().setState(COMPACTION_COMPLETE);
           }
+          if (MRCompactor.this.compactorListener.isPresent()) {
+            try {
+              MRCompactor.this.compactorListener.get().onDatasetCompactionCompletion(jobRunner.getDataset());
+            } catch (Exception e) {
+              t = e;
+            }
+          }
         } else
           if (jobRunner.getDataset().state() == GIVEN_UP && !MRCompactor.this.shouldPublishDataIfCannotVerifyCompl) {
 
@@ -801,8 +812,8 @@ public class MRCompactor implements Compactor {
           // Reduce priority and try again.
           jobRunner.getDataset().reducePriority();
         }
-      } else {
-
+      }
+      if (t != null) {
         // Compaction job of a dataset has failed with a throwable.
         afterExecuteWithThrowable(jobRunner, t);
       }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
@@ -113,7 +113,7 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
   public enum Status {
     ABORTED,
     COMMITTED,
-    RUNNING;
+    RUNNING
   }
 
   protected final Dataset dataset;

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/HivePartition.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/HivePartition.java
@@ -31,6 +31,7 @@ import lombok.Getter;
 @Getter
 @Alpha
 public class HivePartition {
+
   private final List<FieldSchema> keys;
   private final List<String> values;
 

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/HiveRegister.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/HiveRegister.java
@@ -46,8 +46,6 @@ import com.google.common.util.concurrent.MoreExecutors;
 import gobblin.annotation.Alpha;
 import gobblin.configuration.State;
 import gobblin.hive.HiveStripedLocks.HiveLock;
-import gobblin.hive.policy.HiveRegistrationPolicy;
-import gobblin.hive.policy.HiveRegistrationPolicyBase;
 import gobblin.hive.spec.HiveSpec;
 import gobblin.hive.spec.HiveSpecWithPostActivities;
 import gobblin.hive.spec.HiveSpecWithPreActivities;
@@ -160,22 +158,6 @@ public class HiveRegister implements Closeable {
 
     this.futures.add(future);
     return future;
-  }
-
-  /**
-   * Register the given {@link Path}s.
-   *
-   * @param paths The {@link Path}s to be registered.
-   * @param state A {@link State} which will be used to instantiate a {@link HiveRegister} and a
-   * {@link HiveRegistrationPolicy} for registering the given The {@link Path}s.
-   */
-  public static void register(Iterable<String> paths, State state) throws IOException {
-    try (HiveRegister hiveRegister = new HiveRegister(state)) {
-      HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(state);
-      for (String path : paths) {
-        hiveRegister.register(policy.getHiveSpec(new Path(path)));
-      }
-    }
   }
 
   private boolean evaluatePredicates(HiveSpecWithPredicates spec) {

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/HiveRegisterUtils.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/HiveRegisterUtils.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.hive;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.Path;
+
+import gobblin.configuration.State;
+import gobblin.hive.policy.HiveRegistrationPolicy;
+import gobblin.hive.policy.HiveRegistrationPolicyBase;
+
+
+/**
+ * Utility class for registering data into Hive.
+ */
+public class HiveRegisterUtils {
+
+  /**
+   * Register the given {@link Path}s.
+   *
+   * @param paths The {@link Path}s to be registered.
+   * @param state A {@link State} which will be used to instantiate a {@link HiveRegister} and a
+   * {@link HiveRegistrationPolicy} for registering the given The {@link Path}s.
+   */
+  public static void register(Iterable<String> paths, State state) throws IOException {
+    try (HiveRegister hiveRegister = new HiveRegister(state)) {
+      HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(state);
+      for (String path : paths) {
+        hiveRegister.register(policy.getHiveSpec(new Path(path)));
+      }
+    }
+  }
+}

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -93,7 +93,7 @@ public abstract class HiveRegistrationPolicyBase implements HiveRegistrationPoli
   }
 
   protected String getDatabaseOrTableName(Path path, String nameKey, String regexKey, Optional<Pattern> pattern) {
-    String name = null;
+    String name;
     if (this.props.contains(nameKey)) {
       name = this.props.getProp(nameKey);
     } else if (pattern.isPresent()) {


### PR DESCRIPTION
* Initial PR to discuss the approach for adding Hive-Reg for datasets produced by `MRCompactor`
* Registration is done in a `AfterCompactionAction` once compaction has completed
* The `AfterCompactionAction`s are configurable and are invoked in `JobRunnerExecutor.afterExecute`

@zliu41 can you review?