### PR TITLE
Converted Hive dereg / registration to post publish steps, fixed miss…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopySource.java
@@ -279,7 +279,9 @@ public class CopySource extends AbstractSource<String, FileAwareInputStream> {
             computeAndSetWorkUnitGuid(workUnit);
             workUnitsForPartition.add(workUnit);
           }
-          this.workUnitList.addFileSet(fileSet, workUnitsForPartition);
+          if (workUnitsForPartition.size() > 0) {
+            this.workUnitList.addFileSet(fileSet, workUnitsForPartition);
+          }
         }
       } catch (IOException ioe) {
         throw new RuntimeException("Failed to generate work units for dataset " + this.copyableDataset.datasetURN(),

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveCopyEntityHelper.java
@@ -568,12 +568,12 @@ public class HiveCopyEntityHelper {
     if (!partitionPaths.isEmpty()) {
       DeleteFileCommitStep deletePaths = DeleteFileCommitStep.fromPaths(this.targetFs, partitionPaths,
           this.dataset.getProperties(), table.getDataLocation());
-      copyEntities.add(new PrePublishStep(fileSet, Maps.<String, Object> newHashMap(), deletePaths, stepPriority++));
+      copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object> newHashMap(), deletePaths, stepPriority++));
     }
 
     PartitionDeregisterStep deregister =
         new PartitionDeregisterStep(table.getTTable(), partition.getTPartition(), this.targetURI, this.hiveRegProps);
-    copyEntities.add(new PrePublishStep(fileSet, Maps.<String, Object> newHashMap(), deregister, stepPriority++));
+    copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object> newHashMap(), deregister, stepPriority++));
     return stepPriority;
   }
 
@@ -606,19 +606,19 @@ public class HiveCopyEntityHelper {
     if (!tablePaths.isEmpty()) {
       DeleteFileCommitStep deletePaths = DeleteFileCommitStep.fromPaths(this.getTargetFs(), tablePaths,
           this.getDataset().getProperties(), table.getDataLocation());
-      copyEntities.add(new PrePublishStep(fileSet, Maps.<String, Object> newHashMap(), deletePaths, stepPriority++));
+      copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object> newHashMap(), deletePaths, stepPriority++));
     }
 
     TableDeregisterStep deregister =
         new TableDeregisterStep(table.getTTable(), this.getTargetURI(), this.getHiveRegProps());
-    copyEntities.add(new PrePublishStep(fileSet, Maps.<String, Object> newHashMap(), deregister, stepPriority++));
+    copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object> newHashMap(), deregister, stepPriority++));
     return stepPriority;
   }
 
   private int addSharedSteps(List<CopyEntity> copyEntities, String fileSet, int initialPriority) {
     int priority = initialPriority;
     if (this.tableRegistrationStep.isPresent()) {
-      copyEntities.add(new PrePublishStep(fileSet, Maps.<String, Object> newHashMap(), this.tableRegistrationStep.get(),
+      copyEntities.add(new PostPublishStep(fileSet, Maps.<String, Object> newHashMap(), this.tableRegistrationStep.get(),
           priority++));
     }
     return priority;
@@ -678,7 +678,7 @@ public class HiveCopyEntityHelper {
 
     for (CopyableFile.Builder builder : getCopyableFilesFromPaths(diffPathSet.filesToCopy, this.configuration,
         Optional.<Partition> absent())) {
-      copyEntities.add(builder.build());
+      copyEntities.add(builder.fileSet(fileSet).build());
     }
 
     multiTimer.close();

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -35,6 +35,7 @@ import com.google.common.collect.Maps;
 
 import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyEntity;
+import gobblin.data.management.copy.entities.PostPublishStep;
 import gobblin.data.management.copy.entities.PrePublishStep;
 import gobblin.data.management.copy.hive.HiveCopyEntityHelper.DeregisterFileDeleteMethod;
 import gobblin.hive.HiveRegProps;
@@ -168,8 +169,8 @@ public class HiveCopyEntityHelperTest {
     Assert.assertTrue(priority == 1);
     Assert.assertTrue(copyEntities.size() == 1);
 
-    Assert.assertTrue(copyEntities.get(0) instanceof PrePublishStep);
-    PrePublishStep p = (PrePublishStep) (copyEntities.get(0));
+    Assert.assertTrue(copyEntities.get(0) instanceof PostPublishStep);
+    PostPublishStep p = (PostPublishStep) (copyEntities.get(0));
     Assert
         .assertTrue(p.getStep().toString().contains("Deregister table TestDB.TestTable on Hive metastore /targetURI"));
   }


### PR DESCRIPTION
…ing fileset.

This PR fixes two issues:
* For non-partitioned hive tables, the Hive registration and the file publishing were different file sets, so they could happen out of order.
* Made all table/partition deregistration and registration post-publish steps (used to be pre-publish steps), this ensures that the data is available as soon as the new table gets swapped.