### PR TITLE
Add HDFS config deployment tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -212,7 +212,8 @@ ext.externalDependency = [
           "org.eclipse.jetty:jetty-server:9.2.14.v20151106",
           "org.eclipse.jetty:jetty-servlet:9.2.14.v20151106"
   ],
-  "servlet-api": "javax.servlet:servlet-api:3.1.0"
+  "servlet-api": "javax.servlet:servlet-api:3.1.0",
+  "reflections" : "org.reflections:reflections:0.9.9"
 ];
 
 if (!isDefaultEnvironment)

--- a/gobblin-config-management/gobblin-config-core/build.gradle
+++ b/gobblin-config-management/gobblin-config-core/build.gradle
@@ -20,6 +20,7 @@ dependencies {
     compile externalDependency.typesafeConfig
     compile externalDependency.commonsLang
     compile externalDependency.commonsIo
+    compile externalDependency.reflections
 
     testCompile externalDependency.mockito
     testCompile externalDependency.testng

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/ClasspathConfigSource.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/ClasspathConfigSource.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+import java.util.Set;
+import java.util.regex.Pattern;
+
+import org.apache.commons.lang.StringUtils;
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.Sets;
+
+
+/**
+ * A {@link DeployableConfigSource} that reads configs to be deployed from classpath.
+ * Caller can set {@link #CONFIG_STORE_CLASSPATH_RESOURCE_NAME_KEY} to the name of classpath resource under which deployable configs are available.
+ * If the property is not set the {@link #DEFAULT_CONFIG_STORE_CLASSPATH_RESOURCE_NAME} is used to search the classpath for deployable configs
+ * <p>
+ * It finds the config files in classpath under the
+ * <code>classpathRootName</code> directory. Every config file found will be deployed to the <code>storeUri</code> with
+ * a new <code>version</code>.
+ * </p>
+ */
+public class ClasspathConfigSource implements DeployableConfigSource {
+
+  private final String classpathRootName;
+  private static final String DEFAULT_CONFIG_STORE_CLASSPATH_RESOURCE_NAME = "_CONFIG_STORE";
+  private static final String CONFIG_STORE_CLASSPATH_RESOURCE_NAME_KEY = "gobblin.config.management.store.deploy.classpathresource";
+
+  public ClasspathConfigSource(Properties props) {
+    this.classpathRootName = props.getProperty(CONFIG_STORE_CLASSPATH_RESOURCE_NAME_KEY, DEFAULT_CONFIG_STORE_CLASSPATH_RESOURCE_NAME);
+  }
+
+  /**
+   * Scan the classpath for {@link #classpathRootName} and return all resources under it.
+   * {@inheritDoc}
+   * @see gobblin.config.store.deploy.DeployableConfigSource#getDeployableConfigPaths()
+   */
+  private Set<String> getDeployableConfigPaths() {
+
+    ConfigurationBuilder cb =
+        new ConfigurationBuilder().setUrls(ClasspathHelper.forClassLoader()).setScanners(new ResourcesScanner())
+            .filterInputsBy(new FilterBuilder().include(String.format(".*%s.*", this.classpathRootName)));
+
+    Reflections reflections = new Reflections(cb);
+    Pattern pattern = Pattern.compile(".*");
+
+    return reflections.getResources(pattern);
+  }
+
+  /**
+   * Open an {@link InputStream} for <code>resourcePath</code> in classpath
+   * {@inheritDoc}
+   * @see gobblin.config.store.deploy.DeployableConfigSource#getConfigStream(java.lang.String)
+   */
+  private InputStream getConfigStream(String configPath) throws IOException {
+    return ClasspathConfigSource.class.getClassLoader().getResourceAsStream(configPath);
+  }
+
+  /**
+   * Scan the classpath for {@link #classpathRootName} and opens an {@link InputStream} each resource under it.
+   * {@inheritDoc}
+   * @see gobblin.config.store.deploy.DeployableConfigSource#getConfigStreams()
+   */
+  @Override
+  public Set<ConfigStream> getConfigStreams() throws IOException {
+    Set<ConfigStream> configStreams = Sets.newHashSet();
+    for (String configPath : getDeployableConfigPaths()) {
+      configStreams.add(new ConfigStream(Optional.of(getConfigStream(configPath)), StringUtils.substringAfter(
+          Strings.nullToEmpty(configPath), classpathRootName + "/")));
+    }
+    return configStreams;
+  }
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/ConfigStream.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/ConfigStream.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import java.io.InputStream;
+
+import com.google.common.base.Optional;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ *  A wrapper for {@link InputStream} that also contains the path of the resource.
+ */
+@AllArgsConstructor
+@Getter
+public class ConfigStream {
+  private final Optional<InputStream> inputStream;
+  private final String configPath;
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/Deployable.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/Deployable.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import java.io.IOException;
+
+import gobblin.config.store.api.ConfigStore;
+
+
+/**
+ * An interface to deploy and rollback {@link ConfigStore}s. {@link ConfigStore}s that implement {@link Deployable} can
+ * be deployed using {@link StoreDeployer}
+ *
+ * @param <D> {@link DeploymentConfig} or its subclasses that has configs to deploy the store
+ * @param <R> {@link RollbackConfig} or its subclasses that has configs to rollback
+ */
+public interface Deployable<D extends DeploymentConfig, R extends RollbackConfig> {
+
+  /**
+   * Deploy a version {@link DeploymentConfig#getNewVersion()} of configs provided by
+   * {@link DeploymentConfig#getDeployableConfigSource()} on the {@link ConfigStore}
+   *
+   * @param deploymentConfig to use for this deployment
+   */
+  public void deploy(D deploymentConfig) throws IOException;
+
+  /**
+   * Rollback to an older version of configs on the {@link ConfigStore} using {@link RollbackConfig}
+   *
+   * @param rollbackConfig to use for this rollback
+   */
+  public void rollback(R rollbackConfig) throws IOException;
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/DeployableConfigSource.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/DeployableConfigSource.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Set;
+
+import gobblin.config.store.api.ConfigStore;
+
+
+/**
+ * An abstraction for accessing configs to be deployed by the {@link ConfigStore}. The interface finds all the configs
+ * that need to be deployed and also provides a way to read them as {@link InputStream}s
+ */
+public interface DeployableConfigSource {
+
+  /**
+   * Open an {@link InputStream} for every config to be deployed.
+   *
+   * @return a {@link Set} of {@link ConfigStream}s for each resource to be deployed
+   */
+  public Set<ConfigStream> getConfigStreams() throws IOException;
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/DeploymentConfig.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/DeploymentConfig.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.ToString;
+
+/**
+ * Holds deployment configuration to be passed to {@link Deployable#deploy(DeploymentConfig)}
+ */
+@AllArgsConstructor
+@Getter
+@ToString
+public class DeploymentConfig {
+  /**
+   * The source to use for this deployment.
+   */
+  private final DeployableConfigSource deployableConfigSource;
+  /**
+   * Version number to be used for this deployment
+   */
+  private final String newVersion;
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/FsDeploymentConfig.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/FsDeploymentConfig.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.ToString;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+
+/**
+ * A {@link DeploymentConfig} for Hadoop {@link FileSystem} based stores.
+ */
+@Getter
+@ToString
+public class FsDeploymentConfig extends DeploymentConfig {
+
+  /**
+   * Since the config store needs to be accessed by all users, the default permission of the store will be read-execute
+   * for all users
+   */
+  public static final FsPermission DEFAULT_STORE_PERMISSIONS = new FsPermission(FsAction.ALL, FsAction.READ_EXECUTE,
+      FsAction.READ_EXECUTE);
+
+  /**
+   * Build a new {@link FsDeploymentConfig}
+   *
+   * @param deployableConfigSource Source that provides the deployable configs
+   * @param version to be used for this deployment
+   * @param storePermissions for configs being deployed
+   */
+  public FsDeploymentConfig(@NonNull final DeployableConfigSource deployableConfigSource, @NonNull final String version,
+      @NonNull final FsPermission storePermissions) {
+    super(deployableConfigSource, version);
+    this.storePermissions = storePermissions;
+  }
+
+  /**
+   * Build a new {@link FsDeploymentConfig} using the default store permission {@link #DEFAULT_STORE_PERMISSIONS}
+   *
+   * @param deployableConfigSource Source that provides the deployable configs
+   * @param version to be used for this deployment
+   */
+  public FsDeploymentConfig(@NonNull final DeployableConfigSource deployableConfigSource, @NonNull final String version) {
+    this(deployableConfigSource, version, DEFAULT_STORE_PERMISSIONS);
+  }
+
+  /**
+   * Permission to be set on the configs deployed
+   */
+  private final FsPermission storePermissions;
+
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/RollbackConfig.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/RollbackConfig.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Holds rollback configuration to be passed to {@link Deployable#rollback(RollbackConfig)}
+ */
+@AllArgsConstructor
+@Getter
+public class RollbackConfig {
+  private final String versionToRollback;
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/StoreDeployer.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/StoreDeployer.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.config.store.deploy;
+
+import gobblin.config.store.api.ConfigStore;
+import gobblin.config.store.api.ConfigStoreFactory;
+
+import java.net.URI;
+import java.util.ServiceLoader;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A tool to deploy configs provided by a {@link DeployableConfigSource} to a {@link ConfigStore}. The deployment
+ * semantics are defined the {@link ConfigStore} themselves. A {@link ConfigStore} must implement {@link Deployable} for
+ * the {@link StoreDeployer} to deploy on it. If the {@link ConfigStore} for <code>storeUri</code> does not implement
+ * {@link Deployable}, the deployment will be a no-op
+ */
+@Slf4j
+public class StoreDeployer {
+
+  /**
+   * Deploy configs in <code>classpathStoreRoot</code> to <code>storeUri</code>
+   *
+   * @param storeUri to which confgs are deployed
+   * @param confgSource The source that provides deployable configs.
+   * @param version to be used for this deployment
+   *
+   */
+  @SuppressWarnings({ "rawtypes", "unchecked" })
+  public static void deploy(URI storeUri, DeployableConfigSource confgSource, String version) throws Exception {
+
+    ServiceLoader<ConfigStoreFactory> loader = ServiceLoader.load(ConfigStoreFactory.class);
+
+    for (ConfigStoreFactory storeFactory : loader) {
+
+      log.info("Found ConfigStore with scheme : " + storeFactory.getScheme());
+
+      if (storeUri.getScheme().equals(storeFactory.getScheme())) {
+
+        log.info("Using ConfigStore with scheme : " + storeFactory.getScheme());
+
+        ConfigStore configStore = storeFactory.createConfigStore(storeUri);
+
+        if (configStore instanceof Deployable<?, ?>) {
+
+          ((Deployable) configStore).deploy(new FsDeploymentConfig(confgSource, version));
+
+        } else {
+          log.error(String.format("Deployment failed. The store %s does not implement %s", storeFactory.getClass(),
+              Deployable.class.getName()));
+        }
+      }
+    }
+  }
+}

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
@@ -1,4 +1,29 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
 package gobblin.config.store.hdfs;
+
+import gobblin.config.common.impl.SingleLinkedListConfigKeyPath;
+import gobblin.config.store.api.ConfigKeyPath;
+import gobblin.config.store.api.ConfigStore;
+import gobblin.config.store.api.ConfigStoreWithStableVersioning;
+import gobblin.config.store.api.VersionDoesNotExistException;
+import gobblin.config.store.deploy.ConfigStream;
+import gobblin.config.store.deploy.Deployable;
+import gobblin.config.store.deploy.FsDeploymentConfig;
+import gobblin.config.store.deploy.RollbackConfig;
+import gobblin.util.FileListUtils;
+import gobblin.util.PathUtils;
+import gobblin.util.io.SeekableFSInputStream;
+import gobblin.util.io.StreamUtils;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -10,8 +35,26 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
+import java.util.regex.Pattern;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.reflections.Reflections;
+import org.reflections.scanners.ResourcesScanner;
+import org.reflections.util.ClasspathHelper;
+import org.reflections.util.ConfigurationBuilder;
+import org.reflections.util.FilterBuilder;
 
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
@@ -25,21 +68,6 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
-
-import lombok.AllArgsConstructor;
-
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-
-import gobblin.config.common.impl.SingleLinkedListConfigKeyPath;
-import gobblin.config.store.api.ConfigKeyPath;
-import gobblin.config.store.api.ConfigStore;
-import gobblin.config.store.api.ConfigStoreWithStableVersioning;
-import gobblin.config.store.api.VersionDoesNotExistException;
-import gobblin.util.PathUtils;
 
 
 /**
@@ -76,7 +104,7 @@ import gobblin.util.PathUtils;
  * <p>
  *   In the above example, the root of the store is {@code /root/my-simple-store/}. The code automatically assumes that
  *   this folder contains a directory named {@link #CONFIG_STORE_NAME}. In order to access the dataset
- *   {@code dataset1/child-dataset} using {@link ConfigClient#getConfig(URI)}, the specified {@link URI} should be
+ *   {@code dataset1/child-dataset} using ConfigClient#getConfig(URI), the specified {@link URI} should be
  *   {@code simple-hdfs://[authority]:[port]/root/my-simple-store/dataset1/child-dataset/}. Note this is the fully
  *   qualified path to the actual {@link #MAIN_CONF_FILE_NAME} file on HDFS, with the {@link #CONFIG_STORE_NAME} and the
  *   {@code version} directories removed.
@@ -93,9 +121,9 @@ import gobblin.util.PathUtils;
  *
  * @see SimpleHDFSConfigStoreFactory
  */
-
+@Slf4j
 @ConfigStoreWithStableVersioning
-public class SimpleHDFSConfigStore implements ConfigStore{
+public class SimpleHDFSConfigStore implements ConfigStore, Deployable<FsDeploymentConfig, RollbackConfig> {
 
   protected static final String CONFIG_STORE_NAME = "_CONFIG_STORE";
 
@@ -302,11 +330,11 @@ public class SimpleHDFSConfigStore implements ConfigStore{
    */
   private Path getDatasetDirForKey(ConfigKeyPath configKey, String version) throws VersionDoesNotExistException {
     String datasetFromConfigKey = getDatasetFromConfigKey(configKey);
-    
+
     if(StringUtils.isBlank(datasetFromConfigKey)){
       return getVersionRoot(version);
     }
-    
+
     return new Path(getVersionRoot(version), datasetFromConfigKey);
   }
 
@@ -388,5 +416,99 @@ public class SimpleHDFSConfigStore implements ConfigStore{
     public boolean apply(FileStatus input) {
       return input == null ? false : input.isDir();
     }
+  }
+
+  /**
+   * Deploy configs in classpath to HDFS. Finds all the files under
+   * {@link FsDeploymentConfig#getStoreRootNameInClasspath()} in the classpath. For each resource found, creates a
+   * resource on HDFS.
+   *
+   * <p>
+   *  For example: If "test-root" is a resource in classpath and all resources under it needs to be deployed,
+   *  {@link FsDeploymentConfig#getStoreRootNameInClasspath()} is set to "test-root"
+   * <br>
+   * <br>
+   * <b>In Classpath:</b><br>
+   * <blockquote> <code>
+   *       test-root<br>
+   *       &emsp;/data<br>
+   *       &emsp;&emsp;/set1<br>
+   *       &emsp;&emsp;&emsp;/main.conf<br>
+   *       &emsp;/tag<br>
+   *       &emsp;&emsp;/tag1<br>
+   *       &emsp;&emsp;&emsp;/main.conf<br>
+   *     </code> </blockquote>
+   * </p>
+   *
+   * <p>
+   *  A new version 2.0.0 {@link FsDeploymentConfig#getNewVersion()} is created on HDFS under <code>this.physicalStoreRoot/_CONFIG_STORE</code>
+   * <br>
+   * <br>
+   * <b>On HDFS after deploy:</b><br>
+   * <blockquote> <code>
+   *       /_CONFIG_STORE<br>
+   *       &emsp;/2.0.0<br>
+   *       &emsp;&emsp;/data<br>
+   *       &emsp;&emsp;&emsp;/set1<br>
+   *       &emsp;&emsp;&emsp;&emsp;/main.conf<br>
+   *       &emsp;&emsp;/tag<br>
+   *       &emsp;&emsp;&emsp;/tag1<br>
+   *       &emsp;&emsp;&emsp;&emsp;/main.conf<br>
+   *     </code> </blockquote>
+   * </p>
+   *
+   */
+  @Override
+  public void deploy(FsDeploymentConfig deploymentConfig) throws IOException {
+
+    log.info("Deploying with config : " + deploymentConfig);
+
+    Path hdfsconfigStoreRoot = new Path(this.physicalStoreRoot.getPath(), CONFIG_STORE_NAME);
+
+    if (!fs.exists(hdfsconfigStoreRoot)) {
+      throw new IOException("Config store root not present at " + this.physicalStoreRoot.getPath());
+    }
+
+    Path hdfsNewVersionPath = new Path(hdfsconfigStoreRoot, deploymentConfig.getNewVersion());
+
+    if (fs.exists(hdfsNewVersionPath)) {
+      log.warn(String.format("Version %s already exits at %s. Can not overwrite an existing version.",
+          deploymentConfig.getNewVersion(), hdfsNewVersionPath));
+    }
+
+    Set<ConfigStream> confStreams = deploymentConfig.getDeployableConfigSource().getConfigStreams();
+
+    for (ConfigStream confStream : confStreams) {
+      String confAtPath = confStream.getConfigPath();
+
+      log.info("Copying resource at : " + confAtPath);
+
+      Path hdsfConfPath = new Path(hdfsNewVersionPath, confAtPath);
+
+      if (!fs.exists(hdsfConfPath.getParent())) {
+        fs.mkdirs(hdsfConfPath.getParent());
+      }
+
+      // If an empty directory needs to created it may not have a stream.
+      if (confStream.getInputStream().isPresent()) {
+        // Read the resource as a stream from the classpath and write it to HDFS
+        try (SeekableFSInputStream inputStream = new SeekableFSInputStream(confStream.getInputStream().get());
+            FSDataOutputStream os = this.fs.create(hdsfConfPath, false)) {
+          StreamUtils.copy(inputStream, os);
+        }
+      }
+    }
+
+    // Set permission for newly copied files
+    for (FileStatus fileStatus : FileListUtils.listPathsRecursively(this.fs, hdfsNewVersionPath, FileListUtils.NO_OP_PATH_FILTER)) {
+      this.fs.setPermission(fileStatus.getPath(), deploymentConfig.getStorePermissions());
+    }
+
+    log.info(String.format("New version %s of config store deployed at %s", deploymentConfig.getNewVersion(), hdfsconfigStoreRoot));
+  }
+
+  @Override
+  public void rollback(RollbackConfig rollbackConfig) throws IOException {
+    throw new UnsupportedOperationException("Rollback is not supported yet.");
   }
 }

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -1,3 +1,14 @@
+/*
+ * Copyright (C) 2015-16 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
 package gobblin.config.store.hdfs;
 
 import java.io.IOException;


### PR DESCRIPTION
## Changes

- Added `StoreDeployer` which copies config files in classpath to a `ConfigStore`
- Added a new interface called `Deployable` which has a `deploy()` and a `rollback()` method. A `ConfigStore` can implement a `Deployable`. The `StoreDeployer` initializes the right `deployable` `ConfigStore` using the `storeUri`. 
- The actual configs should be in its own package/project and in the classpath. This project will add gobblin-confg-management as a dependency. On calling `StoreDeployer.deploy()`, the configs in classpath are deployed
- Rollback is not yet implemented

## Example

If "test-root" is a resource in classpath and all resources (config files) under it needs to be deployed
**Structure in Classpath:**
           test-root
           &emsp;/data
           &emsp;&emsp;/set1
           &emsp;&emsp;&emsp;/main.conf
           &emsp;/tag
           &emsp;&emsp;/tag1
           &emsp;&emsp;&emsp;/main.conf

A new version say 2.0.0 is created on HDFS under \_CONFIG\_STORE
**Structure on HDFS after deploy:**
           /_CONFIG\_STORE
           &emsp;/2.0.0
           &emsp;&emsp;/data
           &emsp;&emsp;&emsp;/set1
           &emsp;&emsp;&emsp;&emsp;/main.conf
           &emsp;&emsp;/tag
           &emsp;&emsp;&emsp;/tag1
           &emsp;&emsp;&emsp;&emsp;/main.conf

@chavdar and @sahilTakiar can you review?