### PR TITLE
use new DatasetVersion in CombinePolicy

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -191,6 +191,7 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
     }
 
     for (VersionFinderAndPolicy<T> versionFinderAndPolicy : getVersionFindersAndPolicies()) {
+
       VersionSelectionPolicy<T> selectionPolicy = versionFinderAndPolicy.getVersionSelectionPolicy();
       VersionFinder<? extends T> versionFinder = versionFinderAndPolicy.getVersionFinder();
 
@@ -205,7 +206,7 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
 
       if (versions.isEmpty()) {
         this.log.warn("No dataset version can be found. Ignoring.");
-        return;
+        continue;
       }
 
       Collections.sort(versions, Collections.reverseOrder());

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/SnapshotDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/SnapshotDataset.java
@@ -22,10 +22,10 @@ import org.slf4j.LoggerFactory;
 
 import gobblin.data.management.retention.policy.NewestKRetentionPolicy;
 import gobblin.data.management.retention.policy.RetentionPolicy;
-import gobblin.data.management.retention.version.DatasetVersion;
 import gobblin.data.management.retention.version.StringDatasetVersion;
 import gobblin.data.management.retention.version.finder.VersionFinder;
 import gobblin.data.management.retention.version.finder.WatermarkDatasetVersionFinder;
+import gobblin.data.management.version.FileSystemDatasetVersion;
 
 
 /**
@@ -34,10 +34,10 @@ import gobblin.data.management.retention.version.finder.WatermarkDatasetVersionF
  * Uses a {@link gobblin.data.management.retention.version.finder.WatermarkDatasetVersionFinder} and a
  * {@link gobblin.data.management.retention.policy.NewestKRetentionPolicy}.
  */
-public class SnapshotDataset extends CleanableDatasetBase<DatasetVersion> {
+public class SnapshotDataset extends CleanableDatasetBase<FileSystemDatasetVersion> {
 
   private final VersionFinder<StringDatasetVersion> versionFinder;
-  private final RetentionPolicy<DatasetVersion> retentionPolicy;
+  private final RetentionPolicy<FileSystemDatasetVersion> retentionPolicy;
   private final Path datasetRoot;
 
   public SnapshotDataset(FileSystem fs, Properties props, Path datasetRoot) throws IOException {
@@ -49,16 +49,16 @@ public class SnapshotDataset extends CleanableDatasetBase<DatasetVersion> {
     super(fs, props, log);
     this.datasetRoot = datasetRoot;
     this.versionFinder = new WatermarkDatasetVersionFinder(fs, props);
-    this.retentionPolicy = new NewestKRetentionPolicy(props);
+    this.retentionPolicy = new NewestKRetentionPolicy<FileSystemDatasetVersion>(props);
   }
 
   @Override
-  public VersionFinder<? extends DatasetVersion> getVersionFinder() {
+  public VersionFinder<? extends FileSystemDatasetVersion> getVersionFinder() {
     return this.versionFinder;
   }
 
   @Override
-  public RetentionPolicy<DatasetVersion> getRetentionPolicy() {
+  public RetentionPolicy<FileSystemDatasetVersion> getRetentionPolicy() {
     return this.retentionPolicy;
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/CombineRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/CombineRetentionPolicy.java
@@ -56,7 +56,7 @@ import gobblin.data.management.version.DatasetVersion;
  *   Additionally, any configuration necessary for combined policies must be specified.
  * </p>
  */
-public class CombineRetentionPolicy implements RetentionPolicy<DatasetVersion> {
+public class CombineRetentionPolicy<T extends DatasetVersion> implements RetentionPolicy<T> {
 
   public static final String RETENTION_POLICIES_PREFIX = DatasetCleaner.CONFIGURATION_KEY_PREFIX +
       "combine.retention.policy.class.";
@@ -67,10 +67,10 @@ public class CombineRetentionPolicy implements RetentionPolicy<DatasetVersion> {
     INTERSECT, UNION
   }
 
-  private final List<RetentionPolicy<DatasetVersion>> retentionPolicies;
+  private final List<RetentionPolicy<T>> retentionPolicies;
   private final DeletableCombineOperation combineOperation;
 
-  public CombineRetentionPolicy(List<RetentionPolicy<DatasetVersion>> retentionPolicies, DeletableCombineOperation combineOperation) throws IOException {
+  public CombineRetentionPolicy(List<RetentionPolicy<T>> retentionPolicies, DeletableCombineOperation combineOperation) throws IOException {
     this.combineOperation = combineOperation;
     this.retentionPolicies = retentionPolicies;
   }
@@ -80,13 +80,13 @@ public class CombineRetentionPolicy implements RetentionPolicy<DatasetVersion> {
 
     Preconditions.checkArgument(props.containsKey(DELETE_SETS_COMBINE_OPERATION), "Combine operation not specified.");
 
-    ImmutableList.Builder<RetentionPolicy<DatasetVersion>> builder = ImmutableList.builder();
+    ImmutableList.Builder<RetentionPolicy<T>> builder = ImmutableList.builder();
 
     for (String property : props.stringPropertyNames()) {
       if (property.startsWith(RETENTION_POLICIES_PREFIX)) {
 
         try {
-          builder.add((RetentionPolicy<DatasetVersion>) ConstructorUtils.invokeConstructor(Class.forName(props.getProperty(property)), props));
+          builder.add((RetentionPolicy<T>) ConstructorUtils.invokeConstructor(Class.forName(props.getProperty(property)), props));
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException | ClassNotFoundException e) {
           throw new IllegalArgumentException(e);
         }
@@ -105,23 +105,25 @@ public class CombineRetentionPolicy implements RetentionPolicy<DatasetVersion> {
   /**
    * Returns the most specific common superclass for the {@link #versionClass} of each embedded policy.
    */
-  @Override public Class<? extends DatasetVersion> versionClass() {
+  @SuppressWarnings("unchecked")
+  @Override public Class<T> versionClass() {
     if(this.retentionPolicies.size() == 1) {
-      return this.retentionPolicies.get(0).versionClass();
+      return (Class<T>) this.retentionPolicies.get(0).versionClass();
     }
 
-    Class<? extends DatasetVersion> klazz = this.retentionPolicies.get(0).versionClass();
-    for(RetentionPolicy<? extends DatasetVersion> policy : retentionPolicies) {
-      klazz = commonSuperclass(klazz, policy.versionClass());
+    Class<T> klazz = (Class<T>) this.retentionPolicies.get(0).versionClass();
+    for(RetentionPolicy<T> policy : retentionPolicies) {
+      klazz = commonSuperclass(klazz, (Class<T>) policy.versionClass());
     }
     return klazz;
   }
 
-  @Override public Collection<DatasetVersion> listDeletableVersions(final List<DatasetVersion> allVersions) {
+  @Override public Collection<T> listDeletableVersions(final List<T> allVersions) {
 
-    List<Set<DatasetVersion>> candidateDeletableVersions = Lists.newArrayList(Iterables.transform(this.retentionPolicies,
-        new Function<RetentionPolicy<DatasetVersion>, Set<DatasetVersion>>() {
-      @Nullable @Override public Set<DatasetVersion> apply(RetentionPolicy<DatasetVersion> input) {
+    List<Set<T>> candidateDeletableVersions = Lists.newArrayList(Iterables.transform(this.retentionPolicies,
+        new Function<RetentionPolicy<T>, Set<T>>() {
+      @SuppressWarnings("deprecation")
+      @Nullable @Override public Set<T> apply(RetentionPolicy<T> input) {
         return Sets.newHashSet(input.listDeletableVersions(allVersions));
       }
     }));
@@ -140,8 +142,8 @@ public class CombineRetentionPolicy implements RetentionPolicy<DatasetVersion> {
 
   @VisibleForTesting
   @SuppressWarnings("unchecked")
-  public Class<? extends DatasetVersion> commonSuperclass(Class<? extends DatasetVersion> classA,
-      Class<? extends DatasetVersion> classB) {
+  public Class<T> commonSuperclass(Class<T> classA,
+      Class<T> classB) {
 
     if(classA.isAssignableFrom(classB)) {
       // a is superclass of b, so return class of a
@@ -154,32 +156,32 @@ public class CombineRetentionPolicy implements RetentionPolicy<DatasetVersion> {
         klazz = klazz.getSuperclass();
       }
       if(DatasetVersion.class.isAssignableFrom(klazz)) {
-        return (Class<? extends DatasetVersion>) klazz;
+        return (Class<T>) klazz;
       } else {
         // this should never happen, but there for safety
-        return DatasetVersion.class;
+        return (Class<T>) DatasetVersion.class;
       }
     }
   }
 
-  private Set<DatasetVersion> intersectDatasetVersions(Collection<Set<DatasetVersion>> sets) {
+  private Set<T> intersectDatasetVersions(Collection<Set<T>> sets) {
     if(sets.size() <= 0) {
       return Sets.newHashSet();
     }
-    Iterator<Set<DatasetVersion>> it = sets.iterator();
-    Set<DatasetVersion> outputSet = it.next();
+    Iterator<Set<T>> it = sets.iterator();
+    Set<T> outputSet = it.next();
     while(it.hasNext()) {
       outputSet = Sets.intersection(outputSet, it.next());
     }
     return outputSet;
   }
 
-  private Set<DatasetVersion> unionDatasetVersions(Collection<Set<DatasetVersion>> sets) {
+  private Set<T> unionDatasetVersions(Collection<Set<T>> sets) {
     if(sets.size() <= 0) {
       return Sets.newHashSet();
     }
-    Iterator<Set<DatasetVersion>> it = sets.iterator();
-    Set<DatasetVersion> outputSet = it.next();
+    Iterator<Set<T>> it = sets.iterator();
+    Set<T> outputSet = it.next();
     while(it.hasNext()) {
       outputSet = Sets.union(outputSet, it.next());
     }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/NewestKRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/NewestKRetentionPolicy.java
@@ -11,13 +11,13 @@ import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 
 import gobblin.data.management.retention.DatasetCleaner;
-import gobblin.data.management.retention.version.DatasetVersion;
+import gobblin.data.management.version.DatasetVersion;
 
 
 /**
  * Retains the newest k versions of the dataset.
  */
-public class NewestKRetentionPolicy implements RetentionPolicy<DatasetVersion> {
+public class NewestKRetentionPolicy<T extends DatasetVersion> implements RetentionPolicy<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NewestKRetentionPolicy.class);
 
@@ -61,10 +61,10 @@ public class NewestKRetentionPolicy implements RetentionPolicy<DatasetVersion> {
   }
 
   @Override
-  public Collection<DatasetVersion> listDeletableVersions(List<DatasetVersion> allVersions) {
+  public Collection<T> listDeletableVersions(List<T> allVersions) {
     int newerVersions = 0;
-    List<DatasetVersion> deletableVersions = Lists.newArrayList();
-    for(DatasetVersion datasetVersion : allVersions) {
+    List<T> deletableVersions = Lists.newArrayList();
+    for(T datasetVersion : allVersions) {
       if(newerVersions >= this.versionsRetained) {
         deletableVersions.add(datasetVersion);
       }

--- a/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestDataGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestDataGenerator.java
@@ -13,6 +13,8 @@ package gobblin.util.test;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -121,11 +123,20 @@ public class RetentionTestDataGenerator {
     }
 
     List<? extends Config> createConfigs = setupConfig.getConfigList(TEST_DATA_CREATE_KEY);
+
+    Collections.sort(createConfigs, new Comparator<Config>() {
+      @Override
+      public int compare(Config o1, Config o2) {
+        return o1.getString(TEST_DATA_PATH_LOCAL_KEY).compareTo(o2.getString(TEST_DATA_PATH_LOCAL_KEY));
+      }
+    });
+
     for (Config fileToCreate : createConfigs) {
       Path fullFilePath =
           new Path(testTempDirPath, PathUtils.withoutLeadingSeparator(new Path(fileToCreate
               .getString(TEST_DATA_PATH_LOCAL_KEY))));
-      if (!this.fs.createNewFile(fullFilePath)) {
+
+      if (!this.fs.mkdirs(fullFilePath)) {
         throw new RuntimeException("Failed to create test file " + fullFilePath);
       }
       if (fileToCreate.hasPath(TEST_DATA_MOD_TIME_LOCAL_KEY)) {

--- a/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestHelper.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.util.test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.InputStream;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.config.client.ConfigClient;
+import gobblin.data.management.retention.DatasetCleaner;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.retention.dataset.CleanableDatasetBase;
+import gobblin.data.management.retention.profile.ManagedCleanableDatasetFinder;
+import gobblin.data.management.retention.profile.MultiCleanableDatasetFinder;
+import gobblin.dataset.Dataset;
+import gobblin.dataset.DatasetsFinder;
+import gobblin.util.PathUtils;
+
+/**
+ * Helper methods for Retention integration tests
+ */
+public class RetentionTestHelper {
+
+  /**
+  *
+  * Does gobblin retention for test data. {@link DatasetCleaner} which does retention in production can not be directly called as we need to resolve some
+  * runtime properties like ${testNameTempPath}. This directory contains all the setup data created for a test by {@link RetentionTestDataGenerator#setup()}.
+  * It is unique for each test.
+  * The default {@link ConfigClient} used by {@link DatasetCleaner} connects to config store configs. We need to provide a
+  * mock {@link ConfigClient} since the configs are in classpath and not on config store.
+  *
+  * @param retentionConfigClasspathResource this is the same jobProps/config files used while running a real retention job
+  * @param testNameTempPath temp path for this test where test data is generated
+  */
+ public static void clean(FileSystem fs, Path retentionConfigClasspathResource, Path testNameTempPath) throws Exception {
+
+   if (retentionConfigClasspathResource.getName().endsWith(".job")) {
+
+     Properties jobProps = new Properties();
+     try (final InputStream stream = RetentionTestHelper.class.getClassLoader().getResourceAsStream(retentionConfigClasspathResource.toString())) {
+       jobProps.load(stream);
+       for (Entry<Object, Object> entry : jobProps.entrySet()) {
+         jobProps.put(entry.getKey(), StringUtils.replace((String)entry.getValue(), "${testNameTempPath}", testNameTempPath.toString()));
+       }
+     }
+     MultiCleanableDatasetFinder finder = new MultiCleanableDatasetFinder(fs, jobProps);
+     for (Dataset dataset : finder.findDatasets()) {
+       ((CleanableDataset)dataset).clean();
+     }
+   } else {
+     Config testConfig = ConfigFactory.parseResources(retentionConfigClasspathResource.toString())
+         .withFallback(ConfigFactory.parseMap(ImmutableMap.of("testNameTempPath", PathUtils.getPathWithoutSchemeAndAuthority(testNameTempPath).toString()))).resolve();
+
+     ConfigClient client = mock(ConfigClient.class);
+     when(client.getConfig(any(String.class))).thenReturn(testConfig);
+     Properties jobProps = new Properties();
+     jobProps.setProperty(CleanableDatasetBase.SKIP_TRASH_KEY, Boolean.toString(true));
+     jobProps.setProperty(ManagedCleanableDatasetFinder.CONFIG_MANAGEMENT_STORE_URI, "dummy");
+
+     @SuppressWarnings("unchecked")
+     DatasetsFinder<CleanableDataset> finder =
+         (DatasetsFinder<CleanableDataset>) ConstructorUtils.invokeConstructor(
+             Class.forName(testConfig.getString(MultiCleanableDatasetFinder.DATASET_FINDER_CLASS_KEY)),
+             new Object[] { fs, jobProps, testConfig, client });
+     for (CleanableDataset dataset : finder.findDatasets()) {
+       dataset.clean();
+     }
+   }
+ }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/NewestKRetentionPolicyTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/NewestKRetentionPolicyTest.java
@@ -39,8 +39,7 @@ public class NewestKRetentionPolicyTest {
     StringDatasetVersion datasetVersion2 = new StringDatasetVersion("001_mid", new Path("test"));
     StringDatasetVersion datasetVersion3 = new StringDatasetVersion("002_oldest", new Path("test"));
 
-
-    Assert.assertEquals(policy.versionClass(), DatasetVersion.class);
+    Assert.assertEquals(policy.versionClass(), gobblin.data.management.version.DatasetVersion.class);
 
     List<DatasetVersion> versions = Lists.newArrayList();
     versions.add(datasetVersion1);

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
@@ -11,17 +11,8 @@
  */
 package gobblin.data.management.retention.integration;
 
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.InputStream;
-import java.util.Map.Entry;
-import java.util.Properties;
-
 import lombok.extern.slf4j.Slf4j;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -30,19 +21,9 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import com.google.common.collect.ImmutableMap;
-import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
-
-import gobblin.config.client.ConfigClient;
-import gobblin.data.management.retention.DatasetCleaner;
-import gobblin.data.management.retention.dataset.CleanableDataset;
-import gobblin.data.management.retention.dataset.CleanableDatasetBase;
-import gobblin.data.management.retention.profile.ManagedCleanableDatasetFinder;
-import gobblin.data.management.retention.profile.MultiCleanableDatasetFinder;
-import gobblin.dataset.Dataset;
 import gobblin.util.PathUtils;
 import gobblin.util.test.RetentionTestDataGenerator;
+import gobblin.util.test.RetentionTestHelper;
 
 /**
  *
@@ -120,51 +101,10 @@ public class RetentionIntegrationTest {
 
     dataGenerator.setup();
 
-    clean(fs, PathUtils.combinePaths(TEST_PACKAGE_RESOURCE_NAME, testName, testConfFileName), testNameTempPath);
+    RetentionTestHelper.clean(fs, PathUtils.combinePaths(TEST_PACKAGE_RESOURCE_NAME, testName, testConfFileName), testNameTempPath);
 
     dataGenerator.validate();
 
-  }
-
-  /**
-   *
-   * Does the actual gobblin retention. {@link DatasetCleaner} which does retention in production can no be directly called as we need to resolve some
-   * runtime properties like ${testNameTempPath}. This directory contains all the setup data created for a test by {@link RetentionTestDataGenerator#setup()}.
-   * It is unique for each test.
-   * The default {@link ConfigClient} used by {@link DatasetCleaner} connects to config store configs. We need to provide a
-   * mock {@link ConfigClient} since the configs are in classpath and not on config store.
-   *
-   * @param retentionConfigClasspathResource this is the same jobProps/config files used while running a real retention job
-   * @param testNameTempPath temp path for this test where test data is generated
-   */
-  private static void clean(FileSystem fs, Path retentionConfigClasspathResource, Path testNameTempPath) throws Exception {
-
-    if (retentionConfigClasspathResource.getName().endsWith(".job")) {
-
-      Properties jobProps = new Properties();
-      try (final InputStream stream = RetentionIntegrationTest.class.getClassLoader().getResourceAsStream(retentionConfigClasspathResource.toString())) {
-        jobProps.load(stream);
-        for (Entry<Object, Object> entry : jobProps.entrySet()) {
-          jobProps.put(entry.getKey(), StringUtils.replace((String)entry.getValue(), "${testNameTempPath}", testNameTempPath.toString()));
-        }
-      }
-      MultiCleanableDatasetFinder finder = new MultiCleanableDatasetFinder(fs, jobProps);
-      for (Dataset dataset : finder.findDatasets()) {
-        ((CleanableDataset)dataset).clean();
-      }
-    } else {
-      Config testConfig = ConfigFactory.parseResources(retentionConfigClasspathResource.toString())
-          .withFallback(ConfigFactory.parseMap(ImmutableMap.of("testNameTempPath", PathUtils.getPathWithoutSchemeAndAuthority(testNameTempPath).toString()))).resolve();
-
-      ConfigClient client = mock(ConfigClient.class);
-      when(client.getConfig(any(String.class))).thenReturn(testConfig);
-      Properties jobProps = new Properties();
-      jobProps.setProperty(CleanableDatasetBase.SKIP_TRASH_KEY, Boolean.toString(true));
-      ManagedCleanableDatasetFinder finder = new ManagedCleanableDatasetFinder(fs, jobProps, testConfig, client);
-      for (CleanableDataset dataset : finder.findDatasets()) {
-        dataset.clean();
-      }
-    }
   }
 
   @AfterClass


### PR DESCRIPTION
- Fix some generics which cause LiCleanableDataset to fail
- Move some code out of `src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
` to `gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestHelper.java`

@ibuenros can you review?
