### PR TITLE
Simple refactoring of JobContext.commit()

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -378,8 +378,7 @@ public class JobContext {
     try (Closer closer = Closer.create()) {
       dataPublisherClass = getJobDataPublisherClass(datasetState)
           .or((Class<? extends DataPublisher>) Class.forName(ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
-      success = checkForUnpublishedWUHandling(datasetUrn, datasetState, success, dataPublisherClass,
-                                              closer);
+      success = checkForUnpublishedWUHandling(datasetUrn, datasetState,dataPublisherClass, closer);
     } catch (ReflectiveOperationException roe) {
       this.logger.warn("Unable to find publisher class: " + roe, roe);
       success = false;
@@ -434,10 +433,10 @@ public class JobContext {
   }
 
   boolean checkForUnpublishedWUHandling(String datasetUrn, JobState.DatasetState datasetState,
-                                        boolean success,
                                         Class<? extends DataPublisher> dataPublisherClass,
                                         Closer closer)
           throws ReflectiveOperationException, IOException {
+    boolean success = true;
     if (!canCommitDataset(datasetState)) {
       this.logger.warn(String.format("Not committing dataset %s of job %s with commit policy %s and state %s",
           datasetUrn, this.jobId, this.jobCommitPolicy, datasetState.getState()));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -351,7 +351,7 @@ public class JobContext {
     }
 
     for (Map.Entry<String, JobState.DatasetState> entry : this.datasetStatesByUrns.get().entrySet()) {
-      allDatasetsCommit = processDatasetCommit(shouldCommitDataInJob, deliverySemantics,
+      allDatasetsCommit &= processDatasetCommit(shouldCommitDataInJob, deliverySemantics,
                                                entry.getKey(), entry.getValue())
                           & allDatasetsCommit;
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -352,8 +352,7 @@ public class JobContext {
 
     for (Map.Entry<String, JobState.DatasetState> entry : this.datasetStatesByUrns.get().entrySet()) {
       allDatasetsCommit &= processDatasetCommit(shouldCommitDataInJob, deliverySemantics,
-                                               entry.getKey(), entry.getValue())
-                          & allDatasetsCommit;
+                                               entry.getKey(), entry.getValue());
     }
 
     if (!allDatasetsCommit) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -351,8 +351,6 @@ public class JobContext {
     }
 
     for (Map.Entry<String, JobState.DatasetState> entry : this.datasetStatesByUrns.get().entrySet()) {
-      // NOTE: order here is important as we don't want to skip processDatasetCommit if there was
-      // a failure for a previous dataset.
       allDatasetsCommit = processDatasetCommit(shouldCommitDataInJob, deliverySemantics,
                                                entry.getKey(), entry.getValue())
                           & allDatasetsCommit;


### PR DESCRIPTION
Refactor JobContext.commit() in preparation for parallelization for the commit logic:

* Refactor the commit logic from the for loop into a separate method processDatasetCommit()
* Refactor the check for support for failed WorkUnit handling into a separte method checkForUnpublishedWUHandling .
* Move commitSequenceBuilder from a instance variable to a local variable in processDatasetCommit().

@zliu41 can you review?