### PR TITLE
Make NewestKSelectionPolicy use Java Generics instead of FileSystemDatasetVersion

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/NewestKSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/NewestKSelectionPolicy.java
@@ -20,6 +20,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Lists;
+
 import com.typesafe.config.Config;
 
 import gobblin.data.management.version.FileSystemDatasetVersion;
@@ -28,7 +29,7 @@ import gobblin.data.management.version.FileSystemDatasetVersion;
 /**
  * Select the newest k versions of the dataset.
  */
-public class NewestKSelectionPolicy implements VersionSelectionPolicy<FileSystemDatasetVersion> {
+public class NewestKSelectionPolicy<T extends FileSystemDatasetVersion> implements VersionSelectionPolicy<T> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NewestKSelectionPolicy.class);
 
@@ -58,12 +59,12 @@ public class NewestKSelectionPolicy implements VersionSelectionPolicy<FileSystem
   public Class<? extends FileSystemDatasetVersion> versionClass() {
     return FileSystemDatasetVersion.class;
   }
-
+  
   @Override
-  public Collection<FileSystemDatasetVersion> listSelectedVersions(List<FileSystemDatasetVersion> allVersions) {
+  public Collection<T> listSelectedVersions(List<T> allVersions) {
     int newerVersions = 0;
-    List<FileSystemDatasetVersion> selectedVersions = Lists.newArrayList();
-    for (FileSystemDatasetVersion datasetVersion : allVersions) {
+    List<T> selectedVersions = Lists.newArrayList();
+    for (T datasetVersion : allVersions) {
       if (newerVersions < this.versionsSelected) {
         selectedVersions.add(datasetVersion);
       } else {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/NonNewestKSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/NonNewestKSelectionPolicy.java
@@ -25,7 +25,7 @@ import gobblin.data.management.version.FileSystemDatasetVersion;
 /**
  * Select the all the versions except the newest k versions of the dataset. And inverse of {@link NewestKSelectionPolicy}
  */
-public class NonNewestKSelectionPolicy extends NewestKSelectionPolicy {
+public class NonNewestKSelectionPolicy<T extends FileSystemDatasetVersion> extends NewestKSelectionPolicy<T> {
 
   public NonNewestKSelectionPolicy(int versionsRetained) {
     super(versionsRetained);
@@ -41,7 +41,7 @@ public class NonNewestKSelectionPolicy extends NewestKSelectionPolicy {
 
   @SuppressWarnings("unchecked")
   @Override
-  public Collection<FileSystemDatasetVersion> listSelectedVersions(List<FileSystemDatasetVersion> allVersions) {
+  public Collection<T> listSelectedVersions(List<T> allVersions) {
     return CollectionUtils.subtract(allVersions, super.listSelectedVersions(allVersions));
   }
 }


### PR DESCRIPTION
* With this approach, one does not have to cast to `FileSystemDatasetVersion` when using `NewestKSelectionPolicy` - any class that extends `FileSystemDatasetVersion` (such as `TimestampedDatasetVersion`) can be used