### PR TITLE
New file sets in distcp will only be generated if there is space in t…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/ConcurrentBoundedWorkUnitList.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/ConcurrentBoundedWorkUnitList.java
@@ -25,6 +25,7 @@ import com.google.common.collect.Sets;
 
 import gobblin.data.management.partition.FileSet;
 import gobblin.source.workunit.WorkUnit;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -38,6 +39,7 @@ import gobblin.source.workunit.WorkUnit;
  *   (similar to {@link java.util.PriorityQueue}).
  * </p>
  */
+@Slf4j
 class ConcurrentBoundedWorkUnitList {
 
   private final TreeMap<FileSet<CopyEntity>, List<WorkUnit>> workUnitsMap;
@@ -130,6 +132,8 @@ class ConcurrentBoundedWorkUnitList {
     }
 
     this.currentSize += workUnits.size();
+    log.info(String.format("Added %d work units to bounded list. Total size: %d, limit: %d.", workUnits.size(),
+        this.currentSize, this.maxSize));
     return true;
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDatasetBase.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy;
+
+import gobblin.dataset.Dataset;
+
+
+/**
+ * A common superinterface for {@link Dataset}s that can be operated on by distcp.
+ * Concrete classes must implement a subinterface of this interface ({@link CopyableDataset} or {@link IterableCopyableDataset}).
+ */
+interface CopyableDatasetBase extends Dataset {
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDatasetMetadata.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableDatasetMetadata.java
@@ -30,7 +30,7 @@ import com.google.gson.Gson;
 @ToString
 public class CopyableDatasetMetadata {
 
-  public CopyableDatasetMetadata(CopyableDataset copyableDataset) {
+  public CopyableDatasetMetadata(CopyableDatasetBase copyableDataset) {
     this.datasetURN = copyableDataset.datasetURN();
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/IterableCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/IterableCopyableDataset.java
@@ -12,36 +12,28 @@
 
 package gobblin.data.management.copy;
 
-import gobblin.dataset.Dataset;
-
 import java.io.IOException;
-import java.util.Collection;
+import java.util.Iterator;
 
 import org.apache.hadoop.fs.FileSystem;
 
+import gobblin.data.management.partition.FileSet;
+
 
 /**
- * {@link Dataset} that supports finding {@link CopyEntity}s.
+ * A {@link CopyableDatasetBase} that returns {@link CopyEntity}s as an iterator. It allows for scanning for files to
+ * copy only when necessary. Reduces unnecessary work when the queue of {@link CopyEntity}s is full.
  */
-public interface CopyableDataset extends CopyableDatasetBase {
+public interface IterableCopyableDataset extends CopyableDatasetBase {
 
   /**
-   * Find all {@link CopyEntity}s in this dataset.
-   *
-   * <p>
-   *   This method should return a collection of {@link CopyEntity}, each describing one work unit for distcp.
-   *   The most common {@link CopyEntity} is the {@link gobblin.data.management.copy.CopyableDataset}, describing a file
-   *   that should be copied
-   *   to the target.
-   *   See {@link CopyableFile} for explanation of the information contained in the {@link CopyableFile}s.
-   * </p>
-   *
+   * Get an iterator of {@link FileSet}s of {@link CopyEntity}, each one representing a group of files to copy and
+   * associated actions.
    * @param targetFs target {@link org.apache.hadoop.fs.FileSystem} where copied files will be placed.
    * @param configuration {@link gobblin.data.management.copy.CopyConfiguration} for this job. See {@link gobblin.data.management.copy.CopyConfiguration}.
-   * @return List of {@link CopyEntity}s in this dataset.
    * @throws IOException
    */
-  public Collection<? extends CopyEntity> getCopyableFiles(FileSystem targetFs, CopyConfiguration configuration) throws
-      IOException;
+  public Iterator<FileSet<CopyEntity>> getFileSetIterator(FileSystem targetFs, CopyConfiguration configuration)
+      throws IOException;
 
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/IterableCopyableDatasetImpl.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/IterableCopyableDatasetImpl.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Maps;
+import gobblin.data.management.partition.FileSet;
+import gobblin.dataset.Dataset;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import org.apache.hadoop.fs.FileSystem;
+
+
+/**
+ * Wraps a {@link CopyableDataset} to produce an {@link IterableCopyableDataset}.
+ */
+@AllArgsConstructor
+public class IterableCopyableDatasetImpl implements IterableCopyableDataset {
+
+  private final CopyableDataset dataset;
+
+  @Override
+  public Iterator<FileSet<CopyEntity>> getFileSetIterator(FileSystem targetFs, CopyConfiguration configuration)
+      throws IOException {
+    return partitionCopyableFiles(this.dataset, this.dataset.getCopyableFiles(targetFs, configuration));
+  }
+
+  @Override
+  public String datasetURN() {
+    return this.dataset.datasetURN();
+  }
+
+  private Iterator<FileSet<CopyEntity>> partitionCopyableFiles(Dataset dataset, Collection<? extends CopyEntity> files) {
+    Map<String, FileSet.Builder<CopyEntity>> partitionBuildersMaps = Maps.newHashMap();
+    for (CopyEntity file : files) {
+      if (!partitionBuildersMaps.containsKey(file.getFileSet())) {
+        partitionBuildersMaps.put(file.getFileSet(), new FileSet.Builder<>(file.getFileSet(), dataset));
+      }
+      partitionBuildersMaps.get(file.getFileSet()).add(file);
+    }
+    return Iterators.transform(partitionBuildersMaps.values().iterator(),
+        new Function<FileSet.Builder<CopyEntity>, FileSet<CopyEntity>>() {
+          @Nullable
+          @Override public FileSet<CopyEntity> apply(FileSet.Builder<CopyEntity> input) {
+            return input.build();
+          }
+        });
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -12,6 +12,10 @@
 
 package gobblin.data.management.copy.hive;
 
+import com.google.common.collect.Iterators;
+import gobblin.data.management.copy.IterableCopyableDataset;
+import gobblin.data.management.partition.FileSet;
+import java.util.Iterator;
 import lombok.extern.slf4j.Slf4j;
 
 import java.io.IOException;
@@ -38,7 +42,7 @@ import gobblin.util.PathUtils;
  */
 @Slf4j
 @Alpha
-public class HiveDataset implements CopyableDataset {
+public class HiveDataset implements IterableCopyableDataset {
 
   protected final Properties properties;
   protected final FileSystem fs;
@@ -68,13 +72,13 @@ public class HiveDataset implements CopyableDataset {
    * Finds all files read by the table and generates CopyableFiles.
    * For the specific semantics see {@link HiveCopyEntityHelper#getCopyEntities}.
    */
-  @Override public Collection<CopyEntity> getCopyableFiles(FileSystem targetFs, CopyConfiguration configuration)
+  @Override public Iterator<FileSet<CopyEntity>> getFileSetIterator(FileSystem targetFs, CopyConfiguration configuration)
       throws IOException {
     try {
       return new HiveCopyEntityHelper(this, configuration, targetFs).getCopyEntities();
     } catch (IOException ioe) {
       log.error("Failed to copy table " + this.table, ioe);
-      return Lists.newArrayList();
+      return Iterators.emptyIterator();
     }
   }
 


### PR DESCRIPTION
This PR allows `CopyableDatasets` to instead implement `IterableCopyableDataset`, which returns an iterator of `FileSet`s instead of the entire list of `CopyEntities`. The file sets could be created only on demand, avoiding expensive operations that will be unused because the work unit list is full.