### PR TITLE
Fix findbugs warning

### DIFF
--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/FsDeploymentConfig.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/deploy/FsDeploymentConfig.java
@@ -52,7 +52,7 @@ public class FsDeploymentConfig extends DeploymentConfig {
    * @param deployableConfigSource Source that provides the deployable configs
    * @param version to be used for this deployment
    */
-  public FsDeploymentConfig(@NonNull final DeployableConfigSource deployableConfigSource, @NonNull final String version) {
+  public FsDeploymentConfig(final DeployableConfigSource deployableConfigSource, final String version) {
     this(deployableConfigSource, version, DEFAULT_STORE_PERMISSIONS);
   }
 


### PR DESCRIPTION
Findbugs reported redundant null check RCN_REDUNDANT_NULLCHECK_WOULD_HAVE_BEEN_A_NPE