### PR TITLE
Delete empty parent directories on Hive de-registration. Optimize der…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -262,16 +262,7 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
   }
 
   private void deleteEmptyParentDirectories(Path datasetRoot, Path parent) throws IOException {
-    if (PathUtils.isAncestor(datasetRoot, parent)
-        && !PathUtils.getPathWithoutSchemeAndAuthority(datasetRoot).equals(PathUtils.getPathWithoutSchemeAndAuthority(parent))
-        && this.fs.listStatus(parent).length == 0) {
-      if (!this.fs.delete(parent, false)) {
-        log.warn("Failed to delete empty directory " + parent);
-      } else {
-        log.info("Deleted empty directory " + parent);
-      }
-      deleteEmptyParentDirectories(datasetRoot, parent.getParent());
-    }
+    PathUtils.deleteEmptyParentDirectories(this.fs, datasetRoot, parent);
   }
 
   @Override


### PR DESCRIPTION
This PR introduces optimizations to the delete paths logic for distcp-ng.

* User can set `hive.dataset.copy.deregister.deleteLocationRecursively` to true, which will simply delete the root directory location for deregistered partitions (as opposed to deleting the files used by the input format). This is faster, as it involves a single delete. However, if the directory contains data that should not be deleted, this should be set to false.
* Delete step will automatically delete empty parent directories up to the table root.