### PR TITLE
HiveMetastoreBasedRegister should not close Hive client pool, as the …

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -338,12 +338,4 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
     }
   }
 
-  @Override
-  public void close() throws IOException {
-    try {
-      super.close();
-    } finally {
-      this.clientPool.close();
-    }
-  }
 }


### PR DESCRIPTION
…pools are cached and reused.