### PR TITLE
Integration with Confluent Schema Registry, Confluent Deserializers, and Kafka Deserializers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -134,6 +134,7 @@ if (!project.hasProperty('bytemanVersion')) {
 ext.avroVersion = '1.7.7'
 ext.dropwizardMetricsVersion = '3.1.0'
 ext.findBugsVersion = '3.0.0'
+ext.confluentVersion = '2.0.1'
 
 ext.externalDependency = [
   "antlrRuntime": "org.antlr:antlr-runtime:3.5.2",
@@ -178,6 +179,9 @@ ext.externalDependency = [
   "kafka": "org.apache.kafka:kafka_2.11:0.8.2.2",
   "kafkaTest": "org.apache.kafka:kafka_2.11:0.8.2.2:test",
   "kafkaClient": "org.apache.kafka:kafka-clients:0.8.2.2",
+  "confluentSchemaRegistryClient": "io.confluent:kafka-schema-registry-client:" + confluentVersion,
+  "confluentAvroSerializer": "io.confluent:kafka-avro-serializer:" + confluentVersion,
+  "confluentJsonSerializer": "io.confluent:kafka-json-serializer:" + confluentVersion,
   "quartz": "org.quartz-scheduler:quartz:2.2.3",
   "testng": "org.testng:testng:6.9.10",
   "mockserver":"org.mock-server:mockserver-netty:3.10.4",
@@ -446,6 +450,12 @@ subprojects {
 
         // Required to add JDK's tool jar, which is required to run byteman tests.
         testCompile (files(((URLClassLoader) ToolProvider.getSystemToolClassLoader()).getURLs()))
+      }
+    }
+
+    repositories {
+      maven {
+        url "http://packages.confluent.io/maven/"
       }
     }
 

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -47,6 +47,9 @@ dependencies {
   compile externalDependency.typesafeConfig
   compile externalDependency.guavaretrying
   compile externalDependency.findBugsAnnotations
+  compile externalDependency.confluentSchemaRegistryClient
+  compile externalDependency.confluentAvroSerializer
+  compile externalDependency.confluentJsonSerializer
 
   runtime externalDependency.protobuf
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistry.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistry.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.avro.Schema;
+
+import com.google.common.annotations.VisibleForTesting;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+
+import lombok.Getter;
+
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.metrics.kafka.SchemaRegistryException;
+
+
+/**
+ * Extension of {@link KafkaSchemaRegistry} that wraps Confluent's {@link SchemaRegistryClient}.
+ *
+ * <p>
+ *   While Confluent's Schema Registry Client API provides more functionality that Gobblin's {@link KafkaSchemaRegistry},
+ *   most of the methods are not necessary for Gobblin's Kafka Adaptor. Thus only a subset of the
+ *   {@link SchemaRegistryClient} methods are used.
+ * </p>
+ *
+ * <p>
+ *   Like the {@link KafkaSchemaRegistry} this class allows fetching a {@link Schema} by a unique {@link Integer} id
+ *   that uniquely identifies the {@link Schema}. It is also capable of fetching the latest {@link Schema} for a topic.
+ * </p>
+ */
+public class ConfluentKafkaSchemaRegistry extends KafkaSchemaRegistry<Integer, Schema> {
+
+  public static final String CONFLUENT_MAX_SCHEMAS_PER_SUBJECT =
+      "kafka.schema_registry.confluent.max_schemas_per_subject";
+
+  @Getter
+  private final SchemaRegistryClient schemaRegistryClient;
+
+  public ConfluentKafkaSchemaRegistry(Properties props) {
+    this(props, new CachedSchemaRegistryClient(props.getProperty(KAFKA_SCHEMA_REGISTRY_URL),
+        Integer.parseInt(props.getProperty(CONFLUENT_MAX_SCHEMAS_PER_SUBJECT, String.valueOf(Integer.MAX_VALUE)))));
+  }
+
+  @VisibleForTesting
+  ConfluentKafkaSchemaRegistry(Properties props, SchemaRegistryClient schemaRegistryClient) {
+    super(props);
+    this.schemaRegistryClient = schemaRegistryClient;
+  }
+
+  @Override
+  protected Schema fetchSchemaByKey(Integer key) throws SchemaRegistryException {
+    try {
+      return this.schemaRegistryClient.getByID(key);
+    } catch (IOException | RestClientException e) {
+      throw new SchemaRegistryException(e);
+    }
+  }
+
+  @Override
+  public Schema getLatestSchemaByTopic(String topic) throws SchemaRegistryException {
+    try {
+      return new Schema.Parser().parse(this.schemaRegistryClient.getLatestSchemaMetadata(topic).getSchema());
+    } catch (IOException | RestClientException e) {
+      throw new SchemaRegistryException(e);
+    }
+  }
+
+  @Override
+  public Integer register(Schema schema) throws SchemaRegistryException {
+    return register(schema, schema.getName());
+  }
+
+  @Override
+  public Integer register(Schema schema, String name) throws SchemaRegistryException {
+    try {
+      return this.schemaRegistryClient.register(name, schema);
+    } catch (IOException | RestClientException e) {
+      throw new SchemaRegistryException(e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractor.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import org.apache.kafka.common.serialization.ByteArrayDeserializer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.StringDeserializer;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Enums;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+
+import kafka.message.MessageAndOffset;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.metrics.kafka.SchemaRegistryException;
+import gobblin.util.PropertiesUtils;
+
+
+/**
+ * <p>
+ *   Extension of {@link KafkaExtractor} that wraps Kafka's {@link Deserializer} API. Kafka's {@link Deserializer} provides
+ *   a generic way of converting Kafka {@link kafka.message.Message}s to {@link Object}. Typically, a {@link Deserializer}
+ *   will be used along with a {@link org.apache.kafka.common.serialization.Serializer} which is responsible for converting
+ *   an {@link Object} to a Kafka {@link kafka.message.Message}. These APIs are useful for reading and writing to Kafka,
+ *   since Kafka is primarily a byte oriented system.
+ * </p>
+ *
+ * <p>
+ *   This class wraps the {@link Deserializer} API allowing any existing classes that implement the {@link Deserializer}
+ *   API to integrate with seamlessly with Gobblin. The deserializer can be specified in the following ways:
+ *
+ *   <ul>
+ *     <li>{@link #KAFKA_DESERIALIZER_TYPE} can be used to specify a pre-defined enum from {@link Deserializers} or
+ *     it can be used to specify the fully-qualified name of a {@link Class} that defines the {@link Deserializer}
+ *     interface. If this property is set to a class name, then {@link KafkaSchemaRegistry} must also be specified
+ *     using the {@link KafkaSchemaRegistry#KAFKA_SCHEMA_REGISTRY_CLASS} config key</li>
+ *   </ul>
+ * </p>
+ */
+@Getter(AccessLevel.PACKAGE)
+public class KafkaDeserializerExtractor extends KafkaExtractor<Object, Object> {
+
+  public static final String KAFKA_DESERIALIZER_TYPE = "kafka.deserializer.type";
+
+  private static final String CONFLUENT_SCHEMA_REGISTRY_URL = "schema.registry.url";
+
+  private final Deserializer<?> kafkaDeserializer;
+  private final KafkaSchemaRegistry<?, ?> kafkaSchemaRegistry;
+
+  public KafkaDeserializerExtractor(WorkUnitState state) throws ReflectiveOperationException {
+    this(state, getDeserializer(getProps(state)),
+        getKafkaSchemaRegistry(getProps(state)));
+  }
+
+  @VisibleForTesting
+  KafkaDeserializerExtractor(WorkUnitState state, Deserializer<?> kafkaDeserializer,
+      KafkaSchemaRegistry<?, ?> kafkaSchemaRegistry) {
+    super(state);
+    this.kafkaDeserializer = kafkaDeserializer;
+    this.kafkaSchemaRegistry = kafkaSchemaRegistry;
+  }
+
+  @Override
+  protected Object decodeRecord(MessageAndOffset messageAndOffset) throws IOException {
+    return this.kafkaDeserializer.deserialize(this.topicName, getBytes(messageAndOffset.message().payload()));
+  }
+
+  @Override
+  public Object getSchema() throws IOException {
+    try {
+      return this.kafkaSchemaRegistry.getLatestSchemaByTopic(this.topicName);
+    } catch (SchemaRegistryException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Constructs a {@link Deserializer}, using the value of {@link #KAFKA_DESERIALIZER_TYPE}.
+   */
+  private static Deserializer<?> getDeserializer(Properties props) throws ReflectiveOperationException {
+
+    Preconditions.checkArgument(props.containsKey(KAFKA_DESERIALIZER_TYPE),
+        "Missing required property " + KAFKA_DESERIALIZER_TYPE);
+    Optional<Deserializers> deserializerType =
+        Enums.getIfPresent(Deserializers.class, props.getProperty(KAFKA_DESERIALIZER_TYPE).toUpperCase());
+    Deserializer<?> deserializer;
+
+    if (deserializerType.isPresent()) {
+      deserializer = ConstructorUtils.invokeConstructor(deserializerType.get().getDeserializerClass());
+    } else {
+      deserializer = Deserializer.class
+          .cast(ConstructorUtils.invokeConstructor(Class.forName(props.getProperty(KAFKA_DESERIALIZER_TYPE))));
+    }
+    deserializer.configure(PropertiesUtils.propsToStringKeyMap(props), false);
+    return deserializer;
+  }
+
+  /**
+   * Constructs a {@link KafkaSchemaRegistry} using the value of {@link #KAFKA_DESERIALIZER_TYPE}, if not set it
+   * defaults to {@link SimpleKafkaSchemaRegistry}.
+   */
+  private static KafkaSchemaRegistry<?, ?> getKafkaSchemaRegistry(Properties props)
+      throws ReflectiveOperationException {
+
+    Optional<Deserializers> deserializerType =
+        Enums.getIfPresent(Deserializers.class, props.getProperty(KAFKA_DESERIALIZER_TYPE).toUpperCase());
+
+    if (deserializerType.isPresent()) {
+      return ConstructorUtils.invokeConstructor(deserializerType.get().getSchemaRegistryClass(), props);
+    }
+    if (props.containsKey(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_CLASS)) {
+      return KafkaSchemaRegistry.get(props);
+    }
+    return new SimpleKafkaSchemaRegistry(props);
+  }
+
+  /**
+   * Gets {@link Properties} from a {@link WorkUnitState} and sets the config <code>schema.registry.url</code> to value
+   * of {@link KafkaSchemaRegistry#KAFKA_SCHEMA_REGISTRY_URL} if set. This way users don't need to specify both
+   * properties as <code>schema.registry.url</code> is required by the {@link ConfluentKafkaSchemaRegistry}.
+   */
+  private static Properties getProps(WorkUnitState workUnitState) {
+    Properties properties = workUnitState.getProperties();
+    if (properties.containsKey(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL)) {
+      properties.setProperty(CONFLUENT_SCHEMA_REGISTRY_URL,
+          properties.getProperty(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL));
+    }
+    return properties;
+  }
+
+  /**
+   * Pre-defined {@link Deserializer} that can be referenced by the enum name.
+   */
+  @AllArgsConstructor
+  @Getter
+  public enum Deserializers {
+
+    /**
+     * Confluent's Avro {@link Deserializer}
+     *
+     * @see KafkaAvroDeserializer
+     */
+    CONFLUENT_AVRO(KafkaAvroDeserializer.class, ConfluentKafkaSchemaRegistry.class),
+
+    /**
+     * Confluent's JSON {@link Deserializer}
+     *
+     * @see KafkaJsonDeserializer
+     */
+    CONFLUENT_JSON(KafkaJsonDeserializer.class, SimpleKafkaSchemaRegistry.class),
+
+    /**
+     * A custom {@link Deserializer} for converting <code>byte[]</code> to {@link com.google.gson.JsonElement}s
+     *
+     * @see KafkaGsonDeserializer
+     */
+    GSON(KafkaGsonDeserializer.class, SimpleKafkaSchemaRegistry.class),
+
+    /**
+     * A standard Kafka {@link Deserializer} that does nothing, it simply returns the <code>byte[]</code>
+     */
+    BYTE_ARRAY(ByteArrayDeserializer.class, SimpleKafkaSchemaRegistry.class),
+
+    /**
+     * A standard Kafka {@link Deserializer} for converting <code>byte[]</code> to {@link String}s
+     */
+    STRING(StringDeserializer.class, SimpleKafkaSchemaRegistry.class);
+
+    private final Class<? extends Deserializer> deserializerClass;
+    private final Class<? extends KafkaSchemaRegistry> schemaRegistryClass;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaDeserializerSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaDeserializerSource.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.io.IOException;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.Extractor;
+
+
+/**
+ * Extension of {@link KafkaSource} that returns a {@link KafkaDeserializerExtractor}.
+ */
+public class KafkaDeserializerSource extends KafkaSource<Object, Object> {
+
+  @Override
+  public Extractor<Object, Object> getExtractor(WorkUnitState state) throws IOException {
+    try {
+      return new KafkaDeserializerExtractor(state);
+    } catch (ReflectiveOperationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaGsonDeserializer.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaGsonDeserializer.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+
+/**
+ * Implementation of {@link Deserializer} that deserializes Kafka data into a {@link JsonElement} using the
+ * {@link StandardCharsets#UTF_8} encoding.
+ */
+public class KafkaGsonDeserializer implements Deserializer<JsonElement> {
+
+  private static final Gson GSON = new Gson();
+
+  @VisibleForTesting
+  static final Charset CHARSET = StandardCharsets.UTF_8;
+
+  @Override
+  public void configure(Map<String, ?> configs, boolean isKey) {
+    // Do nothing
+  }
+
+  @Override
+  public JsonElement deserialize(String topic, byte[] data) {
+    return GSON.fromJson(new String(data, CHARSET), JsonElement.class);
+  }
+
+  @Override
+  public void close() {
+    // Do nothing
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleJsonExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleJsonExtractor.java
@@ -1,3 +1,15 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
 package gobblin.source.extractor.extract.kafka;
 
 import java.io.IOException;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleSource.java
@@ -21,6 +21,8 @@ import java.io.IOException;
  * A {@link KafkaSource} implementation for SimpleKafkaExtractor.
  *
  * @author akshay@nerdwallet.com
+ *
+ * @deprecated use {@link KafkaDeserializerSource} and {@link KafkaDeserializerExtractor.Deserializers#BYTE_ARRAY} instead
  */
 public class KafkaSimpleSource extends KafkaSource<String, byte[]> {
   /**

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/SimpleKafkaSchemaRegistry.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/SimpleKafkaSchemaRegistry.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.util.Properties;
+
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.metrics.kafka.SchemaRegistryException;
+
+
+/**
+ * Extension of {@link KafkaSchemaRegistry} that treats the topic name and the schema as the same string. The
+ * {@link #getLatestSchemaByTopic(String)} topic will simplye return the specified topic name. All other methods throw
+ * an {@link UnsupportedOperationException}. This class is useful when Kafka records don't have a schema, for example,
+ * in {@link KafkaSimpleExtractor} or {@link KafkaGsonDeserializer}.
+ */
+public class SimpleKafkaSchemaRegistry extends KafkaSchemaRegistry<String, String> {
+
+  public SimpleKafkaSchemaRegistry(Properties props) {
+    super(props);
+  }
+
+  @Override
+  protected String fetchSchemaByKey(String key) throws SchemaRegistryException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String getLatestSchemaByTopic(String topic) throws SchemaRegistryException {
+    return topic;
+  }
+
+  @Override
+  public String register(String schema) throws SchemaRegistryException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String register(String schema, String name) throws SchemaRegistryException {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistryTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistryTest.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.util.Properties;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.confluent.kafka.schemaregistry.client.MockSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.metrics.kafka.SchemaRegistryException;
+
+
+@Test(groups = { "gobblin.source.extractor.extract.kafka" })
+public class ConfluentKafkaSchemaRegistryTest {
+
+  private static final String TEST_TOPIC_NAME = "testTopic";
+  private static final String TEST_URL = "testUrl";
+  private static final String TEST_RECORD_NAME = "testRecord";
+  private static final String TEST_NAMESPACE = "testNamespace";
+  private static final String TEST_FIELD_NAME = "testField";
+
+  @Test
+  public void testRegisterAndGetByKey() throws SchemaRegistryException {
+    Properties properties = new Properties();
+    properties.setProperty(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL, TEST_URL);
+
+    SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    KafkaSchemaRegistry<Integer, Schema> kafkaSchemaRegistry =
+        new ConfluentKafkaSchemaRegistry(properties, schemaRegistryClient);
+
+    Schema schema =
+        SchemaBuilder.record(TEST_RECORD_NAME).namespace(TEST_NAMESPACE).fields().name(TEST_FIELD_NAME).type()
+            .stringType().noDefault().endRecord();
+
+    Integer id = kafkaSchemaRegistry.register(schema);
+    Assert.assertEquals(schema, kafkaSchemaRegistry.getSchemaByKey(id));
+  }
+
+  @Test
+  public void testRegisterAndGetLatest() throws SchemaRegistryException {
+    Properties properties = new Properties();
+    properties.setProperty(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL, TEST_URL);
+
+    SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
+    KafkaSchemaRegistry<Integer, Schema> kafkaSchemaRegistry =
+        new ConfluentKafkaSchemaRegistry(properties, schemaRegistryClient);
+
+    Schema schema1 =
+        SchemaBuilder.record(TEST_RECORD_NAME + "1").namespace(TEST_NAMESPACE).fields().name(TEST_FIELD_NAME).type()
+            .stringType().noDefault().endRecord();
+
+    Schema schema2 =
+        SchemaBuilder.record(TEST_RECORD_NAME + "2").namespace(TEST_NAMESPACE).fields().name(TEST_FIELD_NAME).type()
+            .stringType().noDefault().endRecord();
+
+    kafkaSchemaRegistry.register(schema1, TEST_TOPIC_NAME);
+    kafkaSchemaRegistry.register(schema2, TEST_TOPIC_NAME);
+
+    Assert.assertNotEquals(schema1, kafkaSchemaRegistry.getLatestSchemaByTopic(TEST_TOPIC_NAME));
+    Assert.assertEquals(schema2, kafkaSchemaRegistry.getLatestSchemaByTopic(TEST_TOPIC_NAME));
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/KafkaDeserializerExtractorTest.java
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+
+import org.apache.avro.Schema;
+import org.apache.avro.SchemaBuilder;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+
+import org.apache.kafka.common.serialization.Deserializer;
+import org.apache.kafka.common.serialization.Serializer;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.KafkaJsonDeserializer;
+import io.confluent.kafka.serializers.KafkaJsonSerializer;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import kafka.message.Message;
+import kafka.message.MessageAndOffset;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.source.extractor.WatermarkInterval;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.PropertiesUtils;
+
+
+@Test(groups = { "gobblin.source.extractor.extract.kafka" })
+public class KafkaDeserializerExtractorTest {
+
+  private static final String TEST_TOPIC_NAME = "testTopic";
+  private static final String TEST_URL = "testUrl";
+  private static final String TEST_RECORD_NAME = "testRecord";
+  private static final String TEST_NAMESPACE = "testNamespace";
+  private static final String TEST_FIELD_NAME = "testField";
+
+  @Test
+  public void testDeserializeRecord() throws IOException {
+    WorkUnitState mockWorkUnitState = getMockWorkUnitState();
+
+    String testString = "Hello World";
+    ByteBuffer testStringByteBuffer = ByteBuffer.wrap(testString.getBytes(StandardCharsets.UTF_8));
+
+    Deserializer<?> mockKafkaDecoder = mock(Deserializer.class);
+    KafkaSchemaRegistry<?, ?> mockKafkaSchemaRegistry = mock(KafkaSchemaRegistry.class);
+    when(mockKafkaDecoder.deserialize(TEST_TOPIC_NAME, testStringByteBuffer.array())).thenReturn(testString);
+
+    KafkaDeserializerExtractor kafkaDecoderExtractor =
+        new KafkaDeserializerExtractor(mockWorkUnitState, mockKafkaDecoder, mockKafkaSchemaRegistry);
+
+    MessageAndOffset mockMessageAndOffset = getMockMessageAndOffset(testStringByteBuffer);
+
+    Assert.assertEquals(kafkaDecoderExtractor.decodeRecord(mockMessageAndOffset), testString);
+  }
+
+  @Test
+  public void testBuiltInDeserializers() throws ReflectiveOperationException {
+    WorkUnitState mockWorkUnitState = getMockWorkUnitState();
+    mockWorkUnitState.setProp(KafkaDeserializerExtractor.KAFKA_DESERIALIZER_TYPE,
+        KafkaDeserializerExtractor.Deserializers.CONFLUENT_AVRO.name());
+
+    KafkaDeserializerExtractor kafkaDecoderExtractor = new KafkaDeserializerExtractor(mockWorkUnitState);
+
+    Assert.assertEquals(kafkaDecoderExtractor.getKafkaDeserializer().getClass(),
+        KafkaDeserializerExtractor.Deserializers.CONFLUENT_AVRO.getDeserializerClass());
+    Assert.assertEquals(kafkaDecoderExtractor.getKafkaSchemaRegistry().getClass(),
+        KafkaDeserializerExtractor.Deserializers.CONFLUENT_AVRO.getSchemaRegistryClass());
+  }
+
+  @Test
+  public void testCustomDeserializer() throws ReflectiveOperationException {
+    WorkUnitState mockWorkUnitState = getMockWorkUnitState();
+    mockWorkUnitState
+        .setProp(KafkaDeserializerExtractor.KAFKA_DESERIALIZER_TYPE, KafkaJsonDeserializer.class.getName());
+    mockWorkUnitState
+        .setProp(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_CLASS, SimpleKafkaSchemaRegistry.class.getName());
+
+    KafkaDeserializerExtractor kafkaDecoderExtractor = new KafkaDeserializerExtractor(mockWorkUnitState);
+    Assert.assertEquals(kafkaDecoderExtractor.getKafkaDeserializer().getClass(), KafkaJsonDeserializer.class);
+    Assert.assertEquals(kafkaDecoderExtractor.getKafkaSchemaRegistry().getClass(), SimpleKafkaSchemaRegistry.class);
+  }
+
+  @Test
+  public void testConfluentAvroDeserializer() throws IOException, RestClientException {
+    WorkUnitState mockWorkUnitState = getMockWorkUnitState();
+    mockWorkUnitState.setProp("schema.registry.url", TEST_URL);
+
+    Schema schema =
+        SchemaBuilder.record(TEST_RECORD_NAME).namespace(TEST_NAMESPACE).fields().name(TEST_FIELD_NAME).type()
+            .stringType().noDefault().endRecord();
+    GenericRecord testGenericRecord = new GenericRecordBuilder(schema).set(TEST_FIELD_NAME, "testValue").build();
+
+    SchemaRegistryClient mockSchemaRegistryClient = mock(SchemaRegistryClient.class);
+    when(mockSchemaRegistryClient.getByID(any(Integer.class))).thenReturn(schema);
+
+    Serializer<Object> kafkaEncoder = new KafkaAvroSerializer(mockSchemaRegistryClient);
+    Deserializer<Object> kafkaDecoder = new KafkaAvroDeserializer(mockSchemaRegistryClient);
+
+    ByteBuffer testGenericRecordByteBuffer =
+        ByteBuffer.wrap(kafkaEncoder.serialize(TEST_TOPIC_NAME, testGenericRecord));
+
+    KafkaSchemaRegistry<?, ?> mockKafkaSchemaRegistry = mock(KafkaSchemaRegistry.class);
+    KafkaDeserializerExtractor kafkaDecoderExtractor =
+        new KafkaDeserializerExtractor(mockWorkUnitState, kafkaDecoder, mockKafkaSchemaRegistry);
+
+    MessageAndOffset mockMessageAndOffset = getMockMessageAndOffset(testGenericRecordByteBuffer);
+
+    Assert.assertEquals(kafkaDecoderExtractor.decodeRecord(mockMessageAndOffset), testGenericRecord);
+  }
+
+  @Test
+  public void testConfluentJsonDeserializer() throws IOException {
+    WorkUnitState mockWorkUnitState = getMockWorkUnitState();
+    mockWorkUnitState.setProp("json.value.type", KafkaRecord.class.getName());
+
+    KafkaRecord testKafkaRecord = new KafkaRecord("Hello World");
+
+    Serializer<KafkaRecord> kafkaEncoder = new KafkaJsonSerializer<>();
+    kafkaEncoder.configure(PropertiesUtils.propsToStringKeyMap(mockWorkUnitState.getProperties()), false);
+
+    Deserializer<KafkaRecord> kafkaDecoder = new KafkaJsonDeserializer<>();
+    kafkaDecoder.configure(PropertiesUtils.propsToStringKeyMap(mockWorkUnitState.getProperties()), false);
+
+    ByteBuffer testKafkaRecordByteBuffer = ByteBuffer.wrap(kafkaEncoder.serialize(TEST_TOPIC_NAME, testKafkaRecord));
+
+    KafkaSchemaRegistry<?, ?> mockKafkaSchemaRegistry = mock(KafkaSchemaRegistry.class);
+    KafkaDeserializerExtractor kafkaDecoderExtractor =
+        new KafkaDeserializerExtractor(mockWorkUnitState, kafkaDecoder, mockKafkaSchemaRegistry);
+
+    MessageAndOffset mockMessageAndOffset = getMockMessageAndOffset(testKafkaRecordByteBuffer);
+    Assert.assertEquals(kafkaDecoderExtractor.decodeRecord(mockMessageAndOffset), testKafkaRecord);
+  }
+
+  private WorkUnitState getMockWorkUnitState() {
+    WorkUnit mockWorkUnit = WorkUnit.createEmpty();
+    mockWorkUnit.setWatermarkInterval(new WatermarkInterval(new MultiLongWatermark(new ArrayList<Long>()),
+        new MultiLongWatermark(new ArrayList<Long>())));
+
+    WorkUnitState mockWorkUnitState = new WorkUnitState(mockWorkUnit, new State());
+    mockWorkUnitState.setProp(KafkaSource.TOPIC_NAME, TEST_TOPIC_NAME);
+    mockWorkUnitState.setProp(KafkaSource.PARTITION_ID, "1");
+    mockWorkUnitState.setProp(ConfigurationKeys.KAFKA_BROKERS, "localhost:8080");
+    mockWorkUnitState.setProp(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL, TEST_URL);
+
+    return mockWorkUnitState;
+  }
+
+  private MessageAndOffset getMockMessageAndOffset(ByteBuffer payload) {
+    MessageAndOffset mockMessageAndOffset = mock(MessageAndOffset.class);
+    Message mockMessage = mock(Message.class);
+    when(mockMessage.payload()).thenReturn(payload);
+    when(mockMessageAndOffset.message()).thenReturn(mockMessage);
+    return mockMessageAndOffset;
+  }
+
+  @AllArgsConstructor
+  @NoArgsConstructor
+  @EqualsAndHashCode
+  @Getter
+  @Setter
+  private static class KafkaRecord {
+
+    private String value;
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/KafkaGsonDeserializerTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/KafkaGsonDeserializerTest.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import org.apache.kafka.common.serialization.Deserializer;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+
+@Test(groups = { "gobblin.source.extractor.extract.kafka" })
+public class KafkaGsonDeserializerTest {
+
+  @Test
+  public void testDeserialize() {
+    JsonObject jsonObject = new JsonObject();
+    jsonObject.addProperty("testKey", "testValue");
+
+    Deserializer<JsonElement> deserializer = new KafkaGsonDeserializer();
+    Assert.assertEquals(
+        deserializer.deserialize("testTopic", new Gson().toJson(jsonObject).getBytes(KafkaGsonDeserializer.CHARSET)),
+        jsonObject);
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/SimpleKafkaSchemaRegistryTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/SimpleKafkaSchemaRegistryTest.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.metrics.kafka.SchemaRegistryException;
+
+
+@Test(groups = { "gobblin.source.extractor.extract.kafka" })
+public class SimpleKafkaSchemaRegistryTest {
+
+  @Test
+  public void testGetLatestSchemaByTopic() throws SchemaRegistryException {
+    String topicName = "testTopicName";
+    Assert.assertEquals(topicName, new SimpleKafkaSchemaRegistry(new Properties()).getLatestSchemaByTopic(topicName));
+  }
+}

--- a/gobblin-docs/case-studies/Kafka-HDFS-Ingestion.md
+++ b/gobblin-docs/case-studies/Kafka-HDFS-Ingestion.md
@@ -103,9 +103,9 @@ data.publisher.final.dir=/gobblintest/job-output
 After the job finishes, the job output file will be in `/gobblintest/job-output/test` in HDFS, and the metrics will be in `/gobblin-kafka/metrics`.
 
 
-# Setting up Kafka-HDFS Ingestion Jobs
-## Job Constructs
-**Source and Extractor**
+# Job Constructs
+
+## Source and Extractor
 
 Gobblin provides two abstract classes, [`KafkaSource`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSource.java) and [`KafkaExtractor`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java). `KafkaSource` creates a workunit for each Kafka topic partition to be pulled, then merges and groups the workunits based on the desired number of workunits specified by property `mr.job.max.mappers` (this property is used in both standalone and MR mode). More details about how workunits are merged and grouped is available [here](#merging-and-grouping-workunits-in-kafkasource). `KafkaExtractor` extracts the partitions assigned to a workunit, based on the specified low watermark and high watermark.
 
@@ -115,11 +115,11 @@ As examples, take a look at [`KafkaSimpleSource`](https://github.com/linkedin/go
 
 `KafkaSimpleExtractor` simply returns the payload of the `MessageAndOffset` object as a byte array. A job that uses `KafkaSimpleExtractor` may use a `Converter` to convert the byte array to whatever format desired. For example, if the desired output format is JSON, one may implement an `ByteArrayToJsonConverter` to convert the byte array to JSON. Alternatively one may implement a `KafkaJsonExtractor`, which extends `KafkaExtractor` and convert the `MessageAndOffset` object into a JSON object in the `decodeRecord` method. Both approaches should work equally well. `KafkaAvroExtractor` decodes the payload of the `MessageAndOffset` object into an Avro [`GenericRecord`](http://avro.apache.org/docs/current/api/java/index.html?org/apache/avro/generic/GenericRecord.html) object.
 
-**Writer and Publisher**
+## Writer and Publisher
 
 Any desired writer and publisher can be used, e.g., one may use the [`AvroHdfsDataWriter`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java) and the [`BaseDataPublisher`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java), similar as the [Wikipedia example job](../Getting-Started). If plain text output file is desired, one may use [`SimpleDataWriter`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java).
 
-## Job Config Properties
+# Job Config Properties
 
 These are some of the job config properties used by `KafkaSource` and `KafkaExtractor`.
 
@@ -141,9 +141,9 @@ extract.limit.type=time #(other possible values: rate, count, pool)
 extract.limit.time.limit=15
 extract.limit.time.limit.timeunit=minutes 
 ```
-## Metrics and Events
+# Metrics and Events
 
-**Task Level Metrics**
+## Task Level Metrics
 
 Task level metrics can be created in `Extractor`, `Converter` and `Writer` by extending [`InstrumentedExtractor`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/instrumented/extractor/InstrumentedExtractor.java), [`InstrumentedConverter`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/instrumented/converter/InstrumentedConverter.java) and [`InstrumentedDataWriter`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriter.java).
 
@@ -156,11 +156,11 @@ decodingErrorCounter.inc();
 
 Besides Counter, Meter and Histogram are also supported.
 
-**Task Level Events**
+## Task Level Events
 
 Task level events can be submitted by creating an [`EventSubmitter`](https://github.com/linkedin/gobblin/blob/master/gobblin-metrics/src/main/java/gobblin/metrics/event/EventSubmitter.java) instance and using `EventSubmitter.submit()` or `EventSubmitter.getTimingEvent()`.
 
-**Job Level Metrics**
+## Job Level Metrics
 
 To create job level metrics, one may extend [`AbstractJobLauncher`](https://github.com/linkedin/gobblin/blob/master/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java) and create metrics there. For example:
 
@@ -176,22 +176,23 @@ recordsWrittenCounter.inc(value);
 
 Job level metrics are often aggregations of task level metrics, such as the `job.records.written` counter above. Since `AbstractJobLauncher` doesn't have access to task-level metrics, one should set these counters in `TaskState`s, and override `AbstractJobLauncher.postProcessTaskStates()` to aggregate them. For example, in `AvroHdfsTimePartitionedWriter.close()`, property `writer.records.written` is set for the `TaskState`. 
 
-**Job Level Events**
+## Job Level Events
 
 Job level events can be created by extending `AbstractJobLauncher` and use `this.eventSubmitter.submit()` or `this.eventSubmitter.getTimingEvent()`.
 
 For more details about metrics, events and reporting them, please see Gobblin Metrics section.
 
-## Merging and Grouping Workunits in `KafkaSource`
+# Grouping Workunits
+
 For each topic partition that should be ingested, `KafkaSource` first retrieves the last offset pulled by the previous run, which should be the first offset of the current run. It also retrieves the earliest and latest offsets currently available from the Kafka cluster and verifies that the first offset is between the earliest and the latest offsets. The latest offset is the last offset to be pulled by the current workunit. Since new records may be constantly published to Kafka and old records are deleted based on retention policies, the earliest and latest offsets of a partition may change constantly.
 
 For each partition, after the first and last offsets are determined, a workunit is created. If the number of Kafka partitions exceeds the desired number of workunits specified by property `mr.job.max.mappers`, `KafkaSource` will merge and group them into `n` [`MultiWorkUnit`](https://github.com/linkedin/gobblin/blob/master/gobblin-api/src/main/java/gobblin/source/workunit/MultiWorkUnit.java)s where `n=mr.job.max.mappers`. This is done using [`KafkaWorkUnitPacker`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java), which has two implementations: [`KafkaSingleLevelWorkUnitPacker`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaSingleLevelWorkUnitPacker.java) and [`KafkaBiLevelWorkUnitPacker`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaBiLevelWorkUnitPacker.java). The packer packs workunits based on the estimated size of each workunit, which is obtained from [`KafkaWorkUnitSizeEstimator`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitSizeEstimator.java), which also has two implementations, [`KafkaAvgRecordSizeBasedWorkUnitSizeEstimator`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordSizeBasedWorkUnitSizeEstimator.java) and [`KafkaAvgRecordTimeBasedWorkUnitSizeEstimator`](https://github.com/linkedin/gobblin/blob/master/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaAvgRecordTimeBasedWorkUnitSizeEstimator.java).
 
-### Single-Level Packing
+## Single-Level Packing
 
 The single-level packer uses a worst-fit-decreasing approach for assigning workunits to mappers: each workunit goes to the mapper that currently has the lightest load. This approach balances the mappers well. However, multiple partitions of the same topic are usually assigned to different mappers. This may cause two issues: (1) many small output files: if multiple partitions of a topic are assigned to different mappers, they cannot share output files. (2) task overhead: when multiple partitions of a topic are assigned to different mappers, a task is created for each partition, which may lead to a large number of tasks and large overhead.
 
-### Bi-Level Packing
+## Bi-Level Packing
 
 The bi-level packer packs workunits in two steps.
 
@@ -207,14 +208,14 @@ The second step uses the same worst-fit-decreasing method as the first-level pac
 
 This approach reduces the number of small files and the number of tasks, but it may have more mapper skew for two reasons: (1) in the worst-fit-decreasing approach, the less number of items to be packed, the more skew there will be; (2) when multiple partitions of a topic are assigned to the same mapper, if we underestimate the size of this topic, this mapper may take a much longer time than other mappers and the entire MR job has to wait for this mapper. This, however, can be mitigated by setting a time limit for each task, as explained above.
 
-### Average Record Size-Based Workunit Size Estimator
+## Average Record Size-Based Workunit Size Estimator
 
 This size estimator uses the average record size of each partition to estimate the sizes of workunits. When using this size estimator, each job run will record the average record size of each partition it pulled. In the next run, for each partition the average record size pulled in the previous run is considered the average record size
 to be pulled in this run.
 
 If a partition was not pulled in a run, a default value of 1024 will be used in the next run.
 
-### Average Record Time-Based Workunit Size Estimator
+## Average Record Time-Based Workunit Size Estimator
 
 This size estimator uses the average time to pull a record in each run to estimate the sizes of the workunits in the next run.
 
@@ -224,11 +225,80 @@ If a topic is not pulled in a run, its estimated average time per record is the 
 
 The time-based estimator is more accurate than the size-based estimator when the time to pull a record is not proportional to the size of the record. However, the time-based estimator may lose accuracy when there are fluctuations in the Hadoop cluster which causes the average time for a partition to vary between different runs.
 
-### Topic-specific Partitioning
+# Topic-Specific Configuration
 
 `kafka.topic.specific.state` is a configuration key that allows a user to specify config parameters on a topic specific level. The value of this config should be a JSON Array. Each entry should be a json string and should contain a primitive value that identifies the topic name. All configs in each topic entry will be added to the WorkUnit for that topic.
 
 An example value could be:
-`[{"topic.name" : "myTopic1", "writer.partition.columns" : "header.memberId"}, {"topic.name" : "myTopic2", "writer.partition.columns" : "auditHeader.time"}]`.
 
-The "topic.name" field also allows regular expressions. For example, one can specify key, value "topic.name" : "myTopic.\*". In this case all topics whose name matches the pattern "myTopic.*" will have all the specified config properties added to their WorkUnit. If more than one topic matches multiple "topic.name"s then the properties from all the JSON objects will be added to their WorkUnit.
+```
+[
+  {
+    "topic.name": "myTopic1",
+    "writer.partition.columns": "header.memberId"
+  },
+  {
+    "topic.name": "myTopic2",
+    "writer.partition.columns": "auditHeader.time"
+  }
+]
+```
+
+The `topic.name` field also allows regular expressions. For example, one can specify key, value `"topic.name" : "myTopic.\*"`. In this case all topics whose name matches the pattern `myTopic.*` will have all the specified config properties added to their WorkUnit. If more than one topic matches multiple `topic.name`s then the properties from all the JSON objects will be added to their WorkUnit.
+
+# Kafka `Deserializer` Integration
+
+Gobblin integrates with Kafka's [Deserializer](https://kafka.apache.org/0100/javadoc/org/apache/kafka/common/serialization/Deserializer.html) API. Kafka's `Deserializer` Interface offers a generic interface for Kafka Clients to deserialize data from Kafka into Java Objects. Since Kafka Messages return byte array, the `Deserializer` class offers a convienient way of transforming those byte array's to Java Objects.
+
+Kafka's Client Library already has a few useful `Deserializer`s such as the the [StringDeserializer](https://kafka.apache.org/0100/javadoc/org/apache/kafka/common/serialization/StringDeserializer.html) and the [ByteBufferDeserializer](https://kafka.apache.org/0100/javadoc/org/apache/kafka/common/serialization/ByteBufferDeserializer.html).
+
+Gobblin can integrate with any of these `Deserializer`s, that is any class that implements the `Deserializer` interface can be used to convert Kafka message to Java Objects. This is done in the `KafkaDeserializerSource` and the `KafkaDeserializerExtractor` classes.
+
+The type of `Deserializer` to be used in `KafkaDeserializerExtractor` can be specified by the property `kafka.deserializer.type`. This property can either be set to any of the pre-defined `Deserializer`s such as `CONFLUENT_AVRO`, `CONFLUENT_JSON`, `GSON`, `BYTE_ARRAY`, and `STRING` (see the section on [Confluent Integration](#confluent-integration) and [KafkaGsonDeserializer](#kafkagsondeserializer) for more details). The value of this property can point to the full-qualified path of a `Deserializer` implementation. If the value is set a class name, then a `kafka.schema.registry.class` must also be provided so that the `Extractor` knows how to retrieve the schema for the topic.
+
+## Gobblin `Deserializer` Implementations
+
+### KafkaGsonDeserializer
+
+The `KafkaGsonDeserializer` is an implementation of the `Deserializer` class that converts `byte[]` to [JSONObject](https://google.github.io/gson/apidocs/com/google/gson/JsonObject.html)s. It uses [GSON](https://github.com/google/gson) to do this.
+
+This class is useful for converting Kafka data to JSON Objects.
+
+Using this class simply requires setting `kafka.deserializer.type` to `GSON`.
+
+## Comparison with `KafkaSimpleSource`
+
+Gobblin's `KafkaSimpleSource` and `KafkaSimpleExtractor` are very useful when data just needs to be read from Kafka and written to a text file. However, it does not provide good support for writing to more complex data file formats such as [Avro](https://avro.apache.org/) or [ORC](https://orc.apache.org/). It also doesn't provide good support for record level manipulations such as Gobblin `Converter`s and it lacks good support for use with Gobblin's `WriterPartitioner`. The reason is that `KafkaSimpleExtractor` simply returns a `byte[]`, which is just a black-box of data. It is much easier to maniuplate the record if it is converted to a Java Object. This is where Gobblin's `KafkaDeserializerExtractor` becomes useful.
+
+# Confluent Integration
+
+[Confluent](http://www.confluent.io/) provides a standardized distribution of [Apache Kafka](http://kafka.apache.org/), along with other useful tools for working with Kafka. One useful tool that Confluent provides is a generic [Schema Registry](http://www.confluent.io/blog/schema-registry-kafka-stream-processing-yes-virginia-you-really-need-one).
+
+Gobblin has integration with [Confluent's Schema Registry Library](https://github.com/confluentinc/schema-registry) which provides a service to register and get [Avro Schemas](https://avro.apache.org/docs/1.8.0/spec.html) and provides a generic [Avro Deserializer](https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java) and [JSON Deserializer](https://github.com/confluentinc/schema-registry/blob/master/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializer.java).
+
+## Confluent Schema Registry
+
+Gobblin integrates with Confluent's [SchemaRegistryClient](https://github.com/confluentinc/schema-registry/blob/master/client/src/main/java/io/confluent/kafka/schemaregistry/client/SchemaRegistryClient.java) class in order to register and get Avro Schema's from the Confluent [SchemaRegistry](https://github.com/confluentinc/schema-registry/blob/master/core/src/main/java/io/confluent/kafka/schemaregistry/storage/SchemaRegistry.java). This is implemented in the `ConfluentKafkaSchemaRegistry` class, which extends Gobblin's `KafkaSchemaRegistry` class. The `ConfluentKafkaSchemaRegistry` can be used by setting `kafka.schema.registry.class` to `gobblin.source.extractor.extract.kafka.ConfluentKafkaSchemaRegistry`.
+
+## Confluent Deserializers
+
+Confluent's Schema Registry Library also provides a few useful `Deserializer` implementations:
+
+* [KafkaAvroDeserializer](https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroDeserializer.java) 
+* [KafkaJsonDeserializer](https://github.com/confluentinc/schema-registry/blob/master/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonDeserializer.java)
+
+With regards to Gobblin, these classes are useful if Confluent's [KafkaAvroSerializer](https://github.com/confluentinc/schema-registry/blob/master/avro-serializer/src/main/java/io/confluent/kafka/serializers/KafkaAvroSerializer.java) or [KafkaJsonSerializer](https://github.com/confluentinc/schema-registry/blob/master/json-serializer/src/main/java/io/confluent/kafka/serializers/KafkaJsonSerializer.java) is used to write data to Kafka.
+
+The [Serializer](https://kafka.apache.org/0100/javadoc/org/apache/kafka/common/serialization/Serializer.html) class is a Kafka interface that is the converse of the `Deserializer` class. The `Serializer` provides a generic way of taking Java Objects and converting them to `byte[]` that are written to Kafka by a `KafkaProducer`.
+
+### KafkaAvroDeserializer
+
+Documentation for the `KafkaAvroDeserializer` can be found [here](http://docs.confluent.io/2.0.1/schema-registry/docs/serializer-formatter.html#serializer).
+
+If data is written to a Kafka cluster using Confluent's `KafkaAvroSerializer`, then the `KafkaAvroDeserializer` should be used in Gobblin. Setting this up simply requires a setting the config key `kafka.deserializer.type` to `CONFLUENT_AVRO` (see the section on [Kafka Deserializer Integration](#kafka-deserializer-integration) for more information).
+
+### KafkaJsonDeserializer
+
+The `KafkaJsonDeserializer` class uses [Jackson's Object Mapper](https://fasterxml.github.io/jackson-databind/javadoc/2.7/com/fasterxml/jackson/databind/ObjectMapper.html) to convert `byte[]` to Java Objects. In order to `KafkaJsonDeserializer` to know which class the `byte[]` array should be converted to, the config property `json.value.type` needs to be set to the fully-qualified class name of the Java Object that the `Deserializer` should return. For more information about how the Jackson works, check out the docs [here](https://github.com/FasterXML/jackson-databind).
+
+Using the `KafkaJsonDeserializer` simply requires setting the config key `kafka.deserializer.type` to `CONFLUENT_JSON` (see the section on [Kafka Deserializer Integration](#kafka-deserializer-integration) for more information).

--- a/gobblin-utility/src/main/java/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PropertiesUtils.java
@@ -12,7 +12,10 @@
 
 package gobblin.util;
 
+import java.util.Map;
 import java.util.Properties;
+
+import com.google.common.collect.ImmutableMap;
 
 
 /**
@@ -29,5 +32,16 @@ public class PropertiesUtils {
       combinedProperties.putAll(props);
     }
     return combinedProperties;
+  }
+
+  /**
+   * Converts a {@link Properties} object to a {@link Map} where each key is a {@link String}.
+   */
+  public static Map<String, ?> propsToStringKeyMap(Properties properties) {
+    ImmutableMap.Builder<String, Object> mapBuilder = ImmutableMap.builder();
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      mapBuilder.put(entry.getKey().toString(), entry.getValue());
+    }
+    return mapBuilder.build();
   }
 }


### PR DESCRIPTION
* Adding integration with Confluent's Schema Registry - https://github.com/confluentinc/schema-registry
    * `ConfluentKafkaSchemaRegistry.java`
* Created `KafkaDeserializerExtractor` which wraps Kafka's `Deserializer` API
    * Kafka's `Deserializer` interface provides a generic way for converting `byte[]` to Java Objects
    * The `KafkaDeserializerExtractor` takes in a path to a fully qualified implementation of `Deserializer` and uses it to convert they `byte[]` into a Java Object
    * It has built in support for a few known `Deserializer`s including Confluents `KafkaAvroDeserializer` and `KafkaJsonDeserializer`
* Created a `KafkaGsonDeserializer` that converts `byte[]` to `JsonElement`s
* Updated the `gobblin-docs/case-studies/Kafka-HDFS-Ingestion.md` to document all of these new features
* Unit tests added