### PR TITLE
Separate jobstate from taskstate and datasetstate

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ImmutableWorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ImmutableWorkUnitState.java
@@ -27,8 +27,8 @@ import gobblin.source.extractor.Watermark;
 public class ImmutableWorkUnitState extends WorkUnitState {
 
   public ImmutableWorkUnitState(WorkUnitState workUnitState) {
-    super(workUnitState.getWorkunit());
-    super.addAll(workUnitState);
+    super(workUnitState.getWorkunit(), workUnitState.getJobState());
+    super.addAll(workUnitState.getProperties());
   }
 
   @Override
@@ -53,11 +53,6 @@ public class ImmutableWorkUnitState extends WorkUnitState {
   }
 
   @Override
-  public void addAll(State otherState) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public void addAll(Properties properties) {
     throw new UnsupportedOperationException();
   }
@@ -67,16 +62,7 @@ public class ImmutableWorkUnitState extends WorkUnitState {
     throw new UnsupportedOperationException();
   }
 
-  @Override
-  public void addAllIfNotExist(State otherState) {
-    throw new UnsupportedOperationException();
-  }
-
   public void overrideWith(Properties properties) {
-    throw new UnsupportedOperationException();
-  }
-
-  public void overrideWith(State otherState) {
     throw new UnsupportedOperationException();
   }
 

--- a/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/SourceState.java
@@ -88,7 +88,7 @@ public class SourceState extends State {
    */
   public SourceState(State properties, Map<String, ? extends SourceState> previousDatasetStatesByUrns,
       Iterable<WorkUnitState> previousWorkUnitStates) {
-    super.addAll(properties);
+    super.addAll(properties.getProperties());
     this.previousDatasetStatesByUrns = ImmutableMap.copyOf(previousDatasetStatesByUrns);
     for (WorkUnitState workUnitState : previousWorkUnitStates) {
       this.previousWorkUnitStates.add(new ImmutableWorkUnitState(workUnitState));

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -40,7 +40,7 @@ import org.apache.hadoop.io.Writable;
  *
  * @author kgoodhop
  */
-@EqualsAndHashCode(exclude = {"jsonParser"})
+@EqualsAndHashCode(exclude = { "jsonParser" })
 public class State implements Writable {
 
   private static final Joiner LIST_JOINER = Joiner.on(",");
@@ -80,7 +80,7 @@ public class State implements Writable {
    * @param otherState the other {@link State} instance
    */
   public void addAll(State otherState) {
-    this.properties.putAll(otherState.properties);
+    addAll(otherState.properties);
   }
 
   /**
@@ -201,13 +201,11 @@ public class State implements Writable {
    * @param value property value (if it includes commas, it will be split by the commas).
    */
   public synchronized void appendToSetProp(String key, String value) {
-      Set<String> set = value == null ?
-              Sets.<String>newHashSet() :
-              Sets.newHashSet(LIST_SPLITTER.splitToList(value));
-      if (contains(key)) {
-          set.addAll(getPropAsSet(key));
-      }
-      setProp(key, LIST_JOINER.join(set));
+    Set<String> set = value == null ? Sets.<String> newHashSet() : Sets.newHashSet(LIST_SPLITTER.splitToList(value));
+    if (contains(key)) {
+      set.addAll(getPropAsSet(key));
+    }
+    setProp(key, LIST_JOINER.join(set));
   }
 
   /**
@@ -217,7 +215,7 @@ public class State implements Writable {
    * @return value associated with the key as a string or <code>null</code> if the property is not set
    */
   public String getProp(String key) {
-    return getProperty(key);
+    return this.properties.getProperty(key);
   }
 
   /**
@@ -228,7 +226,7 @@ public class State implements Writable {
    * @return value associated with the key or the default value if the property is not set
    */
   public String getProp(String key, String def) {
-    return getProperty(key, def);
+    return this.properties.getProperty(key, def);
   }
 
   /**
@@ -238,7 +236,7 @@ public class State implements Writable {
    * @return value associated with the key as a {@link List} of strings
    */
   public List<String> getPropAsList(String key) {
-    return LIST_SPLITTER.splitToList(getProperty(key));
+    return LIST_SPLITTER.splitToList(getProp(key));
   }
 
   /**
@@ -259,9 +257,8 @@ public class State implements Writable {
    * @return value associated with the key as a {@link Set} of strings
    */
   public Set<String> getPropAsSet(String key) {
-      return Sets.newHashSet(LIST_SPLITTER.splitToList(getProp(key)));
+    return Sets.newHashSet(LIST_SPLITTER.splitToList(getProp(key)));
   }
-
 
   /**
    * Get the value of a comma separated property as a {@link Set} of strings.
@@ -271,7 +268,7 @@ public class State implements Writable {
    * @return value (the default value if the property is not set) associated with the key as a {@link Set} of strings
    */
   public Set<String> getPropAsSet(String key, String def) {
-      return Sets.newHashSet(LIST_SPLITTER.splitToList(getProp(key, def)));
+    return Sets.newHashSet(LIST_SPLITTER.splitToList(getProp(key, def)));
   }
 
   /**
@@ -281,7 +278,7 @@ public class State implements Writable {
    * @return value associated with the key as a case insensitive {@link Set} of strings
    */
   public Set<String> getPropAsCaseInsensitiveSet(String key) {
-    return ImmutableSortedSet.copyOf(String.CASE_INSENSITIVE_ORDER, LIST_SPLITTER.split(getProperty(key)));
+    return ImmutableSortedSet.copyOf(String.CASE_INSENSITIVE_ORDER, LIST_SPLITTER.split(getProp(key)));
   }
 
   /**
@@ -292,7 +289,7 @@ public class State implements Writable {
    * @return value associated with the key as a case insensitive {@link Set} of strings
    */
   public Set<String> getPropAsCaseInsensitiveSet(String key, String def) {
-    return ImmutableSortedSet.copyOf(String.CASE_INSENSITIVE_ORDER, LIST_SPLITTER.split(getProperty(key, def)));
+    return ImmutableSortedSet.copyOf(String.CASE_INSENSITIVE_ORDER, LIST_SPLITTER.split(getProp(key, def)));
   }
 
   /**
@@ -302,7 +299,7 @@ public class State implements Writable {
    * @return long integer value associated with the key
    */
   public long getPropAsLong(String key) {
-    return Long.parseLong(getProperty(key));
+    return Long.parseLong(getProp(key));
   }
 
   /**
@@ -313,7 +310,7 @@ public class State implements Writable {
    * @return long integer value associated with the key or the default value if the property is not set
    */
   public long getPropAsLong(String key, long def) {
-    return Long.parseLong(getProperty(key, String.valueOf(def)));
+    return Long.parseLong(getProp(key, String.valueOf(def)));
   }
 
   /**
@@ -323,7 +320,7 @@ public class State implements Writable {
    * @return integer value associated with the key
    */
   public int getPropAsInt(String key) {
-    return Integer.parseInt(getProperty(key));
+    return Integer.parseInt(getProp(key));
   }
 
   /**
@@ -334,7 +331,7 @@ public class State implements Writable {
    * @return integer value associated with the key or the default value if the property is not set
    */
   public int getPropAsInt(String key, int def) {
-    return Integer.parseInt(getProperty(key, String.valueOf(def)));
+    return Integer.parseInt(getProp(key, String.valueOf(def)));
   }
 
   /**
@@ -344,7 +341,7 @@ public class State implements Writable {
    * @return short value associated with the key
    */
   public short getPropAsShort(String key) {
-    return Short.parseShort(getProperty(key));
+    return Short.parseShort(getProp(key));
   }
 
   /**
@@ -355,7 +352,7 @@ public class State implements Writable {
    * @return short value associated with the key
    */
   public short getPropAsShortWithRadix(String key, int radix) {
-    return Short.parseShort(getProperty(key), radix);
+    return Short.parseShort(getProp(key), radix);
   }
 
   /**
@@ -366,7 +363,7 @@ public class State implements Writable {
    * @return short value associated with the key or the default value if the property is not set
    */
   public short getPropAsShort(String key, short def) {
-    return Short.parseShort(getProperty(key, String.valueOf(def)));
+    return Short.parseShort(getProp(key, String.valueOf(def)));
   }
 
   /**
@@ -378,7 +375,7 @@ public class State implements Writable {
    * @return short value associated with the key or the default value if the property is not set
    */
   public short getPropAsShortWithRadix(String key, short def, int radix) {
-    return contains(key) ? Short.parseShort(getProperty(key), radix) : def;
+    return contains(key) ? Short.parseShort(getProp(key), radix) : def;
   }
 
   /**
@@ -388,7 +385,7 @@ public class State implements Writable {
    * @return double value associated with the key
    */
   public double getPropAsDouble(String key) {
-    return Double.parseDouble(getProperty(key));
+    return Double.parseDouble(getProp(key));
   }
 
   /**
@@ -399,7 +396,7 @@ public class State implements Writable {
    * @return double value associated with the key or the default value if the property is not set
    */
   public double getPropAsDouble(String key, double def) {
-    return Double.parseDouble(getProperty(key, String.valueOf(def)));
+    return Double.parseDouble(getProp(key, String.valueOf(def)));
   }
 
   /**
@@ -409,7 +406,7 @@ public class State implements Writable {
    * @return boolean value associated with the key
    */
   public boolean getPropAsBoolean(String key) {
-    return Boolean.parseBoolean(getProperty(key));
+    return Boolean.parseBoolean(getProp(key));
   }
 
   /**
@@ -420,7 +417,7 @@ public class State implements Writable {
    * @return boolean value associated with the key or the default value if the property is not set
    */
   public boolean getPropAsBoolean(String key, boolean def) {
-    return Boolean.parseBoolean(getProperty(key, String.valueOf(def)));
+    return Boolean.parseBoolean(getProp(key, String.valueOf(def)));
   }
 
   /**
@@ -450,7 +447,7 @@ public class State implements Writable {
    */
   @Deprecated
   protected String getProperty(String key) {
-    return this.properties.getProperty(key);
+    return getProp(key);
   }
 
   /**
@@ -458,7 +455,7 @@ public class State implements Writable {
    */
   @Deprecated
   protected String getProperty(String key, String def) {
-    return this.properties.getProperty(key, def);
+    return getProp(key, def);
   }
 
   /**
@@ -492,26 +489,26 @@ public class State implements Writable {
       txt.readFields(in);
       String value = txt.toString();
 
-      properties.put(key, value);
+      this.properties.put(key, value);
     }
   }
 
   @Override
   public void write(DataOutput out) throws IOException {
     Text txt = new Text();
-    out.writeInt(properties.size());
+    out.writeInt(this.properties.size());
 
-    for (Object key : properties.keySet()) {
+    for (Object key : this.properties.keySet()) {
       txt.set((String) key);
       txt.write(out);
 
-      txt.set(properties.getProperty((String) key));
+      txt.set(this.properties.getProperty((String) key));
       txt.write(out);
     }
   }
 
   @Override
   public String toString() {
-    return properties.toString();
+    return this.properties.toString();
   }
 }

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -312,7 +312,10 @@ public class WorkUnitState extends State {
 
     WorkUnitState other = (WorkUnitState) object;
     return ((this.workUnit == null && other.workUnit == null)
-        || (this.workUnit != null && this.workUnit.equals(other.workUnit))) && super.equals(other);
+        || (this.workUnit != null && this.workUnit.equals(other.workUnit)))
+        && ((this.jobState == null && other.jobState == null)
+            || (this.jobState != null && this.jobState.equals(other.jobState)))
+        && super.equals(other);
   }
 
   @Override

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -27,6 +27,7 @@ import gobblin.source.extractor.Watermark;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.ImmutableWorkUnit;
 import gobblin.source.workunit.WorkUnit;
+import lombok.Getter;
 
 
 /**
@@ -66,22 +67,35 @@ public class WorkUnitState extends State {
     CANCELLED
   }
 
-  private WorkUnit workunit;
+  private final WorkUnit workUnit;
+
+  @Getter
+  private State jobState;
 
   /**
    * Default constructor used for deserialization.
    */
   public WorkUnitState() {
-    this.workunit = WorkUnit.createEmpty();
+    this.workUnit = WorkUnit.createEmpty();
+    this.jobState = new State();
   }
 
   /**
    * Constructor.
    *
    * @param workUnit a {@link WorkUnit} instance based on which a {@link WorkUnitState} instance is constructed
+   * @deprecated It is recommended to use {@link #WorkUnitState(WorkUnit, State)} rather than combining properties
+   * in the job state into the workunit.
    */
+  @Deprecated
   public WorkUnitState(WorkUnit workUnit) {
-    this.workunit = workUnit;
+    this.workUnit = workUnit;
+    this.jobState = new State();
+  }
+
+  public WorkUnitState(WorkUnit workUnit, State jobState) {
+    this.workUnit = workUnit;
+    this.jobState = jobState;
   }
 
   /**
@@ -90,7 +104,7 @@ public class WorkUnitState extends State {
    * @return an {@link ImmutableWorkUnit} that wraps the internal {@link WorkUnit}
    */
   public WorkUnit getWorkunit() {
-    return new ImmutableWorkUnit(workunit);
+    return new ImmutableWorkUnit(this.workUnit);
   }
 
   /**
@@ -161,7 +175,7 @@ public class WorkUnitState extends State {
    * Backoff the actual high watermark to the low watermark returned by {@link WorkUnit#getLowWatermark()}.
    */
   public void backoffActualHighWatermark() {
-    JsonElement lowWatermark = this.workunit.getLowWatermark();
+    JsonElement lowWatermark = this.workUnit.getLowWatermark();
     if (lowWatermark == null) {
       return;
     }
@@ -194,19 +208,34 @@ public class WorkUnitState extends State {
   @Override
   public Properties getProperties() {
     Properties props = new Properties();
-    props.putAll(this.workunit.getProperties());
+    props.putAll(this.jobState.getProperties());
+    props.putAll(this.workUnit.getProperties());
     props.putAll(super.getProperties());
     return props;
   }
 
   @Override
   public String getProp(String key) {
-    return getProperty(key);
+    String value = super.getProp(key);
+    if (value == null) {
+      value = this.workUnit.getProp(key);
+    }
+    if (value == null) {
+      value = this.jobState.getProp(key);
+    }
+    return value;
   }
 
   @Override
   public String getProp(String key, String def) {
-    return getProperty(key, def);
+    String value = super.getProp(key);
+    if (value == null) {
+      value = this.workUnit.getProp(key);
+    }
+    if (value == null) {
+      value = this.jobState.getProp(key, def);
+    }
+    return value;
   }
 
   /**
@@ -215,12 +244,7 @@ public class WorkUnitState extends State {
   @Deprecated
   @Override
   protected String getProperty(String key) {
-    String propStr = super.getProperty(key);
-    if (propStr != null) {
-      return propStr;
-    } else {
-      return workunit.getProperty(key);
-    }
+    return getProp(key);
   }
 
   /**
@@ -229,24 +253,20 @@ public class WorkUnitState extends State {
   @Deprecated
   @Override
   protected String getProperty(String key, String def) {
-    String propStr = super.getProperty(key);
-    if (propStr != null) {
-      return propStr;
-    } else {
-      return workunit.getProperty(key, def);
-    }
+    return getProp(key, def);
   }
 
   @Override
   public Set<String> getPropertyNames() {
     Set<String> set = Sets.newHashSet(super.getPropertyNames());
-    set.addAll(workunit.getPropertyNames());
+    set.addAll(this.workUnit.getPropertyNames());
+    set.addAll(this.jobState.getPropertyNames());
     return set;
   }
 
   @Override
   public boolean contains(String key) {
-    return super.contains(key) || workunit.contains(key);
+    return super.contains(key) || this.workUnit.contains(key) || this.jobState.contains(key);
   }
 
   /**
@@ -255,7 +275,7 @@ public class WorkUnitState extends State {
    * @return {@link gobblin.source.workunit.Extract} associated with the {@link WorkUnit}
    */
   public Extract getExtract() {
-    Extract curExtract = new Extract(workunit.getExtract());
+    Extract curExtract = new Extract(this.workUnit.getExtract());
     return curExtract;
   }
 
@@ -268,15 +288,19 @@ public class WorkUnitState extends State {
     return getExtract().getPreviousTableState();
   }
 
+  public void setJobState(State jobState) {
+    this.jobState = jobState;
+  }
+
   @Override
   public void readFields(DataInput in) throws IOException {
-    this.workunit.readFields(in);
+    this.workUnit.readFields(in);
     super.readFields(in);
   }
 
   @Override
   public void write(DataOutput out) throws IOException {
-    this.workunit.write(out);
+    this.workUnit.write(out);
     super.write(out);
   }
 
@@ -287,21 +311,22 @@ public class WorkUnitState extends State {
     }
 
     WorkUnitState other = (WorkUnitState) object;
-    return ((this.workunit == null && other.workunit == null)
-        || (this.workunit != null && this.workunit.equals(other.workunit))) && super.equals(other);
+    return ((this.workUnit == null && other.workUnit == null)
+        || (this.workUnit != null && this.workUnit.equals(other.workUnit))) && super.equals(other);
   }
 
   @Override
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();
-    result = prime * result + (this.workunit == null ? 0 : this.workunit.hashCode());
+    result = prime * result + (this.workUnit == null ? 0 : this.workUnit.hashCode());
     return result;
   }
 
   @Override
   public String toString() {
-    return super.toString() + "\nWorkUnit: " + getWorkunit().toString() + "\nExtract: " + getExtract().toString();
+    return super.toString() + "\nWorkUnit: " + getWorkunit().toString() + "\nExtract: " + getExtract().toString()
+        + "\nJobState: " + this.jobState.toString();
   }
 
   /**

--- a/gobblin-api/src/main/java/gobblin/source/workunit/Extract.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/Extract.java
@@ -109,7 +109,7 @@ public class Extract extends State {
    * @param extract the other {@link Extract} instance
    */
   public Extract(Extract extract) {
-    super.addAll(extract);
+    super.addAll(extract.getProperties());
   }
 
   @Override

--- a/gobblin-api/src/main/java/gobblin/source/workunit/ImmutableWorkUnit.java
+++ b/gobblin-api/src/main/java/gobblin/source/workunit/ImmutableWorkUnit.java
@@ -28,7 +28,7 @@ public class ImmutableWorkUnit extends WorkUnit {
 
   public ImmutableWorkUnit(WorkUnit workUnit) {
     super(workUnit.getExtract());
-    super.addAll(workUnit);
+    super.addAll(workUnit.getProperties());
   }
 
   @Override

--- a/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
@@ -79,8 +79,7 @@ public class HiveRegistrationPublisher extends DataPublisher {
 
   @Deprecated
   @Override
-  public void initialize() throws IOException {
-  }
+  public void initialize() throws IOException {}
 
   @Override
   public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
@@ -113,7 +112,7 @@ public class HiveRegistrationPublisher extends DataPublisher {
     log.info("Finished generating all HiveSpecs");
   }
 
-  private Set<String> getUniquePathsToRegister(Collection<? extends WorkUnitState> states) {
+  private static Set<String> getUniquePathsToRegister(Collection<? extends WorkUnitState> states) {
     Set<String> paths = Sets.newHashSet();
     for (State state : states) {
       if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/AbstractSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/AbstractSource.java
@@ -85,7 +85,7 @@ public abstract class AbstractSource<S, D> implements Source<S, D> {
             ConfigurationKeys.DEFAULT_OVERWRITE_CONFIGS_IN_STATESTORE)) {
           // We need to make a copy here since getPreviousWorkUnitStates returns ImmutableWorkUnitStates
           // for which addAll is not supported
-          WorkUnitState workUnitStateCopy = new WorkUnitState(workUnitState.getWorkunit());
+          WorkUnitState workUnitStateCopy = new WorkUnitState(workUnitState.getWorkunit(), state);
           workUnitStateCopy.addAll(workUnitState);
           workUnitStateCopy.overrideWith(state);
           previousWorkUnitStates.add(workUnitStateCopy);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/FsDatasetStateStore.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/FsDatasetStateStore.java
@@ -174,9 +174,7 @@ public class FsDatasetStateStore extends FsStateStore<JobState.DatasetState> {
       if (!previousDatasetStates.isEmpty()) {
         // There should be a single dataset state on the list if the list is not empty
         JobState.DatasetState previousDatasetState = previousDatasetStates.get(0);
-        datasetStatesByUrns.put(
-            previousDatasetState.getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN),
-            previousDatasetState);
+        datasetStatesByUrns.put(previousDatasetState.getDatasetUrn(), previousDatasetState);
       }
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -19,6 +19,7 @@ import java.io.StringWriter;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 
 import org.apache.hadoop.io.Text;
 
@@ -294,7 +295,7 @@ public class JobState extends SourceState {
       String datasetUrn = taskState.getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN);
       if (!datasetStatesByUrns.containsKey(datasetUrn)) {
         DatasetState datasetState = newDatasetState(false);
-        datasetState.setProp(ConfigurationKeys.DATASET_URN_KEY, datasetUrn);
+        datasetState.setDatasetUrn(datasetUrn);
         datasetStatesByUrns.put(datasetUrn, datasetState);
       }
 
@@ -313,7 +314,7 @@ public class JobState extends SourceState {
   public List<WorkUnitState> getTaskStatesAsWorkUnitStates() {
     ImmutableList.Builder<WorkUnitState> builder = ImmutableList.builder();
     for (TaskState taskState : this.taskStates.values()) {
-      WorkUnitState workUnitState = new WorkUnitState(taskState.getWorkunit());
+      WorkUnitState workUnitState = new WorkUnitState(taskState.getWorkunit(), taskState.getJobState());
       workUnitState.setId(taskState.getId());
       workUnitState.addAll(taskState);
       builder.add(workUnitState);
@@ -543,7 +544,6 @@ public class JobState extends SourceState {
    */
   public DatasetState newDatasetState(boolean fullCopy) {
     DatasetState datasetState = new DatasetState(this.jobName, this.jobId);
-    datasetState.addAll(this);
     datasetState.setStartTime(this.startTime);
     datasetState.setEndTime(this.endTime);
     datasetState.setDuration(this.duration);
@@ -564,8 +564,12 @@ public class JobState extends SourceState {
   }
 
   /**
-   * A subclass of {@link JobState} that is used to represent dataset states. This class is currently
-   * identical to {@link JobState} except that the name is more meaningful and less confusing.
+   * A subclass of {@link JobState} that is used to represent dataset states.
+   *
+   * <p>
+   *   A {@code DatasetState} does <em>not</em> contain any properties. Operations such as {@link #getProp(String)}
+   *   and {@link #setProp(String, Object)} are not supported.
+   * </p>
    */
   public static class DatasetState extends JobState {
 
@@ -579,11 +583,50 @@ public class JobState extends SourceState {
     }
 
     public void setDatasetUrn(String datasetUrn) {
-      setProp(ConfigurationKeys.DATASET_URN_KEY, datasetUrn);
+      super.setProp(ConfigurationKeys.DATASET_URN_KEY, datasetUrn);
     }
 
     public String getDatasetUrn() {
-      return getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN);
+      return super.getProp(ConfigurationKeys.DATASET_URN_KEY, ConfigurationKeys.DEFAULT_DATASET_URN);
+    }
+
+    public void incrementJobFailures() {
+      super.setProp(ConfigurationKeys.JOB_FAILURES_KEY,
+          Integer.parseInt(super.getProp(ConfigurationKeys.JOB_FAILURES_KEY, "0")) + 1);
+    }
+
+    public void setNoJobFailure() {
+      super.setProp(ConfigurationKeys.JOB_FAILURES_KEY, 0);
+    }
+
+    public int getJobFailures() {
+      return Integer.parseInt(super.getProp(ConfigurationKeys.JOB_FAILURES_KEY));
+    }
+
+    public String getProp(String key) {
+      throw new UnsupportedOperationException();
+    }
+
+    public String getProp(String key, String def) {
+      throw new UnsupportedOperationException();
+    }
+
+    public void setProp(String key, Object value) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAll(Properties properties) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void addAllIfNotExist(Properties properties) {
+      throw new UnsupportedOperationException();
+    }
+
+    public void overrideWith(Properties properties) {
+      throw new UnsupportedOperationException();
     }
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
@@ -54,12 +54,10 @@ import gobblin.writer.WriterOutputFormat;
  */
 public class TaskContext {
 
-  private final WorkUnit workUnit;
   private final TaskState taskState;
   private final TaskMetrics taskMetrics;
 
   public TaskContext(WorkUnitState workUnitState) {
-    this.workUnit = workUnitState.getWorkunit();
     this.taskState = new TaskState(workUnitState);
     this.taskMetrics = TaskMetrics.get(this.taskState);
     this.taskState.setProp(Instrumented.METRIC_CONTEXT_NAME_KEY, this.taskMetrics.getName());
@@ -91,7 +89,7 @@ public class TaskContext {
    */
   public Source getSource() {
     try {
-      return Source.class.cast(Class.forName(this.workUnit.getProp(ConfigurationKeys.SOURCE_CLASS_KEY)).newInstance());
+      return Source.class.cast(Class.forName(this.taskState.getProp(ConfigurationKeys.SOURCE_CLASS_KEY)).newInstance());
     } catch (ClassNotFoundException cnfe) {
       throw new RuntimeException(cnfe);
     } catch (InstantiationException ie) {
@@ -130,7 +128,7 @@ public class TaskContext {
    * @return interval for status reporting
    */
   public long getStatusReportingInterval() {
-    return this.workUnit.getPropAsLong(ConfigurationKeys.TASK_STATUS_REPORT_INTERVAL_IN_MS_KEY,
+    return this.taskState.getPropAsLong(ConfigurationKeys.TASK_STATUS_REPORT_INTERVAL_IN_MS_KEY,
         ConfigurationKeys.DEFAULT_TASK_STATUS_REPORT_INTERVAL_IN_MS);
   }
 
@@ -142,7 +140,7 @@ public class TaskContext {
    * @return writer {@link Destination.DestinationType}
    */
   public Destination.DestinationType getDestinationType(int branches, int index) {
-    return Destination.DestinationType.valueOf(this.workUnit.getProp(
+    return Destination.DestinationType.valueOf(this.taskState.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_DESTINATION_TYPE_KEY, branches, index),
         Destination.DestinationType.HDFS.name()));
   }
@@ -155,7 +153,7 @@ public class TaskContext {
    * @return output format of the writer
    */
   public WriterOutputFormat getWriterOutputFormat(int branches, int index) {
-    String writerOutputFormatValue = this.workUnit.getProp(
+    String writerOutputFormatValue = this.taskState.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY, branches, index),
         WriterOutputFormat.OTHER.name());
 
@@ -184,7 +182,7 @@ public class TaskContext {
     String converterClassKey =
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.CONVERTER_CLASSES_KEY, index);
 
-    if (!this.workUnit.contains(converterClassKey)) {
+    if (!this.taskState.contains(converterClassKey)) {
       return Collections.emptyList();
     }
 
@@ -194,7 +192,7 @@ public class TaskContext {
 
     List<Converter<?, ?, ?, ?>> converters = Lists.newArrayList();
     for (String converterClass : Splitter.on(",").omitEmptyStrings().trimResults()
-        .split(this.workUnit.getProp(converterClassKey))) {
+        .split(this.taskState.getProp(converterClassKey))) {
       try {
         Converter<?, ?, ?, ?> converter = Converter.class.cast(Class.forName(converterClass).newInstance());
         InstrumentedConverterDecorator instrumentedConverter = new InstrumentedConverterDecorator<>(converter);
@@ -221,7 +219,7 @@ public class TaskContext {
   public ForkOperator getForkOperator() {
     try {
       ForkOperator fork =
-          ForkOperator.class.cast(Class.forName(this.workUnit.getProp(ConfigurationKeys.FORK_OPERATOR_CLASS_KEY,
+          ForkOperator.class.cast(Class.forName(this.taskState.getProp(ConfigurationKeys.FORK_OPERATOR_CLASS_KEY,
               ConfigurationKeys.DEFAULT_FORK_OPERATOR_CLASS)).newInstance());
       return new InstrumentedForkOperatorDecorator<>(fork);
     } catch (ClassNotFoundException cnfe) {
@@ -288,7 +286,7 @@ public class TaskContext {
    * @return a {@link DataWriterBuilder}
    */
   public DataWriterBuilder getDataWriterBuilder(int branches, int index) {
-    String dataWriterBuilderClassName = this.workUnit.getProp(
+    String dataWriterBuilderClassName = this.taskState.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUILDER_CLASS, branches, index),
         ConfigurationKeys.DEFAULT_WRITER_BUILDER_CLASS);
     try {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskStateCollectorService.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskStateCollectorService.java
@@ -149,6 +149,7 @@ public class TaskStateCollectorService extends AbstractScheduledService {
     // Add the TaskStates of completed tasks to the JobState so when the control
     // returns to the launcher, it sees the TaskStates of all completed tasks.
     for (TaskState taskState : taskStateQueue) {
+      taskState.setJobState(this.jobState);
       this.jobState.addTaskState(taskState);
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -64,7 +64,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
   private volatile CountDownLatch countDownLatch;
 
   public LocalJobLauncher(Properties jobProps) throws Exception {
-    super(jobProps, ImmutableList.<Tag<?>>of());
+    super(jobProps, ImmutableList.<Tag<?>> of());
 
     TimingEvent jobLocalSetupTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.JOB_LOCAL_SETUP);
 
@@ -117,8 +117,8 @@ public class LocalJobLauncher extends AbstractJobLauncher {
     TimingEvent workUnitsRunTimer = this.eventSubmitter.getTimingEvent(TimingEventNames.RunJobTimings.WORK_UNITS_RUN);
 
     this.countDownLatch = new CountDownLatch(workUnitsToRun.size());
-    AbstractJobLauncher.runWorkUnits(this.jobContext.getJobId(), workUnitsToRun, this.taskStateTracker,
-        this.taskExecutor, this.countDownLatch);
+    AbstractJobLauncher.runWorkUnits(this.jobContext.getJobId(), this.jobContext.getJobState(), workUnitsToRun,
+        this.taskStateTracker, this.taskExecutor, this.countDownLatch);
 
     LOG.info(String.format("Waiting for submitted tasks of job %s to complete...", jobId));
     while (!this.countDownLatch.await(1, TimeUnit.MINUTES)) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -128,7 +128,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   }
 
   public MRJobLauncher(Properties jobProps, Configuration conf) throws Exception {
-    super(jobProps, ImmutableList.<Tag<?>>of());
+    super(jobProps, ImmutableList.<Tag<?>> of());
 
     this.conf = conf;
     // Put job configuration properties into the Hadoop configuration so they are available in the mappers
@@ -143,7 +143,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
 
     this.fs = buildFileSystem(jobProps, this.conf);
 
-    this.mrJobDir = new Path(this.jobProps.getProperty(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY), this.jobContext.getJobName());
+    this.mrJobDir =
+        new Path(this.jobProps.getProperty(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY), this.jobContext.getJobName());
     if (this.fs.exists(this.mrJobDir)) {
       LOG.warn("Job working directory already exists for job " + this.jobContext.getJobName());
       this.fs.delete(this.mrJobDir, true);
@@ -330,10 +331,10 @@ public class MRJobLauncher extends AbstractJobLauncher {
   }
 
   @VisibleForTesting
-  static void serializeJobState(FileSystem fs, Path mrJobDir, Configuration conf, JobState jobState,
-                                Job job) throws IOException {
+  static void serializeJobState(FileSystem fs, Path mrJobDir, Configuration conf, JobState jobState, Job job)
+      throws IOException {
     Path jobStateFilePath = new Path(mrJobDir, JOB_STATE_FILE_NAME);
-    short jobStateRF = (short)conf.getInt("dfs.replication.max", 20);
+    short jobStateRF = (short) conf.getInt("dfs.replication.max", 20);
     SerializationUtils.serializeState(fs, jobStateFilePath, jobState, jobStateRF);
     job.getConfiguration().set(ConfigurationKeys.JOB_STATE_FILE_PATH_KEY, jobStateFilePath.toString());
 
@@ -516,8 +517,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
       try(Closer closer = Closer.create()) {
         this.fs = FileSystem.get(context.getConfiguration());
         this.taskStateStore =
-            new FsStateStore<>(this.fs, FileOutputFormat.getOutputPath(context).toUri().getPath(),
-                TaskState.class);
+            new FsStateStore<>(this.fs, FileOutputFormat.getOutputPath(context).toUri().getPath(), TaskState.class);
 
         String jobStateFileName = context.getConfiguration().get(ConfigurationKeys.JOB_STATE_DISTRIBUTED_CACHE_NAME);
         boolean foundStateFile = false;
@@ -567,7 +567,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
           this.map(context.getCurrentKey(), context.getCurrentValue(), context);
         }
         // Actually run the list of WorkUnits
-        runWorkUnits(this.jobState.getJobId(), context.getTaskAttemptID().toString(), this.workUnits,
+        runWorkUnits(this.jobState.getJobId(), context.getTaskAttemptID().toString(), this.jobState, this.workUnits,
             this.taskStateTracker, this.taskExecutor, this.taskStateStore, LOG);
       } finally {
         this.cleanup(context);
@@ -575,28 +575,22 @@ public class MRJobLauncher extends AbstractJobLauncher {
     }
 
     @Override
-    public void map(LongWritable key, Text value, Context context)
-        throws IOException, InterruptedException {
-      WorkUnit workUnit = (value.toString().endsWith(MULTI_WORK_UNIT_FILE_EXTENSION) ?
-          MultiWorkUnit.createEmpty() : WorkUnit.createEmpty());
+    public void map(LongWritable key, Text value, Context context) throws IOException, InterruptedException {
+      WorkUnit workUnit = (value.toString().endsWith(MULTI_WORK_UNIT_FILE_EXTENSION) ? MultiWorkUnit.createEmpty()
+          : WorkUnit.createEmpty());
       SerializationUtils.deserializeState(this.fs, new Path(value.toString()), workUnit);
 
       if (workUnit instanceof MultiWorkUnit) {
         List<WorkUnit> flattenedWorkUnits =
             JobLauncherUtils.flattenWorkUnits(((MultiWorkUnit) workUnit).getWorkUnits());
-        for (WorkUnit flattenedWorkUnit : flattenedWorkUnits) {
-          flattenedWorkUnit.addAllIfNotExist(this.jobState);
-        }
         this.workUnits.addAll(flattenedWorkUnits);
       } else {
-        workUnit.addAllIfNotExist(this.jobState);
         this.workUnits.add(workUnit);
       }
     }
 
     @Override
-    protected void cleanup(Context context)
-        throws IOException, InterruptedException {
+    protected void cleanup(Context context) throws IOException, InterruptedException {
       try {
         this.serviceManager.stopAsync().awaitStopped(5, TimeUnit.SECONDS);
       } catch (TimeoutException te) {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/FsDatasetStateStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/FsDatasetStateStoreTest.java
@@ -87,7 +87,6 @@ public class FsDatasetStateStoreTest {
     Assert.assertEquals(jobState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(jobState.getJobId(), TEST_JOB_ID);
     Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
-    Assert.assertEquals(jobState.getProp("foo"), "bar");
     Assert.assertEquals(jobState.getStartTime(), this.startTime);
     Assert.assertEquals(jobState.getEndTime(), this.startTime + 1000);
     Assert.assertEquals(jobState.getDuration(), 1000);
@@ -107,7 +106,6 @@ public class FsDatasetStateStoreTest {
     JobState.DatasetState datasetState = new JobState.DatasetState(TEST_JOB_NAME, TEST_JOB_ID);
 
     datasetState.setDatasetUrn(TEST_DATASET_URN);
-    datasetState.setProp("foo", "bar");
     datasetState.setState(JobState.RunningState.COMMITTED);
     datasetState.setId(TEST_DATASET_URN);
     datasetState.setStartTime(this.startTime);
@@ -135,7 +133,6 @@ public class FsDatasetStateStoreTest {
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
     Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
-    Assert.assertEquals(datasetState.getProp("foo"), "bar");
     Assert.assertEquals(datasetState.getStartTime(), this.startTime);
     Assert.assertEquals(datasetState.getEndTime(), this.startTime + 1000);
     Assert.assertEquals(datasetState.getDuration(), 1000);
@@ -161,7 +158,6 @@ public class FsDatasetStateStoreTest {
     Assert.assertEquals(datasetState.getJobName(), TEST_JOB_NAME);
     Assert.assertEquals(datasetState.getJobId(), TEST_JOB_ID);
     Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
-    Assert.assertEquals(datasetState.getProp("foo"), "bar");
     Assert.assertEquals(datasetState.getStartTime(), this.startTime);
     Assert.assertEquals(datasetState.getEndTime(), this.startTime + 1000);
     Assert.assertEquals(datasetState.getDuration(), 1000);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -41,6 +41,7 @@ import gobblin.configuration.SourceState;
 import gobblin.configuration.WorkUnitState;
 import gobblin.metastore.MetaStoreModule;
 import gobblin.metastore.StateStore;
+import gobblin.runtime.JobState.DatasetState;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.test.TestExtractor;
@@ -80,19 +81,19 @@ public class JobLauncherTestHelper {
     }
 
     List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
-    JobState jobState = datasetStateList.get(0);
+    DatasetState datasetState = datasetStateList.get(0);
 
-    Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
-    Assert.assertEquals(jobState.getCompletedTasks(), 4);
-    Assert.assertEquals(jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY), 0);
-    for (TaskState taskState : jobState.getTaskStates()) {
+    Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
+    Assert.assertEquals(datasetState.getCompletedTasks(), 4);
+    Assert.assertEquals(datasetState.getJobFailures(), 0);
+    for (TaskState taskState : datasetState.getTaskStates()) {
       Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
       Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN),
           TestExtractor.TOTAL_RECORDS);
     }
   }
 
-  public void runTestWithPullLimit(Properties jobProps) throws Exception {
+  public void runTestWithPullLimit(Properties jobProps, long limit) throws Exception {
     String jobName = jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY);
     String jobId = JobLauncherUtils.newJobId(jobName);
     jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, jobId);
@@ -106,18 +107,16 @@ public class JobLauncherTestHelper {
     }
 
     List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
-    JobState jobState = datasetStateList.get(0);
+    DatasetState datasetState = datasetStateList.get(0);
 
-    Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
-    Assert.assertEquals(jobState.getCompletedTasks(), 4);
-    Assert.assertEquals(jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY), 0);
+    Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
+    Assert.assertEquals(datasetState.getCompletedTasks(), 4);
+    Assert.assertEquals(datasetState.getJobFailures(), 0);
 
-    for (TaskState taskState : jobState.getTaskStates()) {
+    for (TaskState taskState : datasetState.getTaskStates()) {
       Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
-      Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.EXTRACTOR_ROWS_EXTRACTED),
-          taskState.getPropAsLong(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY));
-      Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_ROWS_WRITTEN),
-          taskState.getPropAsLong(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY));
+      Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.EXTRACTOR_ROWS_EXTRACTED), limit);
+      Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_ROWS_WRITTEN), limit);
     }
   }
 
@@ -161,32 +160,28 @@ public class JobLauncherTestHelper {
     String jobId = JobLauncherUtils.newJobId(jobName);
     jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, jobId);
 
-    Closer closer = Closer.create();
-    try {
-      JobLauncher jobLauncher = closer.register(JobLauncherFactory.newJobLauncher(this.launcherProps, jobProps));
+    try (JobLauncher jobLauncher = JobLauncherFactory.newJobLauncher(this.launcherProps, jobProps)) {
       jobLauncher.launchJob(null);
-    } finally {
-      closer.close();
     }
 
     List<JobState.DatasetState> datasetStateList = this.datasetStateStore.getAll(jobName, jobId + ".jst");
-    JobState jobState = datasetStateList.get(0);
+    DatasetState datasetState = datasetStateList.get(0);
 
-    Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
-    Assert.assertEquals(jobState.getCompletedTasks(), 4);
-    Assert.assertEquals(jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY), 0);
+    Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
+    Assert.assertEquals(datasetState.getCompletedTasks(), 4);
+    Assert.assertEquals(datasetState.getJobFailures(), 0);
 
     FileSystem lfs = FileSystem.getLocal(new Configuration());
-    for (TaskState taskState : jobState.getTaskStates()) {
+    for (TaskState taskState : datasetState.getTaskStates()) {
       Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
-      Path path = new Path(taskState.getProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR),
+      Path path = new Path(this.launcherProps.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR),
           new Path(taskState.getExtract().getOutputFilePath(), "fork_0"));
       Assert.assertTrue(lfs.exists(path));
       Assert.assertEquals(lfs.listStatus(path).length, 2);
       Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN + ".0"),
           TestExtractor.TOTAL_RECORDS);
 
-      path = new Path(taskState.getProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR),
+      path = new Path(this.launcherProps.getProperty(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR),
           new Path(taskState.getExtract().getOutputFilePath(), "fork_1"));
       Assert.assertTrue(lfs.exists(path));
       Assert.assertEquals(lfs.listStatus(path).length, 2);
@@ -212,13 +207,13 @@ public class JobLauncherTestHelper {
     for (int i = 0; i < 4; i++) {
       List<JobState.DatasetState> datasetStateList =
           this.datasetStateStore.getAll(jobName, "Dataset" + i + "-current.jst");
-      JobState jobState = datasetStateList.get(0);
+      DatasetState datasetState = datasetStateList.get(0);
 
-      Assert.assertEquals(jobState.getProp(ConfigurationKeys.DATASET_URN_KEY), "Dataset" + i);
-      Assert.assertEquals(jobState.getState(), JobState.RunningState.COMMITTED);
-      Assert.assertEquals(jobState.getCompletedTasks(), 1);
-      Assert.assertEquals(jobState.getPropAsInt(ConfigurationKeys.JOB_FAILURES_KEY), 0);
-      for (TaskState taskState : jobState.getTaskStates()) {
+      Assert.assertEquals(datasetState.getDatasetUrn(), "Dataset" + i);
+      Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
+      Assert.assertEquals(datasetState.getCompletedTasks(), 1);
+      Assert.assertEquals(datasetState.getJobFailures(), 0);
+      for (TaskState taskState : datasetState.getTaskStates()) {
         Assert.assertEquals(taskState.getProp(ConfigurationKeys.DATASET_URN_KEY), "Dataset" + i);
         Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
         Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN),
@@ -299,7 +294,7 @@ public class JobLauncherTestHelper {
           this.datasetStateStore.getAll(jobName, "Dataset" + i + "-current.jst");
       JobState.DatasetState datasetState = datasetStateList.get(0);
 
-      Assert.assertEquals(datasetState.getProp(ConfigurationKeys.DATASET_URN_KEY), "Dataset" + i);
+      Assert.assertEquals(datasetState.getDatasetUrn(), "Dataset" + i);
       Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
       Assert.assertEquals(datasetState.getCompletedTasks(), 1);
       for (TaskState taskState : datasetState.getTaskStates()) {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/commit/CommitSequenceTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/commit/CommitSequenceTest.java
@@ -64,8 +64,8 @@ public class CommitSequenceTest {
     this.fs.createNewFile(src2);
 
     DatasetState ds = new DatasetState("job-name", "job-id");
-    ds.setProp("key1", "value1");
-    ds.setProp("key2", "value2");
+    ds.setDatasetUrn("urn");
+    ds.setNoJobFailure();
 
     State state = new State();
     state.setProp(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, storeRootDir.toString());

--- a/gobblin-runtime/src/test/java/gobblin/runtime/commit/FsCommitSequenceStoreTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/commit/FsCommitSequenceStoreTest.java
@@ -13,7 +13,6 @@
 package gobblin.runtime.commit;
 
 import java.io.IOException;
-import java.net.URI;
 
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -54,7 +53,7 @@ public class FsCommitSequenceStoreTest {
 
   @BeforeClass
   public void setUp() throws IOException {
-    FileSystem fs = FileSystem.get(URI.create("file:///"), new Configuration());
+    FileSystem fs = FileSystem.getLocal(new Configuration());
     this.store = new FsCommitSequenceStore(fs, new Path("commit-sequence-store-test"));
 
     State props = new State();
@@ -64,11 +63,10 @@ public class FsCommitSequenceStoreTest {
     DatasetState datasetState = new DatasetState();
 
     datasetState.setDatasetUrn(this.datasetUrn);
-    datasetState.setProp("prop3", "valueOfProp3");
-    datasetState.setProp("prop4", "valueOfProp4");
+    datasetState.incrementJobFailures();
     this.sequence = new CommitSequence.Builder().withJobName("testjob").withDatasetUrn("testurn")
         .beginStep(FsRenameCommitStep.Builder.class).from(new Path("/ab/cd")).to(new Path("/ef/gh")).withProps(props)
-        .endStep().beginStep(DatasetStateCommitStep.Builder.class).withDatasetUrn(datasetUrn)
+        .endStep().beginStep(DatasetStateCommitStep.Builder.class).withDatasetUrn(this.datasetUrn)
         .withDatasetState(datasetState).withProps(props).endStep().build();
   }
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -81,14 +81,15 @@ public class LocalJobLauncherTest {
 
   @Test
   public void testLaunchJobWithPullLimit() throws Exception {
+    int limit = 10;
     Properties jobProps = loadJobProps();
     jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
         jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithPullLimit");
     jobProps.setProperty(ConfigurationKeys.EXTRACT_LIMIT_ENABLED_KEY, Boolean.TRUE.toString());
     jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.COUNT_BASED.toString());
-    jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY, "10");
+    jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY, Integer.toString(limit));
     try {
-      this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
+      this.jobLauncherTestHelper.runTestWithPullLimit(jobProps, limit);
     } finally {
       this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
     }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/mapreduce/MRJobLauncherTest.java
@@ -64,10 +64,9 @@ public class MRJobLauncherTest extends BMNGRunner {
     this.launcherProps.setProperty(ConfigurationKeys.JOB_HISTORY_STORE_URL_KEY,
         "jdbc:derby:memory:gobblin2;create=true");
 
-    StateStore<JobState.DatasetState> datasetStateStore = new FsStateStore<>(
-        this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
-        this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY),
-        JobState.DatasetState.class);
+    StateStore<JobState.DatasetState> datasetStateStore =
+        new FsStateStore<>(this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY),
+            this.launcherProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY), JobState.DatasetState.class);
 
     this.jobLauncherTestHelper = new JobLauncherTestHelper(this.launcherProps, datasetStateStore);
     this.jobLauncherTestHelper.prepareJobHistoryStoreDatabase(this.launcherProps);
@@ -108,14 +107,15 @@ public class MRJobLauncherTest extends BMNGRunner {
 
   @Test
   public void testLaunchJobWithPullLimit() throws Exception {
+    int limit = 10;
     Properties jobProps = loadJobProps();
     jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
         jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithPullLimit");
     jobProps.setProperty(ConfigurationKeys.EXTRACT_LIMIT_ENABLED_KEY, Boolean.TRUE.toString());
     jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.COUNT_BASED.toString());
-    jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY, "10");
+    jobProps.setProperty(DefaultLimiterFactory.EXTRACT_LIMIT_COUNT_LIMIT_KEY, Integer.toString(10));
     try {
-      this.jobLauncherTestHelper.runTestWithPullLimit(jobProps);
+      this.jobLauncherTestHelper.runTestWithPullLimit(jobProps, limit);
     } finally {
       this.jobLauncherTestHelper.deleteStateStore(jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY));
     }
@@ -146,10 +146,10 @@ public class MRJobLauncherTest extends BMNGRunner {
         jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithFork");
     jobProps.setProperty(ConfigurationKeys.CONVERTER_CLASSES_KEY, "gobblin.test.TestConverter2");
     jobProps.setProperty(ConfigurationKeys.FORK_BRANCHES_KEY, "2");
-    jobProps
-        .setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".0", "gobblin.policies.schema.SchemaRowCheckPolicy");
-    jobProps
-        .setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".1", "gobblin.policies.schema.SchemaRowCheckPolicy");
+    jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".0",
+        "gobblin.policies.schema.SchemaRowCheckPolicy");
+    jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST + ".1",
+        "gobblin.policies.schema.SchemaRowCheckPolicy");
     jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE + ".0", "OPTIONAL");
     jobProps.setProperty(ConfigurationKeys.ROW_LEVEL_POLICY_LIST_TYPE + ".1", "OPTIONAL");
     jobProps.setProperty(ConfigurationKeys.TASK_LEVEL_POLICY_LIST + ".0",
@@ -188,12 +188,9 @@ public class MRJobLauncherTest extends BMNGRunner {
    * {@link MRJobLauncher#countersToMetrics(GobblinMetrics)} method is called.
    */
   @Test
-  @BMRule(name = "testJobCleanupOnError",
-          targetClass = "gobblin.runtime.mapreduce.MRJobLauncher",
-          targetMethod = "countersToMetrics(GobblinMetrics)",
-          targetLocation = "AT ENTRY",
-          condition = "true",
-          action = "throw new IOException(\"Exception for testJobCleanupOnError\")")
+  @BMRule(name = "testJobCleanupOnError", targetClass = "gobblin.runtime.mapreduce.MRJobLauncher",
+      targetMethod = "countersToMetrics(GobblinMetrics)", targetLocation = "AT ENTRY", condition = "true",
+      action = "throw new IOException(\"Exception for testJobCleanupOnError\")")
   public void testJobCleanupOnError() throws IOException {
     Properties props = loadJobProps();
     try {
@@ -251,8 +248,8 @@ public class MRJobLauncherTest extends BMNGRunner {
   @Test(groups = { "Hadoop1Only" })
   public void testLaunchJobWithMultipleDatasetsAndFaultyExtractor() throws Exception {
     Properties jobProps = loadJobProps();
-    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
-        "-testLaunchJobWithMultipleDatasetsAndFaultyExtractor");
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY,
+        jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) + "-testLaunchJobWithMultipleDatasetsAndFaultyExtractor");
     try {
       this.jobLauncherTestHelper.runTestWithMultipleDatasetsAndFaultyExtractor(jobProps, false);
     } finally {
@@ -263,8 +260,8 @@ public class MRJobLauncherTest extends BMNGRunner {
   @Test(groups = { "Hadoop1Only" })
   public void testLaunchJobWithMultipleDatasetsAndFaultyExtractorAndPartialCommitPolicy() throws Exception {
     Properties jobProps = loadJobProps();
-    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY) +
-        "-testLaunchJobWithMultipleDatasetsAndFaultyExtractorAndPartialCommitPolicy");
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, jobProps.getProperty(ConfigurationKeys.JOB_NAME_KEY)
+        + "-testLaunchJobWithMultipleDatasetsAndFaultyExtractorAndPartialCommitPolicy");
     try {
       this.jobLauncherTestHelper.runTestWithMultipleDatasetsAndFaultyExtractor(jobProps, true);
     } finally {
@@ -285,9 +282,9 @@ public class MRJobLauncherTest extends BMNGRunner {
     Properties jobProps = new Properties();
     jobProps.load(new FileReader("gobblin-test/resource/mr-job-conf/GobblinMRTest.pull"));
     jobProps.putAll(this.launcherProps);
-    jobProps.setProperty(JobLauncherTestHelper.SOURCE_FILE_LIST_KEY, "gobblin-test/resource/source/test.avro.0,"
-        + "gobblin-test/resource/source/test.avro.1," + "gobblin-test/resource/source/test.avro.2,"
-        + "gobblin-test/resource/source/test.avro.3");
+    jobProps.setProperty(JobLauncherTestHelper.SOURCE_FILE_LIST_KEY,
+        "gobblin-test/resource/source/test.avro.0," + "gobblin-test/resource/source/test.avro.1,"
+            + "gobblin-test/resource/source/test.avro.2," + "gobblin-test/resource/source/test.avro.3");
 
     return jobProps;
   }

--- a/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SerializationUtils.java
@@ -20,7 +20,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
-import java.io.OutputStream;
 import java.io.Serializable;
 
 import org.apache.hadoop.fs.FileSystem;
@@ -33,8 +32,6 @@ import gobblin.configuration.State;
 
 /**
  * A utility class for serializing and deserializing Objects to/from Strings.
- *
- * @author ziliu
  */
 public class SerializationUtils {
 
@@ -95,8 +92,8 @@ public class SerializationUtils {
    */
   public static <T extends Serializable> T deserialize(String serialized, Class<T> clazz, BaseEncoding enc)
       throws IOException {
-    try (ByteArrayInputStream bis = new ByteArrayInputStream(enc.decode(serialized));
-        ObjectInputStream ois = new ObjectInputStream(bis)) {
+
+    try (ObjectInputStream ois = new ObjectInputStream(new ByteArrayInputStream(enc.decode(serialized)))) {
       return clazz.cast(ois.readObject());
     } catch (ClassNotFoundException e) {
       throw new IOException(e);
@@ -129,8 +126,8 @@ public class SerializationUtils {
    */
   public static <T extends State> void serializeState(FileSystem fs, Path jobStateFilePath, T state, short replication)
       throws IOException {
-    try (OutputStream os = fs.create(jobStateFilePath, replication);
-        DataOutputStream dataOutputStream = new DataOutputStream(os)) {
+
+    try (DataOutputStream dataOutputStream = new DataOutputStream(fs.create(jobStateFilePath, replication))) {
       state.write(dataOutputStream);
     }
   }
@@ -159,8 +156,7 @@ public class SerializationUtils {
    * @param <T> the {@link State} object type
    * @throws IOException if it fails to deserialize the {@link State} instance
    */
-  public static <T extends State> void deserializeStateFromInputStream(InputStream is, T state)
-      throws IOException {
+  public static <T extends State> void deserializeStateFromInputStream(InputStream is, T state) throws IOException {
     try (DataInputStream dis = (new DataInputStream(is))) {
       state.readFields(dis);
     }

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinHelixTask.java
@@ -66,7 +66,7 @@ public class GobblinHelixTask implements Task {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(GobblinHelixTask.class);
 
-  @SuppressWarnings({"unused", "FieldCanBeLocal"})
+  @SuppressWarnings({ "unused", "FieldCanBeLocal" })
   private final Optional<JobMetrics> jobMetrics;
   private final TaskExecutor taskExecutor;
   private final TaskStateTracker taskStateTracker;
@@ -81,8 +81,7 @@ public class GobblinHelixTask implements Task {
   private final StateStore<TaskState> taskStateStore;
 
   public GobblinHelixTask(TaskCallbackContext taskCallbackContext, Optional<ContainerMetrics> containerMetrics,
-      TaskExecutor taskExecutor, TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir)
-      throws IOException {
+      TaskExecutor taskExecutor, TaskStateTracker taskStateTracker, FileSystem fs, Path appWorkDir) throws IOException {
     this.taskExecutor = taskExecutor;
     this.taskStateTracker = taskStateTracker;
 
@@ -112,9 +111,8 @@ public class GobblinHelixTask implements Task {
       Path workUnitFilePath =
           new Path(this.taskConfig.getConfigMap().get(GobblinYarnConfigurationKeys.WORK_UNIT_FILE_PATH));
 
-      WorkUnit workUnit =
-          workUnitFilePath.getName().endsWith(AbstractJobLauncher.MULTI_WORK_UNIT_FILE_EXTENSION) ? MultiWorkUnit
-              .createEmpty() : WorkUnit.createEmpty();
+      WorkUnit workUnit = workUnitFilePath.getName().endsWith(AbstractJobLauncher.MULTI_WORK_UNIT_FILE_EXTENSION)
+          ? MultiWorkUnit.createEmpty() : WorkUnit.createEmpty();
       SerializationUtils.deserializeState(this.fs, workUnitFilePath, workUnit);
 
       // The list of individual WorkUnits (flattened) to run
@@ -124,18 +122,13 @@ public class GobblinHelixTask implements Task {
         // Flatten the MultiWorkUnit so the job configuration properties can be added to each individual WorkUnits
         List<WorkUnit> flattenedWorkUnits =
             JobLauncherUtils.flattenWorkUnits(((MultiWorkUnit) workUnit).getWorkUnits());
-        for (WorkUnit flattenedWorkUnit : flattenedWorkUnits) {
-          flattenedWorkUnit.addAllIfNotExist(this.jobState);
-        }
         workUnits.addAll(flattenedWorkUnits);
       } else {
-        workUnit.addAllIfNotExist(this.jobState);
         workUnits.add(workUnit);
       }
 
-      AbstractJobLauncher
-          .runWorkUnits(this.jobId, this.participantId, workUnits, this.taskStateTracker, this.taskExecutor,
-              this.taskStateStore, LOGGER);
+      AbstractJobLauncher.runWorkUnits(this.jobId, this.participantId, this.jobState, workUnits, this.taskStateTracker,
+          this.taskExecutor, this.taskStateStore, LOGGER);
       return new TaskResult(TaskResult.Status.COMPLETED, String.format("completed tasks: %d", workUnits.size()));
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();


### PR DESCRIPTION
This is a solution to #881.
Summary:
- Each `WorkUnitState`/`TaskState` now contains a `JobState` reference, rather than a copy of all properties in `JobState`. `WorkUnitState.getProp()` will first look for the property in its own properties, then in its `WorkUnit`, then in its `JobState`.
- `DatasetState` no longer contains properties in `JobState`, and no longer supports `setProp` or `getProp` methods (will throw `UnsupportedOperationException`). A `DatasetState` can only contain a few specific properties such as `dataset.urn`, and they are accessed via specific setter and getter methods (e.g., `setDatasetUrn()` and `getDatasetUrn()`).
 - The rationale is the following: a `DatasetState` is created in the driver after the job is done. At this point there shouldn’t be a need to look for, change or add any general properties, especially since the driver is not something pluggable like the constructs, where different people can plug in an arbitrarily customized one for their use cases. Also, the driver already has a copy of `JobState`. If it wants to query any properties it can directly query the `JobState`.
 - This means that properties in the `JobState`, which are properties from the job config file and the global property file, will not be persisted into the state store. Since these are static properties rather than runtime properties (runtime properties are in `TaskState`s), there's no need to persist them.

These changes result in a ~90% reduction in memory consumption of a Gobblin job.