### PR TITLE
Hive registration: use full path, make it possible to disable

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveSnapshotRegistrationPolicy.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveSnapshotRegistrationPolicy.java
@@ -13,15 +13,12 @@
 package gobblin.hive.policy;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.regex.Pattern;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 
@@ -46,16 +43,10 @@ public class HiveSnapshotRegistrationPolicy extends HiveRegistrationPolicyBase {
 
   public static final String SNAPSHOT_PATH_PATTERN = "snapshot.path.pattern";
 
-  protected final FileSystem fs;
   protected final Optional<Pattern> snapshotPathPattern;
 
   protected HiveSnapshotRegistrationPolicy(State props) throws IOException {
     super(props);
-    if (props.contains(HiveRegistrationPolicyBase.HIVE_FS_URI)) {
-      this.fs = FileSystem.get(URI.create(props.getProp(HiveRegistrationPolicyBase.HIVE_FS_URI)), new Configuration());
-    } else {
-      this.fs = FileSystem.get(new Configuration());
-    }
     this.snapshotPathPattern = props.contains(SNAPSHOT_PATH_PATTERN)
         ? Optional.of(Pattern.compile(props.getProp(SNAPSHOT_PATH_PATTERN))) : Optional.<Pattern> absent();
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.Subscribe;
@@ -445,7 +446,8 @@ public class JobContext {
         JobCommitPolicy.getCommitPolicy(state.getProperties()) == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS;
     boolean publishDataAtJobLevel = state.getPropAsBoolean(ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL,
         ConfigurationKeys.DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL);
-    boolean jobDataPublisherSpecified = state.contains(ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE);
+    boolean jobDataPublisherSpecified =
+        !Strings.isNullOrEmpty(state.getProp(ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE));
     return jobCommitPolicyIsFull || publishDataAtJobLevel || jobDataPublisherSpecified;
   }
 


### PR DESCRIPTION
- Use full path in table location
- Make it possible to disable Hive registration by specifying an empty `data.publisher.job.type`