### PR TITLE
Fix issue with replicating owner and permission of system directories…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
@@ -42,18 +42,16 @@ public class CopyConfiguration {
    * User supplied directory where files should be published. This value is identical for all datasets in the distcp job.
    */
   private final Path publishDir;
-
   /**
    * Preserve options passed by the user.
    */
   private final PreserveAttributes preserve;
-
   /**
    * {@link CopyContext} for this job.
    */
   private final CopyContext copyContext;
-
   private final Optional<String> targetGroup;
+  private final FileSystem targetFs;
 
   public static class CopyConfigurationBuilder {
 
@@ -62,7 +60,7 @@ public class CopyConfiguration {
     private CopyContext copyContext;
     private Path publishDir;
 
-    public CopyConfigurationBuilder(FileSystem fs, Properties properties) {
+    public CopyConfigurationBuilder(FileSystem targetFs, Properties properties) {
 
       Preconditions.checkArgument(properties.containsKey(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR),
           "Missing property " + ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR);
@@ -73,15 +71,16 @@ public class CopyConfiguration {
       this.preserve = PreserveAttributes.fromMnemonicString(properties.getProperty(PRESERVE_ATTRIBUTES_KEY));
       Path publishDirTmp = new Path(properties.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR));
       if (!publishDirTmp.isAbsolute()) {
-        publishDirTmp = new Path(fs.getWorkingDirectory(), publishDirTmp);
+        publishDirTmp = new Path(targetFs.getWorkingDirectory(), publishDirTmp);
       }
       this.publishDir = publishDirTmp;
       this.copyContext = new CopyContext();
+      this.targetFs = targetFs;
     }
   }
 
-  public static CopyConfigurationBuilder builder(FileSystem fs, Properties properties) {
-    return new CopyConfigurationBuilder(fs, properties);
+  public static CopyConfigurationBuilder builder(FileSystem targetFs, Properties properties) {
+    return new CopyConfigurationBuilder(targetFs, properties);
   }
 
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
@@ -12,10 +12,18 @@
 
 package gobblin.data.management.copy;
 
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+
 import lombok.Getter;
 
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
@@ -25,16 +33,29 @@ import com.google.common.cache.CacheBuilder;
  */
 public class CopyContext {
 
-  /**
-   * Cache for {@link OwnerAndPermission} for various paths in {@link org.apache.hadoop.fs.FileSystem}s. Used to reduce
-   * the number of calls to {@link org.apache.hadoop.fs.FileSystem#getFileStatus} when replicating attributes. Keys
-   * should be fully qualified paths in case multiple {@link org.apache.hadoop.fs.FileSystem}s are in use.
-   */
   @Getter
-  private final Cache<Path, OwnerAndPermission> ownerAndPermissionCache;
+  private final Cache<Path, Optional<FileStatus>> fileStatusCache;
 
   public CopyContext() {
-    this.ownerAndPermissionCache = CacheBuilder.newBuilder().build();
+    this.fileStatusCache = CacheBuilder.newBuilder().build();
+  }
+
+  public Optional<FileStatus> getFileStatus(final FileSystem fs, final Path path) throws IOException {
+    try {
+      return this.fileStatusCache.get(fs.makeQualified(path), new Callable<Optional<FileStatus>>() {
+        @Override
+        public Optional<FileStatus> call()
+            throws Exception {
+          try {
+            return Optional.of(fs.getFileStatus(path));
+          } catch (FileNotFoundException fnfe) {
+            return Optional.absent();
+          }
+        }
+      });
+    } catch (ExecutionException ee) {
+      throw new IOException(ee.getCause());
+    }
   }
 
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
@@ -20,8 +20,6 @@ import gobblin.util.guid.Guid;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutionException;
 
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
@@ -35,6 +33,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 
@@ -163,9 +162,10 @@ public class CopyableFile extends CopyEntity implements File {
      *   * {@link CopyableFile#destinationOwnerAndPermission}: Copy attributes from origin {@link FileStatus} depending
      *       on the {@link PreserveAttributes} flags {@link #preserve}. Non-preserved attributes are left null,
      *       allowing Gobblin distcp to use defaults for the target {@link FileSystem}.
-     *   * {@link CopyableFile#ancestorsOwnerAndPermission}: Copy attributes from ancestors of origin path depending
-     *       on the {@link PreserveAttributes} flags {@link #preserve}. Non-preserved attributes are left null,
-     *       allowing Gobblin distcp to use defaults for the target {@link FileSystem}.
+     *   * {@link CopyableFile#ancestorsOwnerAndPermission}: Copy attributes from ancestors of origin path whose name
+     *       exactly matches the corresponding name in the target path and which don't exist on th target. The actual
+     *       owner and permission depend on the {@link PreserveAttributes} flags {@link #preserve}.
+     *       Non-preserved attributes are left null, allowing Gobblin distcp to use defaults for the target {@link FileSystem}.
      *   * {@link CopyableFile#checksum}: the checksum of the origin {@link FileStatus} obtained using the origin
      *       {@link FileSystem}.
      *   * {@link CopyableFile#fileSet}: empty string. Used as default file set per dataset.
@@ -196,7 +196,8 @@ public class CopyableFile extends CopyEntity implements File {
             new OwnerAndPermission(owner, group, permission);
       }
       if (this.ancestorsOwnerAndPermission == null) {
-        this.ancestorsOwnerAndPermission = replicateOwnerAndPermission(this.originFs, this.origin.getPath(), this.preserve);
+        this.ancestorsOwnerAndPermission = replicateAncestorsOwnerAndPermission(this.originFs, this.origin.getPath(),
+            this.configuration.getTargetFs(), this.destination);
       }
       if (this.checksum == null) {
         FileChecksum checksumTmp = this.originFs.getFileChecksum(origin.getPath());
@@ -218,40 +219,85 @@ public class CopyableFile extends CopyEntity implements File {
           this.originTimestamp, this.upstreamTimestamp, this.additionalMetadata);
     }
 
-    private List<OwnerAndPermission> replicateOwnerAndPermission(final FileSystem originFs, final Path path,
-        PreserveAttributes preserve) throws IOException {
+    private List<OwnerAndPermission> replicateAncestorsOwnerAndPermission(FileSystem originFs, Path originPath,
+        FileSystem targetFs, Path destinationPath) throws IOException {
 
       List<OwnerAndPermission> ancestorOwnerAndPermissions = Lists.newArrayList();
-      try {
-        Path currentPath = PathUtils.getPathWithoutSchemeAndAuthority(path);
-        while (currentPath != null && currentPath.getParent() != null) {
-          currentPath = currentPath.getParent();
-          final Path thisPath = currentPath;
-          OwnerAndPermission ownerAndPermission = this.configuration.getCopyContext().getOwnerAndPermissionCache()
-              .get(originFs.makeQualified(currentPath),
-                  new Callable<OwnerAndPermission>() {
-                    @Override public OwnerAndPermission call() throws Exception {
-                      FileStatus fs = originFs.getFileStatus(thisPath);
-                      return new OwnerAndPermission(fs.getOwner(), fs.getGroup(), fs.getPermission());
-                    }
-                  });
 
-          String group = null;
-          if (this.preserve.preserve(Option.GROUP)) {
-            group = ownerAndPermission.getGroup();
-          } else if (this.configuration.getTargetGroup().isPresent()) {
-            group = this.configuration.getTargetGroup().get();
-          }
-          ancestorOwnerAndPermissions.add(new OwnerAndPermission(
-              preserve.preserve(Option.OWNER) ? ownerAndPermission.getOwner() : null, group,
-              preserve.preserve(Option.PERMISSION) ? ownerAndPermission.getFsPermission() : null));
+      Path currentOriginPath = originPath.getParent();
+      Path currentTargetPath = destinationPath.getParent();
+
+      while (currentOriginPath != null && currentTargetPath != null &&
+          currentOriginPath.getName().equals(currentTargetPath.getName())) {
+
+        Optional<FileStatus> targetFileStatus = this.configuration.getCopyContext().getFileStatus(targetFs, currentTargetPath);
+
+        if (targetFileStatus.isPresent()) {
+          return ancestorOwnerAndPermissions;
         }
-      } catch (ExecutionException ee) {
-        throw new IOException(ee.getCause());
+
+        ancestorOwnerAndPermissions.add(resolveReplicatedOwnerAndPermission(originFs, currentOriginPath,
+            this.configuration));
+
+        currentOriginPath = currentOriginPath.getParent();
+        currentTargetPath = currentTargetPath.getParent();
       }
+
       return ancestorOwnerAndPermissions;
     }
 
+  }
+
+  /**
+   * Computes the correct {@link OwnerAndPermission} obtained from replicating source owner and permissions and applying
+   * the {@link PreserveAttributes} rules in copyConfiguration.
+   * @throws IOException
+   */
+  public static OwnerAndPermission resolveReplicatedOwnerAndPermission(FileSystem fs, Path path,
+      CopyConfiguration copyConfiguration) throws IOException {
+
+    PreserveAttributes preserve = copyConfiguration.getPreserve();
+    Optional<FileStatus> originFileStatus = copyConfiguration.getCopyContext().getFileStatus(fs, path);
+
+    if (!originFileStatus.isPresent()) {
+      throw new IOException(String.format("Origin path %s does not exist.", originFileStatus));
+    }
+
+    String group = null;
+    if (copyConfiguration.getTargetGroup().isPresent()) {
+      group = copyConfiguration.getTargetGroup().get();
+    } else if (preserve.preserve(Option.GROUP)) {
+      group = originFileStatus.get().getGroup();
+    }
+
+    return new OwnerAndPermission(
+        preserve.preserve(Option.OWNER) ? originFileStatus.get().getOwner() : null, group,
+        preserve.preserve(Option.PERMISSION) ? originFileStatus.get().getPermission() : null);
+  }
+
+  /**
+   * Compute the correct {@link OwnerAndPermission} obtained from replicating source owner and permissions and applying
+   * the {@link PreserveAttributes} rules for fromPath and every ancestor up to but excluding toPath.
+   *
+   * @return A list of the computed {@link OwnerAndPermission}s starting from fromPath, up to but excluding toPath.
+   * @throws IOException if toPath is not an ancestor of fromPath.
+   */
+  public static List<OwnerAndPermission> resolveReplicatedOwnerAndPermissionsRecursively(FileSystem fs, Path fromPath,
+      Path toPath, CopyConfiguration copyConfiguration) throws IOException {
+
+    if (!PathUtils.isAncestor(toPath, fromPath)) {
+      throw new IOException(String.format("toPath %s must be an ancestor of fromPath %s.", toPath, fromPath));
+    }
+
+    List<OwnerAndPermission> ownerAndPermissions = Lists.newArrayList();
+    Path currentPath = fromPath;
+
+    while (PathUtils.isAncestor(toPath, currentPath.getParent())) {
+      ownerAndPermissions.add(resolveReplicatedOwnerAndPermission(fs, currentPath, copyConfiguration));
+      currentPath = currentPath.getParent();
+    }
+
+    return ownerAndPermissions;
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursiveCopyableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursiveCopyableDataset.java
@@ -68,7 +68,9 @@ public class RecursiveCopyableDataset implements CopyableDataset, FileSystemData
       Path targetPath = new Path(configuration.getPublishDir(), filePathRelativeToSearchPath);
 
       copyableFiles.add(CopyableFile.fromOriginAndDestination(this.fs, file, targetPath, configuration).
-          fileSet(file.getPath().getParent().toString()).build());
+          fileSet(file.getPath().getParent().toString()).
+          ancestorsOwnerAndPermission(CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(this.fs,
+              file.getPath(), nonGlobSearchPath, configuration)).build());
     }
     return copyableFileFilter.filter(this.fs, targetFs, copyableFiles);
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/RecursiveCopyableDatasetTest.java
@@ -65,7 +65,8 @@ public class RecursiveCopyableDatasetTest {
       Assert.assertTrue(paths.contains(originRelativePath));
       Assert.assertTrue(paths.contains(targetRelativePath));
       Assert.assertEquals(originRelativePath, targetRelativePath);
-      Assert.assertEquals(file.getAncestorsOwnerAndPermission().size(), file.getOrigin().getPath().depth());
+      int ancestorOAP = PathUtils.relativizePath(file.getOrigin().getPath(), new Path(baseDir)).depth();
+      Assert.assertEquals(file.getAncestorsOwnerAndPermission().size(), ancestorOAP);
     }
 
   }


### PR DESCRIPTION
… in distcp.

Distcp was trying to set unnecessary permissions and groups the user was not allowed to set in the staging directory. The cause is that we replicate ancestor permissions, and previously it was replicating all ancestors up to root path. At publish time this is not an issue because paths like "/" and "/data" already exist and we don't overwrite them. However, in the staging directory we recreate this structure and attempt to set the same permissions, so we would create "/path/to/staging/directory/data" with group "hdfs", which user is not allowed to set.

This PR restricts the default permission replication to only directories that don't exist on the target, and for the RecursiveCopyableDataset it only sets permissions between the non-globbed input path and the target path.