### PR TITLE
Distcp on Hive supports predicates for fast partition skips, and supp…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
@@ -17,8 +17,6 @@ import java.io.IOException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import lombok.Getter;
-
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -33,13 +31,20 @@ import com.google.common.cache.CacheBuilder;
  */
 public class CopyContext {
 
-  @Getter
+  /**
+   * Cache for {@link FileStatus}es for various paths in {@link org.apache.hadoop.fs.FileSystem}s. Used to reduce
+   * the number of calls to {@link org.apache.hadoop.fs.FileSystem#getFileStatus} when replicating attributes. Keys
+   * should be fully qualified paths in case multiple {@link org.apache.hadoop.fs.FileSystem}s are in use.
+   */
   private final Cache<Path, Optional<FileStatus>> fileStatusCache;
 
   public CopyContext() {
     this.fileStatusCache = CacheBuilder.newBuilder().build();
   }
 
+  /**
+   * Get cached {@link FileStatus}.
+   */
   public Optional<FileStatus> getFileStatus(final FileSystem fs, final Path path) throws IOException {
     try {
       return this.fileStatusCache.get(fs.makeQualified(path), new Callable<Optional<FileStatus>>() {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursivePathFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursivePathFinder.java
@@ -44,9 +44,13 @@ public class RecursivePathFinder {
 
     this.pathFilter = DatasetUtils.instantiatePathFilter(properties);
   }
-  
+
   public Set<Path> getPaths() throws IOException{
     Set<Path> result = new HashSet<Path>();
+
+    if (!this.fs.exists(this.rootPath)) {
+      return result;
+    }
 
     List<FileStatus> files = FileListUtils.listFilesRecursively(this.fs, this.rootPath, this.pathFilter);
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/AlwaysTrue.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/AlwaysTrue.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.predicates;
+
+import com.google.common.base.Predicate;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * Predicate that is always true.
+ */
+public class AlwaysTrue<T> implements Predicate<T> {
+
+  @Override
+  public boolean apply(@Nullable T input) {
+    return true;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RootDirectoryModtimeSkipPredicate.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RootDirectoryModtimeSkipPredicate.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.predicates;
+
+import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+
+import gobblin.data.management.copy.CopyContext;
+import gobblin.data.management.copy.hive.HiveCopyEntityHelper;
+import gobblin.util.PathUtils;
+
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Use with {@link HiveCopyEntityHelper#FAST_PARTITION_SKIP_PREDICATE}.
+ * Skips partitions whose data location exists in the target, and such that the target location has a newer mod time
+ * than the source location.
+ */
+@AllArgsConstructor
+@Slf4j
+public class RootDirectoryModtimeSkipPredicate implements Predicate<Partition> {
+
+  private HiveCopyEntityHelper helper;
+
+  @Override
+  public boolean apply(@Nullable Partition input) {
+
+    if (input == null) {
+      return true;
+    }
+
+    try {
+
+      if (PathUtils.isGlob(input.getDataLocation())) {
+        log.error(String.format("%s cannot be applied to globbed location %s. Will not skip.", this.getClass().getSimpleName(),
+            input.getDataLocation()));
+        return false;
+      }
+
+      Path targetPath = this.helper.getTargetFileSystem().makeQualified(
+          this.helper.getTargetPath(input.getDataLocation(), this.helper.getTargetFs(), Optional.of(input), false));
+
+      Optional<FileStatus> targetFileStatus =
+          this.helper.getConfiguration().getCopyContext().getFileStatus(this.helper.getTargetFs(), targetPath);
+
+      if (!targetFileStatus.isPresent()) {
+        return false;
+      }
+
+      Optional<FileStatus> sourceFileStatus = this.helper.getConfiguration().getCopyContext().
+          getFileStatus(this.helper.getDataset().getFs(), input.getDataLocation());
+
+
+      if (!sourceFileStatus.isPresent()) {
+        throw new RuntimeException(String.format("Source path %s does not exist!", input.getDataLocation()));
+      }
+
+      return targetFileStatus.get().getModificationTime() > sourceFileStatus.get().getModificationTime();
+
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+
+  }
+
+}


### PR DESCRIPTION
…orts copying full directories recursively.

* Allow skipping partitions for Hive copy based on a predicate.
* Allow listing files on partition recursively from base directory instead of using input format.