### PR TITLE
Hive compactor: Fix ClassNotFoundException in ShutdownHookManager

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/hive/util/HiveJdbcConnector.java
+++ b/gobblin-compaction/src/main/java/gobblin/hive/util/HiveJdbcConnector.java
@@ -184,8 +184,9 @@ public class HiveJdbcConnector implements Closeable {
   private static void addHiveSiteDirToClasspath(String hiveSiteDir) {
     LOG.info("Adding " + hiveSiteDir + " to CLASSPATH");
     File f = new File(hiveSiteDir);
-    try (URLClassLoader urlClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader()) {
+    try {
       URL u = f.toURI().toURL();
+      URLClassLoader urlClassLoader = (URLClassLoader) ClassLoader.getSystemClassLoader();
       Class<URLClassLoader> urlClass = URLClassLoader.class;
       Method method = urlClass.getDeclaredMethod("addURL", new Class[] { URL.class });
       method.setAccessible(true);


### PR DESCRIPTION
When running Hive compaction from command line the following exception is thrown:
```
Exception in thread "main" java.lang.NoClassDefFoundError: org/apache/hadoop/hdfs/DistributedFileSystem$12
	at org.apache.hadoop.hdfs.DistributedFileSystem.delete(DistributedFileSystem.java:634)
	at gobblin.compaction.hive.HdfsWriter.delete(HdfsWriter.java:50)
	at gobblin.compaction.hive.AvroExternalTable.deleteTmpFilesIfNeeded(AvroExternalTable.java:208)
	at gobblin.compaction.hive.SerialCompactor.deleteTmpFiles(SerialCompactor.java:340)
	at gobblin.compaction.hive.SerialCompactor.compact(SerialCompactor.java:127)
	at gobblin.compaction.hive.CompactionRunner.compact(CompactionRunner.java:109)
	at gobblin.compaction.hive.CompactionRunner.main(CompactionRunner.java:94)
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.hdfs.DistributedFileSystem$12
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 7 more
Exception in thread "Thread-1" java.lang.NoClassDefFoundError: org/apache/hadoop/util/ShutdownHookManager$2
	at org.apache.hadoop.util.ShutdownHookManager.getShutdownHooksInOrder(ShutdownHookManager.java:124)
	at org.apache.hadoop.util.ShutdownHookManager$1.run(ShutdownHookManager.java:52)
Caused by: java.lang.ClassNotFoundException: org.apache.hadoop.util.ShutdownHookManager$2
	at java.net.URLClassLoader.findClass(URLClassLoader.java:381)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
	at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:331)
	at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
	... 2 more
```
After some investigation I found that this might be a regression of a code refactoring done in 8592f28876f693ad47a3994788e0e0b9e735081c.
By not closing the classloader in **HiveJdbcConnector#addHiveSiteDirToClasspath** with try-with the problem disappears.
