### PR TITLE
Stream datasets to distcp.

### DIFF
--- a/gobblin-api/src/main/java/gobblin/dataset/IterableDatasetFinder.java
+++ b/gobblin-api/src/main/java/gobblin/dataset/IterableDatasetFinder.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.dataset;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+
+/**
+ * A {@link DatasetsFinder} that can return the {@link Dataset}s as an {@link Iterator}. This allows {@link Dataset}s
+ * to be created on demand instead of all at once, possibly reducing memory usage and improving performance.
+ */
+public interface IterableDatasetFinder<T extends Dataset> extends DatasetsFinder<T> {
+
+  /**
+   * @return An {@link Iterator} over the {@link Dataset}s found.
+   * @throws IOException
+   */
+  public Iterator<T> getDatasetsIterator() throws IOException;
+
+}

--- a/gobblin-api/src/main/java/gobblin/dataset/IterableDatasetFinderImpl.java
+++ b/gobblin-api/src/main/java/gobblin/dataset/IterableDatasetFinderImpl.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.dataset;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+import lombok.AllArgsConstructor;
+import lombok.experimental.Delegate;
+
+
+/**
+ * Wraps a {@link DatasetsFinder} into an {@link IterableDatasetFinder}.
+ */
+@AllArgsConstructor
+public class IterableDatasetFinderImpl<T extends Dataset> implements IterableDatasetFinder<T> {
+
+  @Delegate
+  private final DatasetsFinder<T> datasetFinder;
+
+  @Override
+  public Iterator<T> getDatasetsIterator()
+      throws IOException {
+    return this.datasetFinder.findDatasets().iterator();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/dataset/DatasetUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/dataset/DatasetUtils.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.fs.PathFilter;
 
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.CopyableFileFilter;
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
+import gobblin.dataset.DatasetsFinder;
 
 
 /**
@@ -54,16 +54,16 @@ public class DatasetUtils {
   };
 
   /**
-   * Instantiate a {@link DatasetFinder}. The class of the {@link DatasetFinder} is read from property
+   * Instantiate a {@link DatasetsFinder}. The class of the {@link DatasetsFinder} is read from property
    * {@link #DATASET_PROFILE_CLASS_KEY}.
    *
-   * @param props Properties used for building {@link DatasetFinder}.
+   * @param props Properties used for building {@link DatasetsFinder}.
    * @param fs {@link FileSystem} where datasets are located.
-   * @return A new instance of {@link DatasetFinder}.
+   * @return A new instance of {@link DatasetsFinder}.
    * @throws IOException
    */
   @SuppressWarnings("unchecked")
-  public static <T extends gobblin.dataset.Dataset> DatasetFinder<T> instantiateDatasetFinder(Properties props, FileSystem fs,
+  public static <T extends gobblin.dataset.Dataset> DatasetsFinder<T> instantiateDatasetFinder(Properties props, FileSystem fs,
       String def) throws IOException {
     String className = def;
     if (props.containsKey(DATASET_PROFILE_CLASS_KEY)) {
@@ -71,7 +71,7 @@ public class DatasetUtils {
     }
     try {
       Class<?> datasetFinderClass = Class.forName(className);
-      return (DatasetFinder<T>) datasetFinderClass.getConstructor(FileSystem.class, Properties.class).newInstance(fs,
+      return (DatasetsFinder<T>) datasetFinderClass.getConstructor(FileSystem.class, Properties.class).newInstance(fs,
           props);
     } catch (ClassNotFoundException exception) {
       throw new IOException(exception);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/finder/DatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/finder/DatasetFinder.java
@@ -13,10 +13,13 @@
 package gobblin.data.management.retention.dataset.finder;
 
 import gobblin.dataset.Dataset;
+import gobblin.dataset.DatasetsFinder;
 
 
 /**
  * {@inheritDoc}
+ * @deprecated use {@link DatasetsFinder}
  */
-public interface DatasetFinder<T extends Dataset> extends gobblin.dataset.DatasetsFinder<T> {
+@Deprecated
+public interface DatasetFinder<T extends Dataset> extends DatasetsFinder<T> {
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigurableGlobDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigurableGlobDatasetFinder.java
@@ -32,16 +32,16 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.data.management.retention.DatasetCleaner;
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
 import gobblin.dataset.Dataset;
+import gobblin.dataset.DatasetsFinder;
 import gobblin.util.PathUtils;
 
 
 /**
- * A configurable {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} that looks for
+ * A configurable {@link DatasetsFinder} that looks for
  * {@link gobblin.data.management.retention.dataset.CleanableDataset}s using a glob pattern.
  */
-public abstract class ConfigurableGlobDatasetFinder<T extends Dataset> implements DatasetFinder<T> {
+public abstract class ConfigurableGlobDatasetFinder<T extends Dataset> implements DatasetsFinder<T> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurableGlobDatasetFinder.class);
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ModificationTimeDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ModificationTimeDatasetProfile.java
@@ -22,7 +22,7 @@ import gobblin.data.management.retention.dataset.ModificationTimeDataset;
 
 
 /**
- * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for {@link ModificationTimeDataset}s.
+ * {@link gobblin.dataset.DatasetsFinder} for {@link ModificationTimeDataset}s.
  *
  * Modification time datasets will be cleaned by the modification timestamps of the datasets that match
  * 'gobblin.retention.dataset.pattern'.

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -34,7 +34,6 @@ import gobblin.config.client.api.ConfigStoreFactoryDoesNotExistsException;
 import gobblin.config.client.api.VersionStabilityPolicy;
 import gobblin.config.store.api.ConfigStoreCreationException;
 import gobblin.config.store.api.VersionDoesNotExistException;
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
 import gobblin.dataset.Dataset;
 import gobblin.dataset.DatasetsFinder;
 
@@ -67,7 +66,7 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
 
       if (jobProps.containsKey(datasetFinderClassKey())) {
         try {
-          this.datasetFinders.add((DatasetFinder) ConstructorUtils.invokeConstructor(
+          this.datasetFinders.add((DatasetsFinder) ConstructorUtils.invokeConstructor(
               Class.forName(jobProps.getProperty(datasetFinderClassKey())), fs, jobProps));
           log.info(String.format("Instantiated datasetfinder %s ", jobProps.getProperty(datasetFinderClassKey())));
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
@@ -86,7 +85,7 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
 
           try {
             this.datasetFinders
-                .add((DatasetFinder) ConstructorUtils.invokeConstructor(
+                .add((DatasetsFinder) ConstructorUtils.invokeConstructor(
                     Class.forName(datasetClassConfig.getString(datasetFinderClassKey())), fs, jobProps,
                     datasetClassConfig));
             log.info(String.format("Instantiated datasetfinder %s for %s.",

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/RawDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/RawDatasetProfile.java
@@ -26,7 +26,7 @@ import gobblin.data.management.retention.version.DatasetVersion;
 
 
 /**
- * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for raw datasets.
+ * {@link gobblin.dataset.DatasetsFinder} for raw datasets.
  *
  * <p>
  *   A raw dataset is a dataset with a corresponding refined dataset.

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/SnapshotDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/SnapshotDatasetProfile.java
@@ -22,7 +22,7 @@ import gobblin.data.management.retention.dataset.SnapshotDataset;
 import gobblin.dataset.Dataset;
 
 /**
- * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for snapshot datasets.
+ * {@link gobblin.dataset.DatasetsFinder} for snapshot datasets.
  *
  * <p>
  *   Snapshot datasets are datasets where each version is a snapshot/full-dump of a dataset (e.g. a database).

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/TrackingDatasetProfile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/TrackingDatasetProfile.java
@@ -25,7 +25,7 @@ import gobblin.data.management.retention.version.finder.DateTimeDatasetVersionFi
 
 
 /**
- * {@link gobblin.data.management.retention.dataset.finder.DatasetFinder} for tracking datasets.
+ * {@link gobblin.dataset.DatasetsFinder} for tracking datasets.
  *
  * <p>
  *   Tracking datasets are datasets where each data point represents a timestamped action, and the records are

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyableDatasetFinder.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyableDatasetFinder.java
@@ -12,8 +12,6 @@
 
 package gobblin.data.management.copy;
 
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
@@ -23,8 +21,10 @@ import org.apache.hadoop.fs.Path;
 
 import com.google.common.collect.Lists;
 
+import gobblin.dataset.DatasetsFinder;
 
-public class TestCopyableDatasetFinder implements DatasetFinder<CopyableDataset> {
+
+public class TestCopyableDatasetFinder implements DatasetsFinder<CopyableDataset> {
 
   public TestCopyableDatasetFinder(FileSystem fs, Properties pros) throws IOException {
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyablePartitionableDatasedFinder.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/TestCopyablePartitionableDatasedFinder.java
@@ -12,9 +12,6 @@
 
 package gobblin.data.management.copy;
 
-import gobblin.data.management.copy.CopyableDataset;
-import gobblin.data.management.retention.dataset.finder.DatasetFinder;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
@@ -24,8 +21,10 @@ import org.apache.hadoop.fs.Path;
 
 import com.google.common.collect.Lists;
 
+import gobblin.dataset.DatasetsFinder;
 
-public class TestCopyablePartitionableDatasedFinder implements DatasetFinder<CopyableDataset> {
+
+public class TestCopyablePartitionableDatasedFinder implements DatasetsFinder<CopyableDataset> {
 
   public TestCopyablePartitionableDatasedFinder(FileSystem fs, Properties props) {
   }

--- a/gobblin-utility/src/main/java/gobblin/util/executors/IteratorExecutor.java
+++ b/gobblin-utility/src/main/java/gobblin/util/executors/IteratorExecutor.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.executors;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutorCompletionService;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+
+import com.google.common.collect.Lists;
+
+
+/**
+ * Executes tasks in an {@link Iterator}. Tasks need not be generated until they can be executed.
+ * @param <T>
+ */
+public class IteratorExecutor<T> {
+
+  private final CompletionService<T> completionService;
+  private final int numThreads;
+  private final ExecutorService executor;
+  private final Iterator<Callable<T>> iterator;
+
+  public IteratorExecutor(Iterator<Callable<T>> runnableIterator, int numThreads, ThreadFactory threadFactory) {
+    this.numThreads = numThreads;
+    this.iterator = runnableIterator;
+    this.executor = Executors.newFixedThreadPool(numThreads, threadFactory);
+    this.completionService = new ExecutorCompletionService<>(this.executor);
+  }
+
+  /**
+   * Execute the tasks in the task {@link Iterator}. Blocks until all tasks are completed.
+   * @return a list of completed futures.
+   * @throws InterruptedException
+   */
+  public List<Future<T>> execute() throws InterruptedException {
+    List<Future<T>> futures = Lists.newArrayList();
+    int activeTasks = 0;
+    while (this.iterator.hasNext()) {
+      futures.add(this.completionService.submit(this.iterator.next()));
+      activeTasks++;
+      if (activeTasks == this.numThreads) {
+        this.completionService.take();
+        activeTasks--;
+      }
+    }
+    while (activeTasks > 0) {
+      this.completionService.take();
+      activeTasks--;
+    }
+
+    this.completionService.poll();
+    return futures;
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/util/iterators/InterruptibleIterator.java
+++ b/gobblin-utility/src/main/java/gobblin/util/iterators/InterruptibleIterator.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.iterators;
+
+import java.util.Iterator;
+import java.util.NoSuchElementException;
+import java.util.concurrent.Callable;
+
+import lombok.RequiredArgsConstructor;
+
+
+/**
+ * An iterator that allows ending prematurely (i.e. {@link #hasNext()} becomes false) if a boolean {@link Callable}
+ * becomes true.
+ */
+@RequiredArgsConstructor
+public class InterruptibleIterator<T> implements Iterator<T> {
+
+  private final Iterator<T> iterator;
+  private final Callable<Boolean> interrupt;
+
+  /** Set to true when user calls {@link #hasNext()} to indicate we can no longer interrupt.*/
+  private boolean promisedNext = false;
+
+  @Override
+  public boolean hasNext() {
+    try {
+      if (this.promisedNext || (this.iterator.hasNext() && !this.interrupt.call())) {
+        this.promisedNext = true;
+        return true;
+      }
+      return false;
+    } catch (Exception exception) {
+      throw new RuntimeException(exception);
+    }
+  }
+
+  @Override
+  public T next() {
+    if (hasNext()) {
+      this.promisedNext = false;
+      return this.iterator.next();
+    }
+
+    throw new NoSuchElementException();
+  }
+
+  @Override
+  public void remove() {
+    this.iterator.remove();
+  }
+}

--- a/gobblin-utility/src/test/java/gobblin/util/executors/IteratorExecutorTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/executors/IteratorExecutorTest.java
@@ -1,0 +1,152 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.executors;
+
+import java.util.Iterator;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+
+public class IteratorExecutorTest {
+
+  private final AtomicInteger nextCallCount = new AtomicInteger(0);
+  private final AtomicInteger completedCount = new AtomicInteger(0);
+
+  @Test
+  public void test() throws Exception {
+
+    TestIterator iterator = new TestIterator(5);
+
+    final IteratorExecutor<Void> executor = new IteratorExecutor<>(iterator, 2, new ThreadFactoryBuilder().build());
+
+    ExecutorService singleThread = Executors.newSingleThreadExecutor();
+    Future future = singleThread.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          executor.execute();
+        } catch (InterruptedException ie) {
+          throw new RuntimeException(ie);
+        }
+      }
+    });
+
+    // Only two threads, so exactly two tasks retrieved
+    verify(2, 0);
+    Assert.assertFalse(future.isDone());
+    Assert.assertTrue(iterator.hasNext());
+
+    // end one of the tasks
+    iterator.endOneCallable();
+
+    // three tasks retrieved, one completed
+    verify(3, 1);
+    Assert.assertFalse(future.isDone());
+    Assert.assertTrue(iterator.hasNext());
+
+    // end two tasks
+    iterator.endOneCallable();
+    iterator.endOneCallable();
+
+    // 5 (all) tasks retrieved, 3 completed
+    verify(5, 3);
+    Assert.assertFalse(future.isDone());
+    Assert.assertFalse(iterator.hasNext());
+
+    // end two tasks
+    iterator.endOneCallable();
+    iterator.endOneCallable();
+
+    // all tasks completed, check future is done
+    verify(5, 5);
+    Assert.assertTrue(future.isDone());
+
+  }
+
+  /**
+   * Verify exactly retrieved tasks have been retrieved, and exactly completed tasks have completed.
+   * @throws Exception
+   */
+  private void verify(int retrieved, int completed) throws Exception {
+    for (int i = 0; i < 20; i++) {
+      if (nextCallCount.get() >= retrieved || completedCount.get() >= completed) {
+        break;
+      }
+      Thread.sleep(100);
+    }
+    Thread.sleep(100);
+    Assert.assertEquals(nextCallCount.get(), retrieved);
+    Assert.assertEquals(completedCount.get(), completed);
+  }
+
+  /**
+   * Runnable iterator. Runnables block until a call to {@link #endOneCallable()}.
+   */
+  private class TestIterator implements Iterator<Callable<Void>> {
+
+    private final int maxCallables;
+    private Lock lock = new ReentrantLock();
+    private Condition condition = lock.newCondition();
+
+    public TestIterator(int maxCallables) {
+      this.maxCallables = maxCallables;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return nextCallCount.get() < maxCallables;
+    }
+
+    @Override
+    public Callable<Void> next() {
+      nextCallCount.incrementAndGet();
+
+      return new Callable<Void>() {
+        @Override
+        public Void call()
+            throws Exception {
+
+          lock.lock();
+          condition.await();
+          lock.unlock();
+
+          completedCount.incrementAndGet();
+          return null;
+        }
+      };
+    }
+
+    public void endOneCallable() {
+      lock.lock();
+      condition.signal();
+      lock.unlock();
+    }
+
+    @Override
+    public void remove() {
+      throw new UnsupportedOperationException();
+    }
+  }
+
+}


### PR DESCRIPTION
This PR enables streaming of datasets to distcp using an iterator. It implements an `IterableDatasetFinder` that returns datasets as an iterator. Distcp only consumes as many datasets at a time as copy listing threads are available.
This allows controlling memory footprint (ie datasets are created on demand when needed, whereas before, all datasets needed to exist in memory at the same time).