### PR TITLE
Unified way to execute Hive and MR-based compaction jobs

### DIFF
--- a/bin/gobblin-compaction.sh
+++ b/bin/gobblin-compaction.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+
+##############################################################
+############ Run Gobblin Compaction on Hadoop MR #############
+##############################################################
+
+# Set during the distribution build
+GOBBLIN_VERSION=@project.version@
+
+FWDIR="$(cd `dirname $0`/..; pwd)"
+FWDIR_LIB=$FWDIR/lib
+FWDIR_CONF=$FWDIR/conf
+FWDIR_BIN=$FWDIR/bin
+
+function print_usage(){
+  echo "Usage: gobblin-compaction.sh [OPTION] --type <compaction type: hive or mr> --conf <compaction configuration file>"
+  echo "Where OPTION can be:"
+  echo "  --projectversion <version>    Gobblin version to be used. If set, overrides the distribution build version"
+  echo "  --logdir <log dir>            Gobblin's log directory: if not set, taken from \${GOBBLIN_LOG_DIR} if present. Otherwise \"$FWDIR/logs\" is used"
+  echo "  --help                        Display this help and exit"
+}
+
+# Print an error message and exit
+function die() {
+  echo -e "\nError: $@\n" 1>&2
+  print_usage
+  exit 1
+}
+
+for i in "$@"
+do
+  case "$1" in
+    --type)
+      TYPE="$2"
+      shift
+      ;;
+    --conf)
+      COMP_CONFIG_FILE="$2"
+      shift
+      ;;
+    --jars)
+      JARS="$2"
+      shift
+      ;;
+    --projectversion)
+      GOBBLIN_VERSION="$2"
+      shift
+      ;;
+    --logdir)
+      LOG_DIR="$2"
+      shift
+      ;;
+    --help)
+      print_usage
+      exit 0
+      ;;
+    *)
+      ;;
+  esac
+  shift
+done
+
+if ( [ -z "$GOBBLIN_VERSION" ] || [ "$GOBBLIN_VERSION" == "@project.version@" ] ); then
+  die "Gobblin project version is not set!"
+fi
+
+if [ -z "$COMP_CONFIG_FILE" ]; then
+  die "No compaction configuration file set!"
+fi
+
+if ( [ -z "$TYPE" ] || ( [ "$TYPE" != "hive" ] && [ "$TYPE" != "mr" ] ) ); then
+  die "Invalid compaction type set!"
+fi
+
+# User defined log directory overrides $GOBBLIN_LOG_DIR
+if [ -n "$LOG_DIR" ]; then
+  export GOBBLIN_LOG_DIR="$LOG_DIR"
+fi
+
+if [ -z "$GOBBLIN_LOG_DIR" ]; then
+  GOBBLIN_LOG_DIR="$FWDIR/logs"
+fi
+
+. $FWDIR_BIN/gobblin-env.sh
+
+# Jars Gobblin runtime depends on
+function join { local IFS="$1"; shift; echo "$*"; }
+
+# Add libraries to the Hadoop classpath
+for jarFile in `ls $FWDIR_LIB/*`
+do
+  GOBBLIN_DEP_JARS=${GOBBLIN_DEP_JARS}:$jarFile
+done
+
+export HADOOP_CLIENT_OPTS="$HADOOP_CLIENT_OPTS -Dgobblin.logs.dir=$GOBBLIN_LOG_DIR -Dlog4j.configuration=file:$FWDIR_CONF/log4j-compaction.xml"
+# Honor Gobblin dependencies
+export HADOOP_USER_CLASSPATH_FIRST=true
+export HADOOP_CLASSPATH=$GOBBLIN_DEP_JARS:$HADOOP_CLASSPATH  
+
+if [ "$TYPE" == "hive" ]; then
+  
+  $HADOOP_BIN_DIR/hadoop jar \
+        $FWDIR_LIB/gobblin-compaction-$GOBBLIN_VERSION.jar \
+        "gobblin.compaction.hive.CompactionRunner" \
+        --jobconfig $COMP_CONFIG_FILE
+        
+else
+  
+  LIBJARS=(
+    $FWDIR_LIB/avro-1.7.7.jar
+    $FWDIR_LIB/avro-mapred-1.7.7-hadoop2.jar
+    $FWDIR_LIB/commons-cli-1.3.1.jar
+    $FWDIR_LIB/commons-lang3-3.4.jar
+    $FWDIR_LIB/gobblin-api-$GOBBLIN_VERSION.jar
+    $FWDIR_LIB/gobblin-compaction-$GOBBLIN_VERSION.jar
+    $FWDIR_LIB/gobblin-utility-$GOBBLIN_VERSION.jar
+    $FWDIR_LIB/guava-15.0.jar
+  )
+  LIBJARS=$(join , "${LIBJARS[@]}")
+  
+  $HADOOP_BIN_DIR/hadoop jar \
+        $FWDIR_LIB/gobblin-compaction-$GOBBLIN_VERSION.jar \
+        "gobblin.compaction.mapreduce.MRCompactionRunner" \
+        -D mapreduce.user.classpath.first=true \
+        -D mapreduce.job.user.classpath.first=true \
+        -libjars $LIBJARS \
+        --jobconfig $COMP_CONFIG_FILE
+        
+fi

--- a/conf/log4j-compaction.xml
+++ b/conf/log4j-compaction.xml
@@ -11,8 +11,8 @@
   </appender>
 
   <appender name="file" class="org.apache.log4j.RollingFileAppender">
-    <param name="append" value="false" />
-    <param name="file" value="logs/gobblin-compaction.log" />
+    <param name="append" value="true" />
+    <param name="file" value="${gobblin.logs.dir}/gobblin-compaction.log" />
     <layout class="org.apache.log4j.PatternLayout">
       <param name="ConversionPattern"
         value="%d{yyyy-MM-dd HH:mm:ss z} %-5p [%t] %C %X{tableName} %L - %m%n" />

--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -51,37 +51,6 @@ dependencies {
 
 configurations { 
     compile { transitive = true } 
-    archives
 }
 
 ext.classification="library"
-
-jar {
-  def manifestClasspath = configurations.runtime.collect { "gobblin-compaction_lib/" + it.getName() }.join(' ')
-  manifestClasspath = ". " + manifestClasspath
-  manifest {
-    attributes("Manifest-Version"       : "1.0",
-    "Main-Class"             : "gobblin.compaction.hive.CompactionRunner",
-    "Class-Path"             : manifestClasspath
-    )
-  }
-}
-
-task createCompactionTar(type: Tar) {
-  //there seems to be a bug in the Gradle signing module where X.tar.gz will generate
-  // a signature X.gz.asc instead of X.tar.gz.asc. Therefore, we have to use the .tgz 
-  // extension
-  extension = 'tgz'
-  baseName = project.name
-  compression = Compression.GZIP
-
-  into("gobblin-compaction_lib") { from configurations.runtime }
-  into(".") { from "${project.rootDir}/build/${project.name}/libs/${project.name}-${project.version}.jar" }
-  into(".") { from project.rootDir.path + "/conf/log4j-compaction.xml" rename ('log4j-compaction.xml', 'log4j.xml')}
-}
-
-createCompactionTar.dependsOn ':gobblin-compaction:jar'
-
-artifacts {
-  archives createCompactionTar
-}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/CompactionRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/CompactionRunner.java
@@ -30,6 +30,8 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import gobblin.compaction.CliOptions;
+import gobblin.compaction.mapreduce.MRCompactionRunner;
 
 /**
  * Run Hive compaction based on config files.
@@ -59,15 +61,7 @@ public class CompactionRunner {
 
   public static void main(String[] args) throws IOException, ConfigurationException {
 
-    if (args.length != 1) {
-      LOG.info("Proper usage: java -jar compaction.jar <global-config-file>\n" + "or\n"
-          + "hadoop jar compaction.jar <global-config-file>\n" + "or\n"
-          + "yarn jar compaction.jar <global-config-file>\n");
-      System.exit(1);
-    }
-
-    Configuration globalConfig = new PropertiesConfiguration(args[0]);
-    properties = ConfigurationConverter.getProperties(globalConfig);
+    properties = CliOptions.parseArgs(MRCompactionRunner.class, args);
 
     File compactionConfigDir = new File(properties.getProperty(COMPACTION_CONFIG_DIR));
     File[] listOfFiles = compactionConfigDir.listFiles();

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionRunner.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionRunner.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (C) 2016 Swisscom All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.compaction.mapreduce;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Properties;
+
+import org.apache.commons.cli.ParseException;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.hadoop.conf.Configuration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+
+import gobblin.compaction.CliOptions;
+import gobblin.compaction.Compactor;
+import gobblin.compaction.CompactorCreationException;
+import gobblin.compaction.CompactorFactory;
+import gobblin.compaction.ReflectionCompactorFactory;
+import gobblin.compaction.listeners.CompactorListener;
+import gobblin.compaction.listeners.CompactorListenerCreationException;
+import gobblin.compaction.listeners.CompactorListenerFactory;
+import gobblin.compaction.listeners.ReflectionCompactorListenerFactory;
+import gobblin.metrics.Tag;
+
+/**
+ * A class for launching a Gobblin MR job for compaction through command line.
+ * 
+ * @author Lorand Bendig
+ *
+ */
+public class MRCompactionRunner {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MRCompactionRunner.class);
+
+  private final Properties properties;
+  private final Compactor compactor;
+
+  public MRCompactionRunner(Properties properties) {
+    this.properties = properties;
+    this.compactor = getCompactor(getCompactorFactory(), getCompactorListener(getCompactorListenerFactory()));
+  }
+
+  public static void main(String[] args)
+      throws IOException, ConfigurationException, ParseException, URISyntaxException {
+
+    Properties jobProperties = CliOptions.parseArgs(MRCompactionRunner.class, args, new Configuration());
+    MRCompactionRunner compactionRunner = new MRCompactionRunner(jobProperties);
+    compactionRunner.compact();
+  }
+
+  public void compact() throws IOException {
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        try {
+          compactor.cancel();
+        } catch (IOException e) {
+          LOG.warn("Unable to cancel the compactor jobs!", e);
+        }
+      }
+    });
+    try {
+      compactor.compact();
+    } catch (Exception e) {
+      compactor.cancel();
+    }
+  }
+  
+  protected CompactorListenerFactory getCompactorListenerFactory() {
+    return new ReflectionCompactorListenerFactory();
+  }
+
+  protected CompactorFactory getCompactorFactory() {
+    return new ReflectionCompactorFactory();
+  }
+
+  private Compactor getCompactor(CompactorFactory compactorFactory, Optional<CompactorListener> compactorListener) {
+    try {
+      return compactorFactory.createCompactor(this.properties, new ArrayList<Tag<String>>(), compactorListener);
+    } catch (CompactorCreationException e) {
+      throw new RuntimeException("Unable to create compactor", e);
+    }
+  }
+
+  private Optional<CompactorListener> getCompactorListener(CompactorListenerFactory compactorListenerFactory) {
+    try {
+      return compactorListenerFactory.createCompactorListener(this.properties);
+    } catch (CompactorListenerCreationException e) {
+      throw new RuntimeException("Unable to create compactor listener", e);
+    }
+  }
+
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactor.java
@@ -741,7 +741,9 @@ public class MRCompactor implements Compactor {
       try {
         ExecutorsUtils.shutdownExecutorService(this.jobExecutor, Optional.of(LOG), 0, TimeUnit.NANOSECONDS);
       } finally {
-        this.verifier.get().closeNow();
+        if (this.verifier.isPresent()) {
+          this.verifier.get().closeNow();
+        }
       }
     }
   }

--- a/gobblin-utility/src/main/java/gobblin/util/JobConfigurationUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/JobConfigurationUtils.java
@@ -15,7 +15,9 @@ package gobblin.util;
 import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.util.Iterator;
 import java.util.Properties;
+import java.util.Map.Entry;
 
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.ConfigurationException;
@@ -64,6 +66,20 @@ public class JobConfigurationUtils {
   }
 
   /**
+   * Put all configuration properties in a given {@link Configuration} object into a given
+   * {@link Properties} object.
+   *
+   * @param configuration the given {@link Configuration} object
+   * @param properties the given {@link Properties} object
+   */
+  public static void putConfigurationIntoProperties(Configuration configuration, Properties properties) {
+    for (Iterator<Entry<String, String>> it = configuration.iterator(); it.hasNext();) {
+      Entry<String, String> entry = it.next();
+      properties.put(entry.getKey(), entry.getValue());
+    }
+  }
+  
+  /**
    * Put all configuration properties in a given {@link State} object into a given
    * {@link Configuration} object.
    *
@@ -76,17 +92,18 @@ public class JobConfigurationUtils {
     }
   }
 
+  
   /**
    * Load the properties from the specified file into a {@link Properties} object.
    *
    * @param fileName the name of the file to load properties from
+   * @param conf configuration object to determine the file system to be used
    * @return a new {@link Properties} instance
    */
-  public static Properties fileToProperties(String fileName)
+  public static Properties fileToProperties(String fileName, Configuration conf)
       throws IOException, ConfigurationException, URISyntaxException {
 
     PropertiesConfiguration propsConfig = new PropertiesConfiguration();
-    Configuration conf = new Configuration();
     Path filePath = new Path(fileName);
     URI fileURI = filePath.toUri();
 
@@ -97,4 +114,16 @@ public class JobConfigurationUtils {
     }
     return ConfigurationConverter.getProperties(propsConfig);
   }
+  
+  /**
+   * Load the properties from the specified file into a {@link Properties} object.
+   *
+   * @param fileName the name of the file to load properties from
+   * @return a new {@link Properties} instance
+   */
+  public static Properties fileToProperties(String fileName)
+      throws IOException, ConfigurationException, URISyntaxException {
+    return fileToProperties(fileName, new Configuration());
+  }
+  
 }


### PR DESCRIPTION
Currently the execution of the Hive and MR-based compactors is not out of the box, needs extra work:
- there's no implementation for MR compaction for CLI execution
- Hive compactor is a standalone package that needs to be built separately

This PR tries to fix these issues. A new shell script **bin/gobblin-compaction.sh** was added with which one can execute both Hive and MR-based compaction jobs from the CLI.
```
Usage: gobblin-compaction.sh [OPTION] --type <compaction type: hive or mr> --conf <compaction configuration file>
Where OPTION can be:
  --projectversion <version>    Gobblin version to be used. If set, overrides the distribution build version
  --logdir <log dir>            Gobblin's log directory: if not set, taken from ${GOBBLIN_LOG_DIR} if present. 
  --help                        Display this help and exit
```

I assumed that the executable gobblin-compaction.jar and tarball creation are no longer needed.