### PR TITLE
Null Configuration is passed to MRJobLauncher

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/CliMRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/CliMRJobLauncher.java
@@ -49,7 +49,8 @@ public class CliMRJobLauncher extends Configured implements ApplicationLauncher,
   private final ApplicationLauncher applicationLauncher;
   private final MRJobLauncher mrJobLauncher;
 
-  public CliMRJobLauncher(Properties jobProperties) throws Exception {
+  public CliMRJobLauncher(Configuration conf, Properties jobProperties) throws Exception {
+    setConf(conf);
     this.jobProperties = jobProperties;
     this.applicationLauncher = this.closer.register(new ServiceBasedAppLauncher(jobProperties,
         jobProperties.getProperty(ServiceBasedAppLauncher.APP_NAME, "CliMRJob-" + UUID.randomUUID())));
@@ -106,6 +107,6 @@ public class CliMRJobLauncher extends Configured implements ApplicationLauncher,
     Properties jobProperties = CliOptions.parseArgs(CliMRJobLauncher.class, genericCmdLineOpts);
 
     // Launch and run the job
-    System.exit(ToolRunner.run(conf, new CliMRJobLauncher(jobProperties), args));
+    System.exit(ToolRunner.run(new CliMRJobLauncher(conf,jobProperties), args));
   }
 }


### PR DESCRIPTION
It seems to me that due to a regression of https://github.com/linkedin/gobblin/pull/808 the MRJobLauncher receives a null Configuration object which results in an NPE at `JobConfigurationUtils#putPropertiesIntoConfiguration`.

The instantiation of `MRJobLauncher` was moved from `run()` to the `CliMRJobLauncher`'s constructor, but here `getConf()` is null as `org.apache.hadoop.conf.Configured()` calls to `setConf(null)`. `org.apache.hadoop.util.ToolRunner#run` would set it, but it's too late as MRJobLauncher is instantiated
earlier.