### PR TITLE
Base interfaces for value auditing

### DIFF
--- a/gobblin-api/src/main/java/gobblin/annotation/Alias.java
+++ b/gobblin-api/src/main/java/gobblin/annotation/Alias.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Denotes that a class has an alias.
+ */
+@Documented @Retention(value=RetentionPolicy.RUNTIME) @Target(value=ElementType.TYPE)
+public @interface Alias {
+  /**
+   * Alias for that class
+   */
+  public String value();
+}

--- a/gobblin-api/src/main/java/gobblin/util/ClassAliasResolver.java
+++ b/gobblin-api/src/main/java/gobblin/util/ClassAliasResolver.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.util;
+
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.reflections.Reflections;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Sets;
+
+import gobblin.annotation.Alias;
+
+
+/**
+ * A class that scans through all classes in the classpath annotated with {@link Alias} and is a subType of <code>subTypeOf</code> constructor argument.
+ * It caches the alias to class mapping. Applications can call {@link #resolve(String)} to resolve a class's alias to its
+ * cannonical name.
+ *
+ * <br>
+ * <b>Note : If same alias is used for multiple classes in the classpath, the first mapping in classpath scan holds good.
+ * Subsequent ones will be logged and ignored.
+ * </b>
+ */
+@Slf4j
+public class ClassAliasResolver {
+
+  Map<String, Class<?>> aliasToClassCache;
+
+  public ClassAliasResolver(Class<?> subTypeOf) {
+    Map<String, Class<?>> cache = Maps.newHashMap();
+    // Scan all packages
+    Reflections reflections = new Reflections("");
+    for (Class<?> clazz : Sets.intersection(reflections.getTypesAnnotatedWith(Alias.class), reflections.getSubTypesOf(subTypeOf))) {
+      String alias = clazz.getAnnotation(Alias.class).value();
+      if (cache.containsKey(alias)) {
+        log.warn(String.format("Alias %s already mapped to class %s. Mapping for %s will be ignored", alias,
+            cache.get(alias).getCanonicalName(), clazz.getCanonicalName()));
+      } else {
+        cache.put(clazz.getAnnotation(Alias.class).value(), clazz);
+      }
+
+    }
+    this.aliasToClassCache = ImmutableMap.copyOf(cache);
+  }
+
+  /**
+   * Resolves the given alias to its cannonical name if a mapping exits. To create a mapping for a class,
+   * it has to be annotated with {@link Alias}
+   *
+   * @param possibleAlias to use for resolution.
+   * @return The cannonical name of the class with <code>possibleAlias</code> if mapping is available.
+   * Return the input <code>possibleAlias</code> if no mapping is found.
+   */
+  public String resolve(final String possibleAlias) {
+    if (aliasToClassCache.containsKey(possibleAlias)) {
+      return aliasToClassCache.get(possibleAlias).getCanonicalName();
+    }
+    return possibleAlias;
+  }
+}

--- a/gobblin-api/src/test/java/gobblin/util/ClassAliasResolverTest.java
+++ b/gobblin-api/src/test/java/gobblin/util/ClassAliasResolverTest.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.util;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.annotation.Alias;
+
+@Test(groups = { "gobblin.api.util"})
+public class ClassAliasResolverTest {
+
+  @Test
+  public void testResolve() {
+    ClassAliasResolver resolver = new ClassAliasResolver(IDummyAliasTest.class);
+    Assert.assertEquals(resolver.resolve("abc"), DummyAliasTest.class.getCanonicalName());
+    // Resolve returns the passed string if alias mapping does not exist
+    Assert.assertEquals(resolver.resolve("abcd"), "abcd");
+  }
+
+  @Alias(value="abc")
+  public static class DummyAliasTest implements IDummyAliasTest{}
+
+  public static interface IDummyAliasTest {}
+}

--- a/gobblin-audit/build.gradle
+++ b/gobblin-audit/build.gradle
@@ -11,19 +11,20 @@
 apply plugin: 'java'
 
 dependencies {
+    compile project(":gobblin-api")
+    compile project(":gobblin-utility")
+
     compile externalDependency.guava
-    compile externalDependency.gson
-    compile externalDependency.jasypt
-    compile externalDependency.jodaTime
     compile externalDependency.commonsLang3
     compile externalDependency.slf4j
-    compile externalDependency.commonsCli
     compile externalDependency.lombok
-    compile externalDependency.commonsIo
+    compile externalDependency.avro
+    compile externalDependency.typesafeConfig
     compile externalDependency.reflections
 
     testCompile externalDependency.testng
     testCompile externalDependency.log4j
+    testCompile externalDependency.mockito
 }
 
 configurations {

--- a/gobblin-audit/src/main/java/gobblin/audit/values/auditor/ValueAuditGenerator.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/auditor/ValueAuditGenerator.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.auditor;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import org.apache.avro.generic.GenericRecord;
+
+import com.typesafe.config.Config;
+
+import gobblin.audit.values.policy.column.ColumnProjectionPolicy;
+import gobblin.audit.values.policy.column.DefaultColumnProjectionPolicyFactory;
+import gobblin.audit.values.policy.row.DefaultRowSelectionPolicyFactory;
+import gobblin.audit.values.policy.row.RowSelectionPolicy;
+import gobblin.audit.values.sink.AuditSink;
+import gobblin.audit.values.sink.DefaultAuditSinkFactory;
+
+
+/**
+ * The class that implements value based auditing. The class captures the values of certain
+ * columns from the rows in the dataset using the {@link ColumnProjectionPolicy}.
+ * This is done for every row or for a sample of the rows as defined by the {@link RowSelectionPolicy}.
+ * The selected rows are then written to the {@link AuditSink}
+ *
+ * {@link ValueAuditGenerator#audit(GenericRecord)} is the method that audits an inputRecord.
+ */
+@AllArgsConstructor
+@Getter
+public class ValueAuditGenerator implements Closeable {
+
+  public static final String COLUMN_PROJECTION_CONFIG_SCOPE = "columnProjection";
+  public static final String ROW_SELECTION_CONFIG_SCOPE = "rowSelection";
+  public static final String AUDIT_SINK_CONFIG_SCOPE = "auditSink";
+
+  private final ColumnProjectionPolicy columnProjectionPolicy;
+  private final RowSelectionPolicy rowSelectionPolicy;
+  private final AuditSink auditSink;
+
+  /**
+   * Factory method to create a new {@link ValueAuditGenerator}
+   * @param config job configs
+   * @param runtimeAuditMetadata is used to pass the table specific runtime information like tablename, databaseName, snapshotName etc.
+   *      See {@link ValueAuditRuntimeMetadata}
+   * @return a new {@link ValueAuditGenerator}
+   */
+  public static ValueAuditGenerator create(Config config, ValueAuditRuntimeMetadata runtimeAuditMetadata) {
+    ColumnProjectionPolicy columnProjectionPolicy = DefaultColumnProjectionPolicyFactory.getInstance().create(
+        config.getConfig(COLUMN_PROJECTION_CONFIG_SCOPE),runtimeAuditMetadata.getTableMetadata());
+    RowSelectionPolicy rowSelectionPolicy = DefaultRowSelectionPolicyFactory.getInstance().create(
+        config.getConfig(ROW_SELECTION_CONFIG_SCOPE), runtimeAuditMetadata.getTableMetadata(), columnProjectionPolicy);
+    AuditSink auditSink = DefaultAuditSinkFactory.getInstance().create(
+        config.getConfig(AUDIT_SINK_CONFIG_SCOPE), runtimeAuditMetadata);
+
+    return new ValueAuditGenerator(columnProjectionPolicy, rowSelectionPolicy, auditSink);
+  }
+
+  /**
+   * Write an audit record for the <code>inputRecord</code> to the {@link AuditSink}.
+   * An audit record is generated for every <code>inputRecord</code> that satisfies the {@link RowSelectionPolicy}.
+   * An audit record is created by projecting  <code>inputRecord</code> using the {@link ColumnProjectionPolicy}
+   *
+   * @param inputRecord to be audited
+   * @throws IOException if auditing failed for this record
+   */
+  public void audit(GenericRecord inputRecord) throws IOException {
+    if (this.rowSelectionPolicy.shouldSelectRow(inputRecord)) {
+      auditSink.write(columnProjectionPolicy.project(inputRecord));
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.auditSink.close();
+  }
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/auditor/ValueAuditRuntimeMetadata.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/auditor/ValueAuditRuntimeMetadata.java
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.auditor;
+
+import java.util.List;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NonNull;
+import lombok.RequiredArgsConstructor;
+import lombok.ToString;
+
+import org.apache.avro.Schema;
+
+
+/**
+ * A container for table specific runtime Metadata required for auditing a table.
+ * Use {@link ValueAuditRuntimeMetadataBuilder} to instantiate a new {@link ValueAuditRuntimeMetadata}.
+ * <code>database, table and tableSchema</code> are required fields in the {@link ValueAuditRuntimeMetadata}.
+ * All other fields <code>phase, cluster, extractId, snapshotId, deltaId, partFileName</code> are marked as {@value #DEFAULT_VALUE}
+ * if not present.
+ */
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Getter
+@ToString
+@EqualsAndHashCode
+public class ValueAuditRuntimeMetadata {
+
+  private static final String DEFAULT_VALUE = "NA";
+
+  /**
+   * <i>Required - </i>Table specific metadata like <code>database, table and tableSchema</code>
+   */
+  private TableMetadata tableMetadata;
+  /**
+   * <i>Optional - </i>The snapshot generation phase being audited
+   */
+  private Phase phase;
+  /**
+   * <i>Optional - </i>Audited snapshot data's cluster
+   */
+  private String cluster;
+  /**
+   * <i>Optional - </i>Extract Id of the snapshot
+   */
+  private String extractId;
+  /**
+   * <i>Optional - </i>Snapshot Id being audited
+   */
+  private String snapshotId;
+  /**
+   * <i>Optional - </i>Delta Id of the snapshot
+   */
+  private String deltaId;
+  /**
+   * <i>Optional - </i>Part file in the snapshot being audited
+   */
+  private String partFileName;
+
+  public static ValueAuditRuntimeMetadataBuilder builder(String databaseName, String tableName, Schema tableSchema) {
+    return new ValueAuditRuntimeMetadataBuilder(databaseName, tableName, tableSchema);
+  }
+
+  /**
+   * Container for table specific metadata
+   */
+  @Getter
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  public static class TableMetadata {
+    /**
+     * <i>Required - </i> database name
+     */
+    @NonNull private String database;
+    /**
+     * <i>Required - </i> table name
+     */
+    @NonNull private String table;
+    /**
+     * <i>Required - </i> table schema
+     */
+    @NonNull private Schema tableSchema;
+    /**
+     * <i>Optional - </i> list of key fields in the table that uniquely identify a row.
+     * Each entry in the list is an ordered string specifying the location of the nested key field
+     * For example, field1.nestedField1 refers to the field "nestedField1" inside of field "field1" of the record.
+     */
+    private List<String> keyFieldLocations;
+    /**
+     * <i>Optional - </i> list of delta fields in the table that are used to track changes in the row over time.
+     * Each entry in the list is an ordered string specifying the location of the nested delta field
+     * For example, field1.nestedField1 refers to the field "nestedField1" inside of field "field1" of the record.
+     */
+    private List<String> deltaFieldLocations;
+  }
+
+  /**
+   * An enum for all phases snapshot generation
+   */
+  public static enum Phase {
+    PULL("Pull from extract"),
+    AVRO_CONV("Convert to avro"),
+    SS_GEN("Snapshot Generation, LSB"),
+    SS_UPD("Snapshot update, VSB"),
+    SS_MAT("Snapshot materialization, QSB"),
+    SS_PUB("Publish Snapshot"),
+    NA("Not Applicable");
+
+    private String description;
+
+    Phase(String description) {
+      this.description = description;
+    }
+
+    public String getDescription() {
+      return this.description;
+    }
+  }
+
+  /**
+   * Builder to build A {@link ValueAuditRuntimeMetadata}, <code>databaseName, tableName and tableSchema</code> are required
+   */
+  public static class ValueAuditRuntimeMetadataBuilder {
+
+    private TableMetadata tableMetadata;
+    private Phase phase = Phase.NA;
+    private String cluster = DEFAULT_VALUE;
+    private String extractId = DEFAULT_VALUE;
+    private String snapshotId = DEFAULT_VALUE;
+    private String deltaId = DEFAULT_VALUE;
+    private String partFileName = DEFAULT_VALUE;
+
+    public ValueAuditRuntimeMetadataBuilder(String databaseName, String tableName, Schema tableSchema) {
+      this.tableMetadata = new TableMetadata(databaseName, tableName, tableSchema);
+    }
+
+    public ValueAuditRuntimeMetadataBuilder phase(final Phase phase) {
+      this.phase = phase;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder cluster(final String cluster) {
+      this.cluster = cluster;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder extractId(final String extractId) {
+      this.extractId = extractId;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder snapshotId(final String snapshotId) {
+      this.snapshotId = snapshotId;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder deltaId(final String deltaId) {
+      this.deltaId = deltaId;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder partFileName(final String partFileName) {
+      this.partFileName = partFileName;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder tableMetadataKeyFieldLocations(List<String> keyFieldLocations) {
+      this.tableMetadata.keyFieldLocations = keyFieldLocations;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadataBuilder tableMetadataDeltaFieldLocations(List<String> deltaFieldLocations) {
+      this.tableMetadata.keyFieldLocations = deltaFieldLocations;
+      return this;
+    }
+
+    public ValueAuditRuntimeMetadata build() {
+      return new ValueAuditRuntimeMetadata(tableMetadata, phase, cluster, extractId, snapshotId, deltaId, partFileName);
+    }
+  }
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/AbstractColumnProjectionPolicy.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/AbstractColumnProjectionPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.column;
+
+import java.util.List;
+
+import org.apache.avro.Schema;
+
+import com.google.common.collect.ImmutableList;
+import com.typesafe.config.Config;
+
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+
+
+/**
+ * A base {@link ColumnProjectionPolicy} that reads <code>config</code> to initialize the key and delta columns to project for a table.
+ * <ul>
+ * <li> Key and delta fields/column locations to project should be provided by concrete subclasses by implementing {@link #getDeltaColumnsToProject()}
+ * and {@link #getKeyColumnsToProject()}
+ * <li> The protected member <code>tableMetadata</code> contains the {@link Schema}, tableName and databaseName to derive the projection columns
+ * </ul>
+ */
+public abstract class AbstractColumnProjectionPolicy implements ColumnProjectionPolicy {
+
+  protected final ValueAuditRuntimeMetadata.TableMetadata tableMetadata;
+  public AbstractColumnProjectionPolicy(Config config, ValueAuditRuntimeMetadata.TableMetadata tableMetadata) {
+    this.tableMetadata = tableMetadata;
+  }
+
+  /**
+   * Combine both key columns and delta columns to project
+   * {@inheritDoc}
+   * @see gobblin.audit.values.policy.column.ColumnProjectionPolicy#getAllColumnsToProject()
+   */
+  public List<String> getAllColumnsToProject() {
+    return ImmutableList.<String> builder().addAll(getKeyColumnsToProject()).addAll(getDeltaColumnsToProject()).build();
+  }
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/ColumnProjectionPolicy.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/ColumnProjectionPolicy.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.column;
+
+import java.util.List;
+
+import org.apache.avro.generic.GenericRecord;
+
+
+/**
+ * An interface that projects certain columns/fields of an input {@link GenericRecord} to generate a new {@link GenericRecord} that can be audited.
+ * The field locations to project are an ordered string specifying the location of the nested field to retrieve.
+ * For example, field1.nestedField1 takes the the value of the field "field1" of the record, and retrieves the field "nestedField1" from it
+ */
+public interface ColumnProjectionPolicy {
+
+  /**
+   * Get the key aka unique identifier fields to project in a {@link GenericRecord}
+   */
+  public List<String> getKeyColumnsToProject();
+
+  /**
+   * Get the delta fields to project in a {@link GenericRecord}. These are the fields used to determine changes over time.
+   */
+  public List<String> getDeltaColumnsToProject();
+
+  /**
+   * A union of {@link #getKeyColumnsToProject()} and {@link #getDeltaColumnsToProject()}
+   */
+  public List<String> getAllColumnsToProject();
+
+  /**
+   * Project key and delta columns/fields of the <code>inputRecord</code> and return a new {@link GenericRecord} with only the projected columns/fields
+   * @param inputRecord the original record with all columns/fields
+   * @return a new {@link GenericRecord} with only {@link #getAllColumnsToProject()}
+   */
+  public GenericRecord project(GenericRecord inputRecord);
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/DefaultColumnProjectionPolicyFactory.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/DefaultColumnProjectionPolicyFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.column;
+
+import java.lang.reflect.InvocationTargetException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.util.ClassAliasResolver;
+
+/**
+ * Default factory class to create new {@link ColumnProjectionPolicy}s
+ */
+@Slf4j
+public class DefaultColumnProjectionPolicyFactory {
+
+  private static final String COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY = "class";
+
+  private final ClassAliasResolver aliasResolver;
+
+  private DefaultColumnProjectionPolicyFactory() {
+    this.aliasResolver = new ClassAliasResolver(ColumnProjectionPolicy.class);
+  }
+
+  /**
+   * Create a new {@link ColumnProjectionPolicy} using the alias or cannonical classname specified at {@value #COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY} in the <code>config</code>
+   * The {@link ColumnProjectionPolicy} class MUST have an accessible constructor <code>abc(Config config, TableMetadata tableMetadata)</code>
+   * <b>Note : Must have the key {@value #COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY} set in <code>config</code> to create the {@link ColumnProjectionPolicy}</b>
+   *
+   * @param config job configs, Must have the key {@value #COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY} set to create the {@link ColumnProjectionPolicy}
+   * @param tableMetadata runtime table metadata
+   *
+   * @return a new instance of {@link ColumnProjectionPolicy}
+   */
+  public ColumnProjectionPolicy create(Config config, ValueAuditRuntimeMetadata.TableMetadata tableMetadata) {
+
+    Preconditions.checkArgument(config.hasPath(COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY));
+
+    log.info("Using column projection class name/alias " + config.getString(COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY));
+
+    try {
+      return (ColumnProjectionPolicy)ConstructorUtils.invokeConstructor(Class.forName(this.aliasResolver.resolve(
+              config.getString(COLUMN_PROJECTION_POLICY_CLASS_NAME_KEY))), config, tableMetadata);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
+        | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class DefaultColumnProjectionPolicyFactoryHolder {
+    private static final DefaultColumnProjectionPolicyFactory INSTANCE = new DefaultColumnProjectionPolicyFactory();
+  }
+
+  public static DefaultColumnProjectionPolicyFactory getInstance() {
+    return DefaultColumnProjectionPolicyFactoryHolder.INSTANCE;
+  }
+
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/ProjectAllColumnProjectionPolicy.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/column/ProjectAllColumnProjectionPolicy.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.column;
+
+import java.util.List;
+
+import org.apache.avro.generic.GenericRecord;
+
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+
+/**
+ * An {@link AbstractColumnProjectionPolicy} that projects all columns/fields of the <code>inputRecord</code>
+ */
+@Alias(value = "ProjectAll")
+public class ProjectAllColumnProjectionPolicy extends AbstractColumnProjectionPolicy {
+
+  public ProjectAllColumnProjectionPolicy(Config config, ValueAuditRuntimeMetadata.TableMetadata tableMetadata) {
+    super(config, tableMetadata);
+  }
+
+  /**
+   * Return the entire <code>inputRecord</code>. All fields are projected
+   *
+   * {@inheritDoc}
+   * @see gobblin.audit.values.policy.column.ColumnProjectionPolicy#project(org.apache.avro.generic.GenericRecord)
+   */
+  @Override
+  public GenericRecord project(GenericRecord inputRecord) {
+    return inputRecord;
+  }
+
+  @Override
+  public List<String> getKeyColumnsToProject() {
+    return this.tableMetadata.getKeyFieldLocations();
+  }
+
+  @Override
+  public List<String> getDeltaColumnsToProject() {
+    return this.tableMetadata.getDeltaFieldLocations();
+  }
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/AbstractRowSelectionPolicy.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/AbstractRowSelectionPolicy.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.row;
+
+import com.typesafe.config.Config;
+
+import gobblin.audit.values.auditor.ValueAuditGenerator;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.policy.column.ColumnProjectionPolicy;
+
+
+/**
+ * An abstract {@link RowSelectionPolicy} that contains references to {@link ValueAuditRuntimeMetadata.TableMetadata} and
+ * {@link ColumnProjectionPolicy} used by the {@link ValueAuditGenerator}.
+ * Concrete classes need to implement {@link RowSelectionPolicy#shouldSelectRow(org.apache.avro.generic.GenericRecord)}
+ */
+public abstract class AbstractRowSelectionPolicy implements RowSelectionPolicy {
+  protected final ValueAuditRuntimeMetadata.TableMetadata tableMetadata;
+  protected final ColumnProjectionPolicy columnProjectionPolicy;
+
+  public AbstractRowSelectionPolicy(Config config, ValueAuditRuntimeMetadata.TableMetadata tableMetadata,
+      ColumnProjectionPolicy columnProjectionPolicy) {
+    this.tableMetadata = tableMetadata;
+    this.columnProjectionPolicy = columnProjectionPolicy;
+  }
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/DefaultRowSelectionPolicyFactory.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/DefaultRowSelectionPolicyFactory.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.row;
+
+import java.lang.reflect.InvocationTargetException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import gobblin.audit.values.auditor.ValueAuditGenerator;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.policy.column.ColumnProjectionPolicy;
+import gobblin.util.ClassAliasResolver;
+
+/**
+ * Default factory class to create new {@link RowSelectionPolicy}s
+ */
+@Slf4j
+public class DefaultRowSelectionPolicyFactory {
+
+  private static final String ROW_SELECTION_POLICY_CLASS_NAME_KEY = "class";
+
+  private final ClassAliasResolver aliasResolver;
+
+  private DefaultRowSelectionPolicyFactory() {
+    this.aliasResolver = new ClassAliasResolver(RowSelectionPolicy.class);
+  }
+
+  /**
+   * Create a new {@link RowSelectionPolicy} using the alias or cannonical classname specified at {@value #ROW_SELECTION_POLICY_CLASS_NAME_KEY} in the <code>config</code>
+   * The {@link RowSelectionPolicy} class MUST have an accessible constructor <code>abc(Config config, TableMetadata tableMetadata, ColumnProjectionPolicy columnProjectionPolicy)</code>
+   * <b>Note : must have the key {@value #ROW_SELECTION_POLICY_CLASS_NAME_KEY} set in <code>config</code> to create the {@link RowSelectionPolicy}</b>
+   *
+   * @param config job configs, must have the key {@value #ROW_SELECTION_POLICY_CLASS_NAME_KEY} set to create the {@link RowSelectionPolicy}
+   * @param tableMetadata runtime table metadata
+   * @param columnProjectionPolicy used by the {@link ValueAuditGenerator}
+   *
+   * @return a new instance of {@link RowSelectionPolicy}
+   */
+  public RowSelectionPolicy create(Config config, ValueAuditRuntimeMetadata.TableMetadata tableMetadata, ColumnProjectionPolicy columnProjectionPolicy) {
+
+    Preconditions.checkArgument(config.hasPath(ROW_SELECTION_POLICY_CLASS_NAME_KEY));
+
+    log.info("Using row selection class name/alias " + config.getString(ROW_SELECTION_POLICY_CLASS_NAME_KEY));
+
+    try {
+      return (RowSelectionPolicy)ConstructorUtils.invokeConstructor(Class.forName(this.aliasResolver.resolve(
+              config.getString(ROW_SELECTION_POLICY_CLASS_NAME_KEY))), config, tableMetadata, columnProjectionPolicy);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
+        | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class DefaultRowSelectionPolicyFactoryHolder {
+    private static final DefaultRowSelectionPolicyFactory INSTANCE = new DefaultRowSelectionPolicyFactory();
+  }
+
+  public static DefaultRowSelectionPolicyFactory getInstance() {
+    return DefaultRowSelectionPolicyFactoryHolder.INSTANCE;
+  }
+
+}
+

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/RowSelectionPolicy.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/RowSelectionPolicy.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.row;
+
+import org.apache.avro.generic.GenericRecord;
+
+/**
+ * An interface to decide if a row needs to be audited
+ */
+public interface RowSelectionPolicy {
+
+  /**
+   * Finds if this <code>genericRecord</code> needs to be audited
+   *
+   * @param inputRecord to be audited
+   * @return <code>true</code> if <code>inputRecord</code> needs to be audited <code>false</code> otherwise
+   */
+  public boolean shouldSelectRow(GenericRecord inputRecord);
+
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/SelectAllRowSelectionPolicy.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/policy/row/SelectAllRowSelectionPolicy.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.policy.row;
+
+import org.apache.avro.generic.GenericRecord;
+
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.policy.column.ColumnProjectionPolicy;
+
+/**
+ * A {@link RowSelectionPolicy} that selects all rows for auditing
+ */
+@Alias(value = "SelectAll")
+public class SelectAllRowSelectionPolicy extends AbstractRowSelectionPolicy {
+
+  public SelectAllRowSelectionPolicy(Config config, ValueAuditRuntimeMetadata.TableMetadata tableMetadata, ColumnProjectionPolicy columnProjectionPolicy) {
+    super(config, tableMetadata, columnProjectionPolicy);
+  }
+
+  /**
+   * Return <code>true</code> always
+   * {@inheritDoc}
+   * @see gobblin.audit.values.policy.row.RowSelectionPolicy#shouldSelectRow(org.apache.avro.generic.GenericRecord)
+   */
+  @Override
+  public boolean shouldSelectRow(GenericRecord genericRecord) {
+    return true;
+  }
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/sink/AuditSink.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/sink/AuditSink.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.sink;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+import org.apache.avro.generic.GenericRecord;
+
+
+/**
+ * An interface for persisting value audits
+ */
+public interface AuditSink extends Closeable {
+  /**
+   * Write the <code>record</code> to sink
+   *
+   * @param record to be written
+   * @throws IOException if writing this record failed
+   */
+  public void write(GenericRecord record) throws IOException;
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/sink/DefaultAuditSinkFactory.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/sink/DefaultAuditSinkFactory.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.sink;
+
+import java.lang.reflect.InvocationTargetException;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import com.typesafe.config.Config;
+
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.util.ClassAliasResolver;
+
+/**
+ * Default factory class to create new {@link AuditSink}s
+ */
+@Slf4j
+public class DefaultAuditSinkFactory {
+
+  private static final String AUDIT_SINK_CLASS_NAME_KEY = "class";
+  private static final String DEFAULT_AUDIT_SINK_CLASS =  FsAuditSink.class.getCanonicalName();
+
+  private final ClassAliasResolver aliasResolver;
+
+  private DefaultAuditSinkFactory() {
+    this.aliasResolver = new ClassAliasResolver(AuditSink.class);
+  }
+
+  /**
+   * Create a new {@link AuditSink} using the alias or cannonical classname specified at {@value #AUDIT_SINK_CLASS_NAME_KEY} in the <code>config</code>
+   * The {@link AuditSink} class MUST have an accessible constructor <code>abc(Config config, TableMetadata tableMetadata)</code>
+   * <br>
+   * If {@value #AUDIT_SINK_CLASS_NAME_KEY} is not set in <code>config</code>, a default {@link #DEFAULT_AUDIT_SINK_CLASS} is used
+   *
+   * @param config job configs
+   * @param auditRuntimeMetadata runtime table metadata
+   *
+   * @return a new instance of {@link AuditSink}
+   */
+  public AuditSink create(Config config, ValueAuditRuntimeMetadata auditRuntimeMetadata) {
+
+    String sinkClassName = DEFAULT_AUDIT_SINK_CLASS;
+    if (config.hasPath(AUDIT_SINK_CLASS_NAME_KEY)) {
+      sinkClassName = config.getString(AUDIT_SINK_CLASS_NAME_KEY);
+    }
+    log.info("Using audit sink class name/alias " + sinkClassName);
+
+    try {
+      return (AuditSink)ConstructorUtils.invokeConstructor(Class.forName(this.aliasResolver.resolve(
+          sinkClassName)), config, auditRuntimeMetadata);
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
+        | ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static class DefaultAuditSinkFactoryHolder {
+    private static final DefaultAuditSinkFactory INSTANCE = new DefaultAuditSinkFactory();
+  }
+
+  public static DefaultAuditSinkFactory getInstance() {
+    return DefaultAuditSinkFactoryHolder.INSTANCE;
+  }
+
+}

--- a/gobblin-audit/src/main/java/gobblin/audit/values/sink/FsAuditSink.java
+++ b/gobblin-audit/src/main/java/gobblin/audit/values/sink/FsAuditSink.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values.sink;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
+
+import lombok.Getter;
+
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.io.Closer;
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.ConfigUtils;
+import gobblin.util.PathUtils;
+
+
+/**
+ *  A Hadoop {@link FileSystem} based {@link AuditSink} that writes audit {@link GenericRecord}s to a file on {@link FileSystem}.
+ *  <ul>
+ *  <li> The {@link FileSystem} {@link URI} can be set using key {@link ConfigurationKeys#FS_URI_KEY}, {@link ConfigurationKeys#LOCAL_FS_URI} is used by default.
+ *  <li> All audit files are written under the base path. The base path can be set using key {@link #FS_SINK_AUDIT_OUTPUT_PATH_KEY}.
+ *  The default path is,
+ *  <pre>
+ *  <code>System.getProperty("user.dir") + "/lumos_value_audit/local_audit";</code>
+ *  </pre>
+ *  <li> It uses <code>auditMetadata</code> to build the audit file name and path.<br>
+ *  <b>The layout on {@link FileSystem} - </b>
+ *  <pre>
+ *  |-- &lt;Database&gt;
+ *    |-- &lt;Table&gt;
+ *       |-- P=&lt;PHASE&gt;.C=&lt;CLUSTER&gt;.E=&lt;EXTRACT_ID&gt;.S=&lt;SNAPSHOT_ID&gt;.D=&lt;DELTA_ID&gt;
+ *          |-- *.avro
+ *  </pre>
+ *  </ul>
+ */
+@Alias(value = "FsAuditSink")
+public class FsAuditSink implements AuditSink {
+
+  private static final String FS_SINK_AUDIT_OUTPUT_PATH_KEY = "fs.outputDirPath";
+  private static final String FS_SINK_AUDIT_OUTPUT_DEFAULT_PATH = System.getProperty("user.dir") + "/lumos_value_audit/local_audit";
+  private static final String FILE_NAME_DELIMITTER = "_";
+
+  private final FileSystem fs;
+  private final OutputStream auditFileOutputStream;
+  private final DataFileWriter<GenericRecord> writer;
+  private final Closer closer = Closer.create();
+  private final ValueAuditRuntimeMetadata auditMetadata;
+  @Getter
+  private final Path auditDirPath;
+
+  public FsAuditSink(Config config, ValueAuditRuntimeMetadata auditMetadata) throws IOException {
+
+    this.auditDirPath = new Path(ConfigUtils.getString(config, FS_SINK_AUDIT_OUTPUT_PATH_KEY, FS_SINK_AUDIT_OUTPUT_DEFAULT_PATH));
+    this.fs = this.auditDirPath.getFileSystem(new Configuration());
+    this.auditMetadata = auditMetadata;
+    this.auditFileOutputStream = closer.register(fs.create(getAuditFilePath()));
+    DataFileWriter<GenericRecord> dataFileWriter = this.closer.register(new DataFileWriter<GenericRecord>(new GenericDatumWriter<GenericRecord>()));
+    this.writer = this.closer.register(dataFileWriter.create(this.auditMetadata.getTableMetadata().getTableSchema(), this.auditFileOutputStream));
+  }
+
+  /**
+   * Returns the complete path of the audit file. Generate the audit file path with format
+   *
+   *  <pre>
+   *  |-- &lt;Database&gt;
+   *    |-- &lt;Table&gt;
+   *       |-- P=&lt;PHASE&gt;.C=&lt;CLUSTER&gt;.E=&lt;EXTRACT_ID&gt;.S=&lt;SNAPSHOT_ID&gt;.D=&lt;DELTA_ID&gt;
+   *          |-- *.avro
+   *  </pre>
+   *
+   */
+  public Path getAuditFilePath() {
+    StringBuilder auditFileNameBuilder = new StringBuilder();
+    auditFileNameBuilder.append("P=").append(auditMetadata.getPhase()).append(FILE_NAME_DELIMITTER).append("C=")
+        .append(auditMetadata.getCluster()).append(FILE_NAME_DELIMITTER).append("E=")
+        .append(auditMetadata.getExtractId()).append(FILE_NAME_DELIMITTER).append("S=")
+        .append(auditMetadata.getSnapshotId()).append(FILE_NAME_DELIMITTER).append("D=")
+        .append(auditMetadata.getDeltaId());
+
+    return new Path(auditDirPath, PathUtils.combinePaths(auditMetadata.getTableMetadata().getDatabase(), auditMetadata
+        .getTableMetadata().getTable(), auditFileNameBuilder.toString(), auditMetadata.getPartFileName()));
+  }
+
+  /**
+   * Append this record to the {@link DataFileWriter}
+   *
+   * {@inheritDoc}
+   * @see gobblin.audit.values.sink.AuditSink#write(org.apache.avro.generic.GenericRecord)
+   */
+  @Override
+  public void write(GenericRecord record) throws IOException {
+    this.writer.append(record);
+  }
+
+  @Override
+  public final void close() throws IOException {
+    this.closer.close();
+  }
+}

--- a/gobblin-audit/src/test/java/gobblin/audit/values/FsAuditSinkTest.java
+++ b/gobblin-audit/src/test/java/gobblin/audit/values/FsAuditSinkTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values;
+
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.sink.FsAuditSink;
+
+import java.io.File;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+
+@Test(groups = { "gobblin.audit.values" })
+public class FsAuditSinkTest {
+
+  @Test
+  public void testWrite() throws Exception {
+    Schema testSchema = SchemaBuilder.record("test").fields().name("f1").type().stringType().noDefault().endRecord();
+    GenericRecord r = new GenericRecordBuilder(testSchema).set("f1", "v1").build();
+    ValueAuditRuntimeMetadata auditMetadata =
+        ValueAuditRuntimeMetadata.builder("db", "tb", testSchema).snapshotId(RandomStringUtils.randomAlphanumeric(5))
+            .partFileName("part-1.avro").build();
+    File auditFile = null;
+    Path auditDir = null;
+
+    try (FsAuditSink auditSink = new FsAuditSink(ConfigFactory.empty(), auditMetadata);) {
+      auditFile = new File(auditSink.getAuditFilePath().toString());
+      auditDir = auditSink.getAuditDirPath();
+      auditSink.write(r);
+    } catch (Exception e){
+      FileSystem.get(new Configuration()).delete(auditDir, true);
+      throw e;
+    }
+
+    GenericDatumReader<GenericRecord> reader = new GenericDatumReader<>(testSchema);
+
+    try (DataFileReader<GenericRecord> dataFileReader = new DataFileReader<>(auditFile, reader);) {
+      while (dataFileReader.hasNext()) {
+        GenericRecord recRead = dataFileReader.next();
+        Assert.assertEquals(recRead, r);
+        break;
+      }
+      Assert.assertEquals(dataFileReader.hasNext(), false);
+    } finally {
+      FileSystem.get(new Configuration()).delete(auditDir, true);
+    }
+  }
+}

--- a/gobblin-audit/src/test/java/gobblin/audit/values/MockSink.java
+++ b/gobblin-audit/src/test/java/gobblin/audit/values/MockSink.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values;
+
+import gobblin.annotation.Alias;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.sink.AuditSink;
+
+import java.io.IOException;
+
+import org.apache.avro.generic.GenericRecord;
+
+import com.typesafe.config.Config;
+
+@Alias(value = "MockSink")
+public class MockSink implements AuditSink {
+
+  public MockSink(Config config, ValueAuditRuntimeMetadata auditMetadata) {}
+  @Override
+  public void close() throws IOException {}
+  @Override
+  public void write(GenericRecord record) throws IOException {}
+
+}

--- a/gobblin-audit/src/test/java/gobblin/audit/values/ValueAuditGeneratorTest.java
+++ b/gobblin-audit/src/test/java/gobblin/audit/values/ValueAuditGeneratorTest.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values;
+
+import static org.mockito.Mockito.mock;
+import gobblin.audit.values.auditor.ValueAuditGenerator;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.policy.column.ProjectAllColumnProjectionPolicy;
+import gobblin.audit.values.policy.row.SelectAllRowSelectionPolicy;
+
+import org.apache.avro.generic.GenericRecord;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+@Test(groups = {"gobblin.audit.values"})
+public class ValueAuditGeneratorTest {
+
+  @Test
+  public void testConstructor() throws Exception {
+
+    Config config =ConfigFactory.parseMap(ImmutableMap.of(
+            "columnProjection.class", ProjectAllColumnProjectionPolicy.class.getCanonicalName(),
+            "rowSelection.class", SelectAllRowSelectionPolicy.class.getCanonicalName(),
+            "auditSink.class", MockSink.class.getCanonicalName()));
+    ValueAuditRuntimeMetadata runtimeMetadata = mock(ValueAuditRuntimeMetadata.class, Mockito.RETURNS_SMART_NULLS);
+    ValueAuditGenerator auditGenerator = ValueAuditGenerator.create(config, runtimeMetadata);
+    auditGenerator.audit(mock(GenericRecord.class, Mockito.RETURNS_SMART_NULLS));
+    Assert.assertEquals(auditGenerator.getRowSelectionPolicy().getClass().getCanonicalName(), SelectAllRowSelectionPolicy.class.getCanonicalName());
+    Assert.assertEquals(auditGenerator.getColumnProjectionPolicy().getClass().getCanonicalName(), ProjectAllColumnProjectionPolicy.class.getCanonicalName());
+    Assert.assertEquals(auditGenerator.getAuditSink().getClass().getCanonicalName(), MockSink.class.getCanonicalName());
+  }
+
+  @Test
+  public void testConstructorWithAlias() throws Exception {
+
+    Config config =ConfigFactory.parseMap(ImmutableMap.of(
+            "columnProjection.class", "ProjectAll",
+            "rowSelection.class", "SelectAll",
+            "auditSink.class", "MockSink"));
+    ValueAuditRuntimeMetadata runtimeMetadata = mock(ValueAuditRuntimeMetadata.class, Mockito.RETURNS_SMART_NULLS);
+    ValueAuditGenerator auditGenerator = ValueAuditGenerator.create(config, runtimeMetadata);
+    auditGenerator.audit(mock(GenericRecord.class, Mockito.RETURNS_SMART_NULLS));
+    Assert.assertEquals(auditGenerator.getRowSelectionPolicy().getClass().getCanonicalName(), SelectAllRowSelectionPolicy.class.getCanonicalName());
+    Assert.assertEquals(auditGenerator.getColumnProjectionPolicy().getClass().getCanonicalName(), ProjectAllColumnProjectionPolicy.class.getCanonicalName());
+    Assert.assertEquals(auditGenerator.getAuditSink().getClass().getCanonicalName(), MockSink.class.getCanonicalName());
+  }
+}

--- a/gobblin-audit/src/test/java/gobblin/audit/values/ValueAuditRuntimeMetadataTest.java
+++ b/gobblin-audit/src/test/java/gobblin/audit/values/ValueAuditRuntimeMetadataTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.audit.values;
+
+import static org.mockito.Mockito.mock;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata;
+import gobblin.audit.values.auditor.ValueAuditRuntimeMetadata.Phase;
+
+import org.apache.avro.Schema;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+@Test(groups = { "gobblin.audit.values" })
+public class ValueAuditRuntimeMetadataTest {
+
+  @Test
+  public void testBuilderWithDefaults() throws Exception {
+    Schema mockSchema = mock(Schema.class, Mockito.RETURNS_SMART_NULLS);
+    ValueAuditRuntimeMetadata runtimeMetadata = ValueAuditRuntimeMetadata.builder("db", "t", mockSchema).build();
+
+    Assert.assertEquals(runtimeMetadata.getTableMetadata().getDatabase(), "db");
+    Assert.assertEquals(runtimeMetadata.getTableMetadata().getTable(), "t");
+    Assert.assertEquals(runtimeMetadata.getTableMetadata().getTableSchema(), mockSchema);
+    Assert.assertEquals(runtimeMetadata.getCluster(), "NA");
+    Assert.assertEquals(runtimeMetadata.getDeltaId(), "NA");
+    Assert.assertEquals(runtimeMetadata.getExtractId(), "NA");
+    Assert.assertEquals(runtimeMetadata.getPartFileName(), "NA");
+    Assert.assertEquals(runtimeMetadata.getSnapshotId(), "NA");
+    Assert.assertEquals(runtimeMetadata.getPhase(), Phase.NA);
+
+  }
+
+  @Test
+  public void testBuilder() throws Exception {
+    Schema mockSchema = mock(Schema.class, Mockito.RETURNS_SMART_NULLS);
+    ValueAuditRuntimeMetadata runtimeMetadata =
+        ValueAuditRuntimeMetadata.builder("db", "t", mockSchema).cluster("c").deltaId("d").extractId("e")
+            .partFileName("p").phase(Phase.AVRO_CONV).snapshotId("s").build();
+
+    Assert.assertEquals(runtimeMetadata.getTableMetadata().getDatabase(), "db");
+    Assert.assertEquals(runtimeMetadata.getTableMetadata().getTable(), "t");
+    Assert.assertEquals(runtimeMetadata.getTableMetadata().getTableSchema(), mockSchema);
+    Assert.assertEquals(runtimeMetadata.getCluster(), "c");
+    Assert.assertEquals(runtimeMetadata.getDeltaId(), "d");
+    Assert.assertEquals(runtimeMetadata.getExtractId(), "e");
+    Assert.assertEquals(runtimeMetadata.getPartFileName(), "p");
+    Assert.assertEquals(runtimeMetadata.getSnapshotId(), "s");
+    Assert.assertEquals(runtimeMetadata.getPhase(), Phase.AVRO_CONV);
+
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -94,4 +94,30 @@ public class ConfigUtils {
     }
     return ConfigFactory.parseMap(immutableMapBuilder.build());
   }
+
+
+  /**
+   * Return string value at <code>path</code> if <code>config</code> has path. If not return an empty string
+   *
+   * @param config in which the path may be present
+   * @param path key to look for in the config object
+   * @return string value at <code>path</code> if <code>config</code> has path. If not return an empty string
+   */
+  public static String emptyIfNotPresent(Config config, String path) {
+    return getString(config, path, StringUtils.EMPTY);
+  }
+
+  /**
+   * Return string value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
+   *
+   * @param config in which the path may be present
+   * @param path key to look for in the config object
+   * @return string value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
+   */
+  public static String getString(Config config, String path, String def) {
+    if (config.hasPath(path)) {
+      return config.getString(path);
+    }
+    return def;
+  }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -12,7 +12,7 @@ def modules = ['gobblin-admin','gobblin-api','gobblin-azkaban','gobblin-compacti
                'gobblin-config-management','gobblin-core','gobblin-distribution',
                'gobblin-example','gobblin-hive-registration','gobblin-metrics','gobblin-metastore','gobblin-rest-service',
                'gobblin-runtime','gobblin-utility','gobblin-salesforce','gobblin-test-harness',
-               'gobblin-tunnel', 'gobblin-data-management','gobblin-config-management']
+               'gobblin-tunnel', 'gobblin-data-management','gobblin-config-management', 'gobblin-audit']
 
 modules.each { module ->
   include "${module}"


### PR DESCRIPTION
Added base interfaces for value auditing. The pr mainly has interfaces for 
- `RowSelectionPolicy` - An interface to decide if a row needs to be audited
- `ColomnProjectionPolicy` - An interface that projects certain columns/fields of an input {@link GenericRecord} to generate a new {@link GenericRecord} that can be audited.
- `AuditSink` - An interface for persisting value audits
- `ValueAuditGenerator` - The class that implements value based auditing. The class captures the values of certain columns from the rows in the dataset using the {@link ColumnProjectionPolicy}. This is done for every row or for a sample of the rows as defined by the {@link RowSelectionPolicy}
- The module that drives auditing will create an instance of `ValueAuditGenerator` for each avro file being written and called `ValueAuditGenerator.audit(GenericRecord)`

**The complete javadoc has been generated and hosted through github pages [here] (http://pcadabam.github.io/gobblin-audit-docs/) to easily navigate through the detailed documentation**

I am adding some unit tests while this is being reviewed. 
@chavdar  can you review?