### PR TITLE
Fixing rest of findbugs warnings, and setting findbugs to fail the build on new warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -414,9 +414,10 @@ subprojects {
     plugins.apply('findbugs')
     findbugs {
       toolVersion = findBugsVersion
-      ignoreFailures = true
+      ignoreFailures = false
       effort = "max"
-      // The exclude filter file must be under "ligradle/findbugs/"
+      sourceSets = [sourceSets.main] // Only analyze src/java/main, not src/java/test/
+      // The exclude filter file must be under "ligradle/findbugs/" for internal compatibility with ligradle FindBugs
       excludeFilter = file(rootProject.projectDir.path + "/ligradle/findbugs/findbugsExclude.xml")
     }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyCombineFileRecordReader.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/avro/AvroKeyCombineFileRecordReader.java
@@ -18,10 +18,14 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.mapreduce.AvroJob;
 import org.apache.avro.mapreduce.AvroKeyRecordReader;
+
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.input.CombineFileSplit;
 import org.apache.hadoop.mapreduce.lib.input.FileSplit;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 
 /**
  * A subclass of {@link org.apache.avro.mapreduce.AvroKeyRecordReader}. The purpose is to add a constructor
@@ -35,6 +39,7 @@ public class AvroKeyCombineFileRecordReader extends AvroKeyRecordReader<GenericR
   private final AvroCombineFileSplit split;
   private final Integer idx;
 
+  @SuppressFBWarnings("BC_UNCONFIRMED_CAST")
   public AvroKeyCombineFileRecordReader(CombineFileSplit split, TaskAttemptContext cx, Integer idx) {
       this(split,
           AvroJob.getInputKeySchema(cx.getConfiguration()) != null ?

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
@@ -158,9 +158,9 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
               } else if (copyableDataset instanceof CopyableDataset) {
                 iterableCopyableDataset = new IterableCopyableDatasetImpl((CopyableDataset) copyableDataset);
               } else {
-                throw new RuntimeException(
-                    String.format("Cannot process %s, can only copy %s or %s.", copyableDataset.getClass().getName(),
-                        CopyableDataset.class.getName(), IterableCopyableDataset.class.getName()));
+                throw new RuntimeException(String.format("Cannot process %s, can only copy %s or %s.",
+                    copyableDataset == null ? null : copyableDataset.getClass().getName(),
+                    CopyableDataset.class.getName(), IterableCopyableDataset.class.getName()));
               }
 
               return new DatasetWorkUnitGenerator(iterableCopyableDataset, sourceFs, targetFs, state, workUnitList,

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepCopyEntity.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepCopyEntity.java
@@ -12,6 +12,7 @@
 
 package gobblin.data.management.copy.entities;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 import java.util.Map;
@@ -23,6 +24,7 @@ import gobblin.data.management.copy.CopyEntity;
 /**
  * A {@link CopyEntity} encapsulating a {@link CommitStep}.
  */
+@EqualsAndHashCode(callSuper = true)
 public class CommitStepCopyEntity extends CopyEntity {
 
   @Getter

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -45,6 +45,8 @@ import com.google.common.collect.Maps;
 import com.google.common.io.Closer;
 import com.google.gson.Gson;
 
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
 import gobblin.commit.CommitStep;
 import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyConfiguration;
@@ -584,6 +586,8 @@ public class HiveCopyEntityHelper {
     return priority;
   }
 
+  // Suppress warnings for "stepPriority++" in the PrePublishStep constructor, as stepPriority may be used later
+  @SuppressFBWarnings("DLS_DEAD_LOCAL_STORE")
   private List<CopyEntity> getCopyEntitiesForUnpartitionedTable() throws IOException {
 
     MultiTimingEvent multiTimer = new MultiTimingEvent(this.eventSubmitter, "TableCopy", true);

--- a/gobblin-utility/src/main/java/gobblin/util/io/SeekableFSInputStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/SeekableFSInputStream.java
@@ -46,8 +46,7 @@ public class SeekableFSInputStream extends FSInputStream {
 
   @Override
   public void seek(long pos) throws IOException {
-    in.skip(pos);
-    this.pos = pos;
+    this.pos += this.in.skip(pos - this.pos);
   }
 
   @Override

--- a/ligradle/findbugs/findbugsExclude.xml
+++ b/ligradle/findbugs/findbugsExclude.xml
@@ -22,4 +22,9 @@
   <Match>
     <Package name="~gobblin\.audit\.values\.auditor.*" />
 	</Match>
+  <!-- Ignored until https://github.com/linkedin/gobblin/issues/969 has been resolved -->
+  <Match>
+     <Class name="gobblin.metastore.DatabaseJobHistoryStore" />
+     <Bug pattern="SQL_PREPARED_STATEMENT_GENERATED_FROM_NONCONSTANT_STRING" />
+  </Match>
 </FindBugsFilter>


### PR DESCRIPTION
* Related to https://github.com/linkedin/gobblin/pull/968
* Resolving the rest of the FindBugs warnings and setting the build to fail if any new FindBugs warnings are introduced
* Most changes are minor, except for the following list:
    * `HiveCopyEntityHelper` had a dead local store warning because `stepPriority++` wasn't doing anything
    * `SeekableFSInputStream` doesn't seem to implement `seek` properly; its also possible for `InputStream.skip` isn't guaranteed to skip the specified number of bytes

@ibuenros can you review?