### PR TITLE
Fix permissions for distcp-hive. Fix computation of target paths in d…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyableFile.java
@@ -280,7 +280,7 @@ public class CopyableFile extends CopyEntity implements File {
    * @return A list of the computed {@link OwnerAndPermission}s starting from fromPath, up to but excluding toPath.
    * @throws IOException if toPath is not an ancestor of fromPath.
    */
-  public static List<OwnerAndPermission> resolveReplicatedOwnerAndPermissionsRecursively(FileSystem fs, Path fromPath,
+  public static List<OwnerAndPermission> resolveReplicatedOwnerAndPermissionsRecursively(FileSystem sourceFs, Path fromPath,
       Path toPath, CopyConfiguration copyConfiguration) throws IOException {
 
     if (!PathUtils.isAncestor(toPath, fromPath)) {
@@ -291,7 +291,7 @@ public class CopyableFile extends CopyEntity implements File {
     Path currentPath = fromPath;
 
     while (PathUtils.isAncestor(toPath, currentPath.getParent())) {
-      ownerAndPermissions.add(resolveReplicatedOwnerAndPermission(fs, currentPath, copyConfiguration));
+      ownerAndPermissions.add(resolveReplicatedOwnerAndPermission(sourceFs, currentPath, copyConfiguration));
       currentPath = currentPath.getParent();
     }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -53,6 +53,7 @@ import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyConfiguration;
 import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.CopyableFile;
+import gobblin.data.management.copy.OwnerAndPermission;
 import gobblin.data.management.copy.entities.PostPublishStep;
 import gobblin.data.management.copy.entities.PrePublishStep;
 import gobblin.data.management.copy.hive.avro.HiveAvroCopyEntityHelper;
@@ -86,44 +87,6 @@ import lombok.extern.slf4j.Slf4j;
 @Getter
 public class HiveCopyEntityHelper {
 
-  /**
-   * Specifies a root path for the data in a table. All files containing table data will be placed under this directory.
-   * <p>
-   *   Does some token replacement in the input path. For example, if the table myTable is in DB myDatabase:
-   *   /data/$DB/$TABLE -> /data/myDatabase/myTable.
-   *   /data/$TABLE -> /data/myTable
-   *   /data -> /data/myTable
-   * </p>
-   *
-   * See javadoc for {@link #getCopyEntities} for further explanation.
-   */
-  public static final String COPY_TARGET_TABLE_ROOT = HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.target.table.root";
-
-  /**
-   * These two options, in pair, specify the output location of the data files on copy
-   * {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED} specified the prefix of the path (without Scheme and Authority ) to be replaced
-   * {@link #COPY_TARGET_TABLE_PREFIX_REPLACEMENT} specified the replacement of {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED}
-   * <p>
-   * for example, if the data file is $sourceFs/data/databases/DB/Table/Snapshot/part-00000.avro , 
-   * {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED} is /data/databases
-   * {@link #COPY_TARGET_TABLE_PREFIX_REPLACEMENT} is /data/databases/_parallel
-   * 
-   * then, the output location for that file will be
-   * $targetFs/data/databases/_parallel/DB/Table/Snapshot/part-00000.avro
-   * </p>
-   */
-  public static final String COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED =
-      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.target.table.prefixToBeReplaced";
-  public static final String COPY_TARGET_TABLE_PREFIX_REPLACEMENT =
-      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.target.table.prefixReplacement";
-
-  /**
-   * Specifies that, on copy, data files for this table should all be relocated to a single directory per partition.
-   * See javadoc for {@link #getCopyEntities} for further explanation.
-   */
-  public static final String RELOCATE_DATA_FILES_KEY =
-      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.relocate.data.files";
-  public static final String DEFAULT_RELOCATE_DATA_FILES = Boolean.toString(false);
   public static final String EXISTING_ENTITY_POLICY_KEY =
       HiveDatasetFinder.HIVE_DATASET_PREFIX + ".existing.entity.conflict.policy";
   public static final String DEFAULT_EXISTING_ENTITY_POLICY = ExistingEntityPolicy.ABORT.name();
@@ -149,9 +112,6 @@ public class HiveCopyEntityHelper {
       HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.deregister.fileDeleteMethod";
   public static final DeregisterFileDeleteMethod DEFAULT_DEREGISTER_DELETE_METHOD =
       DeregisterFileDeleteMethod.NO_DELETE;
-
-  private static final String databaseToken = "$DB";
-  private static final String tableToken = "$TABLE";
 
   private static final Gson gson = new Gson();
 
@@ -181,10 +141,6 @@ public class HiveCopyEntityHelper {
   private final CopyConfiguration configuration;
   private final FileSystem targetFs;
 
-  private final Optional<Path> targetTableRoot;
-  private final Optional<Path> targetTablePrefixTobeReplaced;
-  private final Optional<Path> targetTablePrefixReplacement;
-  private final boolean relocateDataFiles;
   private final HiveMetastoreClientPool targetClientPool;
   private final String targetDatabase;
   private final HiveRegProps hiveRegProps;
@@ -202,6 +158,8 @@ public class HiveCopyEntityHelper {
   private final Map<List<String>, Partition> targetPartitions;
 
   private final EventSubmitter eventSubmitter;
+  @Getter
+  protected final HiveTargetPathHelper targetPathHelper;
 
   /**
    * Defines what should be done for partitions that exist in the target but are not compatible with the source.
@@ -260,22 +218,6 @@ public class HiveCopyEntityHelper {
       this.dataset = dataset;
       this.configuration = configuration;
       this.targetFs = targetFs;
-
-      this.relocateDataFiles = Boolean
-          .valueOf(this.dataset.getProperties().getProperty(RELOCATE_DATA_FILES_KEY, DEFAULT_RELOCATE_DATA_FILES));
-      this.targetTableRoot = this.dataset.getProperties().containsKey(COPY_TARGET_TABLE_ROOT)
-          ? Optional.of(resolvePath(this.dataset.getProperties().getProperty(COPY_TARGET_TABLE_ROOT),
-              this.dataset.table.getDbName(), this.dataset.table.getTableName()))
-          : Optional.<Path> absent();
-
-      this.targetTablePrefixTobeReplaced =
-          this.dataset.getProperties().containsKey(COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED)
-              ? Optional.of(new Path(this.dataset.getProperties().getProperty(COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED)))
-              : Optional.<Path> absent();
-
-      this.targetTablePrefixReplacement = this.dataset.getProperties().containsKey(COPY_TARGET_TABLE_PREFIX_REPLACEMENT)
-          ? Optional.of(new Path(this.dataset.getProperties().getProperty(COPY_TARGET_TABLE_PREFIX_REPLACEMENT)))
-          : Optional.<Path> absent();
 
       this.hiveRegProps = new HiveRegProps(new State(this.dataset.getProperties()));
       this.targetURI = Optional.fromNullable(this.dataset.getProperties().getProperty(TARGET_METASTORE_URI_KEY));
@@ -355,6 +297,8 @@ public class HiveCopyEntityHelper {
           this.sourcePartitions = Maps.newHashMap();
           this.targetPartitions = Maps.newHashMap();
         }
+
+        this.targetPathHelper = new HiveTargetPathHelper(this.dataset);
       } catch (TException te) {
         closer.close();
         throw new IOException("Failed to generate work units for table " + dataset.table.getCompleteName(), te);
@@ -372,23 +316,7 @@ public class HiveCopyEntityHelper {
    * 4. If the table is partitioned, create a file set for each partition.
    * 5. Create work units for registering, deregistering partitions / tables, and deleting unnecessary files in the target.
    *
-   * <p>
-   *   The target locations of data files for this table depend on the values of the resolved table root (e.g.
-   *   the value of {@link #COPY_TARGET_TABLE_ROOT} with tokens replaced) and {@link #RELOCATE_DATA_FILES_KEY}:
-   *   * if {@link #RELOCATE_DATA_FILES_KEY} is true, then origin file /path/to/file/myFile will be written to
-   *     /resolved/table/root/<partition>/myFile
-   *   * otherwise, if the resolved table root is defined (e.g. {@link #COPY_TARGET_TABLE_ROOT} is defined in the
-   *     properties), we define:
-   *     origin_table_root := the deepest non glob ancestor of table.getSc().getLocation() iff getLocation() points to
-   *                           a single glob. (e.g. /path/to/*&#47;files -> /path/to). If getLocation() contains none
-   *                           or multiple globs, job will fail.
-   *     relative_path := path of the file relative to origin_table_root. If the path of the file is not a descendant
-   *                      of origin_table_root, job will fail.
-   *     target_path := /resolved/table/root/relative/path
-   *     This mode is useful when moving a table with a complicated directory structure to a different base directory.
-   *   * if {@link #COPY_TARGET_TABLE_ROOT} is not defined in the properties, then the target is identical to the origin
-   *     path.
-   * </p>
+   * For computation of target locations see {@link HiveTargetPathHelper#getTargetPath(Path, FileSystem, Optional, boolean, HiveCopyEntityHelper)}
    */
   Iterator<FileSet<CopyEntity>> getCopyEntities() throws IOException {
     if (HiveUtils.isPartitioned(this.dataset.table)) {
@@ -457,21 +385,6 @@ public class HiveCopyEntityHelper {
     @Override
     public void remove() {
       throw new UnsupportedOperationException();
-    }
-  }
-
-  /**
-   * Takes a path with tokens {@link #databaseToken} or {@link #tableToken} and replaces these tokens with the actual
-   * database names and table name. For example, if db is myDatabase, table is myTable, then /data/$DB/$TABLE will be
-   * resolved to /data/myDatabase/myTable.
-   */
-  protected static Path resolvePath(String pattern, String database, String table) {
-    pattern = pattern.replace(databaseToken, database);
-    if (pattern.contains(tableToken)) {
-      pattern = pattern.replace(tableToken, table);
-      return new Path(pattern);
-    } else {
-      return new Path(pattern, table);
     }
   }
 
@@ -785,7 +698,7 @@ public class HiveCopyEntityHelper {
     multiTimer.nextStage(Stages.PATH_DIFF);
     for (FileStatus sourcePath : sourcePaths.values()) {
       // For each source path
-      Path newPath = helper.getTargetPath(sourcePath.getPath(), desiredTargetLocation.getFileSystem(), partition, true);
+      Path newPath = helper.getTargetPathHelper().getTargetPath(sourcePath.getPath(), desiredTargetLocation.getFileSystem(), partition, true);
       boolean shouldCopy = true;
       if (desiredTargetExistingPaths.containsKey(newPath)) {
         // If the file exists at the destination, check whether it should be replaced, if not, no need to copy
@@ -876,7 +789,7 @@ public class HiveCopyEntityHelper {
     String referenceAuthority = null;
 
     for (FileStatus status : paths) {
-      dataFiles.add(new SourceAndDestination(status, getTargetPath(status.getPath(), this.targetFs, partition, true)));
+      dataFiles.add(new SourceAndDestination(status, getTargetPathHelper().getTargetPath(status.getPath(), this.targetFs, partition, true)));
     }
 
     for (SourceAndDestination sourceAndDestination : dataFiles) {
@@ -889,8 +802,20 @@ public class HiveCopyEntityHelper {
         referenceAuthority = uri.getAuthority();
       }
 
+      if (!this.dataset.getTableRootPath().isPresent()) {
+        // The logic for computing ancestor owner and permissions for hive copies depends on tables having a non-glob
+        // location. Currently, this restriction is also imposed by Hive, so this is not a problem. If this ever changes
+        // on the Hive side, and we try to copy a table with a glob location, this logic will have to change.
+        throw new IOException(String.format("Table %s does not have a concrete table root path.",
+            this.dataset.getTable().getCompleteName()));
+      }
+      List<OwnerAndPermission> ancestorOwnerAndPermission =
+          CopyableFile.resolveReplicatedOwnerAndPermissionsRecursively(actualSourceFs,
+          sourceAndDestination.getSource().getPath(), this.dataset.getTableRootPath().get().getParent(), configuration);
+
       builders.add(CopyableFile.fromOriginAndDestination(actualSourceFs, sourceAndDestination.getSource(),
-          sourceAndDestination.getDestination(), configuration));
+          sourceAndDestination.getDestination(), configuration).
+          ancestorsOwnerAndPermission(ancestorOwnerAndPermission));
     }
 
     return builders;
@@ -906,62 +831,7 @@ public class HiveCopyEntityHelper {
    */
   private Path getTargetLocation(FileSystem sourceFs, FileSystem targetFs, Path path, Optional<Partition> partition)
       throws IOException {
-    return getTargetPath(path, targetFs, partition, false);
-  }
-
-  /**
-   * Compute the target {@link Path} for a file or directory referred by this table.
-   * @param sourcePath Source path to be transformed.
-   * @param targetFs target {@link FileSystem}
-   * @param partition partition this file belongs to.
-   * @param isConcreteFile true if this is a path to an existing file in HDFS.
-   */
-  public Path getTargetPath(Path sourcePath, FileSystem targetFs, Optional<Partition> partition,
-      boolean isConcreteFile) {
-    if (this.relocateDataFiles) {
-      Preconditions.checkArgument(this.targetTableRoot.isPresent(), "Must define %s to relocate data files.",
-          COPY_TARGET_TABLE_ROOT);
-      Path path = this.targetTableRoot.get();
-      if (partition.isPresent()) {
-        addPartitionToPath(path, partition.get());
-      }
-      if (!isConcreteFile) {
-        return targetFs.makeQualified(path);
-      }
-      return targetFs.makeQualified(new Path(path, sourcePath.getName()));
-    }
-
-    // both prefixs must be present as the same time
-    // can not used with option {@link #COPY_TARGET_TABLE_ROOT}
-    if (this.targetTablePrefixTobeReplaced.isPresent() || this.targetTablePrefixReplacement.isPresent()) {
-      Preconditions.checkState(this.targetTablePrefixTobeReplaced.isPresent(),
-          String.format("Must specify both %s option and %s option together", COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED,
-              COPY_TARGET_TABLE_PREFIX_REPLACEMENT));
-      Preconditions.checkState(this.targetTablePrefixReplacement.isPresent(),
-          String.format("Must specify both %s option and %s option together", COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED,
-              COPY_TARGET_TABLE_PREFIX_REPLACEMENT));
-
-      Preconditions.checkState(!this.targetTableRoot.isPresent(),
-          String.format("Can not specify the option %s with option %s ", COPY_TARGET_TABLE_ROOT,
-              COPY_TARGET_TABLE_PREFIX_REPLACEMENT));
-
-      Path targetPathWithoutSchemeAndAuthority =
-          replacedPrefix(sourcePath, this.targetTablePrefixTobeReplaced.get(), this.targetTablePrefixReplacement.get());
-      return targetFs.makeQualified(targetPathWithoutSchemeAndAuthority);
-    } else if (this.targetTableRoot.isPresent()) {
-      Preconditions.checkArgument(this.targetTableRoot.isPresent(), "Must define %s to relocate data files.",
-          COPY_TARGET_TABLE_ROOT);
-      Path path = this.targetTableRoot.get();
-      if (partition.isPresent()) {
-        addPartitionToPath(path, partition.get());
-      }
-      if (!isConcreteFile) {
-        return targetFs.makeQualified(path);
-      }
-      return targetFs.makeQualified(new Path(path, sourcePath.getName()));
-    } else {
-      return targetFs.makeQualified(PathUtils.getPathWithoutSchemeAndAuthority(sourcePath));
-    }
+    return getTargetPathHelper().getTargetPath(path, targetFs, partition, false);
   }
 
   protected static Path replacedPrefix(Path sourcePath, Path prefixTobeReplaced, Path prefixReplacement) {
@@ -973,13 +843,6 @@ public class HiveCopyEntityHelper {
     Path relativePath = PathUtils.relativizePath(sourcePathWithoutSchemeAndAuthority, prefixTobeReplaced);
     Path result = new Path(prefixReplacement, relativePath);
     return result;
-  }
-
-  private static Path addPartitionToPath(Path path, Partition partition) {
-    for (String partitionValue : partition.getValues()) {
-      path = new Path(path, partitionValue);
-    }
-    return path;
   }
 
   public FileSystem getTargetFileSystem() {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveTargetPathHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveTargetPathHelper.java
@@ -1,0 +1,185 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.hive;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.util.PathUtils;
+
+
+public class HiveTargetPathHelper {
+
+  /**
+   * Specifies a root path for the data in a table. All files containing table data will be placed under this directory.
+   * <p>
+   *   Does some token replacement in the input path. For example, if the table myTable is in DB myDatabase:
+   *   /data/$DB/$TABLE -> /data/myDatabase/myTable.
+   *   /data/$TABLE -> /data/myTable
+   *   /data -> /data/myTable
+   * </p>
+   *
+   * See javadoc for {@link #getTargetPath} for further explanation.
+   */
+  public static final String COPY_TARGET_TABLE_ROOT = HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.target.table.root";
+  /**
+   * These two options, in pair, specify the output location of the data files on copy
+   * {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED} specified the prefix of the path (without Scheme and Authority ) to be replaced
+   * {@link #COPY_TARGET_TABLE_PREFIX_REPLACEMENT} specified the replacement of {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED}
+   * <p>
+   * for example, if the data file is $sourceFs/data/databases/DB/Table/Snapshot/part-00000.avro ,
+   * {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED} is /data/databases
+   * {@link #COPY_TARGET_TABLE_PREFIX_REPLACEMENT} is /data/databases/_parallel
+   *
+   * then, the output location for that file will be
+   * $targetFs/data/databases/_parallel/DB/Table/Snapshot/part-00000.avro
+   * </p>
+   */
+  public static final String COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED =
+      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.target.table.prefixToBeReplaced";
+  public static final String COPY_TARGET_TABLE_PREFIX_REPLACEMENT =
+      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.target.table.prefixReplacement";
+  /**
+   * Specifies that, on copy, data files for this table should all be relocated to a single directory per partition.
+   * See javadoc for {@link #getTargetPath} for further explanation.
+   */
+  public static final String RELOCATE_DATA_FILES_KEY =
+      HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.relocate.data.files";
+  public static final String DEFAULT_RELOCATE_DATA_FILES = Boolean.toString(false);
+  private static final String databaseToken = "$DB";
+  private static final String tableToken = "$TABLE";
+  private final boolean relocateDataFiles;
+  private final Optional<Path> targetTableRoot;
+  private final Optional<Path> targetTablePrefixTobeReplaced;
+  private final Optional<Path> targetTablePrefixReplacement;
+  private final HiveDataset dataset;
+
+  public HiveTargetPathHelper(HiveDataset dataset) {
+
+    this.dataset = dataset;
+    this.relocateDataFiles = Boolean
+        .valueOf(this.dataset.getProperties().getProperty(RELOCATE_DATA_FILES_KEY, DEFAULT_RELOCATE_DATA_FILES));
+    this.targetTableRoot = this.dataset.getProperties().containsKey(COPY_TARGET_TABLE_ROOT)
+        ? Optional.of(resolvePath(this.dataset.getProperties().getProperty(COPY_TARGET_TABLE_ROOT),
+        this.dataset.getTable().getDbName(), this.dataset.getTable().getTableName()))
+        : Optional.<Path> absent();
+
+    this.targetTablePrefixTobeReplaced =
+        this.dataset.getProperties().containsKey(COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED)
+            ? Optional.of(new Path(this.dataset.getProperties().getProperty(COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED)))
+            : Optional.<Path> absent();
+
+    this.targetTablePrefixReplacement = this.dataset.getProperties().containsKey(COPY_TARGET_TABLE_PREFIX_REPLACEMENT)
+        ? Optional.of(new Path(this.dataset.getProperties().getProperty(COPY_TARGET_TABLE_PREFIX_REPLACEMENT)))
+        : Optional.<Path> absent();
+  }
+
+  private static Path addPartitionToPath(Path path, Partition partition) {
+    for (String partitionValue : partition.getValues()) {
+      path = new Path(path, partitionValue);
+    }
+    return path;
+  }
+
+  /**
+   * Takes a path with tokens {@link #databaseToken} or {@link #tableToken} and replaces these tokens with the actual
+   * database names and table name. For example, if db is myDatabase, table is myTable, then /data/$DB/$TABLE will be
+   * resolved to /data/myDatabase/myTable.
+   */
+  protected static Path resolvePath(String pattern, String database, String table) {
+    pattern = pattern.replace(databaseToken, database);
+    if (pattern.contains(tableToken)) {
+      pattern = pattern.replace(tableToken, table);
+      return new Path(pattern);
+    } else {
+      return new Path(pattern, table);
+    }
+  }
+
+  /**
+   * Compute the target {@link Path} for a file or directory copied by Hive distcp.
+   *
+   * <p>
+   *   The target locations of data files for this table depend on the values of the resolved table root (e.g.
+   *   the value of {@link #COPY_TARGET_TABLE_ROOT} with tokens replaced) and {@link #RELOCATE_DATA_FILES_KEY}:
+   *   * if {@link #RELOCATE_DATA_FILES_KEY} is true, then origin file /path/to/file/myFile will be written to
+   *     /resolved/table/root/<partition>/myFile
+   *   * if {@link #COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED} and {@link #COPY_TARGET_TABLE_PREFIX_REPLACEMENT} are defined,
+   *     then the specified prefix in each file will be replaced by the specified replacement.
+   *   * otherwise, if the resolved table root is defined (e.g. {@link #COPY_TARGET_TABLE_ROOT} is defined in the
+   *     properties), we define:
+   *     origin_table_root := the deepest non glob ancestor of table.getSc().getLocation() iff getLocation() points to
+   *                           a single glob. (e.g. /path/to/*&#47;files -> /path/to). If getLocation() contains none
+   *                           or multiple globs, job will fail.
+   *     relative_path := path of the file relative to origin_table_root. If the path of the file is not a descendant
+   *                      of origin_table_root, job will fail.
+   *     target_path := /resolved/table/root/relative/path
+   *     This mode is useful when moving a table with a complicated directory structure to a different base directory.
+   *   * otherwise the target is identical to the origin path.
+   * </p>
+   *
+   *
+   * @param sourcePath Source path to be transformed.
+   * @param targetFs target {@link FileSystem}
+   * @param partition partition this file belongs to.
+   * @param isConcreteFile true if this is a path to an existing file in HDFS.
+   */
+  public Path getTargetPath(Path sourcePath, FileSystem targetFs, Optional<Partition> partition, boolean isConcreteFile) {
+    if (this.relocateDataFiles) {
+      Preconditions.checkArgument(this.targetTableRoot.isPresent(), "Must define %s to relocate data files.",
+          COPY_TARGET_TABLE_ROOT);
+      Path path = this.targetTableRoot.get();
+      if (partition.isPresent()) {
+        path = addPartitionToPath(path, partition.get());
+      }
+      if (!isConcreteFile) {
+        return targetFs.makeQualified(path);
+      }
+      return targetFs.makeQualified(new Path(path, sourcePath.getName()));
+    }
+
+    // both prefixs must be present as the same time
+    // can not used with option {@link #COPY_TARGET_TABLE_ROOT}
+    if (this.targetTablePrefixTobeReplaced.isPresent() || this.targetTablePrefixReplacement.isPresent()) {
+      Preconditions.checkState(this.targetTablePrefixTobeReplaced.isPresent(),
+          String.format("Must specify both %s option and %s option together", COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED,
+              COPY_TARGET_TABLE_PREFIX_REPLACEMENT));
+      Preconditions.checkState(this.targetTablePrefixReplacement.isPresent(),
+          String.format("Must specify both %s option and %s option together", COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED,
+              COPY_TARGET_TABLE_PREFIX_REPLACEMENT));
+
+      Preconditions.checkState(!this.targetTableRoot.isPresent(),
+          String.format("Can not specify the option %s with option %s ", COPY_TARGET_TABLE_ROOT,
+              COPY_TARGET_TABLE_PREFIX_REPLACEMENT));
+
+      Path targetPathWithoutSchemeAndAuthority =
+          HiveCopyEntityHelper.replacedPrefix(sourcePath, this.targetTablePrefixTobeReplaced.get(), this.targetTablePrefixReplacement.get());
+      return targetFs.makeQualified(targetPathWithoutSchemeAndAuthority);
+    } else if (this.targetTableRoot.isPresent()) {
+      Preconditions.checkArgument(this.dataset.getTableRootPath().isPresent(),
+          "Cannot move paths to a new root unless table has exactly one location.");
+      Preconditions.checkArgument(PathUtils.isAncestor(this.dataset.getTableRootPath().get(), sourcePath),
+          "When moving paths to a new root, all locations must be descendants of the table root location. "
+              + "Table root location: %s, file location: %s.", this.dataset.getTableRootPath(), sourcePath);
+
+      Path relativePath = PathUtils.relativizePath(sourcePath, this.dataset.getTableRootPath().get());
+      return targetFs.makeQualified(new Path(this.targetTableRoot.get(), relativePath));
+    } else {
+      return targetFs.makeQualified(PathUtils.getPathWithoutSchemeAndAuthority(sourcePath));
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/avro/HiveAvroCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/avro/HiveAvroCopyEntityHelper.java
@@ -56,7 +56,7 @@ public class HiveAvroCopyEntityHelper {
           || (oldAvroSchemaPath.toUri().getScheme().equals(sourceFileSystemURI.getScheme())
           && oldAvroSchemaPath.toUri().getAuthority().equals(sourceFileSystemURI.getAuthority()))) {
 
-        String newAvroSchemaURL = hiveHelper.getTargetPath(oldAvroSchemaPath, hiveHelper.getTargetFileSystem(),
+        String newAvroSchemaURL = hiveHelper.getTargetPathHelper().getTargetPath(oldAvroSchemaPath, hiveHelper.getTargetFileSystem(),
             Optional.<Partition>absent(), true).toString();
 
         targetTable.getTTable().getSd().getSerdeInfo().getParameters().put(HIVE_TABLE_AVRO_SCHEMA_URL, newAvroSchemaURL);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RootDirectoryModtimeSkipPredicate.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/predicates/RootDirectoryModtimeSkipPredicate.java
@@ -56,7 +56,7 @@ public class RootDirectoryModtimeSkipPredicate implements Predicate<HiveCopyEnti
         return false;
       }
 
-      Path targetPath = this.helper.getTargetFileSystem().makeQualified(this.helper.getTargetPath(
+      Path targetPath = this.helper.getTargetFileSystem().makeQualified(this.helper.getTargetPathHelper().getTargetPath(
           input.getPartition().getDataLocation(), this.helper.getTargetFs(), Optional.of(input.getPartition()), false));
 
       Optional<FileStatus> targetFileStatus =

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveTargetPathHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveTargetPathHelperTest.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.hive;
+
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.mockito.Mockito;
+import org.mockito.invocation.InvocationOnMock;
+import org.mockito.stubbing.Answer;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+
+
+public class HiveTargetPathHelperTest {
+
+  private static Path TABLE_ROOT = new Path("/table/path");
+
+  private FileSystem fs;
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    this.fs = Mockito.mock(FileSystem.class);
+    Mockito.when(fs.makeQualified(Mockito.any(Path.class))).thenAnswer(new Answer<Path>() {
+      @Override
+      public Path answer(InvocationOnMock invocation)
+          throws Throwable {
+        return (Path) invocation.getArguments()[0];
+      }
+    });
+  }
+
+  @Test
+  public void testRelocateFilesUnpartitioned() {
+    Properties properties = new Properties();
+    properties.setProperty(HiveTargetPathHelper.RELOCATE_DATA_FILES_KEY, Boolean.toString(true));
+    properties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_ROOT, "/target");
+
+    HiveTargetPathHelper helper = createTestTargetPathHelper(properties);
+
+    Path source = new Path(TABLE_ROOT, "partition/file1");
+    Assert.assertEquals(helper.getTargetPath(source, this.fs, Optional.<Partition>absent(), true), new Path("/target/tableName/file1"));
+  }
+
+  @Test
+  public void testRelocateFilesPartitioned() {
+    Properties properties = new Properties();
+    properties.setProperty(HiveTargetPathHelper.RELOCATE_DATA_FILES_KEY, Boolean.toString(true));
+    properties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_ROOT, "/target");
+
+    HiveTargetPathHelper helper = createTestTargetPathHelper(properties);
+
+    Path source = new Path(TABLE_ROOT, "partition/file1");
+
+    Partition partition = Mockito.mock(Partition.class);
+    Mockito.when(partition.getValues()).thenReturn(Lists.newArrayList("part", "123"));
+
+    Assert.assertEquals(helper.getTargetPath(source, this.fs, Optional.of(partition), true), new Path("/target/tableName/part/123/file1"));
+  }
+
+  @Test
+  public void testTokenReplacement() {
+    Properties properties = new Properties();
+    properties.setProperty(HiveTargetPathHelper.RELOCATE_DATA_FILES_KEY, Boolean.toString(true));
+    properties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_ROOT, "/target/$DB/$TABLE");
+
+    HiveTargetPathHelper helper = createTestTargetPathHelper(properties);
+
+    Path source = new Path(TABLE_ROOT, "partition/file1");
+    Assert.assertEquals(helper.getTargetPath(source, this.fs, Optional.<Partition>absent(), true), new Path("/target/dbName/tableName/file1"));
+  }
+
+  @Test
+  public void testReplacePrefix() {
+    Properties properties = new Properties();
+    properties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_PREFIX_TOBE_REPLACED, "/table");
+    properties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_PREFIX_REPLACEMENT, "/replaced");
+
+    HiveTargetPathHelper helper = createTestTargetPathHelper(properties);
+
+    Path source = new Path(TABLE_ROOT, "partition/file1");
+    Assert.assertEquals(helper.getTargetPath(source, this.fs, Optional.<Partition>absent(), true), new Path("/replaced/path/partition/file1"));
+  }
+
+  @Test
+  public void testNewTableRoot() {
+    Properties properties = new Properties();
+    properties.setProperty(HiveTargetPathHelper.COPY_TARGET_TABLE_ROOT, "/target");
+
+    HiveTargetPathHelper helper = createTestTargetPathHelper(properties);
+
+    Path source = new Path(TABLE_ROOT, "partition/file1");
+    Assert.assertEquals(helper.getTargetPath(source, this.fs, Optional.<Partition>absent(), true), new Path("/target/tableName/partition/file1"));
+  }
+
+  @Test
+  public void testReplicatePaths() {
+    Properties properties = new Properties();
+
+    HiveTargetPathHelper helper = createTestTargetPathHelper(properties);
+
+    Path source = new Path(TABLE_ROOT, "partition/file1");
+    Assert.assertEquals(helper.getTargetPath(source, this.fs, Optional.<Partition>absent(), true), new Path(TABLE_ROOT, "partition/file1"));
+  }
+
+  private HiveTargetPathHelper createTestTargetPathHelper(Properties properties) {
+    HiveDataset dataset = Mockito.mock(HiveDataset.class);
+
+    Table table = new Table(new org.apache.hadoop.hive.metastore.api.Table());
+    table.setDbName("dbName");
+    table.setTableName("tableName");
+    Mockito.when(dataset.getTable()).thenReturn(table);
+
+    Mockito.when(dataset.getTableRootPath()).thenReturn(Optional.of(TABLE_ROOT));
+    Mockito.when(dataset.getProperties()).thenReturn(properties);
+
+    HiveTargetPathHelper helper = new HiveTargetPathHelper(dataset);
+
+    return helper;
+  }
+
+}


### PR DESCRIPTION
…istcp-hive.

This is mostly refactoring of the target path computation logic, previously located in `HiveCopyEntityHelper` it is now in its own class `HiveTargetPathHelper`. The logic is almost the same, except for a fix in the case where new table root is specified.

Also, Hive copy will now specify the desired ancestor owner and permissions (minor change in `HiveCopyEntityHelper`)