### PR TITLE
Use configClient to configure retention jobs

### DIFF
--- a/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigClientCache.java
+++ b/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigClientCache.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.client;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+
+import gobblin.config.client.api.VersionStabilityPolicy;
+
+/**
+ * Caches {@link ConfigClient}s for every {@link VersionStabilityPolicy}.
+ */
+public class ConfigClientCache {
+
+  private static final Cache<VersionStabilityPolicy, ConfigClient> CONFIG_CLIENTS_CACHE = CacheBuilder.newBuilder()
+      .maximumSize(VersionStabilityPolicy.values().length).build();
+
+  public static ConfigClient getClient(final VersionStabilityPolicy policy) {
+    try {
+      return CONFIG_CLIENTS_CACHE.get(policy, new Callable<ConfigClient>() {
+        @Override
+        public ConfigClient call() throws Exception {
+          return ConfigClient.createConfigClient(policy);
+        }
+      });
+    } catch (ExecutionException e) {
+      throw new RuntimeException("Failed to get Config client", e);
+    }
+  }
+}

--- a/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigStoreFactoryRegister.java
+++ b/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigStoreFactoryRegister.java
@@ -12,18 +12,18 @@
 
 package gobblin.config.client;
 
+import gobblin.config.store.api.ConfigStoreFactory;
+
 import java.util.HashMap;
 import java.util.Map;
 import java.util.ServiceLoader;
 
 import org.apache.log4j.Logger;
 
-import gobblin.config.store.api.ConfigStoreFactory;
-
 
 public class ConfigStoreFactoryRegister {
   private static final Logger LOG = Logger.getLogger(ConfigStoreFactoryRegister.class);
-  
+
   //key is the configStore scheme name, value is the ConfigStoreFactory
   @SuppressWarnings("rawtypes")
   private final Map<String, ConfigStoreFactory> configStoreFactoryMap = new HashMap<>() ;
@@ -41,7 +41,7 @@ public class ConfigStoreFactoryRegister {
   public ConfigStoreFactory getConfigStoreFactory(String scheme){
     return configStoreFactoryMap.get(scheme);
   }
-  
+
   @SuppressWarnings("rawtypes")
   public void register(ConfigStoreFactory factory){
     this.configStoreFactoryMap.put(factory.getScheme(), factory);

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -68,10 +68,10 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
   }
 
   /**
-   * Gets a default root directory if one is not specified. The default root dir is {@code /user/[current-user]/}.
+   * Gets a default root directory if one is not specified. The default root dir is {@code /jobs/[current-user]/}.
    */
   protected Path getDefaultRootDir() throws IOException {
-    return new Path("jobs", UserGroupInformation.getCurrentUser().getUserName());
+    return new Path("/jobs", UserGroupInformation.getCurrentUser().getUserName());
   }
 
   /**
@@ -144,7 +144,6 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
     Path path = new Path(configKey.getPath());
 
     while (path != null) {
-      
       try {
         // the abs URI may point to an unexist path for
         // 1. phantom node

--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -16,7 +16,10 @@ dependencies {
   compile project(":gobblin-hive-registration")
   compile project(":gobblin-metrics")
   compile project(":gobblin-utility")
+  compile project(":gobblin-config-management:gobblin-config-client")
+  compile project(":gobblin-config-management:gobblin-config-core")
 
+  compile externalDependency.lombok
   compile externalDependency.commonsLang
   compile externalDependency.commonsLang3
   compile externalDependency.guava
@@ -25,13 +28,13 @@ dependencies {
   compile externalDependency.jodaTime
   compile externalDependency.findBugs
   compile externalDependency.azkaban
-  compile externalDependency.lombok
   compile externalDependency.metricsCore
   compile externalDependency.commonsCodec
   compile externalDependency.commonsCompress
   compile externalDependency.commonsIo
   compile externalDependency.gson
   compile externalDependency.commonsCodec
+  compile externalDependency.typesafeConfig
 
   testCompile externalDependency.calciteCore
   testCompile externalDependency.calciteAvatica
@@ -39,6 +42,7 @@ dependencies {
   testCompile externalDependency.testng
   testCompile externalDependency.mockito
   testCompile externalDependency.joptSimple
+  testCompile externalDependency.hamcrest
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {
@@ -69,3 +73,4 @@ test {
 }
 
 ext.classification="library"
+

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
@@ -12,22 +12,8 @@
 
 package gobblin.data.management.retention;
 
-import gobblin.configuration.State;
-import gobblin.data.management.dataset.Dataset;
-import gobblin.data.management.retention.dataset.CleanableDataset;
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
-import gobblin.instrumented.Instrumentable;
-import gobblin.instrumented.Instrumented;
-import gobblin.metrics.GobblinMetrics;
-import gobblin.metrics.MetricContext;
-import gobblin.metrics.Tag;
-import gobblin.util.ExecutorsUtils;
-import gobblin.util.RateControlledFileSystem;
-import gobblin.util.executors.ScalingThreadPoolExecutor;
-
 import java.io.Closeable;
 import java.io.IOException;
-import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Properties;
 import java.util.concurrent.Callable;
@@ -41,7 +27,6 @@ import org.slf4j.LoggerFactory;
 
 import com.codahale.metrics.Meter;
 import com.google.common.base.Optional;
-import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 import com.google.common.util.concurrent.FutureCallback;
@@ -49,6 +34,20 @@ import com.google.common.util.concurrent.Futures;
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
+
+import gobblin.configuration.State;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.retention.profile.MultiCleanableDatasetFinder;
+import gobblin.dataset.Dataset;
+import gobblin.dataset.DatasetsFinder;
+import gobblin.instrumented.Instrumentable;
+import gobblin.instrumented.Instrumented;
+import gobblin.metrics.GobblinMetrics;
+import gobblin.metrics.MetricContext;
+import gobblin.metrics.Tag;
+import gobblin.util.ExecutorsUtils;
+import gobblin.util.RateControlledFileSystem;
+import gobblin.util.executors.ScalingThreadPoolExecutor;
 
 
 /**
@@ -59,7 +58,6 @@ public class DatasetCleaner implements Instrumentable, Closeable {
   private static final Logger LOGGER = LoggerFactory.getLogger(DatasetCleaner.class);
 
   public static final String CONFIGURATION_KEY_PREFIX = "gobblin.retention.";
-  public static final String DATASET_PROFILE_CLASS_KEY = CONFIGURATION_KEY_PREFIX + "dataset.profile.class";
   public static final String MAX_CONCURRENT_DATASETS_CLEANED = CONFIGURATION_KEY_PREFIX
       + "max.concurrent.datasets.cleaned";
   public static final String DATASET_CLEAN_HDFS_CALLS_PER_SECOND_LIMIT = CONFIGURATION_KEY_PREFIX
@@ -69,7 +67,7 @@ public class DatasetCleaner implements Instrumentable, Closeable {
 
   private static Logger LOG = LoggerFactory.getLogger(DatasetCleaner.class);
 
-  private final DatasetFinder datasetFinder;
+  private final DatasetsFinder<Dataset> datasetFinder;
   private final ListeningExecutorService service;
   private final Closer closer;
   private final boolean isMetricEnabled;
@@ -80,7 +78,6 @@ public class DatasetCleaner implements Instrumentable, Closeable {
 
   public DatasetCleaner(FileSystem fs, Properties props) throws IOException {
 
-    Preconditions.checkArgument(props.containsKey(DATASET_PROFILE_CLASS_KEY));
     this.closer = Closer.create();
     try {
       FileSystem optionalRateControlledFs = fs;
@@ -90,20 +87,7 @@ public class DatasetCleaner implements Instrumentable, Closeable {
                 .getProperty(DATASET_CLEAN_HDFS_CALLS_PER_SECOND_LIMIT))));
         ((RateControlledFileSystem) optionalRateControlledFs).startRateControl();
       }
-      Class<?> datasetFinderClass = Class.forName(props.getProperty(DATASET_PROFILE_CLASS_KEY));
-      this.datasetFinder =
-          (DatasetFinder) datasetFinderClass.getConstructor(FileSystem.class, Properties.class).newInstance(
-              optionalRateControlledFs, props);
-    } catch (ClassNotFoundException exception) {
-      throw new IOException(exception);
-    } catch (NoSuchMethodException exception) {
-      throw new IOException(exception);
-    } catch (InstantiationException exception) {
-      throw new IOException(exception);
-    } catch (IllegalAccessException exception) {
-      throw new IOException(exception);
-    } catch (InvocationTargetException exception) {
-      throw new IOException(exception);
+      this.datasetFinder = new MultiCleanableDatasetFinder(optionalRateControlledFs, props);
     } catch (NumberFormatException exception) {
       throw new IOException(exception);
     } catch (ExecutionException exception) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleanerJob.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleanerJob.java
@@ -25,7 +25,7 @@ import azkaban.utils.Props;
 
 
 /**
- * Job to run {@link gobblin.data.management.retention.DatasetCleaner} job in Azkaban or Hadoop.
+ * Job to run {@link gobblin.data.management.retention.DatasetCleanerNew} job in Azkaban or Hadoop.
  */
 public class DatasetCleanerJob extends AbstractJob implements Tool {
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableDatasetBase.java
@@ -157,7 +157,7 @@ public abstract class CleanableDatasetBase<T extends DatasetVersion> implements 
   }
 
   /**
-   * Perform the cleanup of old / deprecated dataset versions. See {@link gobblin.data.management.retention.DatasetCleaner}
+   * Perform the cleanup of old / deprecated dataset versions. See {@link gobblin.data.management.retention.DatasetCleanerNew}
    * javadoc for more information.
    * @throws java.io.IOException
    */
@@ -184,6 +184,11 @@ public abstract class CleanableDatasetBase<T extends DatasetVersion> implements 
 
     Collection<T> deletableVersions = getRetentionPolicy().listDeletableVersions(versions);
 
+    cleanImpl(deletableVersions);
+
+  }
+
+  protected void cleanImpl(Collection<T> deletableVersions) throws IOException {
     if (deletableVersions.isEmpty()) {
       this.log.warn("No deletable dataset version can be found. Ignoring.");
       return;
@@ -224,7 +229,6 @@ public abstract class CleanableDatasetBase<T extends DatasetVersion> implements 
       }
     }
   }
-
   private void deleteEmptyParentDirectories(Path datasetRoot, Path parent) throws IOException {
     if (PathUtils.isAncestor(datasetRoot, parent) && !datasetRoot.equals(parent) &&
         this.fs.listStatus(parent).length == 0) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/DeleteNothingRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/DeleteNothingRetentionPolicy.java
@@ -1,0 +1,41 @@
+/*
+* Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+package gobblin.data.management.retention.policy;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
+
+import gobblin.data.management.retention.version.DatasetVersion;
+
+/**
+ * A {@link RetentionPolicy} that does not delete any versions. Basically a pass through dummy policy.
+ */
+public class DeleteNothingRetentionPolicy implements RetentionPolicy<DatasetVersion> {
+
+  public DeleteNothingRetentionPolicy(Properties properties) {}
+
+  public DeleteNothingRetentionPolicy(Config conf) {}
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return DatasetVersion.class;
+  }
+
+  @Override
+  public Collection<DatasetVersion> listDeletableVersions(List<DatasetVersion> allVersions) {
+    return Lists.newArrayList();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/NewestKRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/NewestKRetentionPolicy.java
@@ -8,6 +8,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
 
 import gobblin.data.management.retention.DatasetCleaner;
 import gobblin.data.management.retention.version.DatasetVersion;
@@ -20,16 +21,38 @@ public class NewestKRetentionPolicy implements RetentionPolicy<DatasetVersion> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NewestKRetentionPolicy.class);
 
+  /**
+   * @deprecated use {@link #NEWEST_K_VERSIONS_RETAINED_KEY}
+   */
+  @Deprecated
   public static final String VERSIONS_RETAINED_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX +
       "versions.retained";
+
+  public static final String NEWEST_K_VERSIONS_RETAINED_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX +
+      "newestK.versions.retained";
+
   public static final String VERSIONS_RETAINED_DEFAULT = Integer.toString(2);
 
   private final int versionsRetained;
 
-  public NewestKRetentionPolicy(Properties props) {
-    this.versionsRetained = Integer.parseInt(props.getProperty(VERSIONS_RETAINED_KEY, VERSIONS_RETAINED_DEFAULT));
+  public NewestKRetentionPolicy(int versionsRetained) {
+    this.versionsRetained = versionsRetained;
     LOGGER.info(String.format("%s will retain %d versions of each dataset.",
-        NewestKRetentionPolicy.class.getCanonicalName(), this.versionsRetained));
+        NewestKRetentionPolicy.class.getName(), this.versionsRetained));
+  }
+
+  public NewestKRetentionPolicy(Properties props) {
+    if (props.containsKey(VERSIONS_RETAINED_KEY)) {
+      this.versionsRetained = Integer.parseInt(props.getProperty(VERSIONS_RETAINED_KEY));
+    } else if (props.containsKey(NEWEST_K_VERSIONS_RETAINED_KEY)) {
+      this.versionsRetained = Integer.parseInt(props.getProperty(NEWEST_K_VERSIONS_RETAINED_KEY));
+    } else {
+      this.versionsRetained = Integer.parseInt(VERSIONS_RETAINED_DEFAULT);
+    }
+  }
+
+  public NewestKRetentionPolicy(Config config) {
+    this(Integer.parseInt(config.getString(NEWEST_K_VERSIONS_RETAINED_KEY)));
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/TimeBasedRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/TimeBasedRetentionPolicy.java
@@ -16,11 +16,16 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import lombok.extern.slf4j.Slf4j;
+
+import org.joda.time.DateTime;
 import org.joda.time.Duration;
+import org.joda.time.format.ISOPeriodFormat;
 
 import com.google.common.base.Predicate;
 import com.google.common.collect.Collections2;
 import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
 
 import gobblin.data.management.retention.DatasetCleaner;
 import gobblin.data.management.retention.version.DatasetVersion;
@@ -30,17 +35,43 @@ import gobblin.data.management.retention.version.TimestampedDatasetVersion;
 /**
  * Retain dataset versions newer than now - {@link #retention}.
  */
+@Slf4j
 public class TimeBasedRetentionPolicy implements RetentionPolicy<TimestampedDatasetVersion> {
 
   public static final String RETENTION_MINUTES_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX +
       "minutes.retained";
   public static final String RETENTION_MINUTES_DEFAULT = Long.toString(24 * 60); // one day
 
+  // ISO8601 Standard PyYmMwWdDThHmMsS
+  public static final String RETENTION_TIMEBASED_DURATION_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX +
+      "timebased.duration";
   private final Duration retention;
 
   public TimeBasedRetentionPolicy(Properties props) {
     this.retention = Duration.standardMinutes(
         Long.parseLong(props.getProperty(RETENTION_MINUTES_KEY, RETENTION_MINUTES_DEFAULT)));
+  }
+
+  /**
+   * Creates a new {@link TimeBasedRetentionPolicy} using {@link #RETENTION_TIMEBASED_DURATION_KEY} in the
+   * <code>config</code>
+   * <ul> Some Example values for {@link #RETENTION_TIMEBASED_DURATION_KEY} are
+   * <li> P20D = 20 Days
+   * <li> P20H = 20 Hours
+   * <li> P2Y = 2 Years
+   * <li> P2Y3M = 2 Years and 3 Months
+   * <li> PT23M = 23 Minutes (Note this is different from P23M which is 23 Months)
+   * </ul>
+   *
+   * @param config that holds retention duration in ISO8061 format at key {@link #RETENTION_TIMEBASED_DURATION_KEY}.
+   */
+  public TimeBasedRetentionPolicy(Config config) {
+    this(config.getString(RETENTION_TIMEBASED_DURATION_KEY));
+  }
+
+  public TimeBasedRetentionPolicy(String duration) {
+    this.retention = parseDuration(duration);
+    log.info(String.format("%s will delete dataset versions older than %s.", TimeBasedRetentionPolicy.class.getName(), duration));
   }
 
   @Override
@@ -58,4 +89,21 @@ public class TimeBasedRetentionPolicy implements RetentionPolicy<TimestampedData
     }));
   }
 
+  /**
+   * Since months and years can have arbitrary days, joda time does not allow conversion of a period string containing
+   * months or years to a duration. Hence we calculate the duration using 1970 01:01:00:00:00 UTC as a reference time.
+   *
+   * <p>
+   * <code>
+   * (1970 01:01:00:00:00 + P2Y) - 1970 01:01:00:00:00 = Duration for 2 years
+   * </code>
+   * </p>
+   *
+   * @param periodString
+   * @return duration for this period.
+   */
+  private static Duration parseDuration(String periodString) {
+    DateTime zeroEpoc = new DateTime(0);
+    return new Duration(zeroEpoc, zeroEpoc.plus(ISOPeriodFormat.standard().parsePeriod(periodString)));
+  }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/GlobCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/GlobCleanableDatasetFinder.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.slf4j.LoggerFactory;
 
 import gobblin.data.management.retention.dataset.ConfigurableCleanableDataset;
 import gobblin.data.management.retention.version.DatasetVersion;
@@ -32,6 +33,6 @@ public class GlobCleanableDatasetFinder extends ConfigurableGlobDatasetFinder<Co
   }
 
   @Override public ConfigurableCleanableDataset<DatasetVersion> datasetAtPath(Path path) throws IOException {
-    return new ConfigurableCleanableDataset<>(this.fs, this.props, path);
+    return new ConfigurableCleanableDataset<>(this.fs, this.props, path, LoggerFactory.getLogger(ConfigurableCleanableDataset.class));
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ManagedCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ManagedCleanableDatasetFinder.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.profile;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.LoggerFactory;
+
+import com.typesafe.config.Config;
+
+import gobblin.config.client.ConfigClient;
+import gobblin.config.client.ConfigClientCache;
+import gobblin.config.client.api.ConfigStoreFactoryDoesNotExistsException;
+import gobblin.config.client.api.VersionStabilityPolicy;
+import gobblin.config.store.api.ConfigStoreCreationException;
+import gobblin.config.store.api.VersionDoesNotExistException;
+import gobblin.data.management.retention.dataset.ConfigurableCleanableDataset;
+import gobblin.data.management.retention.version.DatasetVersion;
+
+
+/**
+ * A {@link ConfigurableGlobDatasetFinder} backed by gobblin-config-management. It uses {@link ConfigClient} to get dataset configs
+ */
+public class ManagedCleanableDatasetFinder extends ConfigurableGlobDatasetFinder<ConfigurableCleanableDataset<DatasetVersion>> {
+
+  public static final String CONFIG_MANAGEMENT_STORE_URI = "gobblin.config.management.store.uri";
+
+  private final ConfigClient client;
+
+  public ManagedCleanableDatasetFinder(FileSystem fs, Properties jobProps, Config config) throws IOException {
+    super(fs, jobProps, config);
+    this.client = ConfigClientCache.getClient(VersionStabilityPolicy.STRONG_LOCAL_STABILITY);
+  }
+
+  @Override
+  public ConfigurableCleanableDataset<DatasetVersion> datasetAtPath(Path path) throws IOException {
+    try {
+      return new ConfigurableCleanableDataset<DatasetVersion>(this.fs, this.props, path, this.client.getConfig(this.props
+          .getProperty(CONFIG_MANAGEMENT_STORE_URI) + path.toString()), LoggerFactory.getLogger(ConfigurableCleanableDataset.class));
+    } catch (VersionDoesNotExistException | ConfigStoreFactoryDoesNotExistsException | ConfigStoreCreationException | URISyntaxException e) {
+      throw new IllegalArgumentException(e);
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ModificationTimeDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ModificationTimeDatasetProfile.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (C) 2015-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
 package gobblin.data.management.retention.profile;
 
 import java.io.IOException;
@@ -16,7 +27,7 @@ import gobblin.data.management.retention.dataset.ModificationTimeDataset;
  * Modification time datasets will be cleaned by the modification timestamps of the datasets that match
  * 'gobblin.retention.dataset.pattern'.
  */
-public class ModificationTimeDatasetProfile extends ConfigurableGlobDatasetFinder {
+public class ModificationTimeDatasetProfile extends ConfigurableGlobDatasetFinder<Dataset> {
   public ModificationTimeDatasetProfile(FileSystem fs, Properties props) throws IOException {
     super(fs, props);
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2015-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.profile;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import com.typesafe.config.Config;
+
+import gobblin.data.management.retention.DatasetCleaner;
+
+
+/**
+ * A Clenable DatasetFinder that instantiates multiple DatasetFinders.
+ * <p>
+ * If {@link #DATASET_FINDER_CLASS_KEY} is set, a single datasetFinder is created.
+ * Otherwise {@link #TAGS_TO_IMPORT_KEY} is used to find all the importedBy {@link URI}s from gobblin config management.
+ * The {@link Config} for each {@link URI} should have a {@link #DATASET_FINDER_CLASS_KEY} set.
+ * </p>
+ *
+ */
+public class MultiCleanableDatasetFinder extends MultiDatasetFinder {
+
+  public MultiCleanableDatasetFinder(FileSystem fs, Properties jobProps) {
+    super(fs, jobProps);
+  }
+
+  public static final String TAGS_TO_IMPORT_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX  + "tag";
+  public static final String DATASET_FINDER_CLASS_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX + "dataset.finder.class";
+
+  @Override
+  protected String datasetFinderClassKey() {
+    return DATASET_FINDER_CLASS_KEY;
+  }
+  @Override
+  protected String datasetFinderImportedByKey() {
+    return TAGS_TO_IMPORT_KEY;
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2015-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.profile;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
+
+import gobblin.config.client.ConfigClient;
+import gobblin.config.client.ConfigClientCache;
+import gobblin.config.client.api.ConfigStoreFactoryDoesNotExistsException;
+import gobblin.config.client.api.VersionStabilityPolicy;
+import gobblin.config.store.api.ConfigStoreCreationException;
+import gobblin.config.store.api.VersionDoesNotExistException;
+import gobblin.data.management.retention.dataset.finder.DatasetFinder;
+import gobblin.dataset.Dataset;
+import gobblin.dataset.DatasetsFinder;
+
+
+/**
+ * A DatasetFinder that instantiates multiple DatasetFinders. {@link #findDatasets()} will return a union of all the
+ * datasets found by each datasetFinder
+ * <p>
+ * Subclasses will specify the dataset finder class key name to instantiate. If {@link #datasetFinderClassKey()} is set
+ * in jobProps, a single datasetFinder is created. Otherwise {@link #datasetFinderImportedByKey()} is used to find all
+ * the importedBy {@link URI}s from gobblin config management. The {@link Config} for each {@link URI} should have a
+ * {@link #datasetFinderClassKey()} set.
+ * </p>
+ *
+ */
+@Slf4j
+public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
+  protected abstract String datasetFinderClassKey();
+
+  protected abstract String datasetFinderImportedByKey();
+
+  List<DatasetsFinder<Dataset>> datasetFinders;
+
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public MultiDatasetFinder(FileSystem fs, Properties jobProps) {
+
+    try {
+      this.datasetFinders = Lists.newArrayList();
+
+      if (jobProps.containsKey(datasetFinderClassKey())) {
+        try {
+          this.datasetFinders.add((DatasetFinder) ConstructorUtils.invokeConstructor(
+              Class.forName(jobProps.getProperty(datasetFinderClassKey())), fs, jobProps));
+          log.info(String.format("Instantiated datasetfinder %s ", jobProps.getProperty(datasetFinderClassKey())));
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
+            | ClassNotFoundException e) {
+          log.warn(
+              String.format("Retention ignored could not instantiate datasetfinder %s.",
+                  jobProps.getProperty(datasetFinderClassKey())), e);
+        }
+      } else {
+        ConfigClient client = ConfigClientCache.getClient(VersionStabilityPolicy.STRONG_LOCAL_STABILITY);
+        Collection<URI> importedBys =
+            client.getImportedBy(new URI(jobProps.getProperty(datasetFinderImportedByKey())), false);
+
+        for (URI importedBy : importedBys) {
+          Config datasetClassConfig = client.getConfig(importedBy);
+
+          try {
+            this.datasetFinders
+                .add((DatasetFinder) ConstructorUtils.invokeConstructor(
+                    Class.forName(datasetClassConfig.getString(datasetFinderClassKey())), fs, jobProps,
+                    datasetClassConfig));
+            log.info(String.format("Instantiated datasetfinder %s for %s.",
+                datasetClassConfig.getString(datasetFinderClassKey()), importedBy));
+          } catch (InstantiationException | IllegalAccessException | IllegalArgumentException
+              | InvocationTargetException | NoSuchMethodException | SecurityException | ClassNotFoundException e) {
+            log.warn(String.format("Retention ignored for %s. Could not instantiate datasetfinder %s.", importedBy,
+                datasetClassConfig.getString(datasetFinderClassKey())), e);
+          }
+        }
+      }
+
+    } catch (IllegalArgumentException | VersionDoesNotExistException | ConfigStoreFactoryDoesNotExistsException
+        | ConfigStoreCreationException | URISyntaxException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public List<Dataset> findDatasets() throws IOException {
+    List<Dataset> datasets = Lists.newArrayList();
+    for (DatasetsFinder<Dataset> df : this.datasetFinders) {
+      datasets.addAll(df.findDatasets());
+    }
+    return datasets;
+  }
+
+  @Override
+  public Path commonDatasetRoot() {
+    throw new UnsupportedOperationException("There is no common dataset root for MultiDatasetFinder");
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/SnapshotDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/SnapshotDatasetProfile.java
@@ -18,9 +18,8 @@ import java.util.Properties;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import gobblin.dataset.Dataset;
 import gobblin.data.management.retention.dataset.SnapshotDataset;
-
+import gobblin.dataset.Dataset;
 
 /**
  * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for snapshot datasets.
@@ -29,7 +28,8 @@ import gobblin.data.management.retention.dataset.SnapshotDataset;
  *   Snapshot datasets are datasets where each version is a snapshot/full-dump of a dataset (e.g. a database).
  * </p>
  */
-public class SnapshotDatasetProfile extends ConfigurableGlobDatasetFinder {
+public class SnapshotDatasetProfile extends ConfigurableGlobDatasetFinder<Dataset> {
+
 
   public SnapshotDatasetProfile(FileSystem fs, Properties props)
       throws IOException {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DatasetVersionFinder.java
@@ -44,6 +44,10 @@ public abstract class DatasetVersionFinder<T extends DatasetVersion> implements 
     this.fs = fs;
   }
 
+  public DatasetVersionFinder(FileSystem fs) {
+    this(fs, new Properties());
+  }
+
   /**
    * Find dataset versions in the input {@link org.apache.hadoop.fs.Path}. Dataset versions are subdirectories of the
    * input {@link org.apache.hadoop.fs.Path} representing a single manageable unit in the dataset.

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
@@ -12,6 +12,11 @@
 
 package gobblin.data.management.retention.version.finder;
 
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.retention.DatasetCleaner;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+
 import java.util.Properties;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -21,11 +26,6 @@ import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.data.management.retention.DatasetCleaner;
-import gobblin.data.management.retention.version.DatasetVersion;
-import gobblin.data.management.retention.version.TimestampedDatasetVersion;
 
 
 /**

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/GlobModTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/GlobModTimeDatasetVersionFinder.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.version.finder;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
+
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+
+/**
+ * Finds {@link DatasetVersion}s using a glob pattern. Uses Modification time as the version.
+ */
+public class GlobModTimeDatasetVersionFinder extends DatasetVersionFinder<TimestampedDatasetVersion> {
+
+  private final Path globPattern;
+
+  public GlobModTimeDatasetVersionFinder(FileSystem fs, Path globPattern) {
+    super(fs);
+    this.globPattern = globPattern;
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return TimestampedDatasetVersion.class;
+  }
+
+  @Override
+  public Path globVersionPattern() {
+    return this.globPattern;
+  }
+
+  @Override
+  public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, Path fullPath) {
+    try {
+      return new TimestampedDatasetVersion(new DateTime(fs.getFileStatus(fullPath).getModificationTime()), fullPath);
+    } catch (IOException e) {
+      return null;
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/WatermarkDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/WatermarkDatasetVersionFinder.java
@@ -1,8 +1,14 @@
 package gobblin.data.management.retention.version.finder;
 
+import gobblin.data.management.retention.DatasetCleaner;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.StringDatasetVersion;
+
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import javax.annotation.Nullable;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -11,12 +17,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
-
-import javax.annotation.Nullable;
-
-import gobblin.data.management.retention.DatasetCleaner;
-import gobblin.data.management.retention.version.DatasetVersion;
-import gobblin.data.management.retention.version.StringDatasetVersion;
+import com.typesafe.config.Config;
 
 
 /**
@@ -45,16 +46,29 @@ public class WatermarkDatasetVersionFinder extends DatasetVersionFinder<StringDa
   public WatermarkDatasetVersionFinder(FileSystem fs, Properties props) {
     super(fs, props);
     if(props.containsKey(WATERMARK_REGEX_KEY)) {
-      this.pattern = Optional.of(props.getProperty(WATERMARK_REGEX_KEY)).transform(new Function<String, Pattern>() {
-        @Nullable
-        @Override
-        public Pattern apply(String input) {
-          return Pattern.compile(input);
-        }
-      });
+      initPattern(props.getProperty(WATERMARK_REGEX_KEY));
     } else {
       this.pattern = Optional.absent();
     }
+  }
+
+  public WatermarkDatasetVersionFinder(FileSystem fs, Config config) {
+    super(fs);
+    if (config.hasPath(WATERMARK_REGEX_KEY)) {
+      initPattern(config.getString(WATERMARK_REGEX_KEY));
+    } else {
+      this.pattern = Optional.absent();
+    }
+  }
+
+  private void initPattern(String patternString) {
+    this.pattern = Optional.of(patternString).transform(new Function<String, Pattern>() {
+      @Nullable
+      @Override
+      public Pattern apply(String input) {
+        return Pattern.compile(input);
+      }
+    });
   }
 
   @Override

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/ConfigurableCleanableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/ConfigurableCleanableDatasetTest.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.retention.dataset.ConfigurableCleanableDataset;
+import gobblin.data.management.retention.policy.NewestKRetentionPolicy;
+import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.finder.WatermarkDatasetVersionFinder;
+
+import java.net.URI;
+import java.util.Properties;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+public class ConfigurableCleanableDatasetTest {
+
+  @Test
+  public void testConstructor() throws Exception {
+
+    Config conf =
+        ConfigFactory.parseMap(ImmutableMap.<String, String> of("gobblin.retention.version.finder.class",
+            "gobblin.data.management.retention.version.finder.WatermarkDatasetVersionFinder",
+            "gobblin.retention.retention.policy.class",
+            "gobblin.data.management.retention.policy.NewestKRetentionPolicy",
+            "gobblin.retention.newestK.versions.retained", "2"));
+
+    ConfigurableCleanableDataset<DatasetVersion> dataset =
+        new ConfigurableCleanableDataset<DatasetVersion>(FileSystem.get(new URI(ConfigurationKeys.LOCAL_FS_URI),
+            new Configuration()), new Properties(), new Path("/someroot"), conf, LoggerFactory.getLogger(ConfigurableCleanableDatasetTest.class));
+
+    Assert.assertEquals(dataset.getRetentionPolicy().getClass(), NewestKRetentionPolicy.class);
+    Assert.assertEquals(dataset.getVersionFinder().getClass(), WatermarkDatasetVersionFinder.class);
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/TimeBasedRetentionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/TimeBasedRetentionPolicyTest.java
@@ -12,10 +12,16 @@
 
 package gobblin.data.management.retention;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import gobblin.data.management.retention.policy.TimeBasedRetentionPolicy;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+
 import java.util.List;
 import java.util.Properties;
 
+import org.apache.commons.collections.ListUtils;
 import org.apache.hadoop.fs.Path;
+import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.testng.Assert;
@@ -23,14 +29,14 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Lists;
 
-import gobblin.data.management.retention.policy.TimeBasedRetentionPolicy;
-import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+
+import com.google.common.collect.ImmutableList;
 
 
 public class TimeBasedRetentionPolicyTest {
 
   @Test
-  public void test() {
+  public void testDefaultRetention() {
 
     Properties props = new Properties();
 
@@ -38,8 +44,10 @@ public class TimeBasedRetentionPolicyTest {
 
     DateTimeUtils.setCurrentMillisFixed(new DateTime(2015, 6, 2, 18, 0, 0, 0).getMillis());
 
-    TimestampedDatasetVersion datasetVersion1 = new TimestampedDatasetVersion(new DateTime(2015, 6, 2, 10, 0, 0, 0), new Path("test"));
-    TimestampedDatasetVersion datasetVersion2 = new TimestampedDatasetVersion(new DateTime(2015, 6, 1, 10, 0, 0, 0), new Path("test"));
+    TimestampedDatasetVersion datasetVersion1 =
+        new TimestampedDatasetVersion(new DateTime(2015, 6, 2, 10, 0, 0, 0), new Path("test"));
+    TimestampedDatasetVersion datasetVersion2 =
+        new TimestampedDatasetVersion(new DateTime(2015, 6, 1, 10, 0, 0, 0), new Path("test"));
 
     Assert.assertEquals(policy.versionClass(), TimestampedDatasetVersion.class);
 
@@ -47,11 +55,55 @@ public class TimeBasedRetentionPolicyTest {
     versions.add(datasetVersion1);
     versions.add(datasetVersion2);
     List<TimestampedDatasetVersion> deletableVersions = Lists.newArrayList(policy.listDeletableVersions(versions));
-    Assert.assertEquals(deletableVersions.size(),1);
-    Assert.assertEquals(deletableVersions.get(0).getDateTime(),
-        new DateTime(2015, 6, 1, 10, 0, 0, 0));
-
+    Assert.assertEquals(deletableVersions.size(), 1);
+    Assert.assertEquals(deletableVersions.get(0).getDateTime(), new DateTime(2015, 6, 1, 10, 0, 0, 0));
 
     DateTimeUtils.setCurrentMillisSystem();
+  }
+
+  @Test(dependsOnMethods = { "testDefaultRetention" })
+  public void testISORetentionDuration() throws Exception {
+
+    DateTimeUtils.setCurrentMillisFixed(new DateTime(2016, 2, 11, 10, 0, 0, 0).getMillis());
+
+    // 20 Days
+    verify("P20D",
+        ImmutableList.of(WithDate(new DateTime(2016, 1, 5, 10, 0, 0, 0)), WithDate(new DateTime(2016, 1, 6, 10, 0, 0, 0))),
+        ImmutableList.of(WithDate(new DateTime(2016, 2, 10, 10, 0, 0, 0)), WithDate(new DateTime(2016, 2, 11, 10, 0, 0, 0))));
+
+    // 2 Months
+    verify("P2M",
+        ImmutableList.of(WithDate(new DateTime(2015, 12, 5, 10, 0, 0, 0)), WithDate(new DateTime(2015, 11, 5, 10, 0, 0, 0))),
+        ImmutableList.of(WithDate(new DateTime(2016, 2, 10, 10, 0, 0, 0)), WithDate(new DateTime(2016, 1, 10, 10, 0, 0, 0))));
+
+    // 2 Years
+    verify("P2Y",
+        ImmutableList.of(WithDate(new DateTime(2014, 1, 5, 10, 0, 0, 0)), WithDate(new DateTime(2013, 1, 5, 10, 0, 0, 0))),
+        ImmutableList.of(WithDate(new DateTime(2016, 2, 10, 10, 0, 0, 0)), WithDate(new DateTime(2015, 2, 10, 10, 0, 0, 0))));
+
+    // 20 Hours
+    verify("PT20H",
+        ImmutableList.of(WithDate(new DateTime(2016, 2, 10, 11, 0, 0, 0)), WithDate(new DateTime(2016, 2, 9, 11, 0, 0, 0))),
+        ImmutableList.of(WithDate(new DateTime(2016, 2, 11, 8, 0, 0, 0)), WithDate(new DateTime(2016, 2, 11, 9, 0, 0, 0))));
+
+    DateTimeUtils.setCurrentMillisSystem();
+  }
+
+  private static TimestampedDatasetVersion WithDate(DateTime dt){
+    return new TimestampedDatasetVersion(dt, new Path("test"));
+  }
+
+  private void verify(String duration, List<TimestampedDatasetVersion> toBeDeleted,
+      List<TimestampedDatasetVersion> toBeRetained) {
+
+    @SuppressWarnings("unchecked")
+    List<TimestampedDatasetVersion> allVersions = ListUtils.union(toBeRetained, toBeDeleted);
+
+    List<TimestampedDatasetVersion> deletableVersions =
+        Lists.newArrayList(new TimeBasedRetentionPolicy(duration).listDeletableVersions(allVersions));
+
+    assertThat(deletableVersions, Matchers.containsInAnyOrder(toBeDeleted.toArray()));
+    assertThat(deletableVersions, Matchers.not(Matchers.containsInAnyOrder(toBeRetained.toArray())));
+
   }
 }


### PR DESCRIPTION
- Add new DatasetCleaner that uses configClient to initialize DatasetFinders using importedBy tag
- Add new constructor to NewestK, Timebased and Combine policies. This constructor takes a typesafe Config and initializes the policy

Tested in simulate mode for a few datasets

@tuGithub and @ibuenros can you review?