### PR TITLE
Allow disabling state store.

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -45,6 +45,8 @@ public class ConfigurationKeys {
   public static final String STATE_STORE_ROOT_DIR_KEY = "state.store.dir";
   // File system URI for file-system-based task store
   public static final String STATE_STORE_FS_URI_KEY = "state.store.fs.uri";
+  // Enable / disable state store
+  public static final String STATE_STORE_ENABLED = "state.store.enabled";
 
   /**
    * Job scheduler configuration properties.

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -125,7 +125,12 @@ public class JobContext {
         jobProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI);
     FileSystem stateStoreFs = FileSystem.get(URI.create(stateStoreFsUri), conf);
     String stateStoreRootDir = jobProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY);
-    this.datasetStateStore = new FsDatasetStateStore(stateStoreFs, stateStoreRootDir);
+    if (jobProps.containsKey(ConfigurationKeys.STATE_STORE_ENABLED) &&
+        !Boolean.parseBoolean(jobProps.getProperty(ConfigurationKeys.STATE_STORE_ENABLED))) {
+      this.datasetStateStore = new NoopDatasetStateStore(stateStoreFs, stateStoreRootDir);
+    } else {
+      this.datasetStateStore = new FsDatasetStateStore(stateStoreFs, stateStoreRootDir);
+    }
 
     boolean jobHistoryStoreEnabled = Boolean
         .valueOf(jobProps.getProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, Boolean.FALSE.toString()));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/NoopDatasetStateStore.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/NoopDatasetStateStore.java
@@ -1,0 +1,101 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+
+/**
+ * An extension of {@link FsDatasetStateStore} where all operations are noop. Used to disable the state store.
+ */
+public class NoopDatasetStateStore extends FsDatasetStateStore {
+
+  public NoopDatasetStateStore(FileSystem fs, String storeRootDir)
+      throws IOException {
+    super(fs, storeRootDir);
+  }
+
+  @Override
+  public List<JobState.DatasetState> getAll(String storeName, String tableName)
+      throws IOException {
+    return Lists.newArrayList();
+  }
+
+  @Override
+  public List<JobState.DatasetState> getAll(String storeName)
+      throws IOException {
+    return Lists.newArrayList();
+  }
+
+  @Override
+  public Map<String, JobState.DatasetState> getLatestDatasetStatesByUrns(String jobName)
+      throws IOException {
+    return Maps.newHashMap();
+  }
+
+  @Override
+  public void persistDatasetState(String datasetUrn, JobState.DatasetState datasetState)
+      throws IOException {
+  }
+
+  @Override
+  public boolean create(String storeName)
+      throws IOException {
+    return true;
+  }
+
+  @Override
+  public boolean create(String storeName, String tableName)
+      throws IOException {
+    return true;
+  }
+
+  @Override
+  public boolean exists(String storeName, String tableName)
+      throws IOException {
+    return false;
+  }
+
+  @Override
+  public void put(String storeName, String tableName, JobState.DatasetState state)
+      throws IOException {
+  }
+
+  @Override
+  public void putAll(String storeName, String tableName, Collection<JobState.DatasetState> states)
+      throws IOException {
+  }
+
+  @Override
+  public void createAlias(String storeName, String original, String alias)
+      throws IOException {
+  }
+
+  @Override
+  public void delete(String storeName, String tableName)
+      throws IOException {
+  }
+
+  @Override
+  public void delete(String storeName)
+      throws IOException {
+  }
+}


### PR DESCRIPTION
This PR adds an option to disable state store. (Default is state store is enabled). This is useful when jobs don't use the state store, saving the load of reading / writing it. It also provides a workaround for a memory issue when extracts change name often, as this would cause Gobblin to load previous metadata for many runs, causing OOM.