### PR TITLE
Adds support to `HadoopUtils` for overwriting files

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -288,6 +288,7 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".final.dir";
   public static final String DATA_PUBLISHER_REPLACE_FINAL_DIR = DATA_PUBLISHER_PREFIX + ".replace.final.dir";
   public static final String DATA_PUBLISHER_FINAL_NAME = DATA_PUBLISHER_PREFIX + ".final.name";
+  public static final String DATA_PUBLISHER_OVERWRITE_ENABLED = DATA_PUBLISHER_PREFIX + ".overwrite.enabled";
   // This property is used to specify the owner group of the data publisher final output directory
   public static final String DATA_PUBLISHER_FINAL_DIR_GROUP = DATA_PUBLISHER_PREFIX + ".final.dir.group";
   public static final String DATA_PUBLISHER_PERMISSIONS = DATA_PUBLISHER_PREFIX + ".permissions";

--- a/gobblin-core/src/main/java/gobblin/commit/FsRenameCommitStep.java
+++ b/gobblin-core/src/main/java/gobblin/commit/FsRenameCommitStep.java
@@ -41,6 +41,7 @@ public class FsRenameCommitStep extends CommitStepBase {
   private final Path dstPath;
   private final String srcFsUri;
   private final String dstFsUri;
+  private final boolean overwrite;
   private transient FileSystem srcFs;
   private transient FileSystem dstFs;
 
@@ -55,6 +56,7 @@ public class FsRenameCommitStep extends CommitStepBase {
     this.dstFs = builder.dstFs != null ? builder.dstFs
         : getFileSystem(this.props.getProp(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
     this.dstFsUri = this.dstFs.getUri().toString();
+    this.overwrite = builder.overwrite;
   }
 
   public static class Builder<T extends Builder<?>> extends CommitStepBase.Builder<T> {
@@ -71,6 +73,7 @@ public class FsRenameCommitStep extends CommitStepBase {
     private Path dstPath;
     private FileSystem srcFs;
     private FileSystem dstFs;
+    private boolean overwrite;
 
     @Override
     public T withProps(State props) {
@@ -98,6 +101,12 @@ public class FsRenameCommitStep extends CommitStepBase {
     @SuppressWarnings("unchecked")
     public T withDstFs(FileSystem dstFs) {
       this.dstFs = dstFs;
+      return (T) this;
+    }
+
+    @SuppressWarnings("unchecked")
+    public T overwrite() {
+      this.overwrite = true;
       return (T) this;
     }
 
@@ -131,6 +140,6 @@ public class FsRenameCommitStep extends CommitStepBase {
       this.dstFs = getFileSystem(this.dstFsUri);
     }
     log.info(String.format("Moving %s to %s", this.srcPath, this.dstPath));
-    HadoopUtils.movePath(this.srcFs, this.srcPath, this.dstFs, this.dstPath, this.dstFs.getConf());
+    HadoopUtils.movePath(this.srcFs, this.srcPath, this.dstFs, this.dstPath, this.overwrite, this.dstFs.getConf());
   }
 }

--- a/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
@@ -238,7 +238,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
             publisherOutputDir.getParent(), this.permissions.get(branchId));
       }
 
-      movePath(parallelRunner, writerOutputDir, publisherOutputDir, branchId);
+      movePath(parallelRunner, state, writerOutputDir, publisherOutputDir, branchId);
       writerOutputPathsMoved.add(writerOutputDir);
     }
   }
@@ -282,7 +282,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
       WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId),
           publisherOutputPath.getParent(), this.permissions.get(branchId));
 
-      movePath(parallelRunner, taskOutputPath, publisherOutputPath, branchId);
+      movePath(parallelRunner, workUnitState, taskOutputPath, publisherOutputPath, branchId);
     }
   }
 
@@ -302,14 +302,15 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
                       ConfigurationKeys.DATA_PUBLISHER_FINAL_NAME, this.numBranches, branchId)))
           : new Path(publisherOutputDir, status.getPath().getName());
 
-      movePath(parallelRunner, status.getPath(), finalOutputPath, branchId);
+      movePath(parallelRunner, workUnitState, status.getPath(), finalOutputPath, branchId);
     }
   }
 
-  protected void movePath(ParallelRunner parallelRunner, Path src, Path dst, int branchId) throws IOException {
+  protected void movePath(ParallelRunner parallelRunner, State state, Path src, Path dst, int branchId) throws IOException {
     LOG.info(String.format("Moving %s to %s", src, dst));
+    boolean overwrite = state.getPropAsBoolean(ConfigurationKeys.DATA_PUBLISHER_OVERWRITE_ENABLED, false);
     this.publisherOutputDirs.addAll(recordPublisherOutputDirs(src, dst, branchId));
-    parallelRunner.movePath(src, this.publisherFileSystemByBranches.get(branchId), dst,
+    parallelRunner.movePath(src, this.publisherFileSystemByBranches.get(branchId), dst, overwrite,
         this.publisherFinalDirOwnerGroupsByBranches.get(branchId));
   }
 

--- a/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimePartitionedDataPublisher.java
@@ -59,7 +59,7 @@ public class TimePartitionedDataPublisher extends BaseDataPublisher {
       WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId), outputPath.getParent(),
           this.permissions.get(branchId));
 
-      movePath(parallelRunner, status.getPath(), outputPath, branchId);
+      movePath(parallelRunner, workUnitState, status.getPath(), outputPath, branchId);
     }
   }
 }


### PR DESCRIPTION
@sahilTakiar This can be enabled for data publishing by adding `data.publisher.overwrite.enabled=true` to the gobblin config.  Fixes #718 & #778