### PR TITLE
Allow downloading other filetypes in FileBasedExtractor

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -341,6 +341,7 @@ public class ConfigurationKeys {
   public static final String SOURCE_FILEBASED_FS_SNAPSHOT = "source.filebased.fs.snapshot";
   public static final String SOURCE_FILEBASED_FS_URI = "source.filebased.fs.uri";
   public static final String SOURCE_FILEBASED_PRESERVE_FILE_NAME = "source.filebased.preserve.file.name";
+  public static final String SOURCE_FILEBASED_OPTIONAL_DOWNLOADER_CLASS = "source.filebased.downloader.class";
 
   /**
    * Configuration properties used internally by the KafkaSource.

--- a/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileDownloader.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileDownloader.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.source.extractor.filebased;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import gobblin.configuration.ConfigurationKeys;
+
+
+/**
+ * An abstraction for downloading a file in a {@link FileBasedExtractor}. Subclasses are expected to download the file in
+ * the {@link #downloadFile(String)} method and return a record iterator. A {@link FileDownloader} can be set in a
+ * {@link FileBasedExtractor} by setting {@link ConfigurationKeys#SOURCE_FILEBASED_OPTIONAL_DOWNLOADER_CLASS} in the
+ * state.
+ *
+ * @param <D> record type in the file
+ */
+public abstract class FileDownloader<D> {
+
+  protected final FileBasedExtractor<?, ?> fileBasedExtractor;
+
+  public FileDownloader(FileBasedExtractor<?, ?> fileBasedExtractor) {
+    this.fileBasedExtractor = fileBasedExtractor;
+  }
+
+  /**
+   * Downloads the file at <code>filePath</code> using the {@link FileBasedExtractor#fsHelper} and returns an
+   * {@link Iterator} to the records
+   *
+   * @param filePath of the file to be downloaded
+   * @return An iterator to the records in the file
+   */
+  public abstract Iterator<D> downloadFile(final String filePath) throws IOException;
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/filebased/SingleFileDownloader.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/filebased/SingleFileDownloader.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.source.extractor.filebased;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.io.IOUtils;
+
+import gobblin.configuration.ConfigurationKeys;
+
+
+/**
+ * A {@link FileDownloader} that downloads a single file and iterates line by line.
+ *
+ * @param <D> record type in the file
+ */
+@Slf4j
+public class SingleFileDownloader<D> extends FileDownloader<D> {
+
+  public SingleFileDownloader(FileBasedExtractor<?, ?> fileBasedExtractor) {
+    super(fileBasedExtractor);
+  }
+
+  @SuppressWarnings("unchecked")
+  public Iterator<D> downloadFile(String file) throws IOException {
+
+    log.info("Beginning to download file: " + file);
+
+    try {
+      InputStream inputStream = fileBasedExtractor.getCloser().register(fileBasedExtractor.getFsHelper().getFileStream(file));
+      Iterator<D> fileItr = (Iterator<D>) IOUtils.lineIterator(inputStream, ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
+      if (fileBasedExtractor.isShouldSkipFirstRecord() && fileItr.hasNext()) {
+        fileItr.next();
+      }
+      return fileItr;
+    } catch (FileBasedHelperException e) {
+      throw new IOException("Exception while downloading file " + file + " with message " + e.getMessage(), e);
+    }
+  }
+}


### PR DESCRIPTION
Decouple downloading logic from extractor to allow users to download other filetypes like gzip, zip etc.
@sahilTakiar can you review?