### PR TITLE
Substitution of system and env variable in config management

### DIFF
--- a/gobblin-config-management/gobblin-config-client/src/test/java/gobblin/config/client/TestConfigClient.java
+++ b/gobblin-config-management/gobblin-config-client/src/test/java/gobblin/config/client/TestConfigClient.java
@@ -131,10 +131,10 @@ public class TestConfigClient {
   private void mockupConfigValues(){
     /**
      * each node will have a common key "generalKey" with value as "generalValue_${node}"
-     * this key will be overwrite 
-     * 
+     * this key will be overwrite
+     *
      * each node will have own key "keyOf_${node}" with value "valueOf_${node}"
-     * this key will be inherent 
+     * this key will be inherent
      */
     // mock up the configuration values for root
     Map<String, String> rootMap = new HashMap<>();
@@ -147,19 +147,19 @@ public class TestConfigClient {
     dataMap.put("keyOf_data", "valueOf_data");
     dataMap.put("generalKey", "generalValue_data");
     when(mockConfigStore.getOwnConfig(data, version)).thenReturn(ConfigFactory.parseMap(dataMap));
-    
+
     // mock up the configuration values for /data/databases
     Map<String, String> databasesMap = new HashMap<>();
     databasesMap.put("keyOf_databases", "valueOf_databases");
     databasesMap.put("generalKey", "generalValue_data_databases");
     when(mockConfigStore.getOwnConfig(databases, version)).thenReturn(ConfigFactory.parseMap(databasesMap));
-    
+
     // mock up the configuration values for /data/databases/identity
     Map<String, String> identityMap = new HashMap<>();
     identityMap.put("keyOf_identity", "valueOf_identity");
     identityMap.put("generalKey", "generalValue_data_databases_identity");
     when(mockConfigStore.getOwnConfig(identity, version)).thenReturn(ConfigFactory.parseMap(identityMap));
-    
+
     // mock up the configuration values for /tag
     Map<String, String> tagMap = new HashMap<>();
     tagMap.put("keyOf_tag", "valueOf_tag");
@@ -171,28 +171,27 @@ public class TestConfigClient {
     espressoTagMap.put("keyOf_espressoTag", "valueOf_espressoTag");
     espressoTagMap.put("generalKey", "generalValue_tag_espressoTag");
     when(mockConfigStore.getOwnConfig(espressoTag, version)).thenReturn(ConfigFactory.parseMap(espressoTagMap));
-    
+
     // mock up the configuration values for /tag/highPriorityTag
     Map<String, String> highPriorityTagMap = new HashMap<>();
     highPriorityTagMap.put("keyOf_highPriorityTag", "valueOf_highPriorityTag");
     highPriorityTagMap.put("generalKey", "generalValue_tag_highPriorityTag");
     when(mockConfigStore.getOwnConfig(highPriorityTag, version)).thenReturn(ConfigFactory.parseMap(highPriorityTagMap));
-    
+
     // mock up the configuration values for /tag2
     Map<String, String> tag2Map = new HashMap<>();
     tag2Map.put("keyOf_tag2", "valueOf_tag2");
     tag2Map.put("generalKey", "generalValue_tag2");
     when(mockConfigStore.getOwnConfig(tag2, version)).thenReturn(ConfigFactory.parseMap(tag2Map));
-    
+
     // mock up the configuration values for /tag2/nertzTag2
     Map<String, String> nertzTag2Map = new HashMap<>();
     nertzTag2Map.put("keyOf_nertzTag2", "valueOf_nertzTag2");
     nertzTag2Map.put("generalKey", "generalValue_tag2_nertzTag2");
     when(mockConfigStore.getOwnConfig(nertzTag2, version)).thenReturn(ConfigFactory.parseMap(nertzTag2Map));
   }
-  
+
   private void checkValuesForIdentity(Config resolvedConfig){
-    Assert.assertTrue(resolvedConfig.entrySet().size() == 10 );
     Assert.assertTrue(resolvedConfig.getString("keyOf_data").equals("valueOf_data"));
     Assert.assertTrue(resolvedConfig.getString("keyOf_identity").equals("valueOf_identity"));
     Assert.assertTrue(resolvedConfig.getString("keyOf_espressoTag").equals("valueOf_espressoTag"));
@@ -202,7 +201,7 @@ public class TestConfigClient {
     Assert.assertTrue(resolvedConfig.getString("keyOf_tag2").equals("valueOf_tag2"));
     Assert.assertTrue(resolvedConfig.getString("keyOf_tag").equals("valueOf_tag"));
     Assert.assertTrue(resolvedConfig.getString("keyOf_databases").equals("valueOf_databases"));
-    
+
     Assert.assertTrue(resolvedConfig.getString("generalKey").equals("generalValue_data_databases_identity"));
   }
 
@@ -229,7 +228,7 @@ public class TestConfigClient {
 
     resolved = client.getConfig(absoluteURI);
     checkValuesForIdentity(resolved);
-    
+
     // importedBy using relative URI
     String[] expectedImportedBy = {"etl-hdfs:/tag/espressoTag", "etl-hdfs:/data/databases/identity"};
     URI nertzTagURI = new URI("etl-hdfs:///tag2/nertzTag2");
@@ -243,15 +242,15 @@ public class TestConfigClient {
       Assert.assertTrue(u.toString().equals(expectedImportedBy[0]) ||
           u.toString().equals(expectedImportedBy[1]));
     }
-    
+
     // importedBy using abs URI
-    String[] expectedImportedBy_abs = {"etl-hdfs://eat1-nertznn01.grid.linkedin.com:9000/user/mitu/HdfsBasedConfigTest/tag/espressoTag", 
+    String[] expectedImportedBy_abs = {"etl-hdfs://eat1-nertznn01.grid.linkedin.com:9000/user/mitu/HdfsBasedConfigTest/tag/espressoTag",
         "etl-hdfs://eat1-nertznn01.grid.linkedin.com:9000/user/mitu/HdfsBasedConfigTest/data/databases/identity"};
     nertzTagURI = new URI("etl-hdfs://eat1-nertznn01.grid.linkedin.com:9000/user/mitu/HdfsBasedConfigTest/tag2/nertzTag2");
     importedBy = client.getImportedBy(nertzTagURI, false);
     Assert.assertEquals(importedBy.size(), 1);
     Assert.assertEquals(importedBy.iterator().next().toString(), expectedImportedBy_abs[0]);
-    
+
     importedBy = client.getImportedBy(nertzTagURI, true);
     Assert.assertEquals(importedBy.size(), 2);
     for(URI u: importedBy){

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreBackedValueInspector.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreBackedValueInspector.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import gobblin.config.store.api.ConfigKeyPath;
 import gobblin.config.store.api.ConfigStore;
@@ -25,7 +26,7 @@ import gobblin.config.store.api.ConfigStoreWithBatchFetches;
 import gobblin.config.store.api.ConfigStoreWithResolution;
 
 /**
- * ConfigStoreBackedValueInspector always query the underline {@link ConfigStore} to get the freshest 
+ * ConfigStoreBackedValueInspector always query the underline {@link ConfigStore} to get the freshest
  * {@link com.typesafe.config.Config}
  * @author mitu
  *
@@ -37,7 +38,7 @@ public class ConfigStoreBackedValueInspector implements ConfigStoreValueInspecto
   private final ConfigStoreTopologyInspector topology;
 
   /**
-   * @param cs       - internal {@link ConfigStore} to retrieve configuration 
+   * @param cs       - internal {@link ConfigStore} to retrieve configuration
    * @param version  - version of the {@link ConfigStore}
    * @param topology - corresponding {@link ConfigStoreTopologyInspector} for the input {@link ConfigStore}
    */
@@ -54,7 +55,7 @@ public class ConfigStoreBackedValueInspector implements ConfigStoreValueInspecto
   public String getVersion() {
     return this.version;
   }
-  
+
   /**
    * {@inheritDoc}.
    *
@@ -66,7 +67,7 @@ public class ConfigStoreBackedValueInspector implements ConfigStoreValueInspecto
   public Config getOwnConfig(ConfigKeyPath configKey) {
     return this.cs.getOwnConfig(configKey, version);
   }
-  
+
   /**
    * {@inheritDoc}.
    *
@@ -82,52 +83,42 @@ public class ConfigStoreBackedValueInspector implements ConfigStoreValueInspecto
       ConfigStoreWithBatchFetches batchStore = (ConfigStoreWithBatchFetches)this.cs;
       return batchStore.getOwnConfigs(configKeys, version);
     }
-    
+
     Map<ConfigKeyPath, Config> result = new HashMap<>();
     for(ConfigKeyPath configKey: configKeys){
       result.put(configKey, this.cs.getOwnConfig(configKey, version));
     }
-    
+
     return result;
   }
 
-  /**
-   * {@inheritDoc}.
-   *
-   * <p>
-   *   This implementation simply delegate the functionality to the internal {@link ConfigStore}/version if
-   *   the internal {@link ConfigStore} is {@link ConfigStoreWithResolution}, otherwise based on {@link ConfigStoreTopologyInspector}
-   *   
-   *   1. find out all the imports recursively
-   *   2. resolved the config on the fly
-   * </p>
-   */
-  @Override
-  public Config getResolvedConfig(ConfigKeyPath configKey) {
+  private Config getResolvedConfigRecursive(ConfigKeyPath configKey) {
+
+
     if (this.cs instanceof ConfigStoreWithResolution) {
       return ((ConfigStoreWithResolution) this.cs).getResolvedConfig(configKey, this.version);
     }
-    
+
     /**
-     * currently use this function to check the circular dependency for the entire store, the result 
-     * is NOT used 
-     * 
+     * currently use this function to check the circular dependency for the entire store, the result
+     * is NOT used
+     *
      *     root
-     *    /   
+     *    /
      *   l1 -> t1 (imports t1)
      *   /
      *   l2 -> t2 (imports t2)
-     * 
+     *
      * getImportsRecursively(l2) will return {t2,t1} as current implementation did NOT return the implicit
-     * imports ( l1 ), otherwise, there will be a lot of result for both getImportsRecursively and 
+     * imports ( l1 ), otherwise, there will be a lot of result for both getImportsRecursively and
      * getImportedByRecursively
-     * 
-     * if we use the result, the getResolvedConfig may equals 
+     *
+     * if we use the result, the getResolvedConfig may equals
      * l2.ownConfig withFallback t2.ownConfig withFallback t1.ownConfig withFallback l1.ownConfig
-     * 
+     *
      *  but the correct result should be
      *  l2.ownConfig withFallback t2.ownConfig withFallback l1.ownConfig withFallback t1.ownConfig
-     *  
+     *
      *  The wrong ordering for those is because of we did NOT include the implicit imports l1
      */
     this.topology.getImportsRecursively(configKey);
@@ -136,21 +127,40 @@ public class ConfigStoreBackedValueInspector implements ConfigStoreValueInspecto
     if(configKey.isRootPath()){
       return initialConfig;
     }
-    
+
     List<ConfigKeyPath> ownImports = this.topology.getOwnImports(configKey);
     // merge with other configs from imports
     if(ownImports!=null){
       for(ConfigKeyPath p: ownImports){
-        initialConfig = initialConfig.withFallback(this.getResolvedConfig(p));
+        initialConfig = initialConfig.withFallback(this.getResolvedConfigRecursive(p));
       }
     }
-    
+
     // merge with configs from parent for Non root
-    initialConfig = initialConfig.withFallback(this.getResolvedConfig(configKey.getParent())).resolve();
+    initialConfig = initialConfig.withFallback(this.getResolvedConfigRecursive(configKey.getParent()));
 
     return initialConfig;
+
   }
-  
+
+
+  /**
+   * {@inheritDoc}.
+   *
+   * <p>
+   *   This implementation simply delegate the functionality to the internal {@link ConfigStore}/version if
+   *   the internal {@link ConfigStore} is {@link ConfigStoreWithResolution}, otherwise based on {@link ConfigStoreTopologyInspector}
+   *
+   *   1. find out all the imports recursively
+   *   2. resolved the config on the fly
+   * </p>
+   */
+  @Override
+  public Config getResolvedConfig(ConfigKeyPath configKey) {
+    return getResolvedConfigRecursive(configKey).withFallback(ConfigFactory.defaultOverrides())
+        .withFallback(ConfigFactory.systemEnvironment()).resolve();
+  }
+
   /**
    * {@inheritDoc}.
    *
@@ -166,12 +176,12 @@ public class ConfigStoreBackedValueInspector implements ConfigStoreValueInspecto
       ConfigStoreWithBatchFetches batchStore = (ConfigStoreWithBatchFetches)this.cs;
       return batchStore.getResolvedConfigs(configKeys, version);
     }
-    
+
     Map<ConfigKeyPath, Config> result = new HashMap<>();
     for(ConfigKeyPath configKey: configKeys){
       result.put(configKey, this.getResolvedConfig(configKey));
     }
-    
+
     return result;
   }
 

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
@@ -11,20 +11,6 @@
  */
 package gobblin.config.store.hdfs;
 
-import gobblin.config.common.impl.SingleLinkedListConfigKeyPath;
-import gobblin.config.store.api.ConfigKeyPath;
-import gobblin.config.store.api.ConfigStore;
-import gobblin.config.store.api.ConfigStoreWithStableVersioning;
-import gobblin.config.store.api.VersionDoesNotExistException;
-import gobblin.config.store.deploy.ConfigStream;
-import gobblin.config.store.deploy.Deployable;
-import gobblin.config.store.deploy.DeployableConfigSource;
-import gobblin.config.store.deploy.FsDeploymentConfig;
-import gobblin.util.FileListUtils;
-import gobblin.util.PathUtils;
-import gobblin.util.io.SeekableFSInputStream;
-import gobblin.util.io.StreamUtils;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -46,6 +32,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -57,6 +44,20 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+
+import gobblin.config.common.impl.SingleLinkedListConfigKeyPath;
+import gobblin.config.store.api.ConfigKeyPath;
+import gobblin.config.store.api.ConfigStore;
+import gobblin.config.store.api.ConfigStoreWithStableVersioning;
+import gobblin.config.store.api.VersionDoesNotExistException;
+import gobblin.config.store.deploy.ConfigStream;
+import gobblin.config.store.deploy.Deployable;
+import gobblin.config.store.deploy.DeployableConfigSource;
+import gobblin.config.store.deploy.FsDeploymentConfig;
+import gobblin.util.FileListUtils;
+import gobblin.util.PathUtils;
+import gobblin.util.io.SeekableFSInputStream;
+import gobblin.util.io.StreamUtils;
 
 
 /**
@@ -118,6 +119,7 @@ public class SimpleHDFSConfigStore implements ConfigStore, Deployable<FsDeployme
 
   private static final String MAIN_CONF_FILE_NAME = "main.conf";
   private static final String INCLUDES_CONF_FILE_NAME = "includes.conf";
+  private static final String INCLUDES_KEY_NAME = "includes";
 
   private final FileSystem fs;
   private final URI physicalStoreRoot;
@@ -251,15 +253,52 @@ public class SimpleHDFSConfigStore implements ConfigStore, Deployable<FsDeployme
       FileStatus includesFileStatus = this.fs.getFileStatus(includesFile);
       if (!includesFileStatus.isDir()) {
         try (InputStream includesConfInStream = this.fs.open(includesFileStatus.getPath())) {
-          configKeyPaths.addAll(Lists.newArrayList(
-              Iterables.transform(IOUtils.readLines(includesConfInStream, Charsets.UTF_8), new IncludesToConfigKey())));
+          configKeyPaths.addAll(Lists.newArrayList(Iterables.transform(
+              resolveIncludesList(IOUtils.readLines(includesConfInStream, Charsets.UTF_8)),
+                  new IncludesToConfigKey())));
         }
       }
     } catch (IOException e) {
-      throw new RuntimeException(String.format("Error while getting imports for configKey: \"%s\"", configKey), e);
+      throw new RuntimeException(String.format("Error while getting config for configKey: \"%s\"", configKey), e);
     }
+
     return configKeyPaths;
   }
+
+  /**
+   * A helper to resolve System properties and Environment variables in includes paths
+   * The method loads the list of unresolved <code>includes</code> into an in-memory {@link Config} object and reolves
+   * with a fallback on {@link ConfigFactory#defaultOverrides()}
+   *
+   * @param includes list of unresolved includes
+   * @return a list of resolved includes
+   */
+  @VisibleForTesting
+  public static List<String> resolveIncludesList(List<String> includes) {
+
+    if (includes.isEmpty()) {
+      return includes;
+    }
+
+    // Build a string representation of the config as parsing the includes as Map quotes the includes.
+    // Type safe resolves substitutions only for unquoted strings
+    StringBuilder includesBuilder = new StringBuilder();
+    for (String include : includes) {
+      // Skip comments
+      if (StringUtils.isNotBlank(include) && !StringUtils.startsWith(include, "#")) {
+        includesBuilder.append(INCLUDES_KEY_NAME).append("+=").append(include).append("\n");
+      }
+    }
+
+    if (includesBuilder.length() > 0) {
+      return ConfigFactory.parseString(includesBuilder.toString())
+              .withFallback(ConfigFactory.defaultOverrides())
+              .withFallback(ConfigFactory.systemEnvironment()).resolve().getStringList(INCLUDES_KEY_NAME);
+    }
+
+    return includes;
+  }
+
 
   /**
    * Retrieves the {@link Config} for the given {@link ConfigKeyPath} by reading the {@link #MAIN_CONF_FILE_NAME}
@@ -372,6 +411,7 @@ public class SimpleHDFSConfigStore implements ConfigStore, Deployable<FsDeployme
       for (String file : Splitter.on(SingleLinkedListConfigKeyPath.PATH_DELIMETER).omitEmptyStrings().split(input)) {
         configKey = configKey.createChild(file);
       }
+
       return configKey;
     }
   }

--- a/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/TestEnvironment.java
+++ b/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/TestEnvironment.java
@@ -1,0 +1,18 @@
+package gobblin.config;
+
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+
+import gobblin.config.common.impl.TestConfigStoreValueInspector;
+import gobblin.config.store.hdfs.SimpleHdfsConfigStoreTest;
+
+
+@Test
+public class TestEnvironment {
+
+  @BeforeSuite
+  public void setup() {
+    System.setProperty(SimpleHdfsConfigStoreTest.TAG_NAME_SYS_PROP_KEY, SimpleHdfsConfigStoreTest.TAG_NAME_SYS_PROP_VALUE);
+    System.setProperty(TestConfigStoreValueInspector.VALUE_INSPECTOR_SYS_PROP_KEY, TestConfigStoreValueInspector.VALUE_INSPECTOR_SYS_PROP_VALUE);
+  }
+}

--- a/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/common/impl/TestConfigStoreValueInspector.java
+++ b/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/common/impl/TestConfigStoreValueInspector.java
@@ -1,0 +1,69 @@
+package gobblin.config.common.impl;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import gobblin.config.TestEnvironment;
+import gobblin.config.store.api.ConfigKeyPath;
+import gobblin.config.store.api.ConfigStore;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.ConfigFactory;
+
+
+public class TestConfigStoreValueInspector {
+
+  private final String version = "1.0";
+
+  /**Set by {@link TestEnvironment#setup()}**/
+  public static final String VALUE_INSPECTOR_SYS_PROP_KEY = "sysProp.key1";
+  public static final String VALUE_INSPECTOR_SYS_PROP_VALUE = "sysProp.value1";
+
+  @Test
+  public void testSystemPropertyResolution() {
+
+    ConfigStore mockConfigStore = mock(ConfigStore.class, Mockito.RETURNS_SMART_NULLS);
+    when(mockConfigStore.getCurrentVersion()).thenReturn(version);
+
+    ConfigStoreTopologyInspector mockTopology = mock(ConfigStoreTopologyInspector.class, Mockito.RETURNS_SMART_NULLS);
+
+    ConfigStoreBackedValueInspector valueInspector =
+        new ConfigStoreBackedValueInspector(mockConfigStore, version, mockTopology);
+
+    ConfigKeyPath testConfigKeyPath = SingleLinkedListConfigKeyPath.ROOT.createChild("a");
+    when(mockConfigStore.getOwnConfig(testConfigKeyPath.getParent(), version)).thenReturn(ConfigFactory.empty());
+    when(mockConfigStore.getOwnConfig(testConfigKeyPath, version)).thenReturn(
+        ConfigFactory.parseString("configProp = ${?" + VALUE_INSPECTOR_SYS_PROP_KEY + "}"));
+
+    Assert.assertEquals(valueInspector.getResolvedConfig(testConfigKeyPath).getString("configProp"), VALUE_INSPECTOR_SYS_PROP_VALUE);
+
+  }
+
+  @Test
+  public void testResolveConfigOverridingInChild() {
+
+    ConfigStore mockConfigStore = mock(ConfigStore.class, Mockito.RETURNS_SMART_NULLS);
+    when(mockConfigStore.getCurrentVersion()).thenReturn(version);
+
+    ConfigStoreTopologyInspector mockTopology = mock(ConfigStoreTopologyInspector.class, Mockito.RETURNS_SMART_NULLS);
+
+    ConfigStoreBackedValueInspector valueInspector =
+        new ConfigStoreBackedValueInspector(mockConfigStore, version, mockTopology);
+
+    ConfigKeyPath keyPathA = SingleLinkedListConfigKeyPath.ROOT.createChild("a");
+    ConfigKeyPath keyPathA_Slash_B = keyPathA.createChild("b");
+
+    when(mockConfigStore.getOwnConfig(keyPathA.getParent(), version)).thenReturn(ConfigFactory.empty());
+    when(mockConfigStore.getOwnConfig(keyPathA, version)).thenReturn(
+        ConfigFactory.parseString("key1 = value1InA \n key2 = ${key1}"));
+
+    when(mockConfigStore.getOwnConfig(keyPathA_Slash_B, version)).thenReturn(
+        ConfigFactory.parseString("key1 = value1InB"));
+
+    Assert.assertEquals(valueInspector.getResolvedConfig(keyPathA_Slash_B).getString("key2"), "value1InB");
+
+  }
+}

--- a/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/common/impl/TestInMemoryTopology.java
+++ b/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/common/impl/TestInMemoryTopology.java
@@ -214,12 +214,12 @@ public class TestInMemoryTopology {
     testValuesForIdentity(rawValueInspector);
     testValuesForIdentity(inMemoryStrongRef);
     testValuesForIdentity(inMemoryWeakRef);
-    
+
     // test values for Espresso Tag
     testValuesForEspressoTag(rawValueInspector);
     testValuesForEspressoTag(inMemoryStrongRef);
     testValuesForEspressoTag(inMemoryWeakRef);
-    
+
     // test for batch
     Collection<ConfigKeyPath> inputs = new ArrayList<ConfigKeyPath>();
     inputs.add(espressoTag);
@@ -228,7 +228,7 @@ public class TestInMemoryTopology {
     Assert.assertEquals(resultMap.size(), 2);
     testValuesForEspressoTagOwnConfig(resultMap.get(espressoTag));
     checkValuesForIdentityOwnConfig(resultMap.get(identity));
-    
+
     resultMap = rawValueInspector.getResolvedConfigs(inputs);
     Assert.assertEquals(resultMap.size(), 2);
     testValuesForEspressoTagResolvedConfig(resultMap.get(espressoTag));
@@ -238,19 +238,17 @@ public class TestInMemoryTopology {
   private void testValuesForEspressoTag(ConfigStoreValueInspector valueInspector){
     Config config = valueInspector.getOwnConfig(this.espressoTag);
     testValuesForEspressoTagOwnConfig(config);
-    
+
     config = valueInspector.getResolvedConfig(this.espressoTag);
     testValuesForEspressoTagResolvedConfig(config);
   }
-  
+
   private void testValuesForEspressoTagOwnConfig(Config config){
-    Assert.assertTrue(config.entrySet().size() == 2 );
     Assert.assertTrue(config.getString("keyOf_espressoTag").equals("valueOf_espressoTag"));
     Assert.assertTrue(config.getString("generalKey").equals("valueOf_generalKey_espressoTag"));
   }
-  
+
   private void testValuesForEspressoTagResolvedConfig(Config config){
-    Assert.assertTrue(config.entrySet().size() == 6 );
     Assert.assertTrue(config.getString("keyOf_espressoTag").equals("valueOf_espressoTag"));
     Assert.assertTrue(config.getString("generalKey").equals("valueOf_generalKey_espressoTag"));
     Assert.assertTrue(config.getString("keyInRoot").equals("valueInRoot"));
@@ -258,7 +256,7 @@ public class TestInMemoryTopology {
     Assert.assertTrue(config.getString("keyOf_tag2").equals("valueOf_tag2"));
     Assert.assertTrue(config.getString("keyOf_tag").equals("valueOf_tag"));
   }
-  
+
   private void testValuesForIdentity(ConfigStoreValueInspector valueInspector){
     Config ownConfig = valueInspector.getOwnConfig(identity);
     checkValuesForIdentityOwnConfig(ownConfig);
@@ -266,15 +264,14 @@ public class TestInMemoryTopology {
     Config resolvedConfig = valueInspector.getResolvedConfig(identity);
     checkValuesForIdentityResolvedConfig(resolvedConfig);
   }
-  
+
   private void checkValuesForIdentityOwnConfig(Config ownConfig){
     Assert.assertTrue(ownConfig.entrySet().size() == 2 );
     Assert.assertTrue(ownConfig.getString("keyOf_identity").equals("valueOf_identity"));
     Assert.assertTrue(ownConfig.getString("generalKey").equals("valueOf_generalKey_identity"));
   }
-  
+
   private void checkValuesForIdentityResolvedConfig(Config resolvedConfig){
-    Assert.assertTrue(resolvedConfig.entrySet().size() == 10 );
     Assert.assertTrue(resolvedConfig.getString("keyOf_data").equals("valueOf_data"));
     Assert.assertTrue(resolvedConfig.getString("keyOf_identity").equals("valueOf_identity"));
     Assert.assertTrue(resolvedConfig.getString("keyOf_espressoTag").equals("valueOf_espressoTag"));


### PR DESCRIPTION
### Changes
- Added support to resolve system and environment variables in config management. Both in `main.conf` and `includes.conf`
- `Typesafe Config` expects the system/env key to be in the format `${?sys.prop.key}`. Note that `?` signifies system/env variables.
- Added support to resolve system/env variables in `includes.conf`. Since `includes.conf` is in plain text with one include per line, it can not be parsed as `TypeSafe Config`. To workaround that we build a `TypeSafe Config` objects with key `includes` and value a list of include paths. This config object is then resolved with fallback on system/env properties.

E.g. If the includes.conf file looks like

<pre>
/path/to/tag1
/path/to/${?sys.key1}
</pre>

It gets loaded in memory as a `TypeSafe Config` object, 
<pre>
includes = [/path/to/tag1, /path/to/${?sys.key1}]
</pre>

Then resolved with fallback on system/env properties as,
<pre>
includes = [/path/to/tag1, /path/to/sys.value1]
</pre>

- Fixed bug in resolutions. `Config.resolve` should be called only once after all the fallbacks have been configured

@tuGithub and @chavdar please review.