### PR TITLE
Fix javadoc warnings by only adding linksOffline to projects that the current project depends on.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -350,6 +350,15 @@ ext.pomAttributes = {
   }
 }
 
+def getAllDependentProjects(project) {
+  def projectDependencies = project.configurations.runtime.getAllDependencies().withType(ProjectDependency)
+  def dependentProjects = projectDependencies*.dependencyProject
+  if (dependentProjects.size() > 0) {
+      dependentProjects.each { dependentProjects += getAllDependentProjects(it) }
+  }
+  return dependentProjects.unique()
+}
+
 subprojects {
   plugins.withType(JavaPlugin) {
     plugins.apply('idea')
@@ -496,10 +505,6 @@ subprojects {
                                 "https://hive.apache.org/javadocs/r${rootProject.ext.hiveVersion}/api/",
                                 "http://avro.apache.org/docs/${avroVersion}/api/java/",
                                 "https://dropwizard.github.io/metrics/${dropwizardMetricsVersion}/apidocs/"
-    rootProject.ext.javadocPackages.each {
-      tasks.javadoc.options.linksOffline "http://linkedin.github.io/gobblin/javadoc/${javadocVersion}/${it}/",
-                                       "${rootProject.buildDir}/${it}/docs/javadoc/"
-    }
 
     afterEvaluate {
       // add the standard pegasus dependencies wherever the plugin is used
@@ -508,6 +513,17 @@ subprojects {
           dataTemplateCompile externalDependency.pegasus.data
           restClientCompile externalDependency.pegasus.restliClient,externalDependency.pegasus.restliCommon,externalDependency.pegasus.restliTools
         }
+      }
+    }
+  }
+}
+
+gradle.projectsEvaluated {
+  subprojects {
+    plugins.withType(JavaPlugin) {
+      getAllDependentProjects(project).each {
+        tasks.javadoc.options.linksOffline "http://linkedin.github.io/gobblin/javadoc/${javadocVersion}/${it.name}/",
+                                         "${rootProject.buildDir}/${it.name}/docs/javadoc/"
       }
     }
   }


### PR DESCRIPTION
@sahilTakiar Can you review this?  Also, it there a way to verify that the resultant javadocs are correct?