### PR TITLE
Fixing CliOptions config file fs

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/JobConfigurationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobConfigurationUtils.java
@@ -13,15 +13,19 @@
 package gobblin.util;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Properties;
 
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 import gobblin.configuration.State;
-import org.apache.hadoop.fs.Path;
 
 
 /**
@@ -78,10 +82,19 @@ public class JobConfigurationUtils {
    * @param fileName the name of the file to load properties from
    * @return a new {@link Properties} instance
    */
-  public static Properties fileToProperties(String fileName) throws IOException, ConfigurationException {
-    Path filePath = new Path(fileName);
+  public static Properties fileToProperties(String fileName)
+      throws IOException, ConfigurationException, URISyntaxException {
+
     PropertiesConfiguration propsConfig = new PropertiesConfiguration();
-    propsConfig.load(filePath.getFileSystem(new Configuration()).open(filePath));
+    Configuration conf = new Configuration();
+    Path filePath = new Path(fileName);
+    URI fileURI = filePath.toUri();
+
+    if (fileURI.getScheme() == null && fileURI.getAuthority() == null) {
+      propsConfig.load(FileSystem.getLocal(conf).open(filePath));
+    } else {
+      propsConfig.load(filePath.getFileSystem(conf).open(filePath));
+    }
     return ConfigurationConverter.getProperties(propsConfig);
   }
 }


### PR DESCRIPTION
Fixing bug reported in https://github.com/linkedin/gobblin/issues/702

* The `JobLauncherUtils.fileToProperties` method takes a path to a props file and reads it using a `FileSystem` object
* The `FileSystem` object is created by invoking `path.getFileSystem(Configuration)`
* It seems that if the `path` has no scheme + authority the default `FileSystem` is used
* The default fs when running locally is the local fs, the default fs when running on a cluster is the HDFS fs
* This can be confusing as the script expects the config file to be in different filesystems depending on where things are run
* Behavior is changed so if no scheme + authority is specified the local fs is used by default, if users expect the files to be on HDFS then they should set the scheme to `hdfs`
** This should be much more intuitive as most of the time props files will be on the local fs, not on HDFS

@zliu41 can you review?