### PR TITLE
Updated default orc row index stride to a higher number

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtils.java
@@ -45,7 +45,7 @@ public class HiveAvroORCQueryUtils {
   private static final String DEFAULT_ORC_INPUT_FORMAT            = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat";
   private static final String DEFAULT_ORC_OUTPUT_FORMAT           = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat";
   private static final String DEFAULT_ORC_COMPRESSION             = "SNAPPY";
-  private static final String DEFAULT_ORC_ROW_INDEX_STRIDE        = "20000";
+  private static final String DEFAULT_ORC_ROW_INDEX_STRIDE        = "268435456";
   private static final Map<String, String> DEFAULT_TBL_PROPERTIES = ImmutableMap
       .<String, String>builder().
       put(ORC_COMPRESSION_KEY, DEFAULT_ORC_COMPRESSION).


### PR DESCRIPTION
Updated default orc row index stride to a higher number based on internal experimentations. A bit of description around it: https://streever.atlassian.net/wiki/display/HADOOP/Optimizing+ORC+Files+for+Query+Performance 