### PR TITLE
Use dfs.replication.max in job.state replication factor

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -39,7 +39,6 @@ import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.Mapper;
 import org.apache.hadoop.mapreduce.lib.input.NLineInputFormat;
 import org.apache.hadoop.mapreduce.lib.output.SequenceFileOutputFormat;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -313,7 +312,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
     // Serialize source state to a file which will be picked up by the mappers
     Path jobStateFilePath = new Path(this.mrJobDir, JOB_STATE_FILE_NAME);
-    SerializationUtils.serializeState(this.fs, jobStateFilePath, this.jobContext.getJobState(), 100);
+    int jobStateRF = this.conf.getInt("dfs.replication.max", 20);
+    SerializationUtils.serializeState(this.fs, jobStateFilePath, this.jobContext.getJobState(), jobStateRF);
     job.getConfiguration().set(ConfigurationKeys.JOB_STATE_FILE_PATH_KEY, jobStateFilePath.toString());
 
     if (this.jobProps.containsKey(ConfigurationKeys.MR_JOB_MAX_MAPPERS_KEY)) {

--- a/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
@@ -138,12 +138,12 @@ public class SerializationUtils {
    * @param <T> the {@link State} object type
    * @throws IOException if it fails to serialize the {@link State} instance
    */
-  public static <T extends State> void serializeState(FileSystem fs, Path jobStateFilePath, T state, int replication)
-      throws IOException {
+  public static <T extends State> void serializeState(FileSystem fs, Path jobStateFilePath, T state,
+      short replication) throws IOException {
     Closer closer = Closer.create();
 
     try {
-      OutputStream os = closer.register(fs.create(jobStateFilePath, true, replication));
+      OutputStream os = closer.register(fs.create(jobStateFilePath, replication));
       DataOutputStream dataOutputStream = closer.register(new DataOutputStream(os));
       state.write(dataOutputStream);
     } catch (Throwable t) {


### PR DESCRIPTION
This addresses an issue with https://github.com/linkedin/gobblin/pull/910 . If the replication factor > dfs.replication.max , then it won't be changed. This fix attempts to use that property when setting replication.

@ibuenros @ydai1124 Can you review?