### PR TITLE
JDBCWriter. Bug fix on SQL statements. Bug fix on data type mapping.

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/initializer/AvroToJdbcEntryConverterInitializer.java
+++ b/gobblin-core/src/main/java/gobblin/converter/initializer/AvroToJdbcEntryConverterInitializer.java
@@ -76,9 +76,11 @@ public class AvroToJdbcEntryConverterInitializer implements ConverterInitializer
   public void initialize() {
     String table = Preconditions.checkNotNull(this.state.getProp(ForkOperatorUtils
         .getPropertyNameForBranch(JdbcPublisher.JDBC_PUBLISHER_FINAL_TABLE_NAME, this.branches, this.branchId)));
+    String db = Preconditions.checkNotNull(this.state.getProp(ForkOperatorUtils
+        .getPropertyNameForBranch(JdbcPublisher.JDBC_PUBLISHER_DATABASE_NAME, this.branches, this.branchId)));
     try (Connection conn = createConnection()) {
       JdbcWriterCommands commands = this.jdbcWriterCommandsFactory.newInstance(this.state, conn);
-      Map<String, JdbcType> dateColumnMapping = commands.retrieveDateColumns(table);
+      Map<String, JdbcType> dateColumnMapping = commands.retrieveDateColumns(db, table);
       LOG.info("Date column mapping: " + dateColumnMapping);
 
       final String dateFieldsKey = ForkOperatorUtils.getPropertyNameForBranch(

--- a/gobblin-core/src/main/java/gobblin/publisher/JdbcPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/JdbcPublisher.java
@@ -148,7 +148,7 @@ public class JdbcPublisher extends DataPublisher {
             ForkOperatorUtils.getPropertyNameForBranch(JDBC_PUBLISHER_REPLACE_FINAL_TABLE, branches, i), false)
             && !emptiedDestTables.contains(destinationTable)) {
           LOG.info("Deleting table " + destinationTable);
-          commands.deleteAll(destinationTable);
+          commands.deleteAll(databaseName, destinationTable);
           emptiedDestTables.add(destinationTable);
         }
 

--- a/gobblin-core/src/main/java/gobblin/writer/commands/JdbcWriterCommands.java
+++ b/gobblin-core/src/main/java/gobblin/writer/commands/JdbcWriterCommands.java
@@ -30,7 +30,7 @@ public interface JdbcWriterCommands extends JdbcBufferedInserter {
    * @param targetTableName
    * @throws SQLException
    */
-  public void createTableStructure(String fromStructure, String targetTableName) throws SQLException;
+  public void createTableStructure(String databaseName, String fromStructure, String targetTableName) throws SQLException;
 
   /**
    * Check if table is empty.
@@ -38,36 +38,37 @@ public interface JdbcWriterCommands extends JdbcBufferedInserter {
    * @return
    * @throws SQLException
    */
-  public boolean isEmpty(String table) throws SQLException;
+  public boolean isEmpty(String database, String table) throws SQLException;
 
   /**
    * Truncates table. Most RDBMS cannot be rollback from this operation.
    * @param table table name to be truncated.
    * @throws SQLException
    */
-  public void truncate(String table) throws SQLException;
+  public void truncate(String database, String table) throws SQLException;
 
   /**
    * Deletes all contents from the table. This method can be rollback if not committed.
    * @param table
    * @throws SQLException
    */
-  public void deleteAll(String table) throws SQLException;
+  public void deleteAll(String database, String table) throws SQLException;
 
   /**
    * Drops the table.
    * @param table
    * @throws SQLException
    */
-  public void drop(String table) throws SQLException;
+  public void drop(String database, String table) throws SQLException;
 
   /**
    * Retrieves date related column such as Date, Time, DateTime, Timestamp etc.
+   * @param database
    * @param table
    * @return Map of column name and JdbcType that is date related.
    * @throws SQLException
    */
-  public Map<String, JdbcType> retrieveDateColumns(String table) throws SQLException;
+  public Map<String, JdbcType> retrieveDateColumns(String database, String table) throws SQLException;
 
   /**
    * Copy all the contents from one table to another. Both table should be in same structure.

--- a/gobblin-core/src/test/java/gobblin/converter/jdbc/AvroToJdbcEntryConverterTest.java
+++ b/gobblin-core/src/test/java/gobblin/converter/jdbc/AvroToJdbcEntryConverterTest.java
@@ -42,6 +42,7 @@ public class AvroToJdbcEntryConverterTest {
 
   @Test
   public void testDateConversion() throws IOException, SchemaConversionException, SQLException {
+    final String db = "db";
     final String table = "users";
     Map<String, JdbcType> dateColums = new HashMap<>();
     dateColums.put("date_of_birth", JdbcType.DATE);
@@ -49,7 +50,7 @@ public class AvroToJdbcEntryConverterTest {
     dateColums.put("created", JdbcType.TIMESTAMP);
 
     JdbcWriterCommands mockWriterCommands = mock(JdbcWriterCommands.class);
-    when(mockWriterCommands.retrieveDateColumns(table)).thenReturn(dateColums);
+    when(mockWriterCommands.retrieveDateColumns(db, table)).thenReturn(dateColums);
 
     JdbcWriterCommandsFactory factory = mock(JdbcWriterCommandsFactory.class);
     when(factory.newInstance(any(State.class), any(Connection.class))).thenReturn(mockWriterCommands);
@@ -85,9 +86,10 @@ public class AvroToJdbcEntryConverterTest {
     Map<String, JdbcType> dateColums = new HashMap<>();
     dateColums.put("last_updated", JdbcType.TIMESTAMP);
 
+    final String db = "db";
     final String table = "users";
     JdbcWriterCommands mockWriterCommands = mock(JdbcWriterCommands.class);
-    when(mockWriterCommands.retrieveDateColumns(table)).thenReturn(dateColums);
+    when(mockWriterCommands.retrieveDateColumns(db, table)).thenReturn(dateColums);
 
     JdbcWriterCommandsFactory factory = mock(JdbcWriterCommandsFactory.class);
     when(factory.newInstance(any(State.class), any(Connection.class))).thenReturn(mockWriterCommands);

--- a/gobblin-core/src/test/java/gobblin/writer/jdbc/JdbcPublisherTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/jdbc/JdbcPublisherTest.java
@@ -83,7 +83,7 @@ public class JdbcPublisherTest {
     inOrder.verify(conn, times(1)).commit();
     inOrder.verify(conn, times(1)).close();
 
-    verify(commands, never()).deleteAll(destinationTable);
+    verify(commands, never()).deleteAll(database, destinationTable);
   }
 
   public void testPublishReplaceOutput() throws IOException, SQLException {
@@ -93,7 +93,7 @@ public class JdbcPublisherTest {
     InOrder inOrder = inOrder(conn, commands, workUnitState);
 
     inOrder.verify(conn, times(1)).setAutoCommit(false);
-    inOrder.verify(commands, times(1)).deleteAll(destinationTable);
+    inOrder.verify(commands, times(1)).deleteAll(database, destinationTable);
     inOrder.verify(commands, times(1)).copyTable(database, stagingTable, destinationTable);
     inOrder.verify(workUnitState, times(1)).setWorkingState(WorkUnitState.WorkingState.COMMITTED);
     inOrder.verify(conn, times(1)).commit();
@@ -119,7 +119,7 @@ public class JdbcPublisherTest {
     inOrder.verify(conn, times(1)).close();
 
     verify(conn, never()).commit();
-    verify(commands, never()).deleteAll(destinationTable);
+    verify(commands, never()).deleteAll(database, destinationTable);
     verify(workUnitState, never()).setWorkingState(any(WorkUnitState.WorkingState.class));
   }
 }

--- a/gobblin-core/src/test/java/gobblin/writer/jdbc/JdbcWriterCommandsTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/jdbc/JdbcWriterCommandsTest.java
@@ -46,7 +46,7 @@ public class JdbcWriterCommandsTest {
     when(pstmt.executeQuery()).thenReturn(rs);
 
     MySqlWriterCommands writerCommands = new MySqlWriterCommands(new State(), conn);
-    Map<String, JdbcType> actual = writerCommands.retrieveDateColumns("users");
+    Map<String, JdbcType> actual = writerCommands.retrieveDateColumns("db", "users");
 
     ImmutableMap.Builder<String, JdbcType> builder = ImmutableMap.builder();
     builder.put("date_of_birth",JdbcType.DATE);

--- a/gobblin-core/src/test/java/gobblin/writer/jdbc/JdbcWriterInitializerTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/jdbc/JdbcWriterInitializerTest.java
@@ -41,6 +41,7 @@ import com.google.common.collect.Lists;
 
 @Test(groups = { "gobblin.writer" })
 public class JdbcWriterInitializerTest {
+  private static final String DB = "db";
   private static final String DEST_TABLE = "dest";
   private static final String STAGING_TABLE = "stage";
 
@@ -56,6 +57,7 @@ public class JdbcWriterInitializerTest {
   private void setup() throws SQLException {
     this.state = new State();
     this.state.setProp(ConfigurationKeys.WRITER_DESTINATION_TYPE_KEY, DestinationType.MYSQL.name());
+    this.state.setProp(JdbcPublisher.JDBC_PUBLISHER_DATABASE_NAME, DB);
     this.state.setProp(JdbcPublisher.JDBC_PUBLISHER_FINAL_TABLE_NAME, DEST_TABLE);
 
     this.workUnit = WorkUnit.createEmpty();
@@ -79,9 +81,9 @@ public class JdbcWriterInitializerTest {
     this.initializer.initialize();
     this.initializer.close();
     Assert.assertEquals(DEST_TABLE, this.workUnit.getProp(ConfigurationKeys.WRITER_STAGING_TABLE));
-    verify(this.commands, never()).createTableStructure(anyString(), anyString());
-    verify(this.commands, never()).truncate(anyString());
-    verify(this.commands, never()).drop(anyString());
+    verify(this.commands, never()).createTableStructure(anyString(), anyString(), anyString());
+    verify(this.commands, never()).truncate(anyString(), anyString());
+    verify(this.commands, never()).drop(anyString(), anyString());
   }
 
   public void skipStagingTableTruncateDestTable() throws SQLException {
@@ -92,47 +94,47 @@ public class JdbcWriterInitializerTest {
     this.initializer.initialize();
     Assert.assertEquals(DEST_TABLE, this.workUnit.getProp(ConfigurationKeys.WRITER_STAGING_TABLE));
 
-    verify(this.commands, never()).createTableStructure(anyString(), anyString());
+    verify(this.commands, never()).createTableStructure(anyString(), anyString(), anyString());
     InOrder inOrder = inOrder(this.commands);
-    inOrder.verify(this.commands, times(1)).truncate(DEST_TABLE);
+    inOrder.verify(this.commands, times(1)).truncate(DB, DEST_TABLE);
 
     this.initializer.close();
-    inOrder.verify(this.commands, never()).truncate(anyString());
-    verify(this.commands, never()).drop(anyString());
+    inOrder.verify(this.commands, never()).truncate(anyString(), anyString());
+    verify(this.commands, never()).drop(anyString(), anyString());
   }
 
   public void userCreatedStagingTable() throws SQLException {
     this.state.setProp(ConfigurationKeys.WRITER_STAGING_TABLE, STAGING_TABLE);
-    when(this.commands.isEmpty(STAGING_TABLE)).thenReturn(Boolean.TRUE);
+    when(this.commands.isEmpty(DB, STAGING_TABLE)).thenReturn(Boolean.TRUE);
 
     this.initializer.initialize();
 
     Assert.assertEquals(STAGING_TABLE, this.workUnit.getProp(ConfigurationKeys.WRITER_STAGING_TABLE));
-    verify(this.commands, never()).createTableStructure(anyString(), anyString());
-    verify(this.commands, never()).truncate(anyString());
-    verify(this.commands, never()).drop(anyString());
+    verify(this.commands, never()).createTableStructure(anyString(), anyString(), anyString());
+    verify(this.commands, never()).truncate(anyString(), anyString());
+    verify(this.commands, never()).drop(anyString(), anyString());
   }
 
   public void userCreatedStagingTableTruncate() throws SQLException {
     this.state.setProp(ConfigurationKeys.WRITER_STAGING_TABLE, STAGING_TABLE);
     this.state.setProp(ConfigurationKeys.WRITER_TRUNCATE_STAGING_TABLE, Boolean.toString(true));
-    when(this.commands.isEmpty(STAGING_TABLE)).thenReturn(Boolean.TRUE);
+    when(this.commands.isEmpty(DB, STAGING_TABLE)).thenReturn(Boolean.TRUE);
 
     this.initializer.initialize();
     Assert.assertEquals(STAGING_TABLE, this.workUnit.getProp(ConfigurationKeys.WRITER_STAGING_TABLE));
 
     InOrder inOrder = inOrder(this.commands);
-    inOrder.verify(this.commands, times(1)).truncate(STAGING_TABLE);
+    inOrder.verify(this.commands, times(1)).truncate(DB, STAGING_TABLE);
 
     this.initializer.close();
-    inOrder.verify(this.commands, times(1)).truncate(STAGING_TABLE);
+    inOrder.verify(this.commands, times(1)).truncate(DB, STAGING_TABLE);
 
-    verify(this.commands, never()).createTableStructure(anyString(), anyString());
-    verify(this.commands, never()).drop(anyString());
+    verify(this.commands, never()).createTableStructure(anyString(), anyString(), anyString());
+    verify(this.commands, never()).drop(anyString(), anyString());
   }
 
   public void initializeWithCreatingStagingTable() throws SQLException {
-    when(this.commands.isEmpty(STAGING_TABLE)).thenReturn(Boolean.TRUE);
+    when(this.commands.isEmpty(DB, STAGING_TABLE)).thenReturn(Boolean.TRUE);
     DatabaseMetaData metadata = mock(DatabaseMetaData.class);
     when(this.conn.getMetaData()).thenReturn(metadata);
     ResultSet rs = mock(ResultSet.class);
@@ -144,12 +146,12 @@ public class JdbcWriterInitializerTest {
     Assert.assertTrue(!StringUtils.isEmpty(this.workUnit.getProp(ConfigurationKeys.WRITER_STAGING_TABLE)));
 
     InOrder inOrder = inOrder(this.commands);
-    inOrder.verify(this.commands, times(1)).createTableStructure(anyString(), anyString());
-    inOrder.verify(this.commands, times(1)).drop(anyString());
-    inOrder.verify(this.commands, times(1)).createTableStructure(anyString(), anyString());
+    inOrder.verify(this.commands, times(1)).createTableStructure(anyString(), anyString(), anyString());
+    inOrder.verify(this.commands, times(1)).drop(anyString(), anyString());
+    inOrder.verify(this.commands, times(1)).createTableStructure(anyString(), anyString(), anyString());
 
     this.initializer.close();
-    inOrder.verify(this.commands, times(1)).drop(anyString());
-    inOrder.verify(this.commands, never()).truncate(anyString());
+    inOrder.verify(this.commands, times(1)).drop(anyString(), anyString());
+    inOrder.verify(this.commands, never()).truncate(anyString(), anyString());
   }
 }


### PR DESCRIPTION
- Bug fix on data type mapping to use java.sql.Timestamp on MySQL's DATETIME data type.
- Bug fix on SQL statements. Added database check in "where" clause on SQL statements. Previously, it was depending on either default database or the connection.

Passed unit test and integration test.