### PR TITLE
Fix hanging IteratorExecutor. HiveDataset will skip bad tables instea…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -18,35 +18,36 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Properties;
 
-import javax.annotation.Nullable;
-
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.thrift.TException;
 
-import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicate;
+import com.google.common.collect.AbstractIterator;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.dataset.IterableDatasetFinder;
 import gobblin.hive.HiveMetastoreClientPool;
+import gobblin.metrics.event.EventSubmitter;
+import gobblin.metrics.event.sla.SlaEventKeys;
 import gobblin.util.AutoReturnableObject;
 
 import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
  * Finds {@link HiveDataset}s. Will look for tables in a database using a {@link WhitelistBlacklist},
  * and creates a {@link HiveDataset} for each one.
  */
+@Slf4j
 public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
 
   public static final String HIVE_DATASET_PREFIX = "hive.dataset";
@@ -55,17 +56,32 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
   public static final String TABLE_PATTERN_KEY = HIVE_DATASET_PREFIX + ".table.pattern";
   public static final String DEFAULT_TABLE_PATTERN = "*";
 
+  // Event names
+  private static final String DATASET_FOUND = "DatasetFound";
+  private static final String DATASET_ERROR = "DatasetError";
+  private static final String FAILURE_CONTEXT = "FailureContext";
+
   private final Properties properties;
   private final HiveMetastoreClientPool clientPool;
   private final FileSystem fs;
   private final WhitelistBlacklist whitelistBlacklist;
+  private final Optional<EventSubmitter> eventSubmitter;
 
   public HiveDatasetFinder(FileSystem fs, Properties properties) throws IOException {
     this(fs, properties, createClientPool(properties));
   }
 
+  public HiveDatasetFinder(FileSystem fs, Properties properties, EventSubmitter eventSubmitter) throws IOException {
+    this(fs, properties, createClientPool(properties), eventSubmitter);
+  }
+
   protected HiveDatasetFinder(FileSystem fs, Properties properties, HiveMetastoreClientPool clientPool)
       throws IOException {
+    this(fs, properties, clientPool, null);
+  }
+
+  protected HiveDatasetFinder(FileSystem fs, Properties properties, HiveMetastoreClientPool clientPool,
+      EventSubmitter eventSubmitter) throws IOException {
     this.properties = properties;
     this.clientPool = clientPool;
     this.fs = fs;
@@ -82,6 +98,8 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
     } else {
       this.whitelistBlacklist = new WhitelistBlacklist(config.getConfig(HIVE_DATASET_PREFIX));
     }
+
+    this.eventSubmitter = Optional.fromNullable(eventSubmitter);
   }
 
   protected static HiveMetastoreClientPool createClientPool(Properties properties) throws IOException {
@@ -125,6 +143,11 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
   public static class DbAndTable {
     private final String db;
     private final String table;
+
+    @Override
+    public String toString() {
+      return String.format("%s.%s", this.db, this.table);
+    }
   }
 
   @Override
@@ -134,20 +157,28 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
 
   @Override
   public Iterator<HiveDataset> getDatasetsIterator() throws IOException {
-    return Iterators.transform(getTables().iterator(), new Function<DbAndTable, HiveDataset>() {
+
+    return new AbstractIterator<HiveDataset>() {
+      private Iterator<DbAndTable> tables = getTables().iterator();
+
       @Override
-      public HiveDataset apply(@Nullable DbAndTable dbAndTable) {
-        if (dbAndTable == null) {
-          return null;
+      protected HiveDataset computeNext() {
+        while (this.tables.hasNext()) {
+          DbAndTable dbAndTable = this.tables.next();
+          try (AutoReturnableObject<IMetaStoreClient> client = HiveDatasetFinder.this.clientPool.getClient()) {
+            Table table = client.get().getTable(dbAndTable.getDb(), dbAndTable.getTable());
+            EventSubmitter.submit(HiveDatasetFinder.this.eventSubmitter, DATASET_FOUND, SlaEventKeys.DATASET_URN_KEY, dbAndTable.toString());
+            return createHiveDataset(table);
+          } catch (IOException | TException ioe) {
+            log.error(String.format("Failed to create HiveDataset for table %s.%s", dbAndTable.getDb(), dbAndTable.getTable()), ioe);
+            EventSubmitter.submit(HiveDatasetFinder.this.eventSubmitter, DATASET_ERROR,
+                SlaEventKeys.DATASET_URN_KEY, dbAndTable.toString(),
+                FAILURE_CONTEXT, ioe.toString());
+          }
         }
-        try (AutoReturnableObject<IMetaStoreClient> client = HiveDatasetFinder.this.clientPool.getClient()) {
-          Table table = client.get().getTable(dbAndTable.getDb(), dbAndTable.getTable());
-          return createHiveDataset(table);
-        } catch (IOException | TException ioe) {
-          throw new RuntimeException(ioe);
-        }
+        return endOfData();
       }
-    });
+    };
   }
 
   protected HiveDataset createHiveDataset(Table table) throws IOException {

--- a/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java
@@ -86,6 +86,15 @@ public class EventSubmitter {
   }
 
   /**
+   * Calls submit on submitter if present.
+   */
+  public static void submit(Optional<EventSubmitter> submitter, String name) {
+    if (submitter.isPresent()) {
+      submitter.get().submit(name);
+    }
+  }
+
+  /**
    * Submits the {@link gobblin.metrics.GobblinTrackingEvent} to the {@link gobblin.metrics.MetricContext}.
    * @param name Name of the event.
    * @param metadataEls List of keys and values for metadata of the form key1, value2, key2, value2, ...
@@ -103,6 +112,15 @@ public class EventSubmitter {
   }
 
   /**
+   * Calls submit on submitter if present.
+   */
+  public static void submit(Optional<EventSubmitter> submitter, String name, String... metadataEls) {
+    if (submitter.isPresent()) {
+      submitter.get().submit(name, metadataEls);
+    }
+  }
+
+  /**
    * Submits the {@link gobblin.metrics.GobblinTrackingEvent} to the {@link gobblin.metrics.MetricContext}.
    * @param name Name of the event.
    * @param additionalMetadata Additional metadata to be added to the event.
@@ -116,6 +134,15 @@ public class EventSubmitter {
 
       // Timestamp is set by metric context.
       this.metricContext.get().submitEvent(new GobblinTrackingEvent(0l, this.namespace, name, finalMetadata));
+    }
+  }
+
+  /**
+   * Calls submit on submitter if present.
+   */
+  public static void submit(Optional<EventSubmitter> submitter, String name, Map<String, String> additionalMetadata) {
+    if (submitter.isPresent()) {
+      submitter.get().submit(name, additionalMetadata);
     }
   }
 

--- a/gobblin-utility/src/main/java/gobblin/util/executors/IteratorExecutor.java
+++ b/gobblin-utility/src/main/java/gobblin/util/executors/IteratorExecutor.java
@@ -59,29 +59,30 @@ public class IteratorExecutor<T> {
    */
   public List<Future<T>> execute() throws InterruptedException {
 
-    if (this.executed) {
-      throw new RuntimeException(String.format("This %s has already been executed.", IteratorExecutor.class.getSimpleName()));
-    }
-
     List<Future<T>> futures = Lists.newArrayList();
-    int activeTasks = 0;
-    while (this.iterator.hasNext()) {
-      futures.add(this.completionService.submit(this.iterator.next()));
-      activeTasks++;
-      if (activeTasks == this.numThreads) {
+
+    try {
+      if (this.executed) {
+        throw new RuntimeException(String.format("This %s has already been executed.", IteratorExecutor.class.getSimpleName()));
+      }
+
+      int activeTasks = 0;
+      while (this.iterator.hasNext()) {
+        futures.add(this.completionService.submit(this.iterator.next()));
+        activeTasks++;
+        if (activeTasks == this.numThreads) {
+          this.completionService.take();
+          activeTasks--;
+        }
+      }
+      while (activeTasks > 0) {
         this.completionService.take();
         activeTasks--;
       }
+    } finally {
+      ExecutorsUtils.shutdownExecutorService(this.executor, Optional.of(log), 10, TimeUnit.SECONDS);
+      this.executed = true;
     }
-    while (activeTasks > 0) {
-      this.completionService.take();
-      activeTasks--;
-    }
-
-    this.completionService.poll();
-
-    ExecutorsUtils.shutdownExecutorService(this.executor, Optional.of(log), 10, TimeUnit.SECONDS);
-    this.executed = true;
 
     return futures;
   }

--- a/gobblin-utility/src/main/java/gobblin/util/reflection/GobblinConstructorUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/reflection/GobblinConstructorUtils.java
@@ -60,6 +60,38 @@ public class GobblinConstructorUtils {
   }
 
   /**
+   * Returns a new instance of the <code>cls</code> based on a set of arguments. The method will search for a
+   * constructor accepting the first k arguments in <code>args</code> for every k from args.length to 0, and will
+   * invoke the first constructor found.
+   *
+   * For example, {@link #invokeLongestConstructor}(cls, myString, myInt) will first attempt to create an object with
+   * of class <code>cls</code> with constructor <init>(String, int), if it fails it will attempt <init>(String), and
+   * finally <init>().
+   *
+   * @param cls the class to instantiate.
+   * @param args the arguments to use for instantiation.
+   * @throws ReflectiveOperationException
+   */
+  public static <T> T invokeLongestConstructor(Class<T> cls, Object... args) throws ReflectiveOperationException {
+
+    Class<?>[] parameterTypes = new Class[args.length];
+    for (int i = 0; i < args.length; i++) {
+      parameterTypes[i] = args[i].getClass();
+    }
+
+    for (int i = args.length; i >= 0; i--) {
+      if (ConstructorUtils.getMatchingAccessibleConstructor(cls, Arrays.copyOfRange(parameterTypes, 0, i)) != null) {
+        log.info(
+            String.format("Found accessible constructor for class %s with parameter types %s.", cls,
+                Arrays.toString(Arrays.copyOfRange(parameterTypes, 0, i))));
+        return ConstructorUtils.invokeConstructor(cls, Arrays.copyOfRange(args, 0, i));
+      }
+    }
+    throw new NoSuchMethodException(String.format("No accessible constructor for class %s with parameters a subset of %s.",
+        cls, Arrays.toString(parameterTypes)));
+  }
+
+  /**
    * Utility method to create an instance of <code>clsName</code> using the constructor matching the arguments, <code>args</code>
    *
    * @param superType of <code>clsName</code>. The new instance is cast to superType

--- a/gobblin-utility/src/test/java/gobblin/util/reflection/GobblinConstructorUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/reflection/GobblinConstructorUtilsTest.java
@@ -52,4 +52,26 @@ public class GobblinConstructorUtilsTest {
       this.str = str;
     }
   }
+
+  @Test
+  public void testLongestConstructor() throws Exception {
+
+    ConstructorTestClass obj =
+        GobblinConstructorUtils.invokeLongestConstructor(ConstructorTestClass.class, Integer.valueOf(1), "String1", "String2");
+    Assert.assertEquals(obj.id.intValue(), 1);
+    Assert.assertEquals(obj.str, "String1");
+
+    obj =
+        GobblinConstructorUtils.invokeLongestConstructor(ConstructorTestClass.class, Integer.valueOf(1), "String1");
+    Assert.assertEquals(obj.id.intValue(), 1);
+    Assert.assertEquals(obj.str, "String1");
+
+    try {
+      obj =
+          GobblinConstructorUtils.invokeLongestConstructor(ConstructorTestClass.class, Integer.valueOf(1));
+      Assert.fail();
+    } catch (NoSuchMethodException nsme) {
+      //expected to throw exception
+    }
+  }
 }


### PR DESCRIPTION
…d of failing the entire job.

This PR fixes two issues:
* IteratorExecutor does not shutdown executor on a failure, making job hang.
* HiveDatasetFinder fails if a single table is bad. Fix will skip and report bad tables.