### PR TITLE
Sanitize extracts and dataset urns in distpc that are used as path tokens

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
@@ -32,6 +32,7 @@ import gobblin.source.extractor.extract.AbstractSource;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.HadoopUtils;
+import gobblin.util.PathUtils;
 import gobblin.util.RateControlledFileSystem;
 import gobblin.util.WriterUtils;
 import gobblin.util.executors.ScalingThreadPoolExecutor;
@@ -192,7 +193,8 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
         Collections.sort(fileSets, this.workUnitList.getComparator());
 
         for (FileSet<CopyEntity> fileSet : fileSets) {
-          Extract extract = new Extract(Extract.TableType.SNAPSHOT_ONLY, CopyConfiguration.COPY_PREFIX, fileSet.getName());
+          String extractTable = PathUtils.sanitizeForPath(fileSet.getName());
+          Extract extract = new Extract(Extract.TableType.SNAPSHOT_ONLY, CopyConfiguration.COPY_PREFIX, extractTable);
           List<WorkUnit> workUnitsForPartition = Lists.newArrayList();
           for (CopyEntity copyEntity : fileSet.getFiles()) {
 
@@ -205,7 +207,7 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
             serializeCopyableDataset(workUnit, metadata);
             GobblinMetrics.addCustomTagToState(workUnit, new Tag<>(CopyEventSubmitterHelper.DATASET_ROOT_METADATA_NAME,
                 this.copyableDataset.datasetURN()));
-            workUnit.setProp(ConfigurationKeys.DATASET_URN_KEY, datasetAndPartition.toString());
+            workUnit.setProp(ConfigurationKeys.DATASET_URN_KEY, datasetAndPartition.identifier());
             workUnit.setProp(SlaEventKeys.DATASET_URN_KEY, this.copyableDataset.datasetURN());
             workUnit.setProp(SlaEventKeys.PARTITION_KEY, copyEntity.getFileSet());
             computeAndSetWorkUnitGuid(workUnit);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -67,8 +67,10 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
       Path filePathRelativeToSearchPath = PathUtils.relativizePath(file.getPath(), nonGlobSearchPath);
       Path targetPath = new Path(configuration.getPublishDir(), filePathRelativeToSearchPath);
 
+      String fileSet = file.getPath().getParent().toUri().getRawPath();
+
       copyableFiles.add(CopyableFile.fromOriginAndDestination(this.fs, file, targetPath, configuration).
-          fileSet(file.getPath().getParent().toString()).build());
+          fileSet(fileSet).build());
     }
     return copyableFileFilter.filter(this.fs, targetFs, copyableFiles);
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.ql.metadata.HiveException;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
@@ -59,7 +58,6 @@ import gobblin.hive.PartitionDeregisterStep;
 import gobblin.hive.metastore.HiveMetaStoreUtils;
 import gobblin.hive.spec.HiveSpec;
 import gobblin.hive.spec.SimpleHiveSpec;
-import gobblin.util.AutoReturnableObject;
 import gobblin.util.PathUtils;
 import gobblin.util.commit.DeleteFileCommitStep;
 
@@ -456,7 +454,7 @@ class HiveCopyEntityHelper {
     }
 
     public static LocationDescriptor forTable(Table table, FileSystem fs) throws IOException {
-      return new LocationDescriptor(table.getDataLocation(), HiveUtils.getInputFormat(table.getSd()), fs);
+      return new LocationDescriptor(table.getDataLocation(), HiveUtils.getInputFormat(table.getTTable().getSd()), fs);
     }
 
     public static LocationDescriptor forPartition(Partition partition, FileSystem fs) throws IOException {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -16,41 +16,22 @@ import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.List;
-import java.util.Map;
 import java.util.Properties;
-import java.util.Set;
 
-import org.apache.commons.lang3.reflect.ConstructorUtils;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
-import org.apache.hadoop.hive.ql.metadata.HiveException;
-import org.apache.hadoop.hive.ql.metadata.Partition;
-import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
 import org.apache.hadoop.hive.ql.metadata.Table;
-import org.apache.hadoop.mapred.FileInputFormat;
-import org.apache.hadoop.mapred.FileSplit;
-import org.apache.hadoop.mapred.InputFormat;
-import org.apache.hadoop.mapred.InputSplit;
-import org.apache.hadoop.mapred.JobConf;
-import org.apache.hadoop.mapred.JobConfigurable;
-import org.apache.thrift.TException;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Optional;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.common.collect.Sets;
 
 import gobblin.annotation.Alpha;
 import gobblin.data.management.copy.CopyConfiguration;
 import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.CopyableDataset;
 import gobblin.hive.HiveMetastoreClientPool;
-import gobblin.util.AutoReturnableObject;
 import gobblin.util.PathUtils;
 
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/recovery/RecoveryHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/recovery/RecoveryHelper.java
@@ -30,6 +30,7 @@ import gobblin.configuration.State;
 import gobblin.data.management.copy.CopySource;
 import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.CopyableFile;
+import gobblin.util.PathUtils;
 import gobblin.util.guid.Guid;
 
 
@@ -84,7 +85,7 @@ public class RecoveryHelper {
     String guid = computeGuid(state, file);
     StringBuilder nameBuilder = new StringBuilder(guid);
     nameBuilder.append("_");
-    nameBuilder.append(shortenPathName(file.getOrigin().getPath(), 250 - nameBuilder.length()));
+    nameBuilder.append(PathUtils.shortenPathName(file.getOrigin().getPath(), 250 - nameBuilder.length()));
 
     if (!this.fs.exists(this.persistDir.get())) {
       this.fs.mkdirs(this.persistDir.get(), new FsPermission(FsAction.ALL, FsAction.READ, FsAction.NONE));
@@ -116,31 +117,6 @@ public class RecoveryHelper {
       }
     }
     return Optional.absent();
-  }
-
-  /**
-   * Shorten an absolute path into a sanitized String of length at most bytes. This is useful for including a summary
-   * of an absolute path in a file name.
-   *
-   * <p>
-   *   For example: shortenPathName("/user/gobblin/foo/bar/myFile.txt", 25) will be shortened to "_user_gobbl..._myFile.txt".
-   * </p>
-   *
-   * @param path absolute {@link Path} to shorten.
-   * @param bytes max number of UTF8 bytes that output string can use (note that,
-   *              for now, it is assumed that each character uses exactly one byte).
-   * @return a shortened, sanitized String of length at most bytes.
-   */
-  static String shortenPathName(Path path, int bytes) {
-    String pathString = path.toUri().getPath();
-    String replaced = pathString.replace("/", "_");
-
-    if (replaced.length() <= bytes) {
-      return replaced;
-    }
-
-    int bytesPerHalf = (bytes - 3) / 2;
-    return replaced.substring(0, bytesPerHalf) + "..." + replaced.substring(replaced.length() - bytesPerHalf);
   }
 
   private static String computeGuid(State state, CopyEntity file) throws IOException {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/recovery/RecoveryHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/recovery/RecoveryHelperTest.java
@@ -33,10 +33,10 @@ import com.google.common.io.Files;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyConfiguration;
-import gobblin.data.management.copy.CopyContext;
 import gobblin.data.management.copy.CopySource;
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.PreserveAttributes;
+import gobblin.util.PathUtils;
 import gobblin.util.guid.Guid;
 
 
@@ -114,8 +114,8 @@ public class RecoveryHelperTest {
 
   @Test public void testShortenPathName() throws Exception {
 
-    Assert.assertEquals(RecoveryHelper.shortenPathName(new Path("/test"), 10), "_test");
-    Assert.assertEquals(RecoveryHelper.shortenPathName(new Path("/relatively/long/path"), 9), "_re...ath");
+    Assert.assertEquals(PathUtils.shortenPathName(new Path("/test"), 10), "_test");
+    Assert.assertEquals(PathUtils.shortenPathName(new Path("/relatively/long/path"), 9), "_re...ath");
 
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/util/PathUtilsTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/util/PathUtilsTest.java
@@ -117,4 +117,10 @@ public class PathUtilsTest {
     Assert.assertEquals(path, new Path("file.txt.gpg.tar.gz"));
 
   }
+
+  @Test
+  public void testSanitizeForPath() throws Exception {
+    Assert.assertEquals(PathUtils.sanitizeForPath("hdfs://bad/path", 100), "hdfs___bad_path");
+    Assert.assertEquals(PathUtils.sanitizeForPath("hdfs://bad/path", 9), "hdf...ath");
+  }
 }

--- a/gobblin-example/src/main/resources/distcp.pull
+++ b/gobblin-example/src/main/resources/distcp.pull
@@ -11,11 +11,6 @@ data.publisher.final.dir=/tmp/gobblin-copy
 gobblin.dataset.profile.class=gobblin.data.management.copy.hive.HiveDatasetFinder
 gobblin.dataset.pattern=${env:HOME}/gobblin-copy
 
-
-hive.dataset.database=default
-hive.dataset.hive.site.uri=file:/Users/ibuenros/builds/hive/apache-hive-1.2.1-bin/conf/hive-site.xml
-hive.dataset.copy.target.table.root=/tmp/gobblin-copy
-
 # ====================================================================
 # Distcp configurations (do not change)
 # ====================================================================

--- a/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/FsStateStore.java
@@ -33,6 +33,7 @@ import com.google.common.io.Closer;
 
 import gobblin.configuration.State;
 import gobblin.util.HadoopUtils;
+import gobblin.util.PathUtils;
 
 
 /**
@@ -128,8 +129,8 @@ public class FsStateStore<T extends State> implements StateStore<T> {
    */
   @Override
   public void put(String storeName, String tableName, T state) throws IOException {
-    String tmpTableName = this.useTmpFileForPut ? TMP_FILE_PREFIX + tableName : tableName;
-    Path tmpTablePath = new Path(new Path(this.storeRootDir, storeName), tmpTableName);
+    String tmpTableName = PathUtils.sanitizeForPath(this.useTmpFileForPut ? TMP_FILE_PREFIX + tableName : tableName);
+    Path tmpTablePath = new Path(new Path(this.storeRootDir, PathUtils.sanitizeForPath(storeName)), tmpTableName);
 
     if (!this.fs.exists(tmpTablePath) && !create(storeName, tmpTableName)) {
       throw new IOException("Failed to create a state file for table " + tmpTableName);
@@ -147,7 +148,8 @@ public class FsStateStore<T extends State> implements StateStore<T> {
     }
 
     if (this.useTmpFileForPut) {
-      Path tablePath = new Path(new Path(this.storeRootDir, storeName), tableName);
+      Path tablePath =
+          new Path(new Path(this.storeRootDir, PathUtils.sanitizeForPath(storeName)), PathUtils.sanitizeForPath(tableName));
       HadoopUtils.renamePath(this.fs, tmpTablePath, tablePath);
     }
   }

--- a/gobblin-utility/src/main/java/gobblin/util/PathUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PathUtils.java
@@ -144,4 +144,52 @@ public class PathUtils {
     }
     return path;
   }
+
+  /**
+   * Shorten an absolute path into a sanitized String of length at most bytes. This is useful for including a summary
+   * of an absolute path in a file name.
+   *
+   * <p>
+   *   For example: shortenPathName("/user/gobblin/foo/bar/myFile.txt", 25) will be shortened to "_user_gobbl..._myFile.txt".
+   * </p>
+   *
+   * @param path absolute {@link org.apache.hadoop.fs.Path} to shorten.
+   * @param maxBytes max number of UTF8 bytes that output string can use (note that,
+   *              for now, it is assumed that each character uses exactly one byte).
+   * @return a shortened, sanitized String of length at most bytes.
+   */
+  public static String shortenPathName(Path path, int maxBytes) {
+    return sanitizeForPath(path.toUri().getPath(), maxBytes);
+  }
+
+  /**
+   * See {@link #sanitizeForPath(String, int)}. Shortens strings to 250 bytes (Hadoop allows up to 255 for path tokens).
+   */
+  public static String sanitizeForPath(String str) {
+    return sanitizeForPath(str, 250);
+  }
+
+  /**
+   * Sanitize and possibly shorten a string for use as a token in a Hadoop path.
+   * Shorten an absolute path into a sanitized String of length at most bytes.
+   *
+   * <p>
+   *   For example: sanitizeForPath("/user/gobblin/foo/bar/myFile.txt", 25) will be shortened to "_user_gobbl..._myFile.txt".
+   * </p>
+   *
+   * @param str String to sanitize
+   * @param maxBytes max number of UTF8 bytes that output string can use (note that,
+   *              for now, it is assumed that each character uses exactly one byte).
+   * @return a shortened, sanitized String of length at most bytes.
+   */
+  public static String sanitizeForPath(String str, int maxBytes) {
+    String replaced = str.replaceAll("[/:]", "_");
+
+    if (replaced.length() <= maxBytes) {
+      return replaced;
+    }
+
+    int bytesPerHalf = (maxBytes - 3) / 2;
+    return replaced.substring(0, bytesPerHalf) + "..." + replaced.substring(replaced.length() - bytesPerHalf);
+  }
 }


### PR DESCRIPTION
@chavdar this should fix the issue with the invalid staging path.
