### PR TITLE
Enable the maximum log file size for Gobblin Yarn LogCopier to be configured

### DIFF
--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnAppLauncher.java
@@ -677,6 +677,9 @@ public class GobblinYarnAppLauncher {
             .readFrom(getHdfsLogDir(appWorkDir))
             .writeTo(sinkLogDir)
             .acceptsLogFileExtensions(ImmutableSet.of(ApplicationConstants.STDOUT, ApplicationConstants.STDERR));
+    if (config.hasPath(GobblinYarnConfigurationKeys.LOG_COPIER_MAX_FILE_SIZE)) {
+      builder.useMaxBytesPerLogFile(config.getBytes(GobblinYarnConfigurationKeys.LOG_COPIER_MAX_FILE_SIZE));
+    }
     if (config.hasPath(GobblinYarnConfigurationKeys.LOG_COPIER_SCHEDULER)) {
       builder.useScheduler(config.getString(GobblinYarnConfigurationKeys.LOG_COPIER_SCHEDULER));
     }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnConfigurationKeys.java
@@ -86,4 +86,5 @@ public class GobblinYarnConfigurationKeys {
   // Other misc configuration properties.
   public static final String TASK_SUCCESS_OPTIONAL_KEY = "TASK_SUCCESS_OPTIONAL";
   public static final String LOG_COPIER_SCHEDULER = GOBBLIN_YARN_PREFIX + "log.copier.scheduler";
+  public static final String LOG_COPIER_MAX_FILE_SIZE = GOBBLIN_YARN_PREFIX + "log.copier.max.file.size";
 }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnLogSource.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnLogSource.java
@@ -66,6 +66,9 @@ class GobblinYarnLogSource {
             .writeTo(getHdfsLogDir(containerId, destFs, appWorkDir))
             .acceptsLogFileExtensions(ImmutableSet.of(ApplicationConstants.STDOUT, ApplicationConstants.STDERR))
             .useLogFileNamePrefix(containerId.toString());
+    if (config.hasPath(GobblinYarnConfigurationKeys.LOG_COPIER_MAX_FILE_SIZE)) {
+      builder.useMaxBytesPerLogFile(config.getBytes(GobblinYarnConfigurationKeys.LOG_COPIER_MAX_FILE_SIZE));
+    }
     if (config.hasPath(GobblinYarnConfigurationKeys.LOG_COPIER_SCHEDULER)) {
       builder.useScheduler(config.getString(GobblinYarnConfigurationKeys.LOG_COPIER_SCHEDULER));
     }


### PR DESCRIPTION
The new configuration key `gobblin.yarn.log.copier.max.file.size` will allow this to be configured with values such as: 100000, "10M", "512K", etc.  If it is not configured, the log files will not rotate.

Fixes: #814 