### PR TITLE
Automatically enable JMX and pick an open port.

### DIFF
--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -545,6 +545,8 @@ public class GobblinApplicationMaster extends GobblinYarnLogSource {
       Log4jConfigurationHelper.updateLog4jConfiguration(
           GobblinApplicationMaster.class, Log4jConfigurationHelper.LOG4J_CONFIGURATION_FILE_NAME);
 
+      LOGGER.info(YarnHelixUtils.getJvmInputArguments());
+
       ContainerId containerId =
           ConverterUtils.toContainerId(System.getenv().get(ApplicationConstants.Environment.CONTAINER_ID.key()));
       GobblinApplicationMaster applicationMaster =

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinWorkUnitRunner.java
@@ -481,6 +481,8 @@ public class GobblinWorkUnitRunner extends GobblinYarnLogSource {
       Log4jConfigurationHelper.updateLog4jConfiguration(GobblinWorkUnitRunner.class,
           Log4jConfigurationHelper.LOG4J_CONFIGURATION_FILE_NAME);
 
+      LOGGER.info(YarnHelixUtils.getJvmInputArguments());
+
       ContainerId containerId =
           ConverterUtils.toContainerId(System.getenv().get(ApplicationConstants.Environment.CONTAINER_ID.key()));
       String applicationName = cmd.getOptionValue(GobblinYarnConfigurationKeys.APPLICATION_NAME_OPTION_NAME);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -29,6 +29,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String MAX_GET_APP_REPORT_FAILURES_KEY = GOBBLIN_YARN_PREFIX + "max.get.app.report.failures";
   public static final String EMAIL_NOTIFICATION_ON_SHUTDOWN_KEY =
       GOBBLIN_YARN_PREFIX + "email.notification.on.shutdown";
+  public static final String JMX_CONFIGURATION = GOBBLIN_YARN_PREFIX + "jmx.configuration";
 
   // Gobblin Yarn ApplicationMaster configuration properties.
   public static final String APP_MASTER_MEMORY_MBS_KEY = GOBBLIN_YARN_PREFIX + "app.master.memory.mbs";
@@ -38,6 +39,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String APP_MASTER_FILES_REMOTE_KEY = GOBBLIN_YARN_PREFIX + "app.master.files.remote";
   public static final String APP_MASTER_WORK_DIR_NAME = "appmaster";
   public static final String APP_MASTER_JVM_ARGS_KEY = GOBBLIN_YARN_PREFIX + "app.master.jvm.args";
+  public static final String APP_MASTER_JMX_ENABLED = GOBBLIN_YARN_PREFIX + "app.master.jmx.enabled";
 
   // Gobblin Yarn container configuration properties.
   public static final String INITIAL_CONTAINERS_KEY = GOBBLIN_YARN_PREFIX + "initial.containers";
@@ -49,6 +51,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String CONTAINER_WORK_DIR_NAME = "container";
   public static final String CONTAINER_JVM_ARGS_KEY = GOBBLIN_YARN_PREFIX + "container.jvm.args";
   public static final String CONTAINER_HOST_AFFINITY_ENABLED = GOBBLIN_YARN_PREFIX + "container.affinity.enabled";
+  public static final String CONTAINER_JMX_ENABLED = GOBBLIN_YARN_PREFIX + "container.jmx.enabled";
 
   //Helix configuration properties.
   public static final String HELIX_CLUSTER_NAME_KEY = GOBBLIN_YARN_PREFIX + "helix.cluster.name";
@@ -82,6 +85,7 @@ public class GobblinYarnConfigurationKeys {
   public static final String OUTPUT_TASK_STATE_DIR_NAME = "_taskstates";
   public static final String APP_LOGS_DIR_NAME = "_applogs";
   public static final String TAR_GZ_FILE_SUFFIX = ".tar.gz";
+  public static final String DEFAULT_JMX_CONFIGURATION = "-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port=$JMX_PORT -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT";
 
   // Other misc configuration properties.
   public static final String TASK_SUCCESS_OPTIONAL_KEY = "TASK_SUCCESS_OPTIONAL";


### PR DESCRIPTION
# New Configuration

- `gobblin.yarn.app.master.jmx.enabled` _(optional)_  If set to true, JMX will be enabled on the app_master on a randomly picked port.
- `gobblin.yarn.container.jmx.enabled` _(optional)_ If set to true, JMX will be enabled on the containers each with a randomly picked port.
- `gobblin.yarn.jmx.configuration` _(optional)_ If set, the value will be used when specifying the jmx configuration for containers or app_master which have jmx enabled.  The token `$JMX_PORT` will be replaced with a randomly selected port. _Default_: `-Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port=$JMX_PORT -Dcom.sun.management.jmxremote.rmi.port=$JMX_PORT`

# New Logging
JVM input arguments are logged on app_master and container start.  These can be used to determine the JMX port for the 
```
2016-02-22 09:31:13 UTC INFO  [main] gobblin.yarn.GobblinWorkUnitRunner  - JVM Input Arguments: -Dcom.sun.management.jmxremote -Dcom.sun.management.jmxremote.authenticate=false -Dcom.sun.management.jmxremote.ssl=false -Djava.rmi.server.hostname=127.0.0.1 -Dcom.sun.management.jmxremote.port=56298 -Dcom.sun.management.jmxremote.rmi.port=56298 -Xmx1216M
```

# Usage
With the default JMX configuration, to connect an app_master or container for which JMX is enabled:

1. Check the logs to find the JXM port by specified in the line starting with: `JVM Input Arguments:`
2. Open an ssh tunnel: `ssh -nNT -L <JMX_PORT>:localhost:<JMX_PORT> <USER>@<HOST>`
3. Connect to `localhost:<JMX_PORT>` with VisualVM or a similar tool.