### PR TITLE
Copyable file performance

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyContext.java
@@ -25,10 +25,13 @@ import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
+import lombok.extern.slf4j.Slf4j;
+
 
 /**
  * Context that can hold global objects required in a single copy job.
  */
+@Slf4j
 public class CopyContext {
 
   /**
@@ -39,7 +42,7 @@ public class CopyContext {
   private final Cache<Path, Optional<FileStatus>> fileStatusCache;
 
   public CopyContext() {
-    this.fileStatusCache = CacheBuilder.newBuilder().maximumSize(10000).build();
+    this.fileStatusCache = CacheBuilder.newBuilder().recordStats().maximumSize(10000).build();
   }
 
   /**
@@ -61,6 +64,10 @@ public class CopyContext {
     } catch (ExecutionException ee) {
       throw new IOException(ee.getCause());
     }
+  }
+
+  public void logCacheStatistics() {
+    log.info(this.fileStatusCache.stats().toString());
   }
 
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
@@ -172,6 +172,8 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
 
       log.info(String.format("Created %s workunits ", workUnitList.getWorkUnits().size()));
 
+      copyConfiguration.getCopyContext().logCacheStatistics();
+
       if (state.contains(SIMULATE) && state.getPropAsBoolean(SIMULATE)) {
         Map<FileSet<CopyEntity>, List<WorkUnit>> copyEntitiesMap = workUnitList.getRawWorkUnitMap();
         log.info("Simulate mode enabled. Will not execute the copy.");


### PR DESCRIPTION
Generating a new `FileSystem` per work unit is very costly (even though Hadoop caches them). This PR stops doing that. 
Also write out cache statistics after creating work units for distcp.