### PR TITLE
(#798) Adding JaCoCo and Coveralls support for code coverage analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,8 +31,6 @@ tmp
 out
 **/out
 output
-**/gradle/
-**/ligradle
 gobblin-test/basicTest
 gobblin-test/jobOutput
 gobblin-test/state-store

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ install: ./travis/build.sh
 
 script: ./travis/test.sh
 
+after_success: ./gradlew coveralls
 after_failure: ./travis/junit-errors-to-stdout.sh
 
 env:

--- a/build.gradle
+++ b/build.gradle
@@ -16,11 +16,15 @@ buildscript {
   }
   dependencies {
     classpath 'gradle.plugin.org.inferred:gradle-processors:1.1.2'
+    classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.6.3'
+    classpath 'gradle.plugin.com.palantir:jacoco-coverage:0.3.0'
   }
 }
 
 apply plugin: 'org.inferred.processors'
 apply plugin: 'idea'
+
+apply from: rootProject.projectDir.path + '/gradle/scripts/jacoco-coveralls-support.gradle'
 
 idea.project {
   ext.languageLevel = JavaVersion.VERSION_1_7

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,18 +1,26 @@
-#-------------------------------------------------------------
-#For details on recommended settings, see go/gradle.properties
-#-------------------------------------------------------------
+#
+# Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
 
-#long-running Gradle process speeds up local builds
-#to stop the daemon run 'ligradle --stop'
+# Long-running Gradle process speeds up local builds
+# To stop the daemon run 'ligradle --stop'
 org.gradle.daemon=true
 
-#configures only relevant projects to speed up the configuration of large projects
-#useful when specific project/task is invoked e.g: ligradle :cloud:cloud-api:build
+# Configures only relevant projects to speed up the configuration of large projects
+# Useful when specific project/task is invoked
 org.gradle.configureondemand=true
 
-#Gradle will run tasks from subprojects in parallel
-#Higher CPU usage, faster builds
+# Gradle will run tasks from subprojects in parallel
+# Higher CPU usage, faster builds
 org.gradle.parallel=true
 
-#Allows generation of idea/eclipse metadata for a specific subproject and its upstream project dependencies
+# Allows generation of idea/eclipse metadata for a specific subproject and its upstream project dependencies
 ide.recursive=true

--- a/gradle/scripts/jacoco-coveralls-support.gradle
+++ b/gradle/scripts/jacoco-coveralls-support.gradle
@@ -1,0 +1,63 @@
+// Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.
+
+/**
+ * Adds integration with the <a href="https://docs.gradle.org/current/userguide/jacoco_plugin.html">Gradle JaCoCo Plugin</a>
+ * as well as with <a href="https://coveralls.io/">Coveralls</a>. The script uses the
+ * <a href="https://github.com/palantir/gradle-jacoco-coverage">JacocoFullReport</a> to aggregate the JaCoCo report for
+ * each Gradle sub-module into one master report. The Gradle JaCoCo plugin does not do the aggregation by default which
+ * is why this plugin is necessary. The master report is also needed for Coveralls integration which expects a single
+ * aggregated report in <code>xml</code> format. The aggregated report will be placed under
+ * <code>build/reports/jacocoFullReport/</code>.
+ */
+
+apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'com.palantir.jacoco-full-report'
+apply plugin: 'jacoco'
+
+ext.jacocoVersion = '0.7.6.201602180812'
+
+jacoco {
+  toolVersion = jacocoVersion
+}
+
+repositories {
+  jcenter()
+}
+
+// Add the jacoco plugin to each project
+subprojects {
+  plugins.withType(JavaPlugin) {
+
+    plugins.apply('jacoco')
+
+    repositories {
+        jcenter()
+    }
+
+    jacoco {
+        toolVersion = jacocoVersion
+    }
+
+    jacocoTestReport {
+      reports {
+        html.enabled = true
+        xml.enabled = true
+        csv.enabled = false
+      }
+    }
+  }
+}
+
+// Configure the coveralls task to read the aggregated JaCoCo report
+coveralls {
+    sourceDirs = files(subprojects.findAll { subproject -> subproject.plugins.hasPlugin('java') }.sourceSets.main.allSource.srcDirs).files.absolutePath
+    jacocoReportPath = "${rootProject.buildDir}/build/reports/jacoco/jacocoFullReport/jacocoFullReport.xml"
+}

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -19,7 +19,7 @@
 set -e
 
 if [ "$USEHADOOP2" = true ] ; then
-  ./gradlew clean assemble -PuseHadoop2
+  ./gradlew clean assemble -PuseHadoop2 -Dorg.gradle.parallel=false
 else
-  ./gradlew clean assemble
+  ./gradlew clean assemble -Dorg.gradle.parallel=false
 fi

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -19,7 +19,7 @@
 set -e
 
 if [ "$USEHADOOP2" = true ] ; then
-  ./gradlew test -PuseHadoop2 -PskipTestGroup=disabledOnTravis
+  ./gradlew test jacocoFullReport -PuseHadoop2 -PskipTestGroup=disabledOnTravis -Dorg.gradle.parallel=false
 else
-  ./gradlew test -PskipTestGroup=disabledOnTravis
+  ./gradlew test jacocoFullReport -PskipTestGroup=disabledOnTravis -Dorg.gradle.parallel=false
 fi


### PR DESCRIPTION
* Adding support for running JaCoCo and integration with Coveralls
* JaCoCO can be run using `./gradlew test jacocoTestReport` which will generate JaCoCo reports for each individual Java subproject
    * Output will be in `xml` and `html` format and can be found under `build/[subproject]/jacoco`
* Adding the Gradle Plugin `jacoco-full-report`
    * Docs: https://github.com/palantir/gradle-jacoco-coverage and https://plugins.gradle.org/plugin/com.palantir.jacoco-coverage
    * The default Gradle JaCoCo Plugin does not aggregate all reports into one single report, this is problematic as coveralls expects one aggregated report
    * This plugin automatically does the aggregation and is configured in a similar way to the Gradle `jacoco` plugin
    * It can be run using `./gradlew test jacocoFullReport`
* The Travis build has been modified so that JaCoCo report is uploaded to coveralls
* Coveralls Gobblin Page: https://coveralls.io/github/linkedin/gobblin
* Issue: #798 