### PR TITLE
Add typesafe support to glob version finder for audit retention. Add …

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -36,11 +36,11 @@ dependencies {
   compile externalDependency.commonsCodec
   compile externalDependency.typesafeConfig
   compile externalDependency.findBugsAnnotations
+  compile externalDependency.testng
 
   testCompile externalDependency.calciteCore
   testCompile externalDependency.calciteAvatica
   testCompile externalDependency.jhyde
-  testCompile externalDependency.testng
   testCompile externalDependency.mockito
   testCompile externalDependency.joptSimple
   testCompile externalDependency.hamcrest

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigurableGlobDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ConfigurableGlobDatasetFinder.java
@@ -34,6 +34,7 @@ import com.typesafe.config.ConfigFactory;
 import gobblin.data.management.retention.DatasetCleaner;
 import gobblin.dataset.Dataset;
 import gobblin.dataset.DatasetsFinder;
+import gobblin.util.ConfigUtils;
 import gobblin.util.PathUtils;
 
 
@@ -68,11 +69,13 @@ public abstract class ConfigurableGlobDatasetFinder<T extends Dataset> implement
 
   public ConfigurableGlobDatasetFinder(FileSystem fs, Properties jobProps, Config config) throws IOException {
     for (String property : requiredProperties()) {
-      Preconditions.checkArgument(config.hasPath(property) || config.hasPath(DEPRECATIONS.get(property)));
+      Preconditions.checkArgument(config.hasPath(property) || config.hasPath(DEPRECATIONS.get(property)), String.format("Missing required property %s", property));
     }
 
-    if (config.hasPath(DATASET_BLACKLIST_KEY)) {
+    if (ConfigUtils.hasNonEmptyPath(config, DATASET_BLACKLIST_KEY)) {
       this.blacklist = Optional.of(Pattern.compile(config.getString(DATASET_BLACKLIST_KEY)));
+    } else if (ConfigUtils.hasNonEmptyPath(config, DATASET_FINDER_BLACKLIST_KEY)) {
+      this.blacklist = Optional.of(Pattern.compile(config.getString(DATASET_FINDER_BLACKLIST_KEY)));
     } else {
       this.blacklist = Optional.absent();
     }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ManagedCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/ManagedCleanableDatasetFinder.java
@@ -42,8 +42,12 @@ public class ManagedCleanableDatasetFinder extends ConfigurableGlobDatasetFinder
   private final ConfigClient client;
 
   public ManagedCleanableDatasetFinder(FileSystem fs, Properties jobProps, Config config) throws IOException {
+    this(fs, jobProps, config, ConfigClientCache.getClient(VersionStabilityPolicy.STRONG_LOCAL_STABILITY));
+  }
+
+  public ManagedCleanableDatasetFinder(FileSystem fs, Properties jobProps, Config config, ConfigClient client) throws IOException {
     super(fs, jobProps, config);
-    this.client = ConfigClientCache.getClient(VersionStabilityPolicy.STRONG_LOCAL_STABILITY);
+    this.client = client;
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/GlobModTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/GlobModTimeDatasetVersionFinder.java
@@ -14,8 +14,10 @@ package gobblin.data.management.retention.version.finder;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+import com.typesafe.config.Config;
+
 import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
 
 
 /**
@@ -26,6 +28,12 @@ import gobblin.data.management.retention.version.DatasetVersion;
 public class GlobModTimeDatasetVersionFinder extends DatasetVersionFinder<TimestampedDatasetVersion> {
 
   private final gobblin.data.management.version.finder.GlobModTimeDatasetVersionFinder realVersionFinder;
+  private static final String VERSION_FINDER_GLOB_PATTERN_KEY = "gobblin.retention.version.finder.pattern";
+
+  public GlobModTimeDatasetVersionFinder(FileSystem fs, Config config) {
+    this(fs, config.hasPath(VERSION_FINDER_GLOB_PATTERN_KEY) ? new Path(config.getString(VERSION_FINDER_GLOB_PATTERN_KEY)) : new Path("*"));
+  }
+
   public GlobModTimeDatasetVersionFinder(FileSystem fs, Path globPattern) {
     super(fs);
     this.realVersionFinder =

--- a/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestDataGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestDataGenerator.java
@@ -1,0 +1,183 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.util.test;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeUtils.MillisProvider;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.testng.Assert;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.PathUtils;
+
+
+/**
+ * A class to setup files and folders for a retention test.
+ * Class reads a setup-validate.conf file at <code>testSetupConfPath</code> to create data for a retention test.
+ * The config file needs to be in HOCON and parsed using {@link ConfigFactory}.
+ * All the paths listed at {@link #TEST_DATA_CREATE_KEY} in the config file will be created under a <code>testTempDirPath</code>.
+ *  <br>
+ * After retention job is run on this data, the {@link #validate()} method can be used to validate deleted files and retained files
+ * listed in {@link #TEST_DATA_VALIDATE_DELETED_KEY} and {@link #TEST_DATA_VALIDATE_RETAINED_KEY} respectively.
+ *  <br>
+ *  Below is the format of the config file this class parses.
+ *  <br>
+ * <pre>
+ * gobblin.test : {
+
+    // Time the system clock is set before starting the test
+    currentTime : "02/19/2016 11:00:00"
+
+    // Paths to create for the test
+    //{path: path of test file in the dataset, modTime: set the modification time of this path in "MM/dd/yyyy HH:mm:ss"}
+    create : [
+      {path:"/user/gobblin/Dataset1/Version1", modTime:"02/10/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version2", modTime:"02/11/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version3", modTime:"02/12/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version4", modTime:"02/13/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version5", modTime:"02/14/2016 10:00:00"}
+    ]
+
+    // Validation configs to use after the test
+    validate : {
+
+      // Paths that should exist after retention is run
+      retained : [
+        {path:"/user/gobblin/Dataset1/Version4", modTime:"02/13/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version5", modTime:"02/14/2016 10:00:00"}
+      ]
+
+      // Paths that should be deleted after retention is run
+      deleted : [
+        {path:"/user/gobblin/Dataset1/Version1", modTime:"02/10/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version2", modTime:"02/11/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version3", modTime:"02/12/2016 10:00:00"}
+      ]
+    }
+}
+ * </pre>
+ */
+@Slf4j
+public class RetentionTestDataGenerator {
+
+  private static final String DATA_GENERATOR_KEY = "gobblin.test";
+  private static final String DATA_GENERATOR_PREFIX = DATA_GENERATOR_KEY + ".";
+  private static final String TEST_CURRENT_TIME_KEY = DATA_GENERATOR_PREFIX + "currentTime";
+  private static final String TEST_DATA_CREATE_KEY = DATA_GENERATOR_PREFIX + "create";
+  private static final String TEST_DATA_VALIDATE_RETAINED_KEY = DATA_GENERATOR_PREFIX + "validate.retained";
+  private static final String TEST_DATA_VALIDATE_DELETED_KEY = DATA_GENERATOR_PREFIX + "validate.deleted";
+
+  private static final String TEST_DATA_PATH_LOCAL_KEY = "path";
+  private static final String TEST_DATA_MOD_TIME_LOCAL_KEY = "modTime";
+
+  private static final DateTimeFormatter FORMATTER = DateTimeFormat.
+      forPattern("MM/dd/yyyy HH:mm:ss").withZone(DateTimeZone.forID(ConfigurationKeys.PST_TIMEZONE_NAME));
+  private final Path testTempDirPath;
+  private final FileSystem fs;
+  private final Config setupConfig;
+
+  public RetentionTestDataGenerator(Path testTempDirPath, Path testSetupConfPath, FileSystem fs) {
+    this.fs = fs;
+    this.testTempDirPath = testTempDirPath;
+    this.setupConfig =
+        ConfigFactory.parseResources(PathUtils.getPathWithoutSchemeAndAuthority(testSetupConfPath).toString());
+    if (!this.setupConfig.hasPath(DATA_GENERATOR_KEY)) {
+      throw new RuntimeException(String.format("Failed to load setup config at %s", testSetupConfPath.toString()));
+    }
+  }
+
+  /**
+   * Create all the paths listed under {@link #TEST_DATA_CREATE_KEY}. If a path's config has a {@link #TEST_DATA_MOD_TIME_LOCAL_KEY} specified,
+   * the modification time of this path is updated to this value.
+   */
+  public void setup() throws IOException {
+
+    if (this.setupConfig.hasPath(TEST_CURRENT_TIME_KEY)) {
+      DateTimeUtils.setCurrentMillisProvider(new FixedThreadLocalMillisProvider(FORMATTER.parseDateTime(
+          setupConfig.getString(TEST_CURRENT_TIME_KEY)).getMillis()));
+    }
+
+    List<? extends Config> createConfigs = setupConfig.getConfigList(TEST_DATA_CREATE_KEY);
+    for (Config fileToCreate : createConfigs) {
+      Path fullFilePath =
+          new Path(testTempDirPath, PathUtils.withoutLeadingSeparator(new Path(fileToCreate
+              .getString(TEST_DATA_PATH_LOCAL_KEY))));
+      if (!this.fs.createNewFile(fullFilePath)) {
+        throw new RuntimeException("Failed to create test file " + fullFilePath);
+      }
+      if (fileToCreate.hasPath(TEST_DATA_MOD_TIME_LOCAL_KEY)) {
+        File file = new File(PathUtils.getPathWithoutSchemeAndAuthority(fullFilePath).toString());
+        file.setLastModified(FORMATTER.parseMillis(fileToCreate.getString(TEST_DATA_MOD_TIME_LOCAL_KEY)));
+      }
+    }
+  }
+
+  /**
+   * Validate that all paths in {@link #TEST_DATA_VALIDATE_DELETED_KEY} are deleted and
+   * all paths in {@link #TEST_DATA_VALIDATE_RETAINED_KEY} still exist
+   */
+  public void validate() throws IOException {
+
+    List<? extends Config> retainedConfigs = setupConfig.getConfigList(TEST_DATA_VALIDATE_RETAINED_KEY);
+    for (Config retainedConfig : retainedConfigs) {
+      Path fullFilePath =
+          new Path(testTempDirPath, PathUtils.withoutLeadingSeparator(new Path(retainedConfig
+              .getString(TEST_DATA_PATH_LOCAL_KEY))));
+      Assert.assertTrue(this.fs.exists(fullFilePath),
+          String.format("%s should not be deleted", fullFilePath.toString()));
+    }
+
+    List<? extends Config> deletedConfigs = setupConfig.getConfigList(TEST_DATA_VALIDATE_DELETED_KEY);
+    for (Config retainedConfig : deletedConfigs) {
+      Path fullFilePath =
+          new Path(testTempDirPath, PathUtils.withoutLeadingSeparator(new Path(retainedConfig
+              .getString(TEST_DATA_PATH_LOCAL_KEY))));
+      Assert.assertFalse(this.fs.exists(fullFilePath), String.format("%s should be deleted", fullFilePath.toString()));
+    }
+  }
+
+  /**
+   * A Joda time {@link MillisProvider} used provide a mock fixed current time.
+   * Needs to be thread local as TestNg tests may run in parallel
+   */
+  public static class FixedThreadLocalMillisProvider implements MillisProvider {
+
+    private ThreadLocal<Long> currentTimeThreadLocal = new ThreadLocal<Long>() {
+      @Override
+      protected Long initialValue() {
+        return System.currentTimeMillis();
+      }
+    };
+
+    public FixedThreadLocalMillisProvider(Long millis) {
+      currentTimeThreadLocal.set(millis);
+    }
+
+    @Override
+    public long getMillis() {
+      return currentTimeThreadLocal.get();
+    }
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/TimeBasedRetentionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/TimeBasedRetentionPolicyTest.java
@@ -13,8 +13,6 @@
 package gobblin.data.management.retention;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import gobblin.data.management.retention.policy.TimeBasedRetentionPolicy;
-import gobblin.data.management.retention.version.TimestampedDatasetVersion;
 
 import java.util.List;
 import java.util.Properties;
@@ -25,14 +23,17 @@ import org.hamcrest.Matchers;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeUtils;
 import org.testng.Assert;
+import org.testng.annotations.AfterGroups;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
+import gobblin.data.management.retention.policy.TimeBasedRetentionPolicy;
+import gobblin.data.management.retention.version.TimestampedDatasetVersion;
+import gobblin.util.test.RetentionTestDataGenerator.FixedThreadLocalMillisProvider;
 
-import com.google.common.collect.ImmutableList;
-
-
+@Test(groups = { "SystemTimeTests"})
 public class TimeBasedRetentionPolicyTest {
 
   @Test
@@ -42,7 +43,7 @@ public class TimeBasedRetentionPolicyTest {
 
     TimeBasedRetentionPolicy policy = new TimeBasedRetentionPolicy(props);
 
-    DateTimeUtils.setCurrentMillisFixed(new DateTime(2015, 6, 2, 18, 0, 0, 0).getMillis());
+    DateTimeUtils.setCurrentMillisProvider(new FixedThreadLocalMillisProvider(new DateTime(2015, 6, 2, 18, 0, 0, 0).getMillis()));
 
     TimestampedDatasetVersion datasetVersion1 =
         new TimestampedDatasetVersion(new DateTime(2015, 6, 2, 10, 0, 0, 0), new Path("test"));
@@ -58,14 +59,12 @@ public class TimeBasedRetentionPolicyTest {
     Assert.assertEquals(deletableVersions.size(), 1);
     Assert.assertEquals(deletableVersions.get(0).getDateTime(), new DateTime(2015, 6, 1, 10, 0, 0, 0));
 
-    DateTimeUtils.setCurrentMillisSystem();
   }
 
-  @Test(dependsOnMethods = { "testDefaultRetention" })
+  @Test
   public void testISORetentionDuration() throws Exception {
 
     DateTimeUtils.setCurrentMillisFixed(new DateTime(2016, 2, 11, 10, 0, 0, 0).getMillis());
-
     // 20 Days
     verify("P20D",
         ImmutableList.of(WithDate(new DateTime(2016, 1, 5, 10, 0, 0, 0)), WithDate(new DateTime(2016, 1, 6, 10, 0, 0, 0))),
@@ -86,7 +85,6 @@ public class TimeBasedRetentionPolicyTest {
         ImmutableList.of(WithDate(new DateTime(2016, 2, 10, 11, 0, 0, 0)), WithDate(new DateTime(2016, 2, 9, 11, 0, 0, 0))),
         ImmutableList.of(WithDate(new DateTime(2016, 2, 11, 8, 0, 0, 0)), WithDate(new DateTime(2016, 2, 11, 9, 0, 0, 0))));
 
-    DateTimeUtils.setCurrentMillisSystem();
   }
 
   private static TimestampedDatasetVersion WithDate(DateTime dt){
@@ -105,5 +103,10 @@ public class TimeBasedRetentionPolicyTest {
     assertThat(deletableVersions, Matchers.containsInAnyOrder(toBeDeleted.toArray()));
     assertThat(deletableVersions, Matchers.not(Matchers.containsInAnyOrder(toBeRetained.toArray())));
 
+  }
+
+  @AfterGroups("SystemTimeTests")
+  public void resetSystemCurrentTime() {
+    DateTimeUtils.setCurrentMillisSystem();
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.integration;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.config.client.ConfigClient;
+import gobblin.data.management.retention.DatasetCleaner;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.retention.dataset.CleanableDatasetBase;
+import gobblin.data.management.retention.profile.ManagedCleanableDatasetFinder;
+import gobblin.data.management.retention.profile.MultiCleanableDatasetFinder;
+import gobblin.dataset.Dataset;
+import gobblin.util.PathUtils;
+import gobblin.util.test.RetentionTestDataGenerator;
+
+/**
+ *
+ * Integration tests for gobblin retention.
+ * <ul>
+ * <li> Reads a <code>setup_validate.conf</code> to setup files/dirs for the test.
+ *  See {@link RetentionTestDataGenerator#setup()}
+ * <li> Then runs gobblin retention with confgs in <code>retention.conf</code> file.
+ * <li> Validates for deleted and retained files as specified by <code>setup_validate.conf</code> file.
+ * See {@link RetentionTestDataGenerator#validate()}
+ * </ul>
+ *
+ * The class is a parameterized test meaning a test {@link #testRetention(String, String)} is run for every row returned
+ * by the data provider method {@link #retentionTestDataProvider()}
+ *
+ * <p>
+ * <b>Adding a new test is simple</b>
+ * <ul>
+ * <li> Create a package under src/test/resources/retentionIntegrationTest/YOUR_NEW_TEST
+ * <li> Create a <code>setup_validate.conf</code> file under this package to describe data to create
+ * and data to validate after the test
+ * <li> Create a <code>retention.conf</code> file under this package with retention configuration. Finders, policies etc.
+ * <li> Add YOUR_TEST_NAME to the data provider {@link #retentionTestDataProvider()}
+ * </ul>
+ * </p>
+ */
+@Slf4j
+@Test(groups = { "SystemTimeTests"})
+public class RetentionIntegrationTest {
+
+  private FileSystem fs;
+  private Path testClassTempPath;
+  private static final String SETUP_VALIDATE_CONFIG_CLASSPATH_FILENAME = "setup_validate.conf";
+  private static final String TEST_PACKAGE_RESOURCE_NAME = "retentionIntegrationTest";
+
+  @BeforeClass
+  public void setupClass() throws Exception {
+    this.fs = FileSystem.get(new Configuration());
+    testClassTempPath = new Path(RetentionIntegrationTest.class.getClassLoader().getResource("").getFile(), TEST_PACKAGE_RESOURCE_NAME);
+    if (!fs.mkdirs(testClassTempPath)) {
+      throw new RuntimeException("Failed to create temp directory for the test at " + testClassTempPath.toString());
+    }
+  }
+
+  /**
+   *
+   * The method is a data provider for {@link RetentionIntegrationTest#testRetention(String, String)},
+   * Return a 2d string array. The pair of strings in each row is passed to {@link RetentionIntegrationTest#testRetention(String, String)}
+   * The first element in the pair is the name of the test and 2nd string the name of job config file to use.
+   * It may be a .properties file or a .conf file parsed by typesafe
+   */
+  @DataProvider
+  public Object[][] retentionTestDataProvider() {
+    return new Object[][] {
+        { "testTimeBasedRetention", "retention.conf" },
+        { "testNewestKRetention", "retention.conf" },
+        { "testHourlyPatternRetention", "hourly-retention.job" },
+        { "testDailyPatternRetention", "daily-retention.job" }
+    };
+  }
+
+  @Test(dataProvider = "retentionTestDataProvider")
+  public void testRetention(final String testName, final String testConfFileName) throws Exception {
+    // Temp path for this test under which test data is generated
+    Path testNameTempPath = new Path(testClassTempPath, testName);
+
+    RetentionTestDataGenerator dataGenerator = new RetentionTestDataGenerator(testNameTempPath,
+        PathUtils.combinePaths(TEST_PACKAGE_RESOURCE_NAME, testName, SETUP_VALIDATE_CONFIG_CLASSPATH_FILENAME), fs);
+
+    dataGenerator.setup();
+
+    clean(fs, PathUtils.combinePaths(TEST_PACKAGE_RESOURCE_NAME, testName, testConfFileName), testNameTempPath);
+
+    dataGenerator.validate();
+  }
+
+  /**
+   *
+   * Does the actual gobblin retention. {@link DatasetCleaner} which does retention in production can no be directly called as we need to resolve some
+   * runtime properties like ${testNameTempPath}. This directory contains all the setup data created for a test by {@link RetentionTestDataGenerator#setup()}.
+   * It is unique for each test.
+   * The default {@link ConfigClient} used by {@link DatasetCleaner} connects to config store configs. We need to provide a
+   * mock {@link ConfigClient} since the configs are in classpath and not on config store.
+   *
+   * @param retentionConfigClasspathResource this is the same jobProps/config files used while running a real retention job
+   * @param testNameTempPath temp path for this test where test data is generated
+   */
+  private static void clean(FileSystem fs, Path retentionConfigClasspathResource, Path testNameTempPath) throws Exception {
+
+    if (retentionConfigClasspathResource.getName().endsWith(".job")) {
+
+      Properties jobProps = new Properties();
+      try (final InputStream stream = RetentionIntegrationTest.class.getClassLoader().getResourceAsStream(retentionConfigClasspathResource.toString())) {
+        jobProps.load(stream);
+        for (Entry<Object, Object> entry : jobProps.entrySet()) {
+          jobProps.put(entry.getKey(), StringUtils.replace((String)entry.getValue(), "${testNameTempPath}", testNameTempPath.toString()));
+        }
+      }
+      MultiCleanableDatasetFinder finder = new MultiCleanableDatasetFinder(fs, jobProps);
+      for (Dataset dataset : finder.findDatasets()) {
+        ((CleanableDataset)dataset).clean();
+      }
+    } else {
+      Config testConfig = ConfigFactory.parseResources(retentionConfigClasspathResource.toString())
+          .withFallback(ConfigFactory.parseMap(ImmutableMap.of("testNameTempPath", PathUtils.getPathWithoutSchemeAndAuthority(testNameTempPath).toString()))).resolve();
+
+      ConfigClient client = mock(ConfigClient.class);
+      when(client.getConfig(any(String.class))).thenReturn(testConfig);
+      Properties jobProps = new Properties();
+      jobProps.setProperty(CleanableDatasetBase.SKIP_TRASH_KEY, Boolean.toString(true));
+      ManagedCleanableDatasetFinder finder = new ManagedCleanableDatasetFinder(fs, jobProps, testConfig, client);
+      for (CleanableDataset dataset : finder.findDatasets()) {
+        dataset.clean();
+      }
+    }
+  }
+
+  @AfterClass
+  public void cleanUpClass() {
+    try {
+      this.fs.delete(testClassTempPath, true);
+    } catch (Exception e) {
+      log.error("Failed to cleanup test files", e);
+    }
+  }
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testDailyPatternRetention/daily-retention.job
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testDailyPatternRetention/daily-retention.job
@@ -1,0 +1,11 @@
+type=hadoopJava
+job.class=gobblin.data.management.retention.DatasetCleanerJob
+
+gobblin.retention.dataset.profile.class=gobblin.data.management.retention.profile.TrackingDatasetProfile
+gobblin.retention.dataset.pattern=${testNameTempPath}/user/gobblin/data/trackingData/*/daily
+gobblin.retention.datetime.pattern=yyyy/MM/dd
+
+# 3 days
+gobblin.retention.minutes.retained=4320
+gobblin.retention.simulate=false
+gobblin.retention.skip.trash=true

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testDailyPatternRetention/setup_validate.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testDailyPatternRetention/setup_validate.conf
@@ -1,0 +1,26 @@
+gobblin.test : {
+    currentTime : "02/20/2016 11:00:00"
+    create : [
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/10", modTime:"02/10/2016 19:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/11", modTime:"02/20/2016 20:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/12", modTime:"02/12/2016 21:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/17", modTime:"02/13/2016 10:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/18", modTime:"02/18/2016 21:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/19", modTime:"02/19/2016 20:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/20", modTime:"02/20/2016 11:00:00"}
+    ]
+
+    validate : {
+      retained : [
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/18", modTime:"02/18/2016 21:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/19", modTime:"02/19/2016 20:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/20", modTime:"02/20/2016 11:00:00"}
+      ]
+      deleted : [
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/10", modTime:"02/10/2016 19:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/11", modTime:"02/20/2016 20:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/12", modTime:"02/12/2016 21:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent2/daily/2016/02/17", modTime:"02/13/2016 10:00:00"}
+      ]
+    }
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHourlyPatternRetention/hourly-retention.job
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHourlyPatternRetention/hourly-retention.job
@@ -1,0 +1,11 @@
+type=hadoopJava
+job.class=gobblin.data.management.retention.DatasetCleanerJob
+
+gobblin.retention.dataset.profile.class=gobblin.data.management.retention.profile.TrackingDatasetProfile
+gobblin.retention.dataset.pattern=${testNameTempPath}/user/gobblin/data/trackingData/*/hourly
+gobblin.retention.datetime.pattern=yyyy/MM/dd/HH
+
+# 3 days
+gobblin.retention.minutes.retained=4320
+gobblin.retention.simulate=false
+gobblin.retention.skip.trash=true

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHourlyPatternRetention/setup_validate.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHourlyPatternRetention/setup_validate.conf
@@ -1,0 +1,26 @@
+gobblin.test : {
+    currentTime : "02/14/2016 11:00:00"
+    create : [
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/10/18", modTime:"02/10/2016 19:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/10/19", modTime:"02/10/2016 20:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/10/20", modTime:"02/10/2016 21:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/11/09", modTime:"02/11/2016 10:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/11/20", modTime:"02/11/2016 21:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/11/19", modTime:"02/11/2016 20:00:00"},
+      {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/12/10", modTime:"02/12/2016 11:00:00"}
+    ]
+
+    validate : {
+      retained : [
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/11/20", modTime:"02/11/2016 21:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/11/19", modTime:"02/11/2016 20:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/12/10", modTime:"02/12/2016 11:00:00"}
+      ]
+      deleted : [
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/10/18", modTime:"02/10/2016 19:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/10/19", modTime:"02/10/2016 20:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/10/20", modTime:"02/10/2016 21:00:00"},
+        {path:"user/gobblin/data/trackingData/TrackingEvent1/hourly/2016/02/11/09", modTime:"02/11/2016 10:00:00"}
+      ]
+    }
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testNewestKRetention/retention.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testNewestKRetention/retention.conf
@@ -1,0 +1,9 @@
+gobblin.retention : {
+    # ${testNameTempPath} is resolved at runtime by the test
+    dataset.pattern=${testNameTempPath}"/user/gobblin/*"
+    newestK.versions.retained = 2
+
+    dataset.finder.class=gobblin.data.management.retention.profile.ManagedCleanableDatasetFinder
+    retention.policy.class=gobblin.data.management.retention.policy.NewestKRetentionPolicy
+    version.finder.class=gobblin.data.management.retention.version.finder.GlobModTimeDatasetVersionFinder
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testNewestKRetention/setup_validate.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testNewestKRetention/setup_validate.conf
@@ -1,0 +1,24 @@
+gobblin.test : {
+    currentTime : "02/19/2016 11:00:00"
+    create : [
+      {path:"/user/gobblin/Dataset1/Version1", modTime:"02/10/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version2", modTime:"02/11/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version3", modTime:"02/12/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version4", modTime:"02/13/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset2/Version1", modTime:"02/10/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset2/Version2", modTime:"02/11/2016 10:00:00"}
+    ]
+
+    validate : {
+      retained : [
+        {path:"/user/gobblin/Dataset1/Version3", modTime:"02/12/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version4", modTime:"02/13/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset2/Version1", modTime:"02/10/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset2/Version2", modTime:"02/11/2016 10:00:00"}
+      ]
+      deleted : [
+        {path:"/user/gobblin/Dataset1/Version1", modTime:"02/10/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version2", modTime:"02/11/2016 10:00:00"}
+      ]
+    }
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testTimeBasedRetention/retention.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testTimeBasedRetention/retention.conf
@@ -1,0 +1,9 @@
+gobblin.retention : {
+	# ${testNameTempPath} is resolved at runtime by the test
+    dataset.pattern=${testNameTempPath}"/user/gobblin/*"
+    timebased.duration = P7D
+
+    dataset.finder.class=gobblin.data.management.retention.profile.ManagedCleanableDatasetFinder
+    retention.policy.class=gobblin.data.management.retention.policy.TimeBasedRetentionPolicy
+    version.finder.class=gobblin.data.management.retention.version.finder.GlobModTimeDatasetVersionFinder
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testTimeBasedRetention/setup_validate.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testTimeBasedRetention/setup_validate.conf
@@ -1,0 +1,22 @@
+gobblin.test : {
+    currentTime : "02/19/2016 11:00:00"
+    create : [
+      {path:"/user/gobblin/Dataset1/Version1", modTime:"02/10/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version2", modTime:"02/11/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version3", modTime:"02/12/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version4", modTime:"02/13/2016 10:00:00"},
+      {path:"/user/gobblin/Dataset1/Version5", modTime:"02/14/2016 10:00:00"}
+    ]
+
+    validate : {
+      retained : [
+        {path:"/user/gobblin/Dataset1/Version4", modTime:"02/13/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version5", modTime:"02/14/2016 10:00:00"}
+      ]
+      deleted : [
+        {path:"/user/gobblin/Dataset1/Version1", modTime:"02/10/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version2", modTime:"02/11/2016 10:00:00"},
+        {path:"/user/gobblin/Dataset1/Version3", modTime:"02/12/2016 10:00:00"}
+      ]
+    }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -95,7 +95,6 @@ public class ConfigUtils {
     return ConfigFactory.parseMap(immutableMapBuilder.build());
   }
 
-
   /**
    * Return string value at <code>path</code> if <code>config</code> has path. If not return an empty string
    *
@@ -119,5 +118,16 @@ public class ConfigUtils {
       return config.getString(path);
     }
     return def;
+  }
+  /**
+   * Check if the given <code>key</code> exists in <code>config</code> and it is not null or empty
+   * Uses {@link StringUtils#isNotBlank(CharSequence)}
+   * @param config which may have the key
+   * @param key to look for in the config
+   *
+   * @return True if key exits and not null or empty. False otherwise
+   */
+  public static boolean hasNonEmptyPath(Config config, String key) {
+    return config.hasPath(key) && StringUtils.isNotBlank(config.getString(key));
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
@@ -18,7 +18,9 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 public class ConfigUtilsTest {
 
@@ -50,5 +52,12 @@ public class ConfigUtilsTest {
     Assert.assertEquals(conf.getString("k1.kk2"), "v2");
     Assert.assertFalse(conf.hasPath("k2.kk"), "Should not contain key k2.kk");
 
+  }
+
+  @Test
+  public void testHasNonEmptyPath() throws Exception {
+    Assert.assertTrue(ConfigUtils.hasNonEmptyPath(ConfigFactory.parseMap(ImmutableMap.of("key1", "value1")), "key1"));
+    Assert.assertFalse(ConfigUtils.hasNonEmptyPath(ConfigFactory.parseMap(ImmutableMap.of("key2", "value1")), "key1"));
+    Assert.assertFalse(ConfigUtils.hasNonEmptyPath(ConfigFactory.parseMap(ImmutableMap.of("key1", "")), "key1"));
   }
 }


### PR DESCRIPTION
### Changes
- Added `TypeSafe Conifg` support to `GlobModTimeDatasetVersionFinder`. This finder will be used for audit retention
- Added a mechanism to run end-to-end integration/functional tests for retention. Unit tests alone are not sufficient as we have broken backward compatibilty several times. These tests define the config contracts provided to the user by gobblin-retention.
- `RetentionTestDataGenerator` reads a test config file to create dummy data before the test. After the test is run, it validates if the right files/dirs were deleted. Format of the config file is described in the javadoc of `RetentionTestDataGenerator`
- `RetentionIntegrationTest` runs the actual integration using `RetentionTestDataGenerator` to setup and validate
- Directory structure in classpath for integration test resources.

<pre>
test/resources/retentionIntegrationTest/
		├── testNewestKRetention //Represents a test
		│   ├── retention.conf  //conifgs used by the user, finder, policy etc
		│   └── setup_validate.conf // Used to generate test data
		└── testTimeBasedRetention
	   	 	├── retention.conf
	    	└── setup_validate.conf
 </pre>
- `RetentionIntegrationTest` looks for `setup_validate.conf` file for a test and creates the data required for this test. It then runs gobblin retention using `retention.conf` file for this test. Next validates for deleted files.

@chavdar please review.