### PR TITLE
Fixing skipTestGroup option

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -371,6 +371,12 @@ subprojects {
       if (project.hasProperty("printTestOutput")) {
         testLogging.showStandardStreams = true
       }
+      useTestNG () {
+        excludeGroups 'ignore'
+        if (project.hasProperty('skipTestGroup')) {
+          excludeGroups skipTestGroup
+        }
+      }
     }
 
     configurations {

--- a/gobblin-admin/build.gradle
+++ b/gobblin-admin/build.gradle
@@ -30,8 +30,4 @@ dependencies {
     testCompile externalDependency.testng
 }
 
-test {
-    useTestNG () { excludeGroups 'ignore' }
-}
-
 classification="library"

--- a/gobblin-api/build.gradle
+++ b/gobblin-api/build.gradle
@@ -31,9 +31,6 @@ configurations {
 }
 
 test {
-    useTestNG () {
-        excludeGroups 'ignore'
-    }
     workingDir rootProject.rootDir
 }
 

--- a/gobblin-azkaban/build.gradle
+++ b/gobblin-azkaban/build.gradle
@@ -47,9 +47,6 @@ configurations {
 }
 
 test {
-    useTestNG () {
-      excludeGroups 'ignore'
-    }
     workingDir rootProject.rootDir
 }
 

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -69,7 +69,6 @@ configurations {
 }
 
 test {
-  useTestNG () { excludeGroups 'ignore' }
   workingDir rootProject.rootDir
 }
 

--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -61,9 +61,6 @@ artifacts {
 }
 
 test {
-  useTestNG () {
-    excludeGroups 'ignore'
-  }
   workingDir rootProject.rootDir
   maxParallelForks = 1
 }

--- a/gobblin-example/build.gradle
+++ b/gobblin-example/build.gradle
@@ -38,7 +38,6 @@ configurations {
 }
 
 test {
-    useTestNG ()
     include '**/*Test*'
 }
 

--- a/gobblin-metastore/build.gradle
+++ b/gobblin-metastore/build.gradle
@@ -49,9 +49,6 @@ configurations {
 }
 
 test {
-    useTestNG () {
-        excludeGroups 'ignore'
-    }
     workingDir rootProject.rootDir
 }
 

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -94,7 +94,6 @@ artifacts {
 
 test {
     useTestNG () {
-      excludeGroups 'ignore'
       if (project.hasProperty('useHadoop2')) {
         excludeGroups 'Hadoop1Only'
       }

--- a/gobblin-salesforce/build.gradle
+++ b/gobblin-salesforce/build.gradle
@@ -38,9 +38,6 @@ configurations {
 }
 
 test {
-    useTestNG () {
-      excludeGroups 'ignore'
-    }
     workingDir rootProject.rootDir
 }
 

--- a/gobblin-scheduler/build.gradle
+++ b/gobblin-scheduler/build.gradle
@@ -43,9 +43,6 @@ configurations {
 }
 
 test {
-    useTestNG () {
-        excludeGroups 'ignore'
-    }
     workingDir rootProject.rootDir
 }
 

--- a/gobblin-test-harness/build.gradle
+++ b/gobblin-test-harness/build.gradle
@@ -25,9 +25,6 @@ dependencies {
 configurations { compile { transitive = false } }
 
 test {
-  useTestNG () {
-      excludeGroups 'ignore'
-  }
   workingDir rootProject.rootDir
 }
 

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -56,9 +56,6 @@ configurations {
 }
 
 test {
-    useTestNG () {
-        excludeGroups 'ignore'
-    }
     workingDir rootProject.rootDir
 }
 

--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -86,12 +86,6 @@ artifacts {
 }
 
 test {
-  useTestNG () {
-    excludeGroups 'ignore'
-    if (project.hasProperty('skipTestGroup')) {
-      excludeGroups skipTestGroup
-    }
-  }
   workingDir rootProject.rootDir
   maxParallelForks = 1
 }


### PR DESCRIPTION
* Fixing option to skip specific test groups
* Currently, `travis/test.sh` skips tests with group `disabledOnTravis`, but this feature is not currently working, this PR should fix that

@zliu41 can you review?