### PR TITLE
Distcp hive registration metadata

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -44,6 +44,7 @@ dependencies {
   testCompile externalDependency.mockito
   testCompile externalDependency.joptSimple
   testCompile externalDependency.hamcrest
+  testCompile externalDependency.testng
 }
 
 task testJar(type: Jar, dependsOn: testClasses) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursivePathFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/RecursivePathFinder.java
@@ -26,6 +26,9 @@ import org.apache.hadoop.fs.PathFilter;
 import gobblin.data.management.dataset.DatasetUtils;
 import gobblin.util.FileListUtils;
 import gobblin.util.PathUtils;
+import gobblin.util.filters.AndPathFilter;
+import gobblin.util.filters.HiddenFilter;
+
 
 /**
  * Used to find the path recursively from the root based on the {@link PathFilter} created in the {@link Properties}
@@ -45,14 +48,14 @@ public class RecursivePathFinder {
     this.pathFilter = DatasetUtils.instantiatePathFilter(properties);
   }
 
-  public Set<Path> getPaths() throws IOException{
+  public Set<Path> getPaths(boolean skipHiddenPaths) throws IOException {
     Set<Path> result = new HashSet<Path>();
 
     if (!this.fs.exists(this.rootPath)) {
       return result;
     }
-
-    List<FileStatus> files = FileListUtils.listFilesRecursively(this.fs, this.rootPath, this.pathFilter);
+    PathFilter actualFilter = skipHiddenPaths ? new AndPathFilter(new HiddenFilter(), this.pathFilter) : this.pathFilter;
+    List<FileStatus> files = FileListUtils.listFilesRecursively(this.fs, this.rootPath, actualFilter);
 
     for (FileStatus file : files) {
       result.add(file.getPath());

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -63,7 +63,6 @@ import gobblin.util.PathUtils;
 import gobblin.util.commit.DeleteFileCommitStep;
 import gobblin.util.reflection.GobblinConstructorUtils;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
@@ -125,6 +124,9 @@ public class HiveCopyEntityHelper {
 
   private static final String source_client = "source_client";
   private static final String target_client = "target_client";
+  public static final String GOBBLIN_DISTCP = "gobblin-distcp";
+
+  private final long startTime;
 
   private final HiveDataset dataset;
   private final CopyConfiguration configuration;
@@ -140,7 +142,7 @@ public class HiveCopyEntityHelper {
   private final Optional<String> targetURI;
   private final ExistingEntityPolicy existingEntityPolicy;
   private final Optional<String> partitionFilter;
-  private final Optional<Predicate<Partition>> fastPartitionSkip;
+  private final Optional<Predicate<PartitionCopy>> fastPartitionSkip;
 
   private final Optional<CommitStep> tableRegistrationStep;
   private final Map<List<String>, Partition> sourcePartitions;
@@ -180,6 +182,8 @@ public class HiveCopyEntityHelper {
 
     log.info("Finding copy entities for table " + dataset.table.getCompleteName());
 
+    this.startTime = System.currentTimeMillis();
+
     this.dataset = dataset;
     this.configuration = configuration;
     this.targetFs = targetFs;
@@ -216,9 +220,9 @@ public class HiveCopyEntityHelper {
     try {
       this.fastPartitionSkip = this.dataset.properties.containsKey(FAST_PARTITION_SKIP_PREDICATE) ? Optional.of(
           GobblinConstructorUtils.invokeFirstConstructor(
-              (Class<Predicate<Partition>>) Class.forName(this.dataset.properties.getProperty(FAST_PARTITION_SKIP_PREDICATE)),
+              (Class<Predicate<PartitionCopy>>) Class.forName(this.dataset.properties.getProperty(FAST_PARTITION_SKIP_PREDICATE)),
               Lists.<Object>newArrayList(this), Lists.newArrayList()))
-          : Optional.<Predicate<Partition>>absent();
+          : Optional.<Predicate<PartitionCopy>>absent();
     } catch (ReflectiveOperationException roe) {
       throw new IOException(roe);
     }
@@ -236,20 +240,17 @@ public class HiveCopyEntityHelper {
         this.existingTargetTable = Optional.absent();
       }
 
+      Path targetPath = getTargetLocation(dataset.fs, this.targetFs, dataset.table.getDataLocation(),
+          Optional.<Partition>absent());
+      this.targetTable = getTargetTable(this.dataset.table, targetPath);
+      HiveSpec tableHiveSpec = new SimpleHiveSpec.Builder<>(targetPath).
+          withTable(HiveMetaStoreUtils.getHiveTable(this.targetTable.getTTable())).build();
+      CommitStep tableRegistrationStep = new HiveRegisterStep(targetURI, tableHiveSpec, this.hiveRegProps);
+
+      this.tableRegistrationStep = Optional.of(tableRegistrationStep);
+
       if (this.existingTargetTable.isPresent()) {
-        checkTableCompatibility(this.dataset.table, this.existingTargetTable.get());
-        this.targetTable = this.existingTargetTable.get();
-        this.tableRegistrationStep = Optional.absent();
-      } else {
-        Path targetPath = getTargetLocation(dataset.fs, this.targetFs, dataset.table.getDataLocation(),
-            Optional.<Partition>absent());
-        this.targetTable = getTargetTable(this.dataset.table, targetPath);
-
-        HiveSpec tableHiveSpec = new SimpleHiveSpec.Builder<>(targetPath).
-                withTable(HiveMetaStoreUtils.getHiveTable(this.targetTable.getTTable())).build();
-        CommitStep tableRegistrationStep = new HiveRegisterStep(targetURI, tableHiveSpec, this.hiveRegProps);
-
-        this.tableRegistrationStep = Optional.of(tableRegistrationStep);
+        checkTableCompatibility(this.targetTable, this.existingTargetTable.get());
       }
 
       if (HiveUtils.isPartitioned(this.dataset.table)) {
@@ -382,6 +383,8 @@ public class HiveCopyEntityHelper {
 
       targetTable.setDbName(this.targetDatabase);
       targetTable.setDataLocation(targetLocation);
+      targetTable.getTTable().putToParameters(HiveDataset.REGISTERER, GOBBLIN_DISTCP);
+      targetTable.getTTable().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME, Long.toString(this.startTime));
 
       HiveAvroCopyEntityHelper.updateTableAttributesIfAvro(targetTable, this);
 
@@ -396,6 +399,8 @@ public class HiveCopyEntityHelper {
       Partition targetPartition = new Partition(this.targetTable, originPartition.getTPartition().deepCopy());
       targetPartition.getTable().setDbName(this.targetDatabase);
       targetPartition.getTPartition().setDbName(this.targetDatabase);
+      targetPartition.getTPartition().putToParameters(HiveDataset.REGISTERER, GOBBLIN_DISTCP);
+      targetPartition.getTPartition().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME, Long.toString(this.startTime));
       targetPartition.setLocation(targetLocation.toString());
       return targetPartition;
     } catch (HiveException he) {
@@ -406,20 +411,21 @@ public class HiveCopyEntityHelper {
   /**
    * Creates {@link CopyEntity}s for a partition.
    */
-  @AllArgsConstructor
-  private class PartitionCopy {
+  @Getter
+  public class PartitionCopy {
 
     private final Partition partition;
     private final Properties properties;
+    private Optional<Partition> existingTargetPartition;
+
+    public PartitionCopy(Partition partition, Properties properties) {
+      this.partition = partition;
+      this.properties = properties;
+      this.existingTargetPartition = Optional.fromNullable(targetPartitions.get(this.partition.getValues()));
+    }
 
     private List<CopyEntity> getCopyEntities()
         throws IOException {
-
-      if (fastPartitionSkip.isPresent() && fastPartitionSkip.get().apply(this.partition)) {
-        log.info(String.format("Skipping copy of partition %s due to fast partition skip predicate.",
-            this.partition.getCompleteName()));
-        return Lists.newArrayList();
-      }
 
       log.info("Getting copy entities for partition " + this.partition.getCompleteName());
 
@@ -430,15 +436,14 @@ public class HiveCopyEntityHelper {
 
       stepPriority = addSharedSteps(copyEntities, fileSet, stepPriority);
 
+      Path targetPath = getTargetLocation(dataset.fs, targetFs, this.partition.getDataLocation(),
+          Optional.of(this.partition));
+      Partition targetPartition = getTargetPartition(this.partition, targetPath);
 
-      Optional<Partition> existingTargetPartition = Optional.fromNullable(targetPartitions.get(partition.getValues()));
-      Partition targetPartition;
-
-      if (existingTargetPartition.isPresent()) {
+      if (this.existingTargetPartition.isPresent()) {
         targetPartitions.remove(partition.getValues());
-        targetPartition = existingTargetPartition.get();
         try {
-          checkPartitionCompatibility(partition, existingTargetPartition.get());
+          checkPartitionCompatibility(targetPartition, existingTargetPartition.get());
         } catch (IOException ioe) {
           if (existingEntityPolicy != ExistingEntityPolicy.REPLACE_PARTITIONS) {
             log.error("Source and target partitions are not compatible. Aborting copy of partition " + this.partition, ioe);
@@ -448,18 +453,19 @@ public class HiveCopyEntityHelper {
           stepPriority = addDeregisterSteps(copyEntities, fileSet, stepPriority, targetTable, existingTargetPartition.get());
           existingTargetPartition = Optional.absent();
         }
-      } else {
-        Path targetPath = getTargetLocation(dataset.fs, targetFs, this.partition.getDataLocation(),
-            Optional.of(this.partition));
-        targetPartition = getTargetPartition(this.partition, targetPath);
-
-        HiveSpec partitionHiveSpec = new SimpleHiveSpec.Builder<>(targetPath).
-            withTable(HiveMetaStoreUtils.getHiveTable(targetTable.getTTable())).
-            withPartition(Optional.of(HiveMetaStoreUtils.getHivePartition(targetPartition.getTPartition()))).build();
-
-        HiveRegisterStep register = new HiveRegisterStep(targetURI, partitionHiveSpec, hiveRegProps);
-        copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object>newHashMap(), register, stepPriority++));
       }
+
+      if (fastPartitionSkip.isPresent() && fastPartitionSkip.get().apply(this)) {
+        log.info(String.format("Skipping copy of partition %s due to fast partition skip predicate.",
+            this.partition.getCompleteName()));
+        return Lists.newArrayList();
+      }
+
+      HiveSpec partitionHiveSpec = new SimpleHiveSpec.Builder<>(targetPath).
+          withTable(HiveMetaStoreUtils.getHiveTable(targetTable.getTTable())).
+          withPartition(Optional.of(HiveMetaStoreUtils.getHivePartition(targetPartition.getTPartition()))).build();
+      HiveRegisterStep register = new HiveRegisterStep(targetURI, partitionHiveSpec, hiveRegProps);
+      copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object>newHashMap(), register, stepPriority++));
 
       HiveLocationDescriptor sourceLocation = HiveLocationDescriptor.forPartition(this.partition, dataset.fs, properties);
       HiveLocationDescriptor desiredTargetLocation = HiveLocationDescriptor.forPartition(targetPartition, targetFs, properties);
@@ -618,36 +624,33 @@ public class HiveCopyEntityHelper {
         referencePath.getModificationTime() < replacementFile.getModificationTime();
   }
 
-  private void checkTableCompatibility(Table sourceTable, Table targetTable) throws IOException {
+  private void checkTableCompatibility(Table desiredTargetTable, Table existingTargetTable) throws IOException {
 
-    Path targetLocation = getTargetLocation(this.dataset.fs, this.targetFs, sourceTable.getDataLocation(),
-        Optional.<Partition>absent());
-    if (!targetLocation.equals(targetTable.getDataLocation())) {
+    if (!desiredTargetTable.getDataLocation().equals(existingTargetTable.getDataLocation())) {
       throw new IOException(
-          String.format("Computed target location %s and already registered target location %s do not agree.",
-              targetLocation, targetTable.getDataLocation()));
+          String.format("Desired target location %s and already registered target location %s do not agree.",
+              desiredTargetTable.getDataLocation(), existingTargetTable.getDataLocation()));
     }
 
-    if (HiveUtils.isPartitioned(sourceTable) != HiveUtils.isPartitioned(targetTable)) {
+    if (HiveUtils.isPartitioned(desiredTargetTable) != HiveUtils.isPartitioned(existingTargetTable)) {
       throw new IOException(String.format(
-          "%s: Source table %s partitioned, target table %s partitioned. Tables are incompatible.",
-          this.dataset.tableIdentifier, HiveUtils.isPartitioned(sourceTable) ? "is" : "is not", HiveUtils
-              .isPartitioned(targetTable) ? "is" : "is not"));
+          "%s: Desired target table %s partitioned, existing target table %s partitioned. Tables are incompatible.",
+          this.dataset.tableIdentifier, HiveUtils.isPartitioned(desiredTargetTable) ? "is" : "is not", HiveUtils
+              .isPartitioned(existingTargetTable) ? "is" : "is not"));
     }
-    if (sourceTable.isPartitioned() && !sourceTable.getPartitionKeys().equals(targetTable.getPartitionKeys())) {
-      throw new IOException(String.format("%s: Source table has partition keys %s, target table has partition  keys %s. "
+    if (desiredTargetTable.isPartitioned() && !desiredTargetTable.getPartitionKeys().equals(existingTargetTable.getPartitionKeys())) {
+      throw new IOException(String.format("%s: Desired target table has partition keys %s, existing target table has partition  keys %s. "
               + "Tables are incompatible.",
-          this.dataset.tableIdentifier, gson.toJson(sourceTable.getPartitionKeys()), gson.toJson(targetTable.getPartitionKeys())));
+          this.dataset.tableIdentifier, gson.toJson(desiredTargetTable.getPartitionKeys()), gson.toJson(existingTargetTable.getPartitionKeys())));
     }
   }
 
-  private void checkPartitionCompatibility(Partition sourcePartition, Partition targetPartition) throws IOException {
-    Path targetLocation = getTargetLocation(this.dataset.fs,
-        this.targetFs, sourcePartition.getDataLocation(), Optional.<Partition>absent());
-    if (!targetLocation.equals(targetPartition.getDataLocation())) {
+  private void checkPartitionCompatibility(Partition desiredTargetPartition, Partition existingTargetPartition)
+      throws IOException {
+    if (!desiredTargetPartition.getDataLocation().equals(existingTargetPartition.getDataLocation())) {
       throw new IOException(
-          String.format("Computed target location %s and already registered target location %s do not agree.",
-              targetLocation, targetPartition.getDataLocation()));
+          String.format("Desired target location %s and already registered target location %s do not agree.",
+              desiredTargetPartition.getDataLocation(), existingTargetPartition.getDataLocation()));
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -67,6 +67,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.Getter;
 import lombok.Singular;
+import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -162,6 +163,7 @@ public class HiveCopyEntityHelper {
    * A container for the differences between desired and existing files.
    */
   @Builder
+  @ToString
   private static class DiffPathSet {
     /** Desired files that don't exist on target */
     @Singular(value = "copyFile") Collection<FileStatus> filesToCopy;
@@ -384,7 +386,7 @@ public class HiveCopyEntityHelper {
       targetTable.setDbName(this.targetDatabase);
       targetTable.setDataLocation(targetLocation);
       targetTable.getTTable().putToParameters(HiveDataset.REGISTERER, GOBBLIN_DISTCP);
-      targetTable.getTTable().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME, Long.toString(this.startTime));
+      targetTable.getTTable().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS, Long.toString(this.startTime));
 
       HiveAvroCopyEntityHelper.updateTableAttributesIfAvro(targetTable, this);
 
@@ -400,7 +402,7 @@ public class HiveCopyEntityHelper {
       targetPartition.getTable().setDbName(this.targetDatabase);
       targetPartition.getTPartition().setDbName(this.targetDatabase);
       targetPartition.getTPartition().putToParameters(HiveDataset.REGISTERER, GOBBLIN_DISTCP);
-      targetPartition.getTPartition().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME, Long.toString(this.startTime));
+      targetPartition.getTPartition().putToParameters(HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS, Long.toString(this.startTime));
       targetPartition.setLocation(targetLocation.toString());
       return targetPartition;
     } catch (HiveException he) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -44,6 +44,9 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class HiveDataset implements IterableCopyableDataset {
 
+  public static final String REGISTERER = "registerer";
+  public static final String REGISTRATION_GENERATION_TIME = "registrationGenerationTime";
+
   protected final Properties properties;
   protected final FileSystem fs;
   protected final HiveMetastoreClientPool clientPool;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -45,7 +45,7 @@ import lombok.extern.slf4j.Slf4j;
 public class HiveDataset implements IterableCopyableDataset {
 
   public static final String REGISTERER = "registerer";
-  public static final String REGISTRATION_GENERATION_TIME = "registrationGenerationTime";
+  public static final String REGISTRATION_GENERATION_TIME_MILLIS = "registrationGenerationTimeMillis";
 
   protected final Properties properties;
   protected final FileSystem fs;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveLocationDescriptor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveLocationDescriptor.java
@@ -38,6 +38,9 @@ class HiveLocationDescriptor {
       HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.additional.paths.recursively.enabled";
   public static final String HIVE_LOCATION_LISTING_METHOD =
       HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.location.listing.method";
+  public static final String SKIP_HIDDEN_PATHS =
+      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.locations.listing.skipHiddenPaths";
+  public static final String DEFAULT_SKIP_HIDDEN_PATHS = Boolean.toString(false);
   public static final String DEFAULT_HIVE_LOCATION_LISTING_METHOD = PathFindingMethod.INPUT_FORMAT.name();
 
   public enum PathFindingMethod {
@@ -59,14 +62,14 @@ class HiveLocationDescriptor {
       Set<Path> result = HiveUtils.getPaths(this.inputFormat, this.location);
 
       boolean useHiveLocationDescriptorWithAdditionalData =
-          Boolean.valueOf(this.properties.getProperty(HIVE_DATASET_COPY_ADDITIONAL_PATHS_RECURSIVELY_ENABLED, "true"));
+          Boolean.valueOf(this.properties.getProperty(HIVE_DATASET_COPY_ADDITIONAL_PATHS_RECURSIVELY_ENABLED, "false"));
 
       if (useHiveLocationDescriptorWithAdditionalData) {
         if (PathUtils.isGlob(this.location)) {
           throw new IOException("can not get additional data for glob pattern path " + this.location);
         }
         RecursivePathFinder finder = new RecursivePathFinder(this.fileSystem, this.location, this.properties);
-        result.addAll(finder.getPaths());
+        result.addAll(finder.getPaths(false));
       }
 
       return result;
@@ -74,8 +77,9 @@ class HiveLocationDescriptor {
       if (PathUtils.isGlob(this.location)) {
         throw new IOException("Cannot use recursive listing for globbed locations.");
       }
+      boolean skipHiddenPaths =  Boolean.parseBoolean(this.properties.getProperty(SKIP_HIDDEN_PATHS, DEFAULT_SKIP_HIDDEN_PATHS));
       RecursivePathFinder finder = new RecursivePathFinder(this.fileSystem, this.location, this.properties);
-      return finder.getPaths();
+      return finder.getPaths(skipHiddenPaths);
     } else {
       throw new IOException("Hive location listing method not recognized: " + pathFindingMethod);
     }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RegistrationTimeSkipPredicate.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RegistrationTimeSkipPredicate.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.predicates;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FileStatus;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+
+import gobblin.data.management.copy.hive.HiveCopyEntityHelper;
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.util.PathUtils;
+
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A fast partition skip predicate that reads the parameter {@link HiveDataset#REGISTRATION_GENERATION_TIME_MILLIS} from
+ * the Hive partition and skips the copy if it is newer than the modification time of the location of the source
+ * partition.
+ */
+@AllArgsConstructor
+@Slf4j
+public class RegistrationTimeSkipPredicate implements Predicate<HiveCopyEntityHelper.PartitionCopy> {
+
+  private final HiveCopyEntityHelper helper;
+
+  @Override
+  public boolean apply(@Nullable HiveCopyEntityHelper.PartitionCopy input) {
+
+    if (input == null) {
+      return true;
+    }
+
+    if (input.getExistingTargetPartition() == null) {
+      throw new RuntimeException("Existing target partition has not been computed! This is an error in the code.");
+    }
+
+    if (PathUtils.isGlob(input.getPartition().getDataLocation())) {
+      log.error(String.format("%s cannot be applied to globbed location %s. Will not skip.", this.getClass().getSimpleName(),
+          input.getPartition().getDataLocation()));
+      return false;
+    }
+
+    if (!input.getExistingTargetPartition().isPresent()) {
+      // Target partition doesn't exit, don't skip
+      return false;
+    }
+
+    if (!input.getExistingTargetPartition().get().getParameters().containsKey(HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS)) {
+      // Target partition is not annotated with registration time, don't skip
+      return false;
+    }
+
+    try {
+      long oldRegistrationTime = Long.parseLong(
+          input.getExistingTargetPartition().get().getParameters().get(HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS));
+
+      Optional<FileStatus> sourceFileStatus = this.helper.getConfiguration().getCopyContext().
+          getFileStatus(this.helper.getDataset().getFs(), input.getPartition().getDataLocation());
+
+      if (!sourceFileStatus.isPresent()) {
+        throw new RuntimeException(String.format("Source path %s does not exist!", input.getPartition().getDataLocation()));
+      }
+
+      // If the registration time of the partition is higher than the modification time, skip
+      return oldRegistrationTime > sourceFileStatus.get().getModificationTime();
+
+    } catch (NumberFormatException nfe) {
+      // Cannot parse registration generation time, don't skip
+      log.warn(String.format("Cannot parse %s in partition %s. Will not skip.",
+          HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS, input.getPartition().getCompleteName()));
+      return false;
+    } catch (IOException ioe) {
+      throw new RuntimeException(ioe);
+    }
+
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RootDirectoryModtimeSkipPredicate.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RootDirectoryModtimeSkipPredicate.java
@@ -41,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class RootDirectoryModtimeSkipPredicate implements Predicate<HiveCopyEntityHelper.PartitionCopy> {
 
-  private HiveCopyEntityHelper helper;
+  private final HiveCopyEntityHelper helper;
 
   @Override
   public boolean apply(@Nullable HiveCopyEntityHelper.PartitionCopy input) {
@@ -51,10 +51,6 @@ public class RootDirectoryModtimeSkipPredicate implements Predicate<HiveCopyEnti
     }
 
     if (!input.getExistingTargetPartition().isPresent()) {
-      return false;
-    }
-
-    if (!input.getExistingTargetPartition().get().getParameters().containsKey(HiveDataset.REGISTRATION_GENERATION_TIME)) {
       return false;
     }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/predicates/RegistrationTimeSkipPredicateTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/predicates/RegistrationTimeSkipPredicateTest.java
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.predicates;
+
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.mockito.Mockito;
+
+import com.beust.jcommander.internal.Maps;
+import com.google.common.base.Optional;
+
+import gobblin.data.management.copy.CopyConfiguration;
+import gobblin.data.management.copy.CopyContext;
+import gobblin.data.management.copy.hive.HiveCopyEntityHelper;
+import gobblin.data.management.copy.hive.HiveDataset;
+
+
+public class RegistrationTimeSkipPredicateTest {
+
+  @Test
+  public void test() throws Exception {
+
+    Path partition1Path = new Path("/path/to/partition1");
+    long modTime = 100000;
+
+    CopyContext copyContext = new CopyContext();
+    CopyConfiguration copyConfiguration = Mockito.mock(CopyConfiguration.class);
+    Mockito.doReturn(copyContext).when(copyConfiguration).getCopyContext();
+    HiveDataset dataset = Mockito.mock(HiveDataset.class);
+    FileSystem fs = Mockito.spy(FileSystem.getLocal(new Configuration()));
+    FileStatus status = new FileStatus(1, false, 1, 1, modTime, partition1Path);
+    Path qualifiedPath = fs.makeQualified(partition1Path);
+    Mockito.doReturn(status).when(fs).getFileStatus(qualifiedPath);
+    Mockito.doReturn(status).when(fs).getFileStatus(partition1Path);
+    Mockito.doReturn(fs).when(dataset).getFs();
+
+    HiveCopyEntityHelper helper = Mockito.mock(HiveCopyEntityHelper.class);
+    Mockito.doReturn(copyConfiguration).when(helper).getConfiguration();
+    Mockito.doReturn(dataset).when(helper).getDataset();
+
+    RegistrationTimeSkipPredicate predicate = new RegistrationTimeSkipPredicate(helper);
+
+    // partition exists, but registration time before modtime => don't skip
+    HiveCopyEntityHelper.PartitionCopy pc = createPartitionCopy(partition1Path, modTime - 1, true);
+    Assert.assertFalse(predicate.apply(pc));
+
+    // partition exists, registration time equal modtime => don't skip
+    pc = createPartitionCopy(partition1Path, modTime, true);
+    Assert.assertFalse(predicate.apply(pc));
+
+    // partition exists, registration time larger modtime => do skip
+    pc = createPartitionCopy(partition1Path, modTime + 1, true);
+    Assert.assertTrue(predicate.apply(pc));
+
+    // partition doesn't exist => don't skip
+    pc = createPartitionCopy(partition1Path, modTime + 1, false);
+    Assert.assertFalse(predicate.apply(pc));
+
+    // partition exists but is not annotated => don't skip
+    pc = createPartitionCopy(partition1Path, modTime + 1, true);
+    pc.getExistingTargetPartition().get().getParameters().clear();
+    Assert.assertFalse(predicate.apply(pc));
+
+  }
+
+  public HiveCopyEntityHelper.PartitionCopy createPartitionCopy(Path location, long registrationGenerationTime,
+      boolean targetPartitionExists) {
+    HiveCopyEntityHelper.PartitionCopy partitionCopy = Mockito.mock(HiveCopyEntityHelper.PartitionCopy.class);
+
+    Partition partition = Mockito.mock(Partition.class);
+    Mockito.doReturn(location).when(partition).getDataLocation();
+    Mockito.doReturn(partition).when(partitionCopy).getPartition();
+
+    if (targetPartitionExists) {
+
+      Partition targetPartition = Mockito.mock(Partition.class);
+
+      Map<String, String> parameters = Maps.newHashMap();
+      parameters.put(HiveDataset.REGISTRATION_GENERATION_TIME_MILLIS,
+          Long.toString(registrationGenerationTime));
+      Mockito.doReturn(parameters).when(targetPartition).getParameters();
+
+      Mockito.doReturn(Optional.of(targetPartition)).when(partitionCopy).getExistingTargetPartition();
+    } else {
+      Mockito.doReturn(Optional.absent()).when(partitionCopy).getExistingTargetPartition();
+    }
+
+    return partitionCopy;
+  }
+
+}

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/HiveRegistrationUnitComparator.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/HiveRegistrationUnitComparator.java
@@ -12,11 +12,14 @@
 
 package gobblin.hive;
 
+import java.util.Set;
+
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Optional;
 
 import gobblin.annotation.Alpha;
+import gobblin.configuration.State;
 
 
 /**
@@ -134,13 +137,23 @@ public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitCompar
     return (T) this;
   }
 
+  @SuppressWarnings("unchecked")
+  public T compareParameters() {
+    if (!this.result) {
+      checkExistingIsSuperstate(this.existingUnit.getProps(), this.newUnit.getProps());
+      checkExistingIsSuperstate(this.existingUnit.getStorageProps(), this.newUnit.getStorageProps());
+      checkExistingIsSuperstate(this.existingUnit.getSerDeProps(), this.newUnit.getSerDeProps());
+    }
+    return (T) this;
+  }
+
   /**
    * Compare all parameters.
    */
   @SuppressWarnings("unchecked")
   public T compareAll() {
     this.compareInputFormat().compareOutputFormat().compareIsCompressed().compareIsStoredAsSubDirs().compareNumBuckets()
-        .compareBucketCols().compareRawLocation();
+        .compareBucketCols().compareRawLocation().compareParameters();
     return (T) this;
   }
 
@@ -162,6 +175,22 @@ public class HiveRegistrationUnitComparator<T extends HiveRegistrationUnitCompar
       different = !existingValue.isPresent() || !existingValue.get().equals(newValue.get());
     }
     this.result |= different;
+  }
+
+  /**
+   * Compare an existing state and a new {@link State} to ensure that the existing {@link State} contains all entries in the new
+   * {@link State}, and update {@link #result} accordingly.
+   */
+  protected void checkExistingIsSuperstate(State existingState, State newState) {
+    checkExistingIsSuperset(existingState.getProperties().entrySet(), newState.getProperties().entrySet());
+  }
+
+  /**
+   * Compare an existing state and a new {@link Set} to ensure that the existing {@link Set} contains all entries in the new
+   * {@link Set}, and update {@link #result} accordingly.
+   */
+  protected <E> void checkExistingIsSuperset(Set<E> existingSet, Set<E> newSet) {
+    this.result |= !existingSet.containsAll(newSet);
   }
 
   /**

--- a/gobblin-hive-registration/src/test/java/gobblin/hive/HiveRegistrationUnitComparatorTest.java
+++ b/gobblin-hive-registration/src/test/java/gobblin/hive/HiveRegistrationUnitComparatorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.hive;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.State;
+
+public class HiveRegistrationUnitComparatorTest {
+
+  @Test
+  public void testCheckExistingIsSuperstate()
+      throws Exception {
+
+    String key1 = "key1";
+    String value1 = "value1";
+    String key2 = "key2";
+    String value2 = "value2";
+
+    State existingState = new State();
+    State newState = new State();
+
+    HiveRegistrationUnitComparator comparator =
+        new HiveRegistrationUnitComparator<>(null, null);
+    comparator.checkExistingIsSuperstate(existingState, newState);
+    Assert.assertFalse(comparator.result);
+
+    newState.setProp(key1, value1);
+    comparator =
+        new HiveRegistrationUnitComparator<>(null, null);
+    comparator.checkExistingIsSuperstate(existingState, newState);
+    Assert.assertTrue(comparator.result);
+
+    existingState.setProp(key1, value2);
+    comparator =
+        new HiveRegistrationUnitComparator<>(null, null);
+    comparator.checkExistingIsSuperstate(existingState, newState);
+    Assert.assertTrue(comparator.result);
+
+    existingState.setProp(key1, value1);
+    existingState.setProp(key2, value2);
+    comparator =
+        new HiveRegistrationUnitComparator<>(null, null);
+    comparator.checkExistingIsSuperstate(existingState, newState);
+    Assert.assertFalse(comparator.result);
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/filters/AndPathFilter.java
+++ b/gobblin-utility/src/main/java/gobblin/util/filters/AndPathFilter.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.filters;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
+
+
+/**
+ * Combines multiple {@link PathFilter}s. {@link Path} is accepted only if all filters accept it.
+ */
+public class AndPathFilter implements PathFilter {
+
+  public AndPathFilter(PathFilter... pathFilters) {
+    this.pathFilters = pathFilters;
+  }
+
+  PathFilter[] pathFilters;
+
+  @Override
+  public boolean accept(Path path) {
+    for (PathFilter filter : this.pathFilters) {
+      if (!filter.accept(path)) {
+        return false;
+      }
+    }
+    return true;
+  }
+}


### PR DESCRIPTION
This PR adds metadata to the Hive registration in Distcp:
* `registerer`: specifies the entity that registered this Hive table
* `registrationGenerationTime`: specifies the time in millis at which the registration was performed

The data is used for a fast partition skip filter which skips any partitions for which `registrationGenerationTime` is newer than the modtime of the source location.

Also adds an optional hidden file filter to recursive Hive copying.