### PR TITLE
Fix for NullReferenceException cause by #739

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ContextAwareReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ContextAwareReporter.java
@@ -79,6 +79,10 @@ public class ContextAwareReporter implements Reporter, Closeable {
     }
   }
 
+  public boolean isStarted() {
+    return this.started;
+  }
+
   /**
    * Starts the {@link ContextAwareReporter}. If the {@link ContextAwareReporter} has been started
    * (and not stopped since), this is a no-op.

--- a/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ScheduledReporter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/reporter/ScheduledReporter.java
@@ -39,7 +39,6 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigValueFactory;
 
 import lombok.extern.slf4j.Slf4j;
-import lombok.Synchronized;
 
 import gobblin.metrics.InnerMetricContext;
 import gobblin.metrics.context.ReportableContext;
@@ -105,8 +104,7 @@ public abstract class ScheduledReporter extends ContextAwareReporter {
     ensureMetricFilterIsInitialized(config);
   }
 
-  @Synchronized
-  private void ensureMetricFilterIsInitialized(Config config) {
+  private synchronized void ensureMetricFilterIsInitialized(Config config) {
     if (this.metricFilter == null) {
       this.metricFilter = createMetricFilter(config);
     }

--- a/gobblin-metrics/src/test/java/gobblin/metrics/RootMetricContextTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/RootMetricContextTest.java
@@ -58,6 +58,16 @@ public class RootMetricContextTest {
   }
 
   @Test
+  public void testReporterCanBeAddedToStartedContext() throws Exception {
+    RootMetricContext.get().startReporting();
+
+    ContextStoreReporter reporter = new ContextStoreReporter("testReporter", ConfigFactory.empty());
+    Assert.assertTrue(reporter.isStarted());
+
+    RootMetricContext.get().stopReporting();
+  }
+
+  @Test
   public void testMetricContextLifecycle() throws Exception {
 
     String name = UUID.randomUUID().toString();

--- a/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ScheduledReporterTest.java
+++ b/gobblin-metrics/src/test/java/gobblin/metrics/reporter/ScheduledReporterTest.java
@@ -12,12 +12,6 @@
 
 package gobblin.metrics.reporter;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.metrics.MetricContext;
-import gobblin.metrics.context.ReportableContext;
-import gobblin.metrics.context.filter.ContextFilterFactory;
-import gobblin.util.ConfigUtils;
-
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -28,10 +22,14 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Function;
-import com.google.common.base.Optional;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Sets;
 import com.typesafe.config.Config;
+
+import gobblin.metrics.MetricContext;
+import gobblin.metrics.context.ReportableContext;
+import gobblin.metrics.context.filter.ContextFilterFactory;
+import gobblin.util.ConfigUtils;
 
 
 /**


### PR DESCRIPTION
@sahilTakiar The lombok @synchronized attribute isn't initialized before the super call is done, therefore we needed to replace it with the framework synchronized keyword.