### PR TITLE
Make the default store for SimpleHDFSConfigStoreFactory configurable

### DIFF
--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
@@ -22,9 +22,6 @@ import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
-import lombok.AllArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
-
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -58,6 +55,9 @@ import gobblin.util.FileListUtils;
 import gobblin.util.PathUtils;
 import gobblin.util.io.SeekableFSInputStream;
 import gobblin.util.io.StreamUtils;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -515,5 +515,10 @@ public class SimpleHDFSConfigStore implements ConfigStore, Deployable<FsDeployme
     storeMetadata.setCurrentVersion(deploymentConfig.getNewVersion());
 
     log.info(String.format("New version %s of config store deployed at %s", deploymentConfig.getNewVersion(), hdfsconfigStoreRoot));
+  }
+
+  @VisibleForTesting
+  URI getPhysicalStoreRoot() {
+    return physicalStoreRoot;
   }
 }

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -19,7 +19,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.security.UserGroupInformation;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
@@ -127,7 +126,7 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
    * Gets a default root directory if one is not specified. The default root dir is {@code /jobs/[current-user]/}.
    */
   protected Path getDefaultRootDir() throws IOException {
-    return new Path("/jobs", UserGroupInformation.getCurrentUser().getUserName());
+    return this.defaultStoreFS.getHomeDirectory();
   }
 
   /**

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -41,19 +41,25 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
   protected static final String SIMPLE_HDFS_SCHEME_PREFIX = "simple-";
   protected static final String HDFS_SCHEME_NAME = "hdfs";
 
-  public final static String DEFAULT_STORE_URI_KEY = "default_store_uri";
-
-  public SimpleHDFSConfigStoreFactory() {
-    this(ConfigFactory.empty());
-  }
+  public static final String DEFAULT_CONFIG_NAMESPACE = SimpleHDFSConfigStoreFactory.class.getName();
+  public static final String DEFAULT_STORE_URI_KEY = "default_store_uri";
 
   private final Optional<URI> defaultStoreURI;
   private final FileSystem defaultStoreFS;
+
+  /** Instantiates a new instance using standard typesafe config defaults:
+   * {@link ConfigFactory#load()} */
+  public SimpleHDFSConfigStoreFactory() {
+    this(ConfigFactory.load().getConfig(DEFAULT_CONFIG_NAMESPACE));
+  }
 
   public SimpleHDFSConfigStoreFactory(Config factoryConfig) {
     try {
       if (factoryConfig.hasPath(DEFAULT_STORE_URI_KEY)) {
         String uri = factoryConfig.getString(DEFAULT_STORE_URI_KEY);
+        if (Strings.isNullOrEmpty(uri)) {
+          throw new IllegalArgumentException("Default store URI should be non-empty!");
+        }
         Path defStorePath = new Path(uri);
         this.defaultStoreFS = defStorePath.getFileSystem(new Configuration());
         this.defaultStoreURI = Optional.of(defaultStoreFS.makeQualified(defStorePath).toUri());

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -125,7 +125,7 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
    * {@link FileSystem} implementations, subclasses should override this method.
    */
   protected String getPhysicalScheme() {
-    return this.defaultStoreFS.getScheme();
+    return this.defaultStoreFS.getUri().getScheme();
   }
 
   /**

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -41,7 +41,9 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
   protected static final String SIMPLE_HDFS_SCHEME_PREFIX = "simple-";
   protected static final String HDFS_SCHEME_NAME = "hdfs";
 
+  /** Global namespace for properties if no scope is used */
   public static final String DEFAULT_CONFIG_NAMESPACE = SimpleHDFSConfigStoreFactory.class.getName();
+  /** Scoped configuration properties */
   public static final String DEFAULT_STORE_URI_KEY = "default_store_uri";
 
   private final Optional<URI> defaultStoreURI;
@@ -53,6 +55,10 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
     this(ConfigFactory.load().getConfig(DEFAULT_CONFIG_NAMESPACE));
   }
 
+  /**
+   * Instantiates a new instance of the factory with the specified config. The configuration is
+   * expected to be scoped, i.e. the properties should not be prefixed.
+   */
   public SimpleHDFSConfigStoreFactory(Config factoryConfig) {
     try {
       if (factoryConfig.hasPath(DEFAULT_STORE_URI_KEY)) {

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStoreFactory.java
@@ -15,13 +15,17 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
-import com.google.common.base.Strings;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.security.UserGroupInformation;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import gobblin.config.store.api.ConfigStoreCreationException;
 import gobblin.config.store.api.ConfigStoreFactory;
@@ -37,6 +41,47 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
 
   protected static final String SIMPLE_HDFS_SCHEME_PREFIX = "simple-";
   protected static final String HDFS_SCHEME_NAME = "hdfs";
+
+  public final static String DEFAULT_STORE_URI_KEY = "default_store_uri";
+
+  public SimpleHDFSConfigStoreFactory() {
+    this(ConfigFactory.empty());
+  }
+
+  private final Optional<URI> defaultStoreURI;
+  private final FileSystem defaultStoreFS;
+
+  public SimpleHDFSConfigStoreFactory(Config factoryConfig) {
+    try {
+      if (factoryConfig.hasPath(DEFAULT_STORE_URI_KEY)) {
+        String uri = factoryConfig.getString(DEFAULT_STORE_URI_KEY);
+        Path defStorePath = new Path(uri);
+        this.defaultStoreFS = defStorePath.getFileSystem(new Configuration());
+        this.defaultStoreURI = Optional.of(defaultStoreFS.makeQualified(defStorePath).toUri());
+        if (!isValidStoreRootPath(this.defaultStoreFS, defStorePath)) {
+          throw new IllegalArgumentException("Path does not appear to be a config store root: " +
+              this.defaultStoreFS);
+        }
+       }
+      else {
+        this.defaultStoreFS = FileSystem.get(new Configuration());
+        Path candidateStorePath = getDefaultRootDir();
+        if (isValidStoreRootPath(this.defaultStoreFS, candidateStorePath)) {
+          this.defaultStoreURI = Optional.of(this.defaultStoreFS.makeQualified(candidateStorePath).toUri());
+        }
+        else {
+          this.defaultStoreURI = Optional.absent();
+        }
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Unable to initialize Hadoop FS store factory:" + e, e);
+    }
+  }
+
+  private static boolean isValidStoreRootPath(FileSystem fs, Path storeRootPath) throws IOException {
+    Path storeRoot = new Path(storeRootPath, SimpleHDFSConfigStore.CONFIG_STORE_NAME);
+    return fs.exists(storeRoot);
+  }
 
   @Override
   public String getScheme() {
@@ -75,7 +120,7 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
    * {@link FileSystem} implementations, subclasses should override this method.
    */
   protected String getPhysicalScheme() {
-    return HDFS_SCHEME_NAME;
+    return this.defaultStoreFS.getScheme();
   }
 
   /**
@@ -86,12 +131,13 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
   }
 
   /**
-   * Gets a default authority if one is not specified. The default authority is the authority of the {@link FileSystem}
-   * the current process is running on. For example, when running on a HDFS node, the authority will taken from the
-   * NameNode {@link URI}.
+   * Gets a default authority if one is not specified. The default authority is the authority
+   * configured as part of the {@link #DEFAULT_STORE_URI_KEY} configuration setting or the {@link FileSystem}
+   * the current process is running if the setting is missing.. For example, when running on a
+   * HDFS node, the authority will taken from the NameNode {@link URI}.
    */
   private String getDefaultAuthority() throws IOException {
-    return FileSystem.get(new Configuration()).getUri().getAuthority();
+    return this.defaultStoreFS.getUri().getAuthority();
   }
 
   /**
@@ -99,17 +145,17 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
    */
   private FileSystem createFileSystem(URI configKey) throws ConfigStoreCreationException {
     try {
-      return FileSystem.get(createHDFSURI(configKey), new Configuration());
+      return FileSystem.get(createFileSystemURI(configKey), new Configuration());
     } catch (IOException | URISyntaxException e) {
       throw new ConfigStoreCreationException(configKey, e);
     }
   }
 
   /**
-   * Creates a HDFS {@link URI} given a user specified configKey. If the given configKey does not have an authority,
+   * Creates a Hadoop FS {@link URI} given a user-specified configKey. If the given configKey does not have an authority,
    * a default one is used instead, provided by the {@link #getDefaultAuthority()} method.
    */
-  private URI createHDFSURI(URI configKey) throws URISyntaxException, IOException {
+  private URI createFileSystemURI(URI configKey) throws URISyntaxException, IOException {
     // Validate the scheme
     String configKeyScheme = configKey.getScheme();
     if (!configKeyScheme.startsWith(SIMPLE_HDFS_SCHEME_PREFIX)) {
@@ -120,7 +166,11 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
     if (Strings.isNullOrEmpty(configKey.getAuthority())) {
       return new URI(getPhysicalScheme(), getDefaultAuthority(), "", "", "");
     }
-    return new URI(getPhysicalScheme(), configKey.getAuthority(), "", "", "");
+    else {
+      String uriPhysicalScheme =
+          configKeyScheme.substring(SIMPLE_HDFS_SCHEME_PREFIX.length(), configKeyScheme.length());
+      return new URI(uriPhysicalScheme, configKey.getAuthority(), "", "", "");
+    }
   }
 
   /**
@@ -138,18 +188,11 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
    */
   private URI getStoreRoot(FileSystem fs, URI configKey) throws ConfigStoreCreationException {
     if (Strings.isNullOrEmpty(configKey.getAuthority())) {
-      try {
-        Path defaultRootDir = getDefaultRootDir();
-        Path configStoreDir = new Path(defaultRootDir, SimpleHDFSConfigStore.CONFIG_STORE_NAME);
-        if (fs.exists(configStoreDir)) {
-          return fs.getUri().resolve(defaultRootDir.toUri());
-        } else {
-          throw new ConfigStoreCreationException(configKey,
-              String.format("Cannot find store root for default path \"%s\"", configStoreDir));
-        }
-      } catch (IOException e) {
-        throw new ConfigStoreCreationException(configKey, e);
+      if (! hasDefaultStoreURI()) {
+        throw new ConfigStoreCreationException(configKey,
+                                               "No default store has been configured.");
       }
+      return defaultStoreURI.get();
     }
 
     Path path = new Path(configKey.getPath());
@@ -173,6 +216,16 @@ public class SimpleHDFSConfigStoreFactory implements ConfigStoreFactory<SimpleHD
       path = path.getParent();
     }
     throw new ConfigStoreCreationException(configKey, "Cannot find the store root!");
+  }
+
+  @VisibleForTesting
+  boolean hasDefaultStoreURI() {
+    return this.defaultStoreURI.isPresent();
+  }
+
+  @VisibleForTesting
+  URI getDefaultStoreURI() {
+    return this.defaultStoreURI.get();
   }
 }
 

--- a/gobblin-config-management/gobblin-config-core/src/main/resources/reference.conf
+++ b/gobblin-config-management/gobblin-config-core/src/main/resources/reference.conf
@@ -1,0 +1,2 @@
+gobblin.config.store.hdfs.SimpleHDFSConfigStoreFactory {
+}

--- a/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/store/hdfs/SimpleHdfsConfigureStoreFactoryTest.java
+++ b/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/store/hdfs/SimpleHdfsConfigureStoreFactoryTest.java
@@ -65,6 +65,8 @@ public class SimpleHdfsConfigureStoreFactoryTest {
       Assert.assertTrue(confFactory.hasDefaultStoreURI());
       Assert.assertEquals(confFactory.getDefaultStoreURI(), configRoot.toUri());
       Assert.assertEquals(confFactory.getPhysicalScheme(), "file");
+      Assert.assertEquals(confFactory.getDefaultRootDir().toString(),
+                          "file:" + System.getProperty("user.home"));
 
       // Valid path
       SimpleHDFSConfigStore store1 = confFactory.createConfigStore(new URI("simple-file:/d"));

--- a/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/store/hdfs/SimpleHdfsConfigureStoreFactoryTest.java
+++ b/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/store/hdfs/SimpleHdfsConfigureStoreFactoryTest.java
@@ -7,9 +7,12 @@ import java.net.URISyntaxException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.testng.Assert;
 import org.testng.annotations.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
 
 import gobblin.config.store.api.ConfigStoreCreationException;
 
@@ -42,6 +45,49 @@ public class SimpleHdfsConfigureStoreFactoryTest {
       if (fs != null && fs.exists(configStoreDir)) {
         fs.delete(configStoreDir, true);
       }
+    }
+  }
+
+
+  @Test
+  public void testConfiguration() throws Exception {
+    FileSystem localFS = FileSystem.getLocal(new Configuration());
+    Path testRoot = localFS.makeQualified(new Path("dir1"));
+    Path configRoot = localFS.makeQualified(new Path(testRoot, "dir2"));
+    Path configStoreRoot = new Path(configRoot,
+                                    SimpleHDFSConfigStore.CONFIG_STORE_NAME);
+    Assert.assertTrue(localFS.mkdirs(configStoreRoot));
+    try {
+      Config confConf1 =
+          ConfigFactory.empty().withValue(SimpleHDFSConfigStoreFactory.DEFAULT_STORE_URI_KEY,
+                                          ConfigValueFactory.fromAnyRef(configRoot.toString()));
+      SimpleHDFSConfigStoreFactory confFactory = new SimpleHDFSConfigStoreFactory(confConf1);
+      Assert.assertTrue(confFactory.hasDefaultStoreURI());
+      Assert.assertEquals(confFactory.getDefaultStoreURI(), configRoot.toUri());
+      Assert.assertEquals(confFactory.getPhysicalScheme(), "file");
+
+      // Valid path
+      SimpleHDFSConfigStore store1 = confFactory.createConfigStore(new URI("simple-file:/d"));
+      Assert.assertEquals(store1.getStoreURI().getScheme(), confFactory.getScheme());
+      Assert.assertEquals(store1.getStoreURI().getAuthority(),
+                          confFactory.getDefaultStoreURI().getAuthority());
+      Assert.assertEquals(store1.getStoreURI().getPath(),
+                          confFactory.getDefaultStoreURI().getPath());
+
+      // Invalid path
+      Config confConf2 =
+          ConfigFactory.empty().withValue(SimpleHDFSConfigStoreFactory.DEFAULT_STORE_URI_KEY,
+                                          ConfigValueFactory.fromAnyRef(testRoot.toString()));
+      try {
+        new SimpleHDFSConfigStoreFactory(confConf2);
+        Assert.fail("Exception expected");
+      }
+      catch (IllegalArgumentException e) {
+        Assert.assertTrue(e.getMessage().contains("Path does not appear to be a config store root"));
+      }
+    }
+    finally {
+      localFS.delete(testRoot, true);
     }
   }
 }


### PR DESCRIPTION
Changes:

- Add a default_store_uri option to specify the default store
- Add validation in the constructor if the default config root exists
- Make changes to support use of any Hadoop FS rather than just HDFS.
- Add some unit tests.

@tuGithub @pcadabam Can you review?