### PR TITLE
More flexible Admin configuration

### DIFF
--- a/gobblin-admin/src/main/java/gobblin/admin/AdminWebServer.java
+++ b/gobblin-admin/src/main/java/gobblin/admin/AdminWebServer.java
@@ -26,6 +26,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
+import java.net.InetSocketAddress;
 import java.net.URI;
 import java.util.Properties;
 
@@ -35,28 +36,24 @@ import java.util.Properties;
 public class AdminWebServer extends AbstractIdleService {
     private static final Logger LOGGER = LoggerFactory.getLogger(AdminWebServer.class);
 
-    private final Properties properties;
     private final URI restServerUri;
+    private final URI serverUri;
     protected Server server;
 
     public AdminWebServer(Properties properties, URI restServerUri) {
         Preconditions.checkNotNull(properties);
         Preconditions.checkNotNull(restServerUri);
 
-        this.properties = properties;
         this.restServerUri = restServerUri;
+        int port = getPort(properties);
+        serverUri = URI.create(String.format("http://%s:%d", getHost(properties), port));
     }
 
     @Override
     protected void startUp() throws Exception {
-        int port = Integer.parseInt(
-                properties.getProperty(
-                        ConfigurationKeys.ADMIN_SERVER_PORT_KEY,
-                        ConfigurationKeys.DEFAULT_ADMIN_SERVER_PORT));
-
         LOGGER.info("Starting the admin web server");
 
-        server = new Server(port);
+        server = new Server(new InetSocketAddress(serverUri.getHost(), serverUri.getPort()));
 
         HandlerCollection handlerCollection = new HandlerCollection();
 
@@ -101,5 +98,17 @@ public class AdminWebServer extends AbstractIdleService {
         if (server != null) {
             server.stop();
         }
+    }
+
+    private static int getPort(Properties properties) {
+        return Integer.parseInt(properties.getProperty(
+                ConfigurationKeys.ADMIN_SERVER_PORT_KEY,
+                ConfigurationKeys.DEFAULT_ADMIN_SERVER_PORT));
+    }
+
+    private static String getHost(Properties properties) {
+        return properties.getProperty(
+                ConfigurationKeys.ADMIN_SERVER_HOST_KEY,
+                ConfigurationKeys.DEFAULT_ADMIN_SERVER_HOST);
     }
 }

--- a/gobblin-admin/src/main/resources/static/index.html
+++ b/gobblin-admin/src/main/resources/static/index.html
@@ -148,7 +148,7 @@
     </script>
 
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-    <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
+    <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.tablesorter/2.23.5/js/jquery.tablesorter.combined.min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/backbone.js/1.2.3/backbone-min.js"></script>
     <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/1.0.2/Chart.min.js"></script>

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -469,6 +469,7 @@ public class ConfigurationKeys {
   public static final String DEFAULT_REST_SERVER_HOST = "localhost";
   public static final String REST_SERVER_PORT_KEY = "rest.server.port";
   public static final String DEFAULT_REST_SERVER_PORT = "8080";
+  public static final String REST_SERVER_ADVERTISED_URI_KEY = "rest.server.advertised.uri";
 
   /**
    * Admin server configuration properties.

--- a/gobblin-scheduler/src/main/java/gobblin/scheduler/SchedulerDaemon.java
+++ b/gobblin-scheduler/src/main/java/gobblin/scheduler/SchedulerDaemon.java
@@ -80,7 +80,7 @@ public class SchedulerDaemon {
       services.add(executionInfoServer);
       if (adminUiServerEnabled) {
         LOG.info("Starting the admin UI server since it is enabled");
-        services.add(new AdminWebServer(properties, executionInfoServer.getServerUri()));
+        services.add(new AdminWebServer(properties, executionInfoServer.getAdvertisedServerUri()));
       }
     }  else if (adminUiServerEnabled) {
       LOG.warn("NOT starting the admin UI because the job execution info server is NOT enabled");

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -277,7 +277,7 @@ public class GobblinYarnAppLauncher {
       services.add(executionInfoServer);
       if (config.getBoolean(ConfigurationKeys.ADMIN_SERVER_ENABLED_KEY)) {
         LOGGER.info("Starting the admin UI server since it is enabled");
-        services.add(new AdminWebServer(properties, executionInfoServer.getServerUri()));
+        services.add(new AdminWebServer(properties, executionInfoServer.getAdvertisedServerUri()));
       }
     } else if (config.getBoolean(ConfigurationKeys.ADMIN_SERVER_ENABLED_KEY)) {
       LOGGER.warn("NOT starting the admin UI because the job execution info server is NOT enabled");


### PR DESCRIPTION
1. Allow specifying the host for the AdminWebServer in the configuration file.
1. Allow the JobExecutionInfoServer to advertise a different URI from what it is listening on 
1. Fix one of the cdn dependencies to use the https scheme so that it will work correctly when using SSL/TLS.

_Rational:_ This enables us to put the Admin UI and Rest service behind an nginx proxy