### PR TITLE
(#825) fixing and improving useHadoop2 and hadoopVersion gradle properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,10 @@ File getEnvironmentScript()
 
 apply from: environmentScript
 
+allprojects {
+  apply from: rootProject.projectDir.path + '/gradle/scripts/hadoop-version.gradle'
+}
+
 ext.publishToMaven = project.hasProperty('publishToMaven')
 if (ext.publishToMaven) {
     plugins.apply('maven')
@@ -76,21 +80,13 @@ if (!project.hasProperty('version') || project.version == 'unspecified') {
     else {
         project.version = tagStr
     }
-    if (!project.hasProperty('useHadoop2')) {
+    if (!useHadoop2) {
       project.version = project.version + "-hadoop1"
     }
 }
 
 println "name=" + project.name + " group=" + project.group
 println "project.version=" + project.version
-
-if (!project.hasProperty('hadoopVersion')) {
-  if (project.hasProperty('useHadoop2')) {
-    ext.hadoopVersion = '2.3.0'
-  } else {
-    ext.hadoopVersion = '1.2.1'
-  }
-}
 
 if (!project.hasProperty('hiveVersion')) {
   ext.hiveVersion = '1.0.1'
@@ -378,7 +374,7 @@ subprojects {
         if (project.hasProperty('skipTestGroup')) {
           excludeGroups skipTestGroup
         }
-        if (project.hasProperty('useHadoop2')) {
+        if (useHadoop2) {
           excludeGroups 'Hadoop1Only'
         }
       }
@@ -387,7 +383,7 @@ subprojects {
     configurations {
       compile
       dependencies {
-        if (project.hasProperty('useHadoop2')) {
+        if (useHadoop2) {
           compile(externalDependency.hadoopCommon) {
             exclude module: 'servlet-api'
           }

--- a/gobblin-azkaban/build.gradle
+++ b/gobblin-azkaban/build.gradle
@@ -19,7 +19,7 @@ dependencies {
   compile project(":gobblin-core")
   compile project(":gobblin-metrics")
   compile project(":gobblin-utility")
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile project(":gobblin-yarn")
   }
 
@@ -30,7 +30,7 @@ dependencies {
   compile externalDependency.jodaTime
   compile externalDependency.lombok
   compile externalDependency.slf4j
-  if (project.hasProperty('useHadoop2')) {
+  if (project.getProperty('useHadoop2')) {
     compile externalDependency.typesafeConfig
     compile externalDependency.hadoopYarnApi
   }
@@ -40,7 +40,7 @@ configurations {
     compile {
       transitive = false
 
-      if (!project.hasProperty('useHadoop2')) {
+      if (!useHadoop2) {
         sourceSets.main.java.exclude "**/AzkabanGobblinYarnAppLauncher.java"
       }
     }

--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -23,8 +23,7 @@ dependencies {
   compile externalDependency.commonsLang
   compile externalDependency.commonsMath
   compile externalDependency.hiveExec
-
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     runtime externalDependency.hadoopCommon
     runtime externalDependency.hadoopClientCore
     runtime externalDependency.hadoopHdfs

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -46,7 +46,7 @@ dependencies {
 
   runtime externalDependency.protobuf
 
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile externalDependency.avroMapredH2
     testRuntime externalDependency.hadoopAws
   } else {

--- a/gobblin-distribution/build.gradle
+++ b/gobblin-distribution/build.gradle
@@ -39,12 +39,12 @@ dependencies {
   compile project(":gobblin-rest-service:gobblin-rest-server")
   compile project(":gobblin-config-management:gobblin-config-client")
   compile project(":gobblin-config-management:gobblin-config-core")
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile project(':gobblin-yarn')
   }
 }
 
-task build(type: Tar, overwrite: true) {
+task buildDistributionTar(type: Tar, overwrite: true) {
   extension = 'tar.gz'
   baseName = project.name
   compression = Compression.GZIP
@@ -68,3 +68,5 @@ task build(type: Tar, overwrite: true) {
     }
   }
 }
+
+assemble.dependsOn buildDistributionTar

--- a/gobblin-example/build.gradle
+++ b/gobblin-example/build.gradle
@@ -22,7 +22,7 @@ dependencies {
     compile externalDependency.slf4j
     compile externalDependency.gson
     compile externalDependency.commonsVfs
-    if (project.hasProperty('useHadoop2')) {
+    if (useHadoop2) {
       compile externalDependency.avroMapredH2
     } else {
       compile externalDependency.avroMapredH1

--- a/gobblin-hive-registration/build.gradle
+++ b/gobblin-hive-registration/build.gradle
@@ -30,7 +30,7 @@ dependencies {
   compile externalDependency.commonsPool
   compile externalDependency.findBugsAnnotations
   compile externalDependency.lombok
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile externalDependency.avroMapredH2
   } else {
     compile externalDependency.avroMapredH1

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -42,7 +42,7 @@ dependencies {
   compile externalDependency.guice
   compile externalDependency.javaxInject
   compile externalDependency.lombok
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile externalDependency.avroMapredH2
   } else {
     compile externalDependency.avroMapredH1

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -34,7 +34,7 @@ dependencies {
   compile externalDependency.typesafeConfig
   compile externalDependency.commonsPool
 
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile externalDependency.avroMapredH2
     runtime externalDependency.hadoopCommon
     runtime externalDependency.hadoopClientCore

--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -44,7 +44,7 @@ dependencies {
   compile externalDependency.hadoopYarnApi
   compile externalDependency.hadoopYarnCommon
   compile externalDependency.hadoopYarnClient
-  if (project.hasProperty('useHadoop2')) {
+  if (useHadoop2) {
     compile externalDependency.avroMapredH2
   } else {
     compile externalDependency.avroMapredH1

--- a/gradle/scripts/hadoop-version.gradle
+++ b/gradle/scripts/hadoop-version.gradle
@@ -1,0 +1,39 @@
+// Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.
+
+/**
+ * Gradle script to handle proper setting of the useHadoop2 property
+ */
+
+if (!hasProperty('hadoopVersion')) {
+  if (hasProperty('useHadoop2')) {
+    ext.hadoopVersion = '2.3.0'
+    ext.useHadoop2 = true
+  } else {
+    ext.hadoopVersion = '1.2.1'
+    ext.useHadoop2 = false
+  }
+} else {
+  ext.useHadoop2 = isHadoopTwo(hadoopVersion)
+}
+
+/**
+ * Returns true if the given version is a Hadoop 2.x.x library, otherwise it returns false
+ */
+def isHadoopTwo(version) {
+  def versionComponents = version.split("\\.")
+  if (versionComponents.length == 0) {
+    throw new GradleScriptException("Invalid Hadoop Version: " + version);
+  } else if (versionComponents[0].equals('2')) {
+    return true
+  } else {
+    return false
+  }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -8,6 +8,8 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied.
 
+apply from: 'gradle/scripts/hadoop-version.gradle'
+
 def modules = ['gobblin-admin','gobblin-api','gobblin-azkaban','gobblin-compaction',
                'gobblin-config-management','gobblin-core','gobblin-distribution',
                'gobblin-example','gobblin-hive-registration','gobblin-metrics','gobblin-metastore','gobblin-rest-service',
@@ -23,6 +25,6 @@ modules.each { module ->
   }
 }
 
-if (hasProperty('useHadoop2')) {
+if (useHadoop2) {
   include "gobblin-yarn"
 }


### PR DESCRIPTION
* Created a separate `.gradle` file for setting the `useHadoop2` property
* The property is now dynamically set based on the hadoop version specified
* The original behavior of `-PuseHadoop2` is preserved
* The only change is that if `-PhadoopVersion=` a 2.x.x version, then `useHadoop2` does not need to be specified also
* Fixes #825

@ibuenros can you review?