### PR TITLE
Fixing Fork + Task Retry Logic #776

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -14,9 +14,9 @@ package gobblin.runtime;
 
 import java.io.IOException;
 import java.util.List;
-import java.util.concurrent.CompletionService;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.slf4j.Logger;
@@ -25,7 +25,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 
 import gobblin.Constructs;
@@ -82,12 +82,9 @@ public class Task implements Runnable {
   private final TaskContext taskContext;
   private final TaskState taskState;
   private final TaskStateTracker taskStateTracker;
+  private final TaskExecutor taskExecutor;
   private final Optional<CountDownLatch> countDownLatch;
-
-  private final List<Optional<Fork>> forks = Lists.newArrayList();
-
-  // A CompletionService used to run the batch of Forks of this Task
-  private final CompletionService forkCompletionService;
+  private final Map<Optional<Fork>, Optional<Future<?>>> forks = Maps.newLinkedHashMap();
 
   // Number of task retries
   private final AtomicInteger retryCount = new AtomicInteger();
@@ -107,7 +104,7 @@ public class Task implements Runnable {
     this.jobId = this.taskState.getJobId();
     this.taskId = this.taskState.getTaskId();
     this.taskStateTracker = taskStateTracker;
-    this.forkCompletionService = new ExecutorCompletionService(taskExecutor.getForkExecutor());
+    this.taskExecutor = taskExecutor;
     this.countDownLatch = countDownLatch;
   }
 
@@ -118,7 +115,7 @@ public class Task implements Runnable {
     this.taskState.setStartTime(startTime);
     this.taskState.setWorkingState(WorkUnitState.WorkingState.RUNNING);
 
-    // Clear the list so it starts with a fresh list of forks for each run/retry
+    // Clear the map so it starts with a fresh set of forks for each run/retry
     this.forks.clear();
 
     Closer closer = Closer.create();
@@ -155,10 +152,9 @@ public class Task implements Runnable {
           Fork fork = closer.register(new Fork(this.taskContext,
               schema instanceof Copyable ? ((Copyable) schema).copy() : schema, branches, i));
           // Run the Fork
-          this.forkCompletionService.submit(fork, fork);
-          this.forks.add(Optional.of(fork));
+          this.forks.put(Optional.of(fork), Optional.<Future<?>> of(this.taskExecutor.submit(fork)));
         } else {
-          this.forks.add(Optional.<Fork> absent());
+          this.forks.put(Optional.<Fork> absent(), Optional.<Future<?>> absent());
         }
       }
 
@@ -182,17 +178,17 @@ public class Task implements Runnable {
       this.taskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXTRACTED, recordsPulled);
       this.taskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED, extractor.getExpectedRecordCount());
 
-      for (Optional<Fork> fork : this.forks) {
+      for (Optional<Fork> fork : this.forks.keySet()) {
         if (fork.isPresent()) {
           // Tell the fork that the main branch is completed and no new incoming data records should be expected
           fork.get().markParentTaskDone();
         }
       }
 
-      for (Optional<Fork> fork : this.forks) {
-        if (fork.isPresent()) {
+      for (Optional<Future<?>> forkFuture : this.forks.values()) {
+        if (forkFuture.isPresent()) {
           try {
-            this.forkCompletionService.take();
+            forkFuture.get().get();
           } catch (InterruptedException ie) {
             Thread.currentThread().interrupt();
           }
@@ -201,7 +197,7 @@ public class Task implements Runnable {
 
       // Check if all forks succeeded
       boolean allForksSucceeded = true;
-      for (Optional<Fork> fork : this.forks) {
+      for (Optional<Fork> fork : this.forks.keySet()) {
         if (fork.isPresent()) {
           if (fork.get().isSucceeded()) {
             if (!fork.get().commit()) {
@@ -235,6 +231,16 @@ public class Task implements Runnable {
         closer.close();
       } catch (Throwable t) {
         LOG.error("Failed to close all open resources", t);
+      }
+
+      for (Map.Entry<Optional<Fork>, Optional<Future<?>>> forkAndFuture : this.forks.entrySet()) {
+        if (forkAndFuture.getKey().isPresent() && forkAndFuture.getValue().isPresent()) {
+          try {
+            forkAndFuture.getValue().get().cancel(true);
+          } catch (Throwable t) {
+            LOG.error(String.format("Failed to cancel Fork \"%s\"", forkAndFuture.getKey().get()), t);
+          }
+        }
       }
 
       try {
@@ -372,14 +378,14 @@ public class Task implements Runnable {
    * @return the list of {@link Fork}s created by this {@link Task}
    */
   public List<Optional<Fork>> getForks() {
-    return ImmutableList.copyOf(this.forks);
+    return ImmutableList.copyOf(this.forks.keySet());
   }
 
   /**
    * Update record-level metrics.
    */
   public void updateRecordMetrics() {
-    for (Optional<Fork> fork : this.forks) {
+    for (Optional<Fork> fork : this.forks.keySet()) {
       if (fork.isPresent()) {
         fork.get().updateRecordMetrics();
       }
@@ -395,7 +401,7 @@ public class Task implements Runnable {
    */
   public void updateByteMetrics() {
     try {
-      for (Optional<Fork> fork : this.forks) {
+      for (Optional<Fork> fork : this.forks.keySet()) {
         if (fork.isPresent()) {
           fork.get().updateByteMetrics();
         }
@@ -470,20 +476,24 @@ public class Task implements Runnable {
     // until all puts succeed, at which point the task moves to the next record.
     while (!allPutsSucceeded) {
       allPutsSucceeded = true;
-      for (int i = 0; i < branches; i++) {
-        if (succeededPuts[i]) {
+
+      int branch = 0;
+      for (Optional<Fork> fork : this.forks.keySet()) {
+        if (succeededPuts[branch]) {
+          branch++;
           continue;
         }
-        if (this.forks.get(i).isPresent() && forkedRecords.get(i)) {
-          boolean succeeded = this.forks.get(i).get()
+        if (fork.isPresent() && forkedRecords.get(branch)) {
+          boolean succeeded = fork.get()
               .putRecord(convertedRecord instanceof Copyable ? ((Copyable) convertedRecord).copy() : convertedRecord);
-          succeededPuts[i] = succeeded;
+          succeededPuts[branch] = succeeded;
           if (!succeeded) {
             allPutsSucceeded = false;
           }
         } else {
-          succeededPuts[i] = true;
+          succeededPuts[branch] = true;
         }
+        branch++;
       }
     }
   }
@@ -508,10 +518,8 @@ public class Task implements Runnable {
    */
   private long getRecordsWritten() {
     long recordsWritten = 0;
-    for (Optional<Fork> fork : this.forks) {
-      if (fork.isPresent()) {
-        recordsWritten += fork.get().getRecordsWritten();
-      }
+    for (Optional<Fork> fork : this.forks.keySet()) {
+      recordsWritten += fork.get().getRecordsWritten();
     }
     return recordsWritten;
   }
@@ -523,10 +531,8 @@ public class Task implements Runnable {
    */
   private long getBytesWritten() {
     long bytesWritten = 0;
-    for (Optional<Fork> fork : this.forks) {
-      if (fork.isPresent()) {
-        bytesWritten += fork.get().getBytesWritten();
-      }
+    for (Optional<Fork> fork : this.forks.keySet()) {
+      bytesWritten += fork.get().getBytesWritten();
     }
     return bytesWritten;
   }
@@ -550,11 +556,9 @@ public class Task implements Runnable {
       constructState.addConstructState(Constructs.ROW_QUALITY_CHECKER, new ConstructState(rowChecker.getFinalState()));
     }
     int forkIdx = 0;
-    for (Optional<Fork> fork : this.forks) {
-      if (fork.isPresent()) {
-        constructState.addConstructState(Constructs.FORK_OPERATOR, new ConstructState(fork.get().getFinalState()),
-            Integer.toString(forkIdx));
-      }
+    for (Optional<Fork> fork : this.forks.keySet()) {
+      constructState.addConstructState(Constructs.FORK_OPERATOR, new ConstructState(fork.get().getFinalState()),
+          Integer.toString(forkIdx));
       forkIdx++;
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskExecutor.java
@@ -205,13 +205,4 @@ public class TaskExecutor extends AbstractIdleService {
     LOG.info(String.format("Scheduled retry of failed task %s to run in %d seconds", task.getTaskId(), interval));
     task.incrementRetryCount();
   }
-
-  /**
-   * Get the {@link ExecutorService} used to run {@link Fork}s.
-   *
-   * @return the {@link ExecutorService} used to run {@link Fork}s
-   */
-  ExecutorService getForkExecutor() {
-    return this.forkExecutor;
-  }
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/TaskTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/TaskTest.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Properties;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import com.google.common.base.Optional;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.fork.IdentityForkOperator;
+import gobblin.publisher.TaskPublisher;
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.extractor.Extractor;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
+import gobblin.qualitychecker.task.TaskLevelPolicyChecker;
+
+
+/**
+ * Integration tests for {@link Task}.
+ */
+@Test
+public class TaskTest {
+
+  /**
+   * Check if a {@link WorkUnitState.WorkingState} of a {@link Task} is set properly after a {@link Task} fails once,
+   * but then is successful the next time.
+   */
+  @Test
+  public void testRetryTask() throws Exception {
+    // Create a TaskState
+    TaskState taskState = new TaskState(new WorkUnitState(WorkUnit.create(
+        new Extract(Extract.TableType.SNAPSHOT_ONLY, this.getClass().getName(), this.getClass().getSimpleName()))));
+    taskState.setProp(ConfigurationKeys.METRICS_ENABLED_KEY, Boolean.toString(false));
+    taskState.setTaskId("testRetryTaskId");
+
+    // Create a mock TaskContext
+    TaskContext mockTaskContext = mock(TaskContext.class);
+    when(mockTaskContext.getExtractor()).thenReturn(new FailOnceExtractor());
+    when(mockTaskContext.getForkOperator()).thenReturn(new IdentityForkOperator());
+    when(mockTaskContext.getTaskState()).thenReturn(taskState);
+    when(mockTaskContext.getTaskLevelPolicyChecker(any(TaskState.class), anyInt()))
+        .thenReturn(mock(TaskLevelPolicyChecker.class));
+
+    // Create a mock TaskPublisher
+    TaskPublisher mockTaskPublisher = mock(TaskPublisher.class);
+    when(mockTaskPublisher.canPublish()).thenReturn(TaskPublisher.PublisherState.SUCCESS);
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class), anyInt()))
+        .thenReturn(mockTaskPublisher);
+
+    // Create a mock TaskStateTracker
+    TaskStateTracker mockTaskStateTracker = mock(TaskStateTracker.class);
+
+    // Create a TaskExecutor - a real TaskExecutor must be created so a Fork is run in a separate thread
+    TaskExecutor taskExecutor = new TaskExecutor(new Properties());
+
+    // Create the Task
+    Task task = new Task(mockTaskContext, mockTaskStateTracker, taskExecutor, Optional.<CountDownLatch> absent());
+
+    // The first run of the Task should fail
+    task.run();
+    Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.FAILED);
+
+    // The second run of the Task should succeed
+    task.run();
+    Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.SUCCESSFUL);
+  }
+
+  /**
+   * An implementation of {@link Extractor} that throws an {@link IOException} during the invocation of
+   * {@link #readRecord(Object)}.
+   */
+  private static class FailOnceExtractor implements Extractor {
+
+    private static final AtomicBoolean HAS_FAILED = new AtomicBoolean();
+
+    @Override
+    public Object getSchema() throws IOException {
+      return null;
+    }
+
+    @Override
+    public Object readRecord(@Deprecated Object reuse) throws DataRecordException, IOException {
+      if (!HAS_FAILED.get()) {
+        HAS_FAILED.set(true);
+        throw new IOException();
+      }
+      return null;
+    }
+
+    @Override
+    public long getExpectedRecordCount() {
+      return -1;
+    }
+
+    @Override
+    public long getHighWatermark() {
+      return -1;
+    }
+
+    @Override
+    public void close() throws IOException {
+      // Do nothing
+    }
+  }
+}


### PR DESCRIPTION
* Fix for #776
* Change is to cancel all `Future`s launched by a `Task`
    * A `Task` launches a `Future` for each `Fork` it runs, the PR ensures all the `Future`s are cancelled if any exception is thrown by the `Task`

@zliu41 can you review?