### PR TITLE
Fix #740 for FsStateStore.createAlias and removing usage of FileUtil.copy

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/HdfsWriter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/HdfsWriter.java
@@ -17,10 +17,11 @@ import java.io.IOException;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.io.Closer;
+
+import gobblin.util.HadoopUtils;
 
 
 /**
@@ -58,12 +59,12 @@ public class HdfsWriter extends HdfsIO {
   public static void moveSelectFiles(String extension, String source, String destination) throws IOException {
     FileSystem fs = getFileSystem();
     fs.mkdirs(new Path(destination));
-    //RemoteIterator<LocatedFileStatus> iterator = fs.listFiles(new Path(source), false);
     FileStatus[] fileStatuses = fs.listStatus(new Path(source));
     for (FileStatus fileStatus : fileStatuses) {
       Path path = fileStatus.getPath();
       if (!fileStatus.isDir() && path.toString().toLowerCase().endsWith(extension.toLowerCase())) {
-        FileUtil.copy(fs, path, fs, new Path(destination), false, true, getConfiguration());
+        HadoopUtils.deleteIfExists(fs, new Path(destination), true);
+        HadoopUtils.copyPath(fs, path, fs, new Path(destination), getConfiguration());
       }
     }
   }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactorJobRunner.java
@@ -276,7 +276,7 @@ public abstract class MRCompactorJobRunner implements Runnable, Comparable<MRCom
           .convertPath(this.lateInputRecordCountProvider.restoreFilePath(filePath), this.inputRecordCountProvider);
       String targetFileName = convertedFilePath.getName();
       Path outPath = this.lateOutputRecordCountProvider.constructLateFilePath(targetFileName, this.fs, outputDirectory);
-      HadoopUtils.copyPath(this.fs, filePath, outPath);
+      HadoopUtils.copyPath(this.fs, filePath, this.fs, outPath, this.fs.getConf());
       LOG.info(String.format("Copied %s to %s.", filePath, outPath));
     }
   }

--- a/gobblin-core/src/main/java/gobblin/commit/FsRenameCommitStep.java
+++ b/gobblin-core/src/main/java/gobblin/commit/FsRenameCommitStep.java
@@ -131,6 +131,6 @@ public class FsRenameCommitStep extends CommitStepBase {
       this.dstFs = getFileSystem(this.dstFsUri);
     }
     log.info(String.format("Moving %s to %s", this.srcPath, this.dstPath));
-    HadoopUtils.movePath(this.srcFs, this.srcPath, this.dstFs, this.dstPath);
+    HadoopUtils.movePath(this.srcFs, this.srcPath, this.dstFs, this.dstPath, this.dstFs.getConf());
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -121,6 +121,8 @@ public abstract class AbstractJobLauncher implements JobLauncher {
     Preconditions.checkArgument(jobProps.containsKey(ConfigurationKeys.JOB_NAME_KEY),
         "A job must have a job name specified by job.name");
 
+    addInterruptedShutdownHook();
+
     // Make a copy for both the system and job configuration properties
     this.jobProps = new Properties();
     this.jobProps.putAll(jobProps);
@@ -798,5 +800,16 @@ public abstract class AbstractJobLauncher implements JobLauncher {
 
   private interface JobListenerAction {
     void apply(JobListener jobListener, JobContext jobContext) throws Exception;
+  }
+
+  private void addInterruptedShutdownHook() {
+    final Thread mainThread = Thread.currentThread();
+
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        mainThread.interrupt();
+      }
+    });
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HadoopUtils.java
@@ -12,18 +12,23 @@
 
 package gobblin.util;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
-import gobblin.writer.DataWriter;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map.Entry;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.Lists;
+import com.google.common.io.BaseEncoding;
+import com.google.common.io.Closer;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -35,13 +40,13 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.util.ReflectionUtils;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
-import com.google.common.io.BaseEncoding;
-import com.google.common.io.Closer;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.writer.DataWriter;
 
 
 /**
@@ -51,6 +56,21 @@ import com.google.common.io.Closer;
 public class HadoopUtils {
 
   public static final String HDFS_ILLEGAL_TOKEN_REGEX = "[\\s:\\\\]";
+
+  /**
+   * A {@link Collection} of all known {@link FileSystem} schemes that do not support atomic renames or copies.
+   *
+   * <p>
+   *   The following important properties are useful to remember when writing code that is compatible with S3:
+   *   <ul>
+   *     <li>Renames are not atomic, and require copying the entire source file to the destination file</li>
+   *     <li>Writes to S3 using {@link FileSystem#create(Path)} will first go to the local filesystem, when the stream
+   *     is closed the local file will be uploaded to S3</li>
+   *   </ul>
+   * </p>
+   */
+  public static final Collection<String> FS_SCHEMES_NON_ATOMIC = ImmutableSortedSet.orderedBy(
+      String.CASE_INSENSITIVE_ORDER).add("s3").add("s3a").add("s3n").build();
 
   public static Configuration newConfiguration() {
     Configuration conf = new Configuration();
@@ -101,6 +121,16 @@ public class HadoopUtils {
     }
   }
 
+  /**
+   * A wrapper around {@link FileSystem#delete(Path, boolean)} that only deletes a given {@link Path} if it is present
+   * on the given {@link FileSystem}.
+   */
+  public static void deleteIfExists(FileSystem fs, Path path, boolean recursive) throws IOException {
+    if (fs.exists(path)) {
+      deletePath(fs, path, recursive);
+    }
+  }
+
   public static void deletePathAndEmptyAncestors(FileSystem fs, Path f, boolean recursive) throws IOException {
     deletePath(fs, f, recursive);
     Path parent = f.getParent();
@@ -132,29 +162,141 @@ public class HadoopUtils {
   }
 
   /**
-   * A wrapper around {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, Configuration)}
-   * which throws {@link IOException}
-   * if {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, Configuration)} returns false.
+   * Moves a src {@link Path} from a srcFs {@link FileSystem} to a dst {@link Path} on a dstFs {@link FileSystem}. If
+   * the srcFs and the dstFs have the same scheme, and neither of them or S3 schemes, then the {@link Path} is simply
+   * renamed. Otherwise, the data is from the src {@link Path} to the dst {@link Path}. So this method can handle copying
+   * data between different {@link FileSystem} implementations.
+   *
+   * @param srcFs the source {@link FileSystem} where the src {@link Path} exists
+   * @param src the source {@link Path} which will me moved
+   * @param dstFs the destination {@link FileSystem} where the dst {@link Path} should be created
+   * @param dst the {@link Path} to move data to
    */
-  public static void copyPath(FileSystem fs, Path src, Path dst) throws IOException {
-    if (!FileUtil.copy(fs, src, fs, dst, false, fs.getConf())) {
-      throw new IOException(String.format("Failed to copy %s to %s", src, dst));
+  public static void movePath(FileSystem srcFs, Path src, FileSystem dstFs, Path dst, Configuration conf)
+      throws IOException {
+
+    if (srcFs.getUri().getScheme().equals(dstFs.getUri().getScheme()) && !FS_SCHEMES_NON_ATOMIC
+        .contains(srcFs.getUri().getScheme()) && !FS_SCHEMES_NON_ATOMIC.contains(dstFs.getUri().getScheme())) {
+      renamePath(srcFs, src, dst);
+    } else {
+      copyPath(srcFs, src, dstFs, dst, conf);
     }
   }
 
   /**
-   * A wrapper around {@link HadoopUtils#renamePath(FileSystem, Path, Path)} and
-   * {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, Configuration)} which will rename the path
-   * if the src and dst filesystems are the same; otherwise, the src file will be moved the the dst filesystem.
-   * An {@link IOException} if {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, Configuration)} returns false.
+   * Copies data from a src {@link Path} to a dst {@link Path}.
+   *
+   * <p>
+   *   This method should be used in preference to
+   *   {@link FileUtil#copy(FileSystem, Path, FileSystem, Path, boolean, boolean, Configuration)}, which does not handle
+   *   clean up of incomplete files if there is an error while copying data.
+   * </p>
+   *
+   * <p>
+   *   TODO this method does not handle cleaning up any local files leftover by writing to S3.
+   * </p>
+   *
+   * @param srcFs the source {@link FileSystem} where the src {@link Path} exists
+   * @param src the {@link Path} to copy from the source {@link FileSystem}
+   * @param dstFs the destination {@link FileSystem} where the dst {@link Path} should be created
+   * @param dst the {@link Path} to copy data to
    */
-  public static void movePath(FileSystem srcFs, Path src, FileSystem dstFs, Path dst) throws IOException {
-    if (srcFs.getUri().equals(dstFs.getUri())) {
-      renamePath(srcFs, src, dst);
-    } else {
-      if (!FileUtil.copy(srcFs, src, dstFs, dst, true, false, dstFs.getConf())) {
-        throw new IOException(String.format("Failed to move %s to %s", src, dst));
+  public static void copyPath(FileSystem srcFs, Path src, FileSystem dstFs, Path dst, Configuration conf) throws IOException {
+
+    Preconditions.checkArgument(srcFs.exists(src),
+        String.format("Cannot copy from %s to %s because src does not exist", src, dst));
+    Preconditions
+        .checkArgument(!dstFs.exists(dst), String.format("Cannot copy from %s to %s because dst exists", src, dst));
+
+    try {
+      if (!FileUtil.copy(srcFs, src, dstFs, dst, false, false, conf)) {
+        throw new IOException(String.format("Failed to copy %s to %s", src, dst));
       }
+    } catch (Throwable t1) {
+      try {
+        deleteIfExists(dstFs, dst, true);
+      } catch (Throwable t2) {
+        // Do nothing
+      }
+      throw t1;
+    }
+  }
+
+  /**
+   * Copies a src {@link Path} from a srcFs {@link FileSystem} to a dst {@link Path} on a dstFs {@link FileSystem}. If
+   * either the srcFs or dstFs are S3 {@link FileSystem}s (as dictated by {@link #FS_SCHEMES_NON_ATOMIC}) then data is directly
+   * copied from the src to the dst. Otherwise data is first copied to a tmp {@link Path}, which is then renamed to the
+   * dst.
+   *
+   * @param srcFs the source {@link FileSystem} where the src {@link Path} exists
+   * @param src the {@link Path} to copy from the source {@link FileSystem}
+   * @param dstFs the destination {@link FileSystem} where the dst {@link Path} should be created
+   * @param dst the {@link Path} to copy data to
+   * @param tmp the temporary {@link Path} to use when copying data
+   * @param overwriteDst true if the destination and tmp path should should be overwritten, false otherwise
+   */
+  public static void  copyFile(FileSystem srcFs, Path src, FileSystem dstFs, Path dst, Path tmp,
+      boolean overwriteDst, Configuration conf)
+      throws IOException {
+
+    Preconditions.checkArgument(srcFs.isFile(src),
+        String.format("Cannot copy from %s to %s because src is not a file", src, dst));
+
+    if (FS_SCHEMES_NON_ATOMIC.contains(srcFs.getUri().getScheme()) || FS_SCHEMES_NON_ATOMIC
+        .contains(dstFs.getUri().getScheme())) {
+      copyFile(srcFs, src, dstFs, dst, overwriteDst, conf);
+    } else {
+      copyFile(srcFs, src, dstFs, tmp, overwriteDst, conf);
+      try {
+        boolean renamed = false;
+        if (overwriteDst && dstFs.exists(dst)) {
+          try {
+            deletePath(dstFs, dst, true);
+          } finally {
+            renamePath(dstFs, tmp, dst);
+            renamed = true;
+          }
+        }
+        if (!renamed) {
+          renamePath(dstFs, tmp, dst);
+        }
+      } finally {
+        deletePath(dstFs, tmp, true);
+      }
+    }
+  }
+
+  /**
+   * Copy a file from a srcFs {@link FileSystem} to a dstFs {@link FileSystem}. The src {@link Path} must be a file,
+   * that is {@link FileSystem#isFile(Path)} must return true for src.
+   *
+   * <p>
+   *   If overwrite is specified to true, this method may delete the dst directory even if the copy from src to dst fails.
+   * </p>
+   *
+   * @param srcFs the src {@link FileSystem} to copy the file from
+   * @param src the src {@link Path} to copy
+   * @param dstFs the destination {@link FileSystem} to write to
+   * @param dst the destination {@link Path} to write to
+   * @param overwrite true if the dst {@link Path} should be overwritten, false otherwise
+   */
+  public static void copyFile(FileSystem srcFs, Path src, FileSystem dstFs, Path dst, boolean overwrite,
+      Configuration conf) throws IOException {
+
+    Preconditions.checkArgument(srcFs.isFile(src),
+        String.format("Cannot copy from %s to %s because src is not a file", src, dst));
+    Preconditions.checkArgument(overwrite || !dstFs.exists(dst),
+        String.format("Cannot copy from %s to %s because dst exists", src, dst));
+
+    try (InputStream in = srcFs.open(src); OutputStream out = dstFs.create(dst, overwrite)) {
+      IOUtils.copyBytes(in, out, conf, false);
+    } catch (Throwable t1) {
+      try {
+        deleteIfExists(dstFs, dst, true);
+      } catch (Throwable t2) {
+        // Do nothing
+      }
+      throw t1;
     }
   }
 

--- a/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ParallelRunner.java
@@ -290,7 +290,7 @@ public class ParallelRunner implements Closeable {
         lock.lock();
         try {
           if (fs.exists(src)) {
-            HadoopUtils.movePath(fs, src, dstFs, dst);
+            HadoopUtils.movePath(fs, src, dstFs, dst, dstFs.getConf());
             if (group.isPresent()) {
               HadoopUtils.setGroup(dstFs, dst, group.get());
             }


### PR DESCRIPTION
* Fix for #740 
* Adds a overloaded `copyPath` method that allows writing data first to a temp file, and then committing the data using `renamePath`
    * This should fix the problems with `FsStateStore.createAlias`
* Removed all direct usages of `FileUtil.copy` with `HadoopUtils.copyPath`
* Unit tests are coming

@zliu41 can you review?