### PR TITLE
Fix includes order

### DIFF
--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/hdfs/SimpleHDFSConfigStore.java
@@ -256,7 +256,8 @@ public class SimpleHDFSConfigStore implements ConfigStore, Deployable<FsDeployme
       if (!includesFileStatus.isDirectory()) {
         try (InputStream includesConfInStream = this.fs.open(includesFileStatus.getPath())) {
           /*
-           * With the natural order of includes, a key found in the first include can not be overriden by the next include.
+           * The includes returned are used to build a fallback chain.
+           * With the natural order, if a key found in the first include it is not be overriden by the next include.
            * By reversing the list, the Typesafe fallbacks are constructed bottom up.
            */
           configKeyPaths.addAll(Lists.newArrayList(

--- a/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/store/hdfs/SimpleHdfsConfigStoreTest.java
+++ b/gobblin-config-management/gobblin-config-core/src/test/java/gobblin/config/store/hdfs/SimpleHdfsConfigStoreTest.java
@@ -127,8 +127,8 @@ public class SimpleHdfsConfigStoreTest {
       List<ConfigKeyPath> imports = this.simpleHDFSConfigStore.getOwnImports(datasetConfigKey, VERSION);
 
       Assert.assertEquals(imports.size(), 2);
-      Assert.assertEquals(imports.get(0).getAbsolutePathString(), tagKey1);
-      Assert.assertEquals(imports.get(1).getAbsolutePathString(), tagKey2);
+      Assert.assertEquals(imports.get(0).getAbsolutePathString(), tagKey2);
+      Assert.assertEquals(imports.get(1).getAbsolutePathString(), tagKey1);
     } finally {
       if (this.fs.exists(datasetPath)) {
         this.fs.delete(datasetPath, true);
@@ -139,7 +139,6 @@ public class SimpleHdfsConfigStoreTest {
   @Test
   public void testGetOwnImportsWithResolution() throws IOException, URISyntaxException, ConfigStoreCreationException {
 
-    System.out.println("testGetOwnImportsWithResolution called");
     String datasetName = "dataset-test-get-own-imports-resolution";
 
     Path datasetPath = new Path(CONFIG_DIR_PATH, datasetName);


### PR DESCRIPTION
The includes returned are used to build a fallback chain.
With the natural order, if a key found in the first include it is not be overriden by the next include.
By reversing the list, the Typesafe fallbacks are constructed bottom up.

@ibuenros can you review?