### PR TITLE
extension of loading config file from general file system

### DIFF
--- a/conf/gobblin-standalone.properties
+++ b/conf/gobblin-standalone.properties
@@ -25,6 +25,7 @@ data.publisher.replace.final.dir=false
 
 # Directory where job configuration files are stored
 jobconf.dir=${env:GOBBLIN_JOB_CONFIG_DIR}
+jobconf.fullyQualifiedPath=file://${env:GOBBLIN_JOB_CONFIG_DIR}
 
 # Directory where job/task state files are stored
 state.store.dir=${env:GOBBLIN_WORK_DIR}/state-store

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -57,8 +57,11 @@ public class ConfigurationKeys {
   // Job configuration file monitor polling interval in milliseconds
   public static final String JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY = "jobconf.monitor.interval";
   public static final long DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL = 300000;
-  // Directory where all job configuration files are stored
+  // Directory where all job configuration files are stored WHEN ALL confs reside in local FS.
   public static final String JOB_CONFIG_FILE_DIR_KEY = "jobconf.dir";
+
+  // Path where all job configuration files stored
+  public static final String JOB_CONFIG_FILE_GENERAL_PATH_KEY = "jobconf.fullyQualifiedPath" ;
   // Job configuration file extensions
   public static final String JOB_CONFIG_FILE_EXTENSIONS_KEY = "jobconf.extensions";
   public static final String DEFAULT_JOB_CONFIG_FILE_EXTENSIONS = "pull,job";
@@ -66,6 +69,7 @@ public class ConfigurationKeys {
   // Note this only applies to jobs scheduled by the built-in Quartz-based job scheduler.
   public static final String SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY = "scheduler.wait.for.job.completion";
   public static final String DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION = Boolean.TRUE.toString();
+
 
   /**
    * Task executor and state tracker configuration properties.
@@ -448,20 +452,20 @@ public class ConfigurationKeys {
   public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(true);
   public static final String METRICS_REPORT_INTERVAL_KEY = METRICS_CONFIGURATIONS_PREFIX + "report.interval";
   public static final String DEFAULT_METRICS_REPORT_INTERVAL = Long.toString(TimeUnit.SECONDS.toMillis(30));
-  
-  // File-based reporting 
+
+  // File-based reporting
   public static final String METRICS_REPORTING_FILE_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
   public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(false);
   public static final String METRICS_LOG_DIR_KEY = METRICS_CONFIGURATIONS_PREFIX + "log.dir";
   public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
   public static final String DEFAULT_METRICS_FILE_SUFFIX = "";
-  
+
   // JMX-based reporting
   public static final String METRICS_REPORTING_JMX_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
   public static final String DEFAULT_METRICS_REPORTING_JMX_ENABLED = Boolean.toString(false);
-  
+
   // Kafka-based reporting
   public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
@@ -481,49 +485,49 @@ public class ConfigurationKeys {
   // Topic used only for event reporting.
   public static final String METRICS_KAFKA_TOPIC_EVENTS =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic.events";
-  
+
   //Graphite-based reporting
-  public static final String METRICS_REPORTING_GRAPHITE_METRICS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_GRAPHITE_METRICS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.metrics.enabled";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_METRICS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.events.enabled";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_EVENTS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_GRAPHITE_HOSTNAME = 
+  public static final String METRICS_REPORTING_GRAPHITE_HOSTNAME =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.hostname";
-  public static final String METRICS_REPORTING_GRAPHITE_PORT = 
+  public static final String METRICS_REPORTING_GRAPHITE_PORT =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.port";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_PORT = "2003";
-  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_PORT = 
+  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_PORT =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.events.port";
-  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_VALUE_AS_KEY = 
+  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_VALUE_AS_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.events.value.as.key";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_EVENTS_VALUE_AS_KEY = Boolean.toString(false);
-  public static final String METRICS_REPORTING_GRAPHITE_SENDING_TYPE = 
+  public static final String METRICS_REPORTING_GRAPHITE_SENDING_TYPE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.sending.type";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_SENDING_TYPE = "TCP";
-  
+
   //InfluxDB-based reporting
-  public static final String METRICS_REPORTING_INFLUXDB_METRICS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_INFLUXDB_METRICS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.metrics.enabled";
   public static final String DEFAULT_METRICS_REPORTING_INFLUXDB_METRICS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.events.enabled";
   public static final String DEFAULT_METRICS_REPORTING_INFLUXDB_EVENTS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_INFLUXDB_URL = 
+  public static final String METRICS_REPORTING_INFLUXDB_URL =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.url";
-  public static final String METRICS_REPORTING_INFLUXDB_DATABASE = 
+  public static final String METRICS_REPORTING_INFLUXDB_DATABASE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.database";
-  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_DATABASE = 
+  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_DATABASE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.events.database";
-  public static final String METRICS_REPORTING_INFLUXDB_USER = 
+  public static final String METRICS_REPORTING_INFLUXDB_USER =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.user";
-  public static final String METRICS_REPORTING_INFLUXDB_PASSWORD = 
+  public static final String METRICS_REPORTING_INFLUXDB_PASSWORD =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.password";
-  public static final String METRICS_REPORTING_INFLUXDB_SENDING_TYPE = 
+  public static final String METRICS_REPORTING_INFLUXDB_SENDING_TYPE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.sending.type";
   public static final String DEFAULT_METRICS_REPORTING_INFLUXDB_SENDING_TYPE = "TCP";
-  
+
   //Custom-reporting
   public static final String METRICS_CUSTOM_BUILDERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.custom.builders";
 

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinDaemon.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinDaemon.java
@@ -1,0 +1,35 @@
+package gobblin.azkaban;
+
+import java.util.Properties;
+import org.apache.log4j.Logger;
+import gobblin.scheduler.SchedulerDaemon;
+import azkaban.jobExecutor.AbstractJob;
+
+
+/**
+ * Wrapper of {@link SchedulerDaemon}, specially used by Azkaban to launch a job scheduler daemon.
+ */
+
+public class AzkabanGobblinDaemon extends AbstractJob {
+
+  private static final Logger LOG = Logger.getLogger(AzkabanGobblinDaemon.class);
+
+  private SchedulerDaemon daemon;
+
+  public AzkabanGobblinDaemon(String jobId, Properties props) throws Exception {
+    super(jobId, LOG);
+    this.daemon = new SchedulerDaemon(props);
+  }
+
+  @Override
+  public void run()
+      throws Exception {
+    this.daemon.start();
+  }
+
+  @Override
+  public void cancel()
+      throws Exception {
+    this.daemon.stop();
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
@@ -33,7 +33,7 @@ public class SchedulerDaemon extends ServiceBasedAppLauncher {
     this(PropertiesUtils.combineProperties(defaultProperties, customProperties));
   }
 
-  private SchedulerDaemon(Properties properties) throws Exception {
+  public SchedulerDaemon(Properties properties) throws Exception {
     super(properties, getAppName(properties));
     addService(new JobScheduler(properties));
   }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -73,6 +73,7 @@ public class JobLauncherTestHelper {
     Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
     Assert.assertEquals(datasetState.getCompletedTasks(), 4);
     Assert.assertEquals(datasetState.getJobFailures(), 0);
+
     for (TaskState taskState : datasetState.getTaskStates()) {
       Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
       Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN),

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
+
 import gobblin.metastore.testing.ITestMetastoreDatabase;
 import gobblin.metastore.testing.TestMetastoreDatabaseFactory;
 import gobblin.runtime.JobLauncherTestHelper;

--- a/gobblin-utility/src/main/java/gobblin/util/SchedulerUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SchedulerUtils.java
@@ -12,12 +12,11 @@
 
 package gobblin.util;
 
-import gobblin.configuration.ConfigurationKeys;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -28,9 +27,15 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -38,6 +43,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
+
+import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -68,21 +75,32 @@ public class SchedulerUtils {
     }
   };
 
+  private static final PathFilter PROPERTIES_PATH_FILTER = new PathFilter() {
+    @Override
+    public boolean accept(Path path) {
+      String fileExtension = path.getName().substring(path.getName().lastIndexOf('.') + 1);
+      return fileExtension.equalsIgnoreCase(JOB_PROPS_FILE_EXTENSION);
+    }
+  };
+
+  private static final PathFilter NON_PROPERTIES_PATH_FILTER = new PathFilter() {
+    @Override
+    public boolean accept(Path path) {
+      return !PROPERTIES_PATH_FILTER.accept(path);
+    }
+  };
+
   /**
-   * Load job configurations from job configuration files stored under the
-   * root job configuration file directory.
-   *
+   * Load job configuration from job configuration files stored in general file system,
+   * located by Path
    * @param properties Gobblin framework configuration properties
    * @return a list of job configurations in the form of {@link java.util.Properties}
    */
-  public static List<Properties> loadJobConfigs(Properties properties)
-      throws ConfigurationException {
-    Preconditions.checkArgument(properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY),
-        "Missing configuration property: " + ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY);
-
+  public static List<Properties> loadGenericJobConfigs(Properties properties)
+      throws ConfigurationException, IOException {
     List<Properties> jobConfigs = Lists.newArrayList();
-    loadJobConfigsRecursive(jobConfigs, properties, getJobConfigurationFileExtensions(properties),
-        new File(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY)));
+    loadGenericJobConfigsRecursive(jobConfigs, properties, getJobConfigurationFileExtensions(properties),
+        new Path(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY)));
     return jobConfigs;
   }
 
@@ -178,6 +196,81 @@ public class SchedulerUtils {
   }
 
   /**
+   * Recursively load job configuration files under given URI of **directory of config files folder**
+   */
+  private static void loadGenericJobConfigsRecursive(List<Properties> jobConfigs, Properties rootProps,
+      Set<String> jobConfigFileExtensions, Path configDirPath)
+      throws ConfigurationException, IOException {
+
+    /* create the generic file system */
+    Configuration conf = new Configuration();
+    try (FileSystem filesystem = configDirPath.getFileSystem(conf)) {
+      if (!filesystem.exists(configDirPath)) {
+        throw new RuntimeException(
+            "The specified job configurations directory was not found: " + configDirPath.toString());
+      }
+
+      FileStatus[] propertiesFilesStatus = filesystem.listStatus(configDirPath, PROPERTIES_PATH_FILTER);
+      if ( propertiesFilesStatus != null && propertiesFilesStatus.length > 0) {
+        // There should be a single properties file in each directory (or sub directory)
+        if (propertiesFilesStatus.length != 1) {
+          throw new RuntimeException("Found more than one .properties file in directory: " + configDirPath);
+        }
+
+        // Load the properties, which may overwrite the same properties defined in the parent or ancestor directories.
+        // Open the inputStream, construct a reader and send to the loader for constructing propertiesConfiguration.
+        PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+        Path uniqueConfigFilePath = propertiesFilesStatus[0].getPath();
+        try (InputStreamReader inputStreamReader = new InputStreamReader(filesystem.open(uniqueConfigFilePath),
+            Charsets.UTF_8)) {
+          propertiesConfiguration.load(inputStreamReader);
+          rootProps.putAll(ConfigurationConverter.getProperties(propertiesConfiguration));
+        }
+      }
+
+      // Get all non-properties files
+      FileStatus[] nonPropFiles = filesystem.listStatus(configDirPath, NON_PROPERTIES_PATH_FILTER);
+      if ( nonPropFiles == null || nonPropFiles.length == 0 ) {
+        return;
+      }
+
+      for (FileStatus nonPropFile : nonPropFiles) {
+        Path configFilePath = nonPropFile.getPath();
+        if (nonPropFile.isDirectory()) {
+          Properties rootPropsCopy = new Properties();
+          rootPropsCopy.putAll(rootProps);
+          loadGenericJobConfigsRecursive(jobConfigs, rootPropsCopy, jobConfigFileExtensions, configFilePath);
+        } else {
+          if (!jobConfigFileExtensions.contains(
+              configFilePath.getName().substring(configFilePath.getName().lastIndexOf('.') + 1).toLowerCase())) {
+            LOGGER.warn("Skipped file " + configFilePath + " that has an unsupported extension");
+            continue;
+          }
+
+          Path doneFilePath = configFilePath.suffix(".done");
+          if (filesystem.exists(doneFilePath)) {
+            LOGGER.info("Skipped job configuration file " + doneFilePath + " for which a .done file exists");
+            continue;
+          }
+
+          Properties jobProps = new Properties();
+          // Put all parent/ancestor properties first
+          jobProps.putAll(rootProps);
+          // Then load the job configuration properties defined in the job configuration file
+          PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+          try (InputStreamReader inputStreamReader = new InputStreamReader(filesystem.open(configFilePath),
+              Charsets.UTF_8)) {
+            propertiesConfiguration.load(inputStreamReader);
+            jobProps.putAll(ConfigurationConverter.getProperties(propertiesConfiguration));
+            jobProps.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY, configFilePath.toString());
+            jobConfigs.add(jobProps);
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Recursively load job configuration files under the given directory.
    */
   private static void loadJobConfigsRecursive(List<Properties> jobConfigs, Properties rootProps,
@@ -193,8 +286,8 @@ public class SchedulerUtils {
       }
 
       // Load the properties, which may overwrite the same properties defined in the parent or ancestor directories.
-      rootProps.putAll(ConfigurationConverter
-          .getProperties(new PropertiesConfiguration(new File(jobConfigDir, propertiesFiles[0]))));
+      rootProps.putAll(ConfigurationConverter.getProperties(
+          new PropertiesConfiguration(new File(jobConfigDir, propertiesFiles[0]))));
     }
 
     // Get all non-properties files
@@ -236,7 +329,9 @@ public class SchedulerUtils {
   }
 
   private static Set<String> getJobConfigurationFileExtensions(Properties properties) {
-    Iterable<String> jobConfigFileExtensionsIterable = Splitter.on(",").omitEmptyStrings().trimResults()
+    Iterable<String> jobConfigFileExtensionsIterable = Splitter.on(",")
+        .omitEmptyStrings()
+        .trimResults()
         .split(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_EXTENSIONS_KEY,
             ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_EXTENSIONS));
     return ImmutableSet.copyOf(Iterables.transform(jobConfigFileExtensionsIterable, new Function<String, String>() {

--- a/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
@@ -15,25 +15,28 @@ package gobblin.util;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.Semaphore;
-
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-
 import gobblin.configuration.ConfigurationKeys;
+
 
 
 /**
@@ -47,11 +50,19 @@ public class SchedulerUtilsTest {
   private File subDir11;
   private File subDir2;
 
+  // For general type of File system
+  private URI uri;
+  private FileSystem filesystem;
+  private Path jobConfigDirPath;
+  private Path subDirPath1;
+  private Path subDirPath11;
+  private Path subDirPath2;
+
   @BeforeClass
   public void setUp()
-      throws IOException {
+      throws IOException, URISyntaxException {
     this.jobConfigDir = java.nio.file.Files.createTempDirectory(
-            String.format("gobblin-test_%s_job-conf", this.getClass().getSimpleName())).toFile();
+        String.format("gobblin-test_%s_job-conf", this.getClass().getSimpleName())).toFile();
     FileUtils.forceDeleteOnExit(this.jobConfigDir);
     this.subDir1 = new File(this.jobConfigDir, "test1");
     this.subDir11 = new File(this.subDir1, "test11");
@@ -61,17 +72,34 @@ public class SchedulerUtilsTest {
     this.subDir11.mkdirs();
     this.subDir2.mkdirs();
 
+    // The setting up required for loadGenerailConfigFile, expressed in Path.
+    // TODO: URI should be specified as a Base for FileSystem constructor to recognize.
+    // TODO: Before the unit test, you may not don't want to keep this change.
+    this.uri = new URI("some uri that makes sense.");
+    this.filesystem = FileSystem.get(uri, new Configuration());
+    this.jobConfigDirPath = new Path(uri);
+
+    filesystem.mkdirs(jobConfigDirPath);
+    subDirPath1 = new Path(jobConfigDirPath + "test1");
+    subDirPath2 = new Path(jobConfigDirPath + "test11");
+    subDirPath11 = new Path(jobConfigDirPath + "test2");
+    filesystem.mkdirs(subDirPath1);
+    filesystem.mkdirs(subDirPath2);
+    filesystem.mkdirs(subDirPath11);
+
     Properties rootProps = new Properties();
     rootProps.setProperty("k1", "a1");
     rootProps.setProperty("k2", "a2");
     // test-job-conf-dir/root.properties
     rootProps.store(new FileWriter(new File(this.jobConfigDir, "root.properties")), "");
+    rootProps.store(filesystem.create(new Path(jobConfigDirPath + "root.properties")), "");
 
     Properties props1 = new Properties();
     props1.setProperty("k1", "b1");
     props1.setProperty("k3", "a3");
     // test-job-conf-dir/test1/test.properties
     props1.store(new FileWriter(new File(this.subDir1, "test.properties")), "");
+    props1.store(filesystem.create(new Path(this.subDir1 + "test.properties")), "") ;
 
     Properties jobProps1 = new Properties();
     jobProps1.setProperty("k1", "c1");
@@ -79,11 +107,13 @@ public class SchedulerUtilsTest {
     jobProps1.setProperty("k6", "a6");
     // test-job-conf-dir/test1/test11.pull
     jobProps1.store(new FileWriter(new File(this.subDir1, "test11.pull")), "");
+    jobProps1.store(filesystem.create(new Path(this.subDir1 + "test11.pull")), "") ;
 
     Properties jobProps2 = new Properties();
     jobProps2.setProperty("k7", "a7");
     // test-job-conf-dir/test1/test12.PULL
     jobProps2.store(new FileWriter(new File(this.subDir1, "test12.PULL")), "");
+    jobProps2.store(filesystem.create(new Path(this.subDir1 + "test12.PULL")), "") ;
 
     Properties jobProps3 = new Properties();
     jobProps3.setProperty("k1", "d1");
@@ -91,31 +121,36 @@ public class SchedulerUtilsTest {
     jobProps3.setProperty("k9", "${k8}");
     // test-job-conf-dir/test1/test11/test111.pull
     jobProps3.store(new FileWriter(new File(this.subDir11, "test111.pull")), "");
+    jobProps3.store(filesystem.create(new Path(this.subDir11 + "test111.pull")), "") ;
 
     Properties props2 = new Properties();
     props2.setProperty("k2", "b2");
     props2.setProperty("k5", "a5");
     // test-job-conf-dir/test2/test.properties
     props2.store(new FileWriter(new File(this.subDir2, "test.PROPERTIES")), "");
+    props2.store(filesystem.create(new Path(this.subDir2 + "test.PROPERTIES")), "") ;
 
     Properties jobProps4 = new Properties();
     jobProps4.setProperty("k5", "b5");
     // test-job-conf-dir/test2/test21.PULL
     jobProps4.store(new FileWriter(new File(this.subDir2, "test21.PULL")), "");
+    jobProps4.store(filesystem.create(new Path(this.subDir2 + "test21.PULL")), "") ;
   }
 
+
   @Test
-  public void testLoadJobConfigs()
-      throws ConfigurationException {
+  public void testLoadGenericJobConfigs()
+      throws ConfigurationException, IOException {
     Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    List<Properties> jobConfigs = SchedulerUtils.loadJobConfigs(properties);
+    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, this.uri.toString());
+    List<Properties> jobConfigs = SchedulerUtils.loadGenericJobConfigs(properties) ;
     Assert.assertEquals(jobConfigs.size(), 4);
 
+    // Simply the same testing routine as testLoadJobConfigs()
     // test-job-conf-dir/test1/test11/test111.pull
     Properties jobProps1 = getJobConfigForFile(jobConfigs, "test111.pull");
     Assert.assertEquals(jobProps1.stringPropertyNames().size(), 7);
-    Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps1.getProperty("k1"), "d1");
     Assert.assertEquals(jobProps1.getProperty("k2"), "a2");
@@ -126,7 +161,7 @@ public class SchedulerUtilsTest {
     // test-job-conf-dir/test1/test11.pull
     Properties jobProps2 = getJobConfigForFile(jobConfigs, "test11.pull");
     Assert.assertEquals(jobProps2.stringPropertyNames().size(), 6);
-    Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps2.getProperty("k1"), "c1");
     Assert.assertEquals(jobProps2.getProperty("k2"), "a2");
@@ -136,7 +171,7 @@ public class SchedulerUtilsTest {
     // test-job-conf-dir/test1/test12.PULL
     Properties jobProps3 = getJobConfigForFile(jobConfigs, "test12.PULL");
     Assert.assertEquals(jobProps3.stringPropertyNames().size(), 6);
-    Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps3.getProperty("k1"), "b1");
     Assert.assertEquals(jobProps3.getProperty("k2"), "a2");
@@ -146,24 +181,28 @@ public class SchedulerUtilsTest {
     // test-job-conf-dir/test2/test21.PULL
     Properties jobProps4 = getJobConfigForFile(jobConfigs, "test21.PULL");
     Assert.assertEquals(jobProps4.stringPropertyNames().size(), 5);
-    Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps4.getProperty("k1"), "a1");
     Assert.assertEquals(jobProps4.getProperty("k2"), "b2");
     Assert.assertEquals(jobProps4.getProperty("k5"), "b5");
   }
 
-  @Test(dependsOnMethods = {"testLoadJobConfigs"})
-  public void testLoadJobConfigsWithDoneFile()
+
+  // Testing routine for local file system, for LoadJobConfigsWithDoneFile()
+  @Test(dependsOnMethods = {"testLoadGenericJobConfigs"})
+  public void testLoadGenericJobConfigsWithDoneFile()
       throws ConfigurationException, IOException {
     // Create a .done file for test21.pull so it should not be loaded
-    Files.copy(new File(this.subDir2, "test21.PULL"), new File(this.subDir2, "test21.PULL.done"));
-
+    Path src = new Path(this.subDirPath2, "test21.PULL");
+    Path dst = new Path(this.subDirPath2, "test21.PULL.done");
+    filesystem.copyFromLocalFile(src, dst);
     Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    List<Properties> jobConfigs = SchedulerUtils.loadJobConfigs(properties);
+    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, this.jobConfigDirPath.toString());
+    List<Properties> jobConfigs = SchedulerUtils.loadGenericJobConfigs(properties);
     Assert.assertEquals(jobConfigs.size(), 3);
 
+    // todo : modify the path above first.
     // test-job-conf-dir/test1/test11/test111.pull
     Properties jobProps1 = getJobConfigForFile(jobConfigs, "test111.pull");
     Assert.assertEquals(jobProps1.stringPropertyNames().size(), 7);
@@ -199,8 +238,7 @@ public class SchedulerUtilsTest {
 
     Properties properties = new Properties();
     properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    List<Properties> jobConfigs =
-        SchedulerUtils.loadJobConfigs(properties, commonPropsFile, this.jobConfigDir);
+    List<Properties> jobConfigs = SchedulerUtils.loadJobConfigs(properties, commonPropsFile, this.jobConfigDir);
     Assert.assertEquals(jobConfigs.size(), 3);
 
     // test-job-conf-dir/test1/test11/test111.pull
@@ -247,11 +285,9 @@ public class SchedulerUtilsTest {
     Assert.assertEquals(jobProps.getProperty("k9"), "a8");
   }
 
-  @Test(dependsOnMethods = {
-      "testLoadJobConfigsWithDoneFile",
-      "testLoadJobConfigsForCommonPropsFile",
-      "testLoadJobConfig"})
-  public void testFileAlterationObserver() throws Exception {
+  @Test(dependsOnMethods = {"testLoadJobConfigsWithDoneFile", "testLoadJobConfigsForCommonPropsFile", "testLoadJobConfig"})
+  public void testFileAlterationObserver()
+      throws Exception {
     FileAlterationMonitor monitor = new FileAlterationMonitor(3000);
     final Set<File> fileAltered = Sets.newHashSet();
     final Semaphore semaphore = new Semaphore(0);

--- a/gobblin-yarn/src/main/java/gobblin/yarn/JobConfigurationManager.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/JobConfigurationManager.java
@@ -60,6 +60,7 @@ public class JobConfigurationManager extends AbstractIdleService {
   }
 
   @Override
+  // TODO : Modify this 'File-approach'
   protected void startUp() throws Exception {
     if (this.jobConfDirPath.isPresent()) {
       File path = new File(this.jobConfDirPath.get());
@@ -70,7 +71,7 @@ public class JobConfigurationManager extends AbstractIdleService {
         LOGGER.info("Loading job configurations from " + jobConfigDir);
         Properties properties = new Properties();
         properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, jobConfigDir.getAbsolutePath());
-        List<Properties> jobConfigs = SchedulerUtils.loadJobConfigs(properties);
+        List<Properties> jobConfigs = SchedulerUtils.loadGenericJobConfigs(properties);
         LOGGER.info("Loaded " + jobConfigs.size() + " job configuration(s)");
         for (Properties config : jobConfigs) {
           postNewJobConfigArrival(config.getProperty(ConfigurationKeys.JOB_NAME_KEY), config);


### PR DESCRIPTION
- Replace the original config loading method with new one, which build by general file system api provided by hadoop.fs package. 

--- 

TODO: 
- `JobConfigurationManager` requires modification. What about testing ? [June 27:Addressed in #1066]
