### PR TITLE
Allow ports in the jvm arguments to be automatically picked.

### DIFF
--- a/gobblin-cluster/src/main/java/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/GobblinTaskRunner.java
@@ -29,6 +29,7 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import gobblin.util.JvmUtils;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -465,6 +466,8 @@ public class GobblinTaskRunner {
       Log4jConfigurationHelper.updateLog4jConfiguration(GobblinTaskRunner.class,
           GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE,
           GobblinClusterConfigurationKeys.GOBBLIN_CLUSTER_LOG4J_CONFIGURATION_FILE);
+
+      LOGGER.info(JvmUtils.getJvmInputArguments());
 
       String applicationName = cmd.getOptionValue(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME);
       String helixInstanceName = cmd.getOptionValue(GobblinClusterConfigurationKeys.HELIX_INSTANCE_NAME_OPTION_NAME);

--- a/gobblin-utility/src/main/java/gobblin/util/JvmUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JvmUtils.java
@@ -1,0 +1,40 @@
+package gobblin.util;
+
+import com.google.common.base.Joiner;
+import com.google.common.base.Optional;
+import org.apache.commons.lang.StringUtils;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.RuntimeMXBean;
+import java.util.List;
+
+public class JvmUtils {
+  private static final Joiner JOINER = Joiner.on(" ").skipNulls();
+
+  private static final PortUtils PORT_UTILS = new PortUtils();
+
+  private JvmUtils() {
+  }
+
+  /**
+   * Gets the input arguments passed to the JVM.
+   * @return The input arguments.
+   */
+  public static String getJvmInputArguments() {
+    RuntimeMXBean runtimeMxBean = ManagementFactory.getRuntimeMXBean();
+    List<String> arguments = runtimeMxBean.getInputArguments();
+    return String.format("JVM Input Arguments: %s", JOINER.join(arguments));
+  }
+
+  /**
+   * Formats the specified jvm arguments such that any tokens are replaced with concrete values;
+   * @param jvmArguments
+   * @return The formatted jvm arguments.
+   */
+  public static String formatJvmArguments(Optional<String> jvmArguments) {
+    if (jvmArguments.isPresent()) {
+      return PORT_UTILS.replacePortTokens(jvmArguments.get());
+    }
+    return StringUtils.EMPTY;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/PortUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PortUtils.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+
+import java.net.ServerSocket;
+import java.util.Map;
+import java.util.concurrent.ConcurrentMap;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class PortUtils {
+  public static final int MINIMUM_PORT = 1025;
+  public static final int MAXIMUM_PORT = 65535;
+  private static final Pattern PORT_REGEX =
+          Pattern.compile("\\$\\{PORT_(?>(?>\\?(\\d+))|(?>(\\d+)\\?)|(\\d+|\\?))\\}");
+  private final PortLocator portLocator;
+  private final ConcurrentMap<Integer, Boolean> assignedPorts;
+
+  public PortUtils() {
+    this(new ServerSocketPortLocator());
+  }
+
+  @VisibleForTesting
+  PortUtils(PortLocator locator) {
+    this.portLocator = locator;
+    this.assignedPorts = Maps.newConcurrentMap();
+  }
+
+  /**
+   * Replaces any port tokens in the specified string.
+   *
+   * NOTE: Tokens can be in the following forms:
+   *   1. ${PORT_123}
+   *   2. ${PORT_?123}
+   *   3. ${PORT_123?}
+   *   4. ${PORT_?}
+   *
+   * @param value The string in which to replace port tokens.
+   * @return The replaced string.
+   */
+  public String replacePortTokens(String value) {
+    BiMap<String, Optional<Integer>> portMappings = HashBiMap.create();
+    Matcher regexMatcher = PORT_REGEX.matcher(value);
+    while (regexMatcher.find()) {
+      String token = regexMatcher.group(0);
+      if (!portMappings.containsKey(token)) {
+        Optional<Integer> portStart = Optional.absent();
+        Optional<Integer> portEnd = Optional.absent();
+        String unboundedStart = regexMatcher.group(1);
+        if (unboundedStart != null) {
+          int requestedEndPort = Integer.parseInt(unboundedStart);
+          Preconditions.checkArgument(requestedEndPort <= PortUtils.MAXIMUM_PORT);
+          portEnd = Optional.of(requestedEndPort);
+        } else {
+          String unboundedEnd = regexMatcher.group(2);
+          if (unboundedEnd != null) {
+            int requestedStartPort = Integer.parseInt(unboundedEnd);
+            Preconditions.checkArgument(requestedStartPort >= PortUtils.MINIMUM_PORT);
+            portStart = Optional.of(requestedStartPort);
+          } else {
+            String absolute = regexMatcher.group(3);
+            if (!"?".equals(absolute)) {
+              int requestedPort = Integer.parseInt(absolute);
+              Preconditions.checkArgument(requestedPort >= PortUtils.MINIMUM_PORT &&
+                      requestedPort <= PortUtils.MAXIMUM_PORT);
+              portStart = Optional.of(requestedPort);
+              portEnd = Optional.of(requestedPort);
+            }
+          }
+        }
+        Optional<Integer> port = takePort(portStart, portEnd);
+        portMappings.put(token, port);
+      }
+    }
+    for (Map.Entry<String, Optional<Integer>> port : portMappings.entrySet()) {
+      if (port.getValue().isPresent()) {
+        value = value.replace(port.getKey(), port.getValue().get().toString());
+      }
+    }
+    return value;
+  }
+
+  /**
+   * Finds an open port. {@param portStart} and {@param portEnd} can be absent
+   *
+   * ______________________________________________________
+   * | portStart | portEnd  | takenPort                   |
+   * |-----------|----------|-----------------------------|
+   * |  absent   | absent   | random                      |
+   * |  absent   | provided | 1024 < port <= portEnd      |
+   * |  provided | absent   | portStart <= port <= 65535  |
+   * |  provided | provided | portStart = port = portEnd  |
+   * ------------------------------------------------------
+   *
+   * @param portStart the inclusive starting port
+   * @param portEnd the inclusive ending port
+   * @return The selected open port.
+   */
+  private synchronized Optional<Integer> takePort(Optional<Integer> portStart, Optional<Integer> portEnd) {
+    if (!portStart.isPresent() && !portEnd.isPresent()) {
+      for (int i = 0; i < 65535; i++) {
+        try {
+          int port = this.portLocator.random();
+          Boolean wasAssigned = assignedPorts.putIfAbsent(port, true);
+          if (wasAssigned == null || !wasAssigned) {
+            return Optional.of(port);
+          }
+        } catch (Exception ignored) {
+        }
+      }
+    }
+
+    for (int port = portStart.or(MINIMUM_PORT); port <= portEnd.or(MAXIMUM_PORT); port++) {
+      try {
+        this.portLocator.specific(port);
+        Boolean wasAssigned = assignedPorts.putIfAbsent(port, true);
+        if (wasAssigned == null || !wasAssigned) {
+          return Optional.of(port);
+        }
+      } catch (Exception ignored) {
+      }
+    }
+
+    throw new RuntimeException(String.format("No open port could be found for %s to %s", portStart, portEnd));
+  }
+
+  @VisibleForTesting
+  interface PortLocator {
+    int random() throws Exception;
+    int specific(int port) throws Exception;
+  }
+
+  private static class ServerSocketPortLocator implements PortLocator {
+    @Override
+    public int random() throws Exception {
+        try (ServerSocket serverSocket = new ServerSocket(0)) {
+          return serverSocket.getLocalPort();
+        }
+    }
+
+    @Override
+    public int specific(int port) throws Exception {
+      try (ServerSocket serverSocket = new ServerSocket(port)) {
+        return serverSocket.getLocalPort();
+      }
+    }
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/PortUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/PortUtilsTest.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util;
+
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+
+public class PortUtilsTest {
+  @Test
+  public void testReplaceAbsolutePortToken() throws Exception {
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.specific(1025)).thenReturn(1025);
+    PortUtils portUtils = new PortUtils(portLocator);
+    String actual = portUtils.replacePortTokens("-Dvar1=${PORT_1025}");
+    Assert.assertEquals(actual, "-Dvar1=1025");
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testFailIfCannotReplaceAbsolutePortToken() throws Exception {
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.specific(1025)).thenThrow(new IOException());
+    PortUtils portUtils = new PortUtils(portLocator);
+    portUtils.replacePortTokens("-Dvar1=${PORT_1025}");
+  }
+
+  @Test
+  public void testReplaceUnboundMinimumPortToken() throws Exception {
+    int expectedPort = PortUtils.MINIMUM_PORT + 1;
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.specific(PortUtils.MINIMUM_PORT)).thenThrow(new IOException());
+    Mockito.when(portLocator.specific(expectedPort)).thenReturn(expectedPort);
+    PortUtils portUtils = new PortUtils(portLocator);
+    String actual = portUtils.replacePortTokens("-Dvar1=${PORT_?1026}");
+    Assert.assertEquals(actual, "-Dvar1=1026");
+  }
+
+  @Test
+  public void testReplaceUnboundMaximumPortToken() throws Exception {
+    int expectedPort = PortUtils.MINIMUM_PORT + 1;
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.specific(PortUtils.MINIMUM_PORT)).thenThrow(new IOException());
+    Mockito.when(portLocator.specific(expectedPort)).thenReturn(expectedPort);
+    PortUtils portUtils = new PortUtils(portLocator);
+    String actual = portUtils.replacePortTokens("-Dvar1=${PORT_1025?}");
+    Assert.assertEquals(actual, "-Dvar1=1026");
+  }
+
+  @Test
+  public void testReplaceRandomPortToken() throws Exception {
+    int expectedPort = PortUtils.MINIMUM_PORT + 1;
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.random()).thenReturn(1027);
+    PortUtils portUtils = new PortUtils(portLocator);
+    String actual = portUtils.replacePortTokens("-Dvar1=${PORT_?}");
+    Assert.assertEquals(actual, "-Dvar1=1027");
+  }
+
+  @Test
+  public void testReplaceDuplicateTokensGetSamePort() throws Exception {
+    final int expectedPort = PortUtils.MINIMUM_PORT + 1;
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.random()).thenAnswer(new Answer<Integer>() {
+      public int callCount;
+
+      @Override
+      public Integer answer(InvocationOnMock invocation) throws Throwable {
+        if (this.callCount++ == 0) {
+          return expectedPort;
+        }
+        return expectedPort + callCount++;
+      }
+    });
+    Mockito.when(portLocator.specific(expectedPort)).thenReturn(expectedPort);
+    PortUtils portUtils = new PortUtils(portLocator);
+    String actual = portUtils.replacePortTokens("-Dvar1=${PORT_?} -Dvar2=${PORT_?}");
+    Assert.assertEquals(actual, "-Dvar1=1026 -Dvar2=1026");
+  }
+
+  @Test
+  public void testReplacePortTokensKeepsTrackOfAssignedPorts() throws Exception {
+    int expectedPort1 = PortUtils.MINIMUM_PORT + 1;
+    int expectedPort2 = PortUtils.MINIMUM_PORT + 2;
+    PortUtils.PortLocator portLocator = Mockito.mock(PortUtils.PortLocator.class);
+    Mockito.when(portLocator.specific(PortUtils.MINIMUM_PORT)).thenThrow(new IOException());
+    Mockito.when(portLocator.specific(expectedPort1)).thenReturn(expectedPort1);
+    Mockito.when(portLocator.specific(expectedPort2)).thenReturn(expectedPort2);
+    PortUtils portUtils = new PortUtils(portLocator);
+    String actual = portUtils.replacePortTokens("-Dvar1=${PORT_1026?} -Dvar2=${PORT_1025?}");
+    Assert.assertEquals(actual, "-Dvar1=1026 -Dvar2=1027");
+  }
+}

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -47,6 +47,7 @@ import com.typesafe.config.ConfigFactory;
 import gobblin.annotation.Alpha;
 import gobblin.cluster.GobblinClusterConfigurationKeys;
 import gobblin.cluster.GobblinClusterManager;
+import gobblin.util.JvmUtils;
 import gobblin.util.logs.Log4jConfigurationHelper;
 import gobblin.yarn.event.DelegationTokenUpdatedEvent;
 
@@ -193,6 +194,8 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
       Log4jConfigurationHelper.updateLog4jConfiguration(GobblinApplicationMaster.class,
           GobblinYarnConfigurationKeys.GOBBLIN_YARN_LOG4J_CONFIGURATION_FILE,
           GobblinYarnConfigurationKeys.GOBBLIN_YARN_LOG4J_CONFIGURATION_FILE);
+
+      LOGGER.info(JvmUtils.getJvmInputArguments());
 
       ContainerId containerId =
           ConverterUtils.toContainerId(System.getenv().get(ApplicationConstants.Environment.CONTAINER_ID.key()));

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -98,6 +98,7 @@ import gobblin.util.ConfigUtils;
 import gobblin.util.EmailUtils;
 import gobblin.util.ExecutorsUtils;
 import gobblin.util.io.StreamUtils;
+import gobblin.util.JvmUtils;
 import gobblin.util.logs.LogCopier;
 import gobblin.yarn.event.ApplicationReportArrivalEvent;
 import gobblin.yarn.event.GetApplicationReportFailureEvent;
@@ -637,7 +638,7 @@ public class GobblinYarnAppLauncher {
     return new StringBuilder()
         .append(ApplicationConstants.Environment.JAVA_HOME.$()).append("/bin/java")
         .append(" -Xmx").append(memoryMbs).append("M")
-        .append(" ").append(this.appMasterJvmArgs.or(""))
+        .append(" ").append(JvmUtils.formatJvmArguments(this.appMasterJvmArgs))
         .append(" ").append(GobblinApplicationMaster.class.getName())
         .append(" --").append(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME)
         .append(" ").append(this.applicationName)

--- a/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/YarnService.java
@@ -90,6 +90,7 @@ import gobblin.metrics.Tag;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.util.ConfigUtils;
 import gobblin.util.ExecutorsUtils;
+import gobblin.util.JvmUtils;
 import gobblin.cluster.event.ClusterManagerShutdownRequest;
 import gobblin.yarn.event.ContainerShutdownRequest;
 import gobblin.yarn.event.NewContainerRequest;
@@ -411,7 +412,7 @@ public class YarnService extends AbstractIdleService {
     return new StringBuilder()
         .append(ApplicationConstants.Environment.JAVA_HOME.$()).append("/bin/java")
         .append(" -Xmx").append(container.getResource().getMemory()).append("M")
-        .append(" ").append(this.containerJvmArgs.or(""))
+        .append(" ").append(JvmUtils.formatJvmArguments(this.containerJvmArgs))
         .append(" ").append(GobblinYarnTaskRunner.class.getName())
         .append(" --").append(GobblinClusterConfigurationKeys.APPLICATION_NAME_OPTION_NAME)
         .append(" ").append(this.applicationName)


### PR DESCRIPTION
@ibuenros @sahilTakiar Can you review?
### Usage

This allows the user of gobblin to specify JVM arguments to the app_master and containers and have gobblin automatically pick ports where needed.  This is done by detecting a specific token within the jvm argument string.  This token is in any of the following forms:
1. `${PORT_1234}` : Try to get port 1234 and fail if it is not available
2. `${PORT_1234+}`: Try to get any port from the specified port inclusive to the maximum port (65535) inclusive
3. `${PORT_?}`: Try to get a random port between the minimum port (1025) inclusive and the maximum port (65535) inclusive

Gobblin will attempt to pick the specified port, but if it is not available Gobblin will successively try each high port until an open one is found. The actual JVM argument script will be logged as the first log line of the app_master and containers.
### Example

```
gobblin.yarn.app.master.jvm.args="-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=${PORT_5005+}"
```
