### PR TITLE
Making HiveRegistrationPolicyBase constructor public

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -79,7 +79,7 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
   protected final String tableNamePrefix;
   protected final String tableNameSuffix;
 
-  protected HiveRegistrationPolicyBase(State props) {
+  public HiveRegistrationPolicyBase(State props) {
     Preconditions.checkNotNull(props);
     this.props = new HiveRegProps(props);
     this.sanitizeNameAllowed = props.getPropAsBoolean(HIVE_SANITIZE_INVALID_NAMES, true);


### PR DESCRIPTION
* Making the constructor for `HiveRegistrationPolicyBase` public so that it can be initialized in other classes
* Otherwise `HiveRegistrationPolicyBase.getPolicy(state)` throws `NoSuchMethodException: No such accessible constructor on object`