### PR TITLE
Parallelize commit rebased

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -97,6 +97,8 @@ public class ConfigurationKeys {
   public static final String DEFAULT_FORK_OPERATOR_CLASS = "gobblin.fork.IdentityForkOperator";
   public static final String JOB_COMMIT_POLICY_KEY = "job.commit.policy";
   public static final String DEFAULT_JOB_COMMIT_POLICY = "full";
+  public static final String PARALLELIZE_DATASET_COMMIT = "job.commit.parallelize";
+  public static final boolean DEFAULT_PARALLELIZE_DATASET_COMMIT = true;
   public static final String WORK_UNIT_RETRY_POLICY_KEY = "workunit.retry.policy";
   public static final String WORK_UNIT_RETRY_ENABLED_KEY = "workunit.retry.enabled";
   public static final String JOB_RUN_ONCE_KEY = "job.runonce";
@@ -448,20 +450,20 @@ public class ConfigurationKeys {
   public static final String DEFAULT_METRICS_ENABLED = Boolean.toString(true);
   public static final String METRICS_REPORT_INTERVAL_KEY = METRICS_CONFIGURATIONS_PREFIX + "report.interval";
   public static final String DEFAULT_METRICS_REPORT_INTERVAL = Long.toString(TimeUnit.SECONDS.toMillis(30));
-  
-  // File-based reporting 
+
+  // File-based reporting
   public static final String METRICS_REPORTING_FILE_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.file.enabled";
   public static final String DEFAULT_METRICS_REPORTING_FILE_ENABLED = Boolean.toString(false);
   public static final String METRICS_LOG_DIR_KEY = METRICS_CONFIGURATIONS_PREFIX + "log.dir";
   public static final String METRICS_FILE_SUFFIX = METRICS_CONFIGURATIONS_PREFIX + "reporting.file.suffix";
   public static final String DEFAULT_METRICS_FILE_SUFFIX = "";
-  
+
   // JMX-based reporting
   public static final String METRICS_REPORTING_JMX_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.jmx.enabled";
   public static final String DEFAULT_METRICS_REPORTING_JMX_ENABLED = Boolean.toString(false);
-  
+
   // Kafka-based reporting
   public static final String METRICS_REPORTING_KAFKA_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.enabled";
@@ -481,49 +483,49 @@ public class ConfigurationKeys {
   // Topic used only for event reporting.
   public static final String METRICS_KAFKA_TOPIC_EVENTS =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.kafka.topic.events";
-  
+
   //Graphite-based reporting
-  public static final String METRICS_REPORTING_GRAPHITE_METRICS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_GRAPHITE_METRICS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.metrics.enabled";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_METRICS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.events.enabled";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_EVENTS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_GRAPHITE_HOSTNAME = 
+  public static final String METRICS_REPORTING_GRAPHITE_HOSTNAME =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.hostname";
-  public static final String METRICS_REPORTING_GRAPHITE_PORT = 
+  public static final String METRICS_REPORTING_GRAPHITE_PORT =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.port";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_PORT = "2003";
-  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_PORT = 
+  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_PORT =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.events.port";
-  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_VALUE_AS_KEY = 
+  public static final String METRICS_REPORTING_GRAPHITE_EVENTS_VALUE_AS_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.events.value.as.key";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_EVENTS_VALUE_AS_KEY = Boolean.toString(false);
-  public static final String METRICS_REPORTING_GRAPHITE_SENDING_TYPE = 
+  public static final String METRICS_REPORTING_GRAPHITE_SENDING_TYPE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.graphite.sending.type";
   public static final String DEFAULT_METRICS_REPORTING_GRAPHITE_SENDING_TYPE = "TCP";
-  
+
   //InfluxDB-based reporting
-  public static final String METRICS_REPORTING_INFLUXDB_METRICS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_INFLUXDB_METRICS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.metrics.enabled";
   public static final String DEFAULT_METRICS_REPORTING_INFLUXDB_METRICS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_ENABLED_KEY = 
+  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_ENABLED_KEY =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.events.enabled";
   public static final String DEFAULT_METRICS_REPORTING_INFLUXDB_EVENTS_ENABLED = Boolean.toString(false);
-  public static final String METRICS_REPORTING_INFLUXDB_URL = 
+  public static final String METRICS_REPORTING_INFLUXDB_URL =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.url";
-  public static final String METRICS_REPORTING_INFLUXDB_DATABASE = 
+  public static final String METRICS_REPORTING_INFLUXDB_DATABASE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.database";
-  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_DATABASE = 
+  public static final String METRICS_REPORTING_INFLUXDB_EVENTS_DATABASE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.events.database";
-  public static final String METRICS_REPORTING_INFLUXDB_USER = 
+  public static final String METRICS_REPORTING_INFLUXDB_USER =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.user";
-  public static final String METRICS_REPORTING_INFLUXDB_PASSWORD = 
+  public static final String METRICS_REPORTING_INFLUXDB_PASSWORD =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.password";
-  public static final String METRICS_REPORTING_INFLUXDB_SENDING_TYPE = 
+  public static final String METRICS_REPORTING_INFLUXDB_SENDING_TYPE =
       METRICS_CONFIGURATIONS_PREFIX + "reporting.influxdb.sending.type";
   public static final String DEFAULT_METRICS_REPORTING_INFLUXDB_SENDING_TYPE = "TCP";
-  
+
   //Custom-reporting
   public static final String METRICS_CUSTOM_BUILDERS = METRICS_CONFIGURATIONS_PREFIX + "reporting.custom.builders";
 

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -97,8 +97,14 @@ public class ConfigurationKeys {
   public static final String DEFAULT_FORK_OPERATOR_CLASS = "gobblin.fork.IdentityForkOperator";
   public static final String JOB_COMMIT_POLICY_KEY = "job.commit.policy";
   public static final String DEFAULT_JOB_COMMIT_POLICY = "full";
+  // If true, commit of different datasets will be performed in parallel
+  // only turn on if publisher is thread-safe
   public static final String PARALLELIZE_DATASET_COMMIT = "job.commit.parallelize";
-  public static final boolean DEFAULT_PARALLELIZE_DATASET_COMMIT = true;
+  public static final boolean DEFAULT_PARALLELIZE_DATASET_COMMIT = false;
+  /** Only applicable if {@link #PARALLELIZE_DATASET_COMMIT} is true. */
+  public static final String DATASET_COMMIT_THREADS = "job.commit.parallelCommits";
+  public static final int DEFAULT_DATASET_COMMIT_THREADS = 20;
+
   public static final String WORK_UNIT_RETRY_POLICY_KEY = "workunit.retry.policy";
   public static final String WORK_UNIT_RETRY_ENABLED_KEY = "workunit.retry.enabled";
   public static final String JOB_RUN_ONCE_KEY = "job.runonce";

--- a/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
@@ -77,4 +77,16 @@ public abstract class DataPublisher implements Closeable {
     Constructor<? extends DataPublisher> dataPublisherConstructor = dataPublisherClass.getConstructor(State.class);
     return dataPublisherConstructor.newInstance(state);
   }
+
+  /**
+   * Returns true if the implementation of {@link DataPublisher} is thread-safe.
+   *
+   * <p>
+   *   For a thread-safe {@link DataPublisher}, this method should return this.getClass() == <class>.class
+   *   to ensure that any extensions must explicitly be marked as thread safe.
+   * </p>
+   */
+  public boolean isThreadSafe() {
+    return this.getClass() == DataPublisher.class;
+  }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -62,6 +62,12 @@ import gobblin.util.HadoopUtils;
 public class CopyDataPublisher extends DataPublisher implements UnpublishedHandling {
 
   private final Path writerOutputDir;
+
+  @Override
+  public boolean isThreadSafe() {
+    return this.getClass() == CopyDataPublisher.class;
+  }
+
   private final FileSystem fs;
   protected final EventSubmitter eventSubmitter;
   protected final RecoveryHelper recoveryHelper;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -14,15 +14,14 @@ package gobblin.runtime;
 
 import java.io.IOException;
 import java.net.URI;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Future;
 
 import javax.annotation.Nullable;
+import lombok.AccessLevel;
 import lombok.Getter;
 
 import org.apache.hadoop.conf.Configuration;
@@ -31,36 +30,28 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Strings;
-import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Maps;
 import com.google.common.eventbus.Subscribe;
-import com.google.common.io.Closer;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 
-import gobblin.commit.CommitSequence;
-import gobblin.commit.CommitSequence.Builder;
 import gobblin.commit.CommitSequenceStore;
-import gobblin.commit.CommitStep;
 import gobblin.commit.DeliverySemantics;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
-import gobblin.configuration.WorkUnitState;
 import gobblin.instrumented.Instrumented;
 import gobblin.metastore.JobHistoryStore;
 import gobblin.metastore.MetaStoreModule;
 import gobblin.metrics.GobblinMetrics;
-import gobblin.publisher.CommitSequencePublisher;
 import gobblin.publisher.DataPublisher;
-import gobblin.publisher.UnpublishedHandling;
 import gobblin.runtime.JobState.DatasetState;
-import gobblin.runtime.commit.DatasetStateCommitStep;
 import gobblin.runtime.commit.FsCommitSequenceStore;
 import gobblin.runtime.util.JobMetrics;
 import gobblin.source.Source;
@@ -87,16 +78,22 @@ public class JobContext {
   private final String jobName;
   private final String jobId;
   private final JobState jobState;
+  @Getter(AccessLevel.PACKAGE)
   private final JobCommitPolicy jobCommitPolicy;
   private final boolean jobLockEnabled;
   private final Optional<JobMetrics> jobMetricsOptional;
   private final Source<?, ?> source;
 
   // State store for persisting job states
+  @Getter(AccessLevel.PACKAGE)
   private final FsDatasetStateStore datasetStateStore;
 
   // Store for runtime job execution information
   private final Optional<JobHistoryStore> jobHistoryStoreOptional;
+
+  // Should commits be done in parallel
+  private final boolean parallelizeCommit;
+  private final int parallelCommits;
 
   @Getter
   private final DeliverySemantics semantics;
@@ -129,25 +126,8 @@ public class JobContext {
       conf.set(key, jobProps.getProperty(key));
     }
 
-    String stateStoreFsUri =
-        jobProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI);
-    FileSystem stateStoreFs = FileSystem.get(URI.create(stateStoreFsUri), conf);
-    String stateStoreRootDir = jobProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY);
-    if (jobProps.containsKey(ConfigurationKeys.STATE_STORE_ENABLED) &&
-        !Boolean.parseBoolean(jobProps.getProperty(ConfigurationKeys.STATE_STORE_ENABLED))) {
-      this.datasetStateStore = new NoopDatasetStateStore(stateStoreFs, stateStoreRootDir);
-    } else {
-      this.datasetStateStore = new FsDatasetStateStore(stateStoreFs, stateStoreRootDir);
-    }
-
-    boolean jobHistoryStoreEnabled = Boolean
-        .valueOf(jobProps.getProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, Boolean.FALSE.toString()));
-    if (jobHistoryStoreEnabled) {
-      Injector injector = Guice.createInjector(new MetaStoreModule(jobProps));
-      this.jobHistoryStoreOptional = Optional.of(injector.getInstance(JobHistoryStore.class));
-    } else {
-      this.jobHistoryStoreOptional = Optional.absent();
-    }
+    this.datasetStateStore = createStateStore(jobProps, conf);
+    this.jobHistoryStoreOptional = createJobHistoryStore(jobProps);
 
     State jobPropsState = new State();
     jobPropsState.addAll(jobProps);
@@ -166,14 +146,42 @@ public class JobContext {
     this.semantics = DeliverySemantics.parse(this.jobState);
     this.commitSequenceStore = createCommitSequenceStore();
 
-    this.source = new SourceDecorator<>(
-        Source.class.cast(Class.forName(jobProps.getProperty(ConfigurationKeys.SOURCE_CLASS_KEY)).newInstance()),
-        this.jobId, logger);
+    this.source = createSource(jobProps);
 
     this.logger = logger;
+
+    this.parallelizeCommit = this.jobState.getPropAsBoolean(ConfigurationKeys.PARALLELIZE_DATASET_COMMIT,
+        ConfigurationKeys.DEFAULT_PARALLELIZE_DATASET_COMMIT);
+    this.parallelCommits = this.parallelizeCommit
+        ? this.jobState.getPropAsInt(ConfigurationKeys.DATASET_COMMIT_THREADS, ConfigurationKeys.DEFAULT_DATASET_COMMIT_THREADS)
+        : 1;
   }
 
-  private Optional<CommitSequenceStore> createCommitSequenceStore() throws IOException {
+  protected FsDatasetStateStore createStateStore(Properties jobProps, Configuration conf) throws IOException {
+    String stateStoreFsUri =
+        jobProps.getProperty(ConfigurationKeys.STATE_STORE_FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI);
+    FileSystem stateStoreFs = FileSystem.get(URI.create(stateStoreFsUri), conf);
+    String stateStoreRootDir = jobProps.getProperty(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY);
+    if (jobProps.containsKey(ConfigurationKeys.STATE_STORE_ENABLED) &&
+        !Boolean.parseBoolean(jobProps.getProperty(ConfigurationKeys.STATE_STORE_ENABLED))) {
+      return new NoopDatasetStateStore(stateStoreFs, stateStoreRootDir);
+    } else {
+      return new FsDatasetStateStore(stateStoreFs, stateStoreRootDir);
+    }
+  }
+
+  protected Optional<JobHistoryStore> createJobHistoryStore(Properties jobProps) {
+    boolean jobHistoryStoreEnabled = Boolean
+        .valueOf(jobProps.getProperty(ConfigurationKeys.JOB_HISTORY_STORE_ENABLED_KEY, Boolean.FALSE.toString()));
+    if (jobHistoryStoreEnabled) {
+      Injector injector = Guice.createInjector(new MetaStoreModule(jobProps));
+      return Optional.of(injector.getInstance(JobHistoryStore.class));
+    } else {
+      return Optional.absent();
+    }
+  }
+
+  protected Optional<CommitSequenceStore> createCommitSequenceStore() throws IOException {
 
     if (this.semantics != DeliverySemantics.EXACTLY_ONCE) {
       return Optional.<CommitSequenceStore> absent();
@@ -188,6 +196,13 @@ public class JobContext {
       return Optional.<CommitSequenceStore> of(new FsCommitSequenceStore(fs,
           new Path(this.jobState.getProp(FsCommitSequenceStore.GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_DIR))));
     }
+  }
+
+  protected Source<?, ?> createSource(Properties jobProps)
+      throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    return new SourceDecorator<>(
+        Source.class.cast(Class.forName(jobProps.getProperty(ConfigurationKeys.SOURCE_CLASS_KEY)).newInstance()),
+        this.jobId, logger);
   }
 
   /**
@@ -244,7 +259,7 @@ public class JobContext {
     return this.jobLockEnabled;
   }
 
-  private void setTaskStagingAndOutputDirs() {
+  protected void setTaskStagingAndOutputDirs() {
     if (this.jobState.contains(ConfigurationKeys.TASK_DATA_ROOT_DIR_KEY)) {
 
       // Add jobId to task data root dir
@@ -354,10 +369,10 @@ public class JobContext {
    * Commit the job on a per-dataset basis.
    */
   void commit() throws IOException {
-    this.datasetStatesByUrns = Optional.of(this.jobState.createDatasetStatesByUrns());
+    this.datasetStatesByUrns = Optional.of(computeDatasetStatesByUrns());
     final boolean shouldCommitDataInJob = shouldCommitDataInJob(this.jobState);
     final DeliverySemantics deliverySemantics = DeliverySemantics.parse(this.jobState);
-    int numCommitThreads = numCommitThreads(this.jobState);
+    final int numCommitThreads = numCommitThreads();
 
     if (!shouldCommitDataInJob) {
       this.logger.info("Job will not commit data since data are committed by tasks.");
@@ -369,22 +384,18 @@ public class JobContext {
           new Function<Map.Entry<String, DatasetState>, Callable<Void>>() {
             @Nullable
             @Override
-            public Callable<Void> apply(@Nullable final Map.Entry<String, DatasetState> entry) {
-              return new Callable<Void>() {
-                @Override
-                public Void call()
-                    throws Exception {
-                  processDatasetCommit(shouldCommitDataInJob, deliverySemantics, entry.getKey(), entry.getValue());
-                  return null;
-                }
-              };
+            public Callable<Void> apply(final Map.Entry<String, DatasetState> entry) {
+              return createSafeDatasetCommit(shouldCommitDataInJob, deliverySemantics, entry.getKey(), entry.getValue(),
+                  numCommitThreads > 1, JobContext.this);
             }
           }).iterator(), numCommitThreads, ExecutorsUtils.newThreadFactory(Optional.of(this.logger), Optional.of("Commit-thread-%d")))
           .executeAndGetResults();
+
       if (!IteratorExecutor.verifyAllSuccessful(result)) {
         this.jobState.setState(JobState.RunningState.FAILED);
         throw new IOException("Failed to commit dataset state for some dataset(s) of job " + this.jobId);
       }
+
     } catch (InterruptedException exc) {
       throw new IOException(exc);
     }
@@ -392,93 +403,27 @@ public class JobContext {
     this.jobState.setState(JobState.RunningState.COMMITTED);
   }
 
-  private int numCommitThreads(JobState jobState) {
-    return jobState.getPropAsBoolean(ConfigurationKeys.PARALLELIZE_DATASET_COMMIT,
-        ConfigurationKeys.DEFAULT_PARALLELIZE_DATASET_COMMIT) ? 20 : 1;
+  private int numCommitThreads() {
+    return this.parallelCommits;
+  }
+
+  /**
+   * The only reason for this methods is so that we can test the parallelization of commits.
+   * DO NOT OVERRIDE.
+   */
+  @VisibleForTesting
+  protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob, DeliverySemantics deliverySemantics,
+      String datasetUrn, JobState.DatasetState datasetState, boolean isMultithreaded, JobContext jobContext) {
+    return new SafeDatasetCommit(shouldCommitDataInJob, deliverySemantics, datasetUrn, datasetState,
+        isMultithreaded, jobContext);
+  }
+
+  protected Map<String, JobState.DatasetState> computeDatasetStatesByUrns() {
+    return this.jobState.createDatasetStatesByUrns();
   }
 
   @SuppressWarnings("unchecked")
-  boolean processDatasetCommit(boolean shouldCommitDataInJob, DeliverySemantics deliverySemantics, String datasetUrn,
-      JobState.DatasetState datasetState) throws IOException {
-    boolean success = true;
-
-    finalizeDatasetStateBeforeCommit(datasetState);
-
-    Class<? extends DataPublisher> dataPublisherClass = null;
-    try (Closer closer = Closer.create()) {
-      dataPublisherClass = getJobDataPublisherClass(this.jobState)
-          .or((Class<? extends DataPublisher>) Class.forName(ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
-      if (!canCommitDataset(datasetState)) {
-        this.logger.warn(String.format("Not committing dataset %s of job %s with commit policy %s and state %s",
-            datasetUrn, this.jobId, this.jobCommitPolicy, datasetState.getState()));
-        checkForUnpublishedWUHandling(datasetUrn, datasetState, dataPublisherClass, closer);
-        success = false;
-      }
-    } catch (ReflectiveOperationException roe) {
-      this.logger.warn("Unable to find publisher class: " + roe, roe);
-      success = false;
-    }
-
-    if (!success) {
-      return false;
-    }
-
-    Optional<CommitSequence.Builder> commitSequenceBuilder = Optional.<CommitSequence.Builder> absent();
-    try (Closer closer = Closer.create()) {
-      if (shouldCommitDataInJob) {
-        this.logger.info(String.format("Committing dataset %s of job %s with commit policy %s and state %s", datasetUrn,
-            this.jobId, this.jobCommitPolicy, datasetState.getState()));
-        if (deliverySemantics == DeliverySemantics.EXACTLY_ONCE) {
-          generateCommitSequenceBuilder(datasetState);
-        } else {
-          commitDataset(datasetState, closer.register(DataPublisher.getInstance(dataPublisherClass, this.jobState)));
-        }
-      } else {
-        if (datasetState.getState() == JobState.RunningState.SUCCESSFUL) {
-          datasetState.setState(JobState.RunningState.COMMITTED);
-        }
-      }
-    } catch (ReflectiveOperationException roe) {
-      this.logger.error(
-          String.format("Failed to instantiate data publisher for dataset %s of job %s.", datasetUrn, this.jobId), roe);
-      success = false;
-    } catch (IOException ioe) {
-      this.logger
-          .error(String.format("Failed to commit dataset state for dataset %s of job %s", datasetUrn, this.jobId), ioe);
-      success = false;
-    } finally {
-      try {
-        finalizeDatasetState(datasetState, datasetUrn);
-
-        if (commitSequenceBuilder.isPresent()) {
-          buildAndExecuteCommitSequence(commitSequenceBuilder.get(), datasetState, datasetUrn);
-          datasetState.setState(JobState.RunningState.COMMITTED);
-        } else {
-          persistDatasetState(datasetUrn, datasetState);
-        }
-      } catch (IOException | RuntimeException ioe) {
-        this.logger.error(
-            String.format("Failed to persist dataset state for dataset %s of job %s", datasetUrn, this.jobId), ioe);
-        success = false;
-      }
-    }
-    return success;
-  }
-
-  void checkForUnpublishedWUHandling(String datasetUrn, JobState.DatasetState datasetState,
-      Class<? extends DataPublisher> dataPublisherClass, Closer closer)
-      throws ReflectiveOperationException, IOException {
-    if (UnpublishedHandling.class.isAssignableFrom(dataPublisherClass)) {
-      // pass in jobstate to retrieve properties
-      DataPublisher publisher = closer.register(DataPublisher.getInstance(dataPublisherClass, this.jobState));
-      this.logger.info(String.format("Calling publisher to handle unpublished work units for dataset %s of job %s.",
-          datasetUrn, this.jobId));
-      ((UnpublishedHandling) publisher).handleUnpublishedWorkUnits(datasetState.getTaskStatesAsWorkUnitStates());
-    }
-  }
-
-  @SuppressWarnings("unchecked")
-  private static Optional<Class<? extends DataPublisher>> getJobDataPublisherClass(State state)
+  public static Optional<Class<? extends DataPublisher>> getJobDataPublisherClass(State state)
       throws ReflectiveOperationException {
     if (!Strings.isNullOrEmpty(state.getProp(ConfigurationKeys.JOB_DATA_PUBLISHER_TYPE))) {
       return Optional.<Class<? extends DataPublisher>> of(
@@ -498,7 +443,7 @@ public class JobContext {
    * Data should be committed by the job if either {@link ConfigurationKeys#JOB_COMMIT_POLICY_KEY} is set to "full",
    * or {@link ConfigurationKeys#PUBLISH_DATA_AT_JOB_LEVEL} is set to true.
    */
-  public static boolean shouldCommitDataInJob(State state) {
+  private static boolean shouldCommitDataInJob(State state) {
     boolean jobCommitPolicyIsFull =
         JobCommitPolicy.getCommitPolicy(state.getProperties()) == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS;
     boolean publishDataAtJobLevel = state.getPropAsBoolean(ConfigurationKeys.PUBLISH_DATA_AT_JOB_LEVEL,
@@ -508,133 +453,4 @@ public class JobContext {
     return jobCommitPolicyIsFull || publishDataAtJobLevel || jobDataPublisherSpecified;
   }
 
-  /**
-   * Finalize a given {@link JobState.DatasetState} before committing the dataset.
-   *
-   * This method is thread-safe.
-   */
-  private void finalizeDatasetStateBeforeCommit(JobState.DatasetState datasetState) {
-    for (TaskState taskState : datasetState.getTaskStates()) {
-      if (taskState.getWorkingState() != WorkUnitState.WorkingState.SUCCESSFUL
-          && this.jobCommitPolicy == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS) {
-        // The dataset state is set to FAILED if any task failed and COMMIT_ON_FULL_SUCCESS is used
-        datasetState.setState(JobState.RunningState.FAILED);
-        datasetState.incrementJobFailures();
-        return;
-      }
-    }
-
-    datasetState.setState(JobState.RunningState.SUCCESSFUL);
-    datasetState.setNoJobFailure();
-  }
-
-  /**
-   * Check if it is OK to commit the output data of a dataset.
-   *
-   * <p>
-   *   A dataset can be committed if and only if any of the following conditions is satisfied:
-   *
-   *   <ul>
-   *     <li>The {@link JobCommitPolicy#COMMIT_ON_PARTIAL_SUCCESS} policy is used.</li>
-   *     <li>The {@link JobCommitPolicy#COMMIT_SUCCESSFUL_TASKS} policy is used.</li>
-   *     <li>The {@link JobCommitPolicy#COMMIT_ON_FULL_SUCCESS} policy is used and all of the tasks succeed.</li>
-   *   </ul>
-   * </p>
-   * This method is thread-safe.
-   */
-  private boolean canCommitDataset(JobState.DatasetState datasetState) {
-    // Only commit a dataset if 1) COMMIT_ON_PARTIAL_SUCCESS is used, or 2)
-    // COMMIT_ON_FULL_SUCCESS is used and all of the tasks of the dataset have succeeded.
-    return this.jobCommitPolicy == JobCommitPolicy.COMMIT_ON_PARTIAL_SUCCESS
-        || this.jobCommitPolicy == JobCommitPolicy.COMMIT_SUCCESSFUL_TASKS
-        || (this.jobCommitPolicy == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS
-            && datasetState.getState() == JobState.RunningState.SUCCESSFUL);
-  }
-
-  /**
-   * Commit the output data of a dataset.
-   */
-  private static void commitDataset(JobState.DatasetState datasetState, DataPublisher publisher) {
-
-    try {
-      publisher.publish(datasetState.getTaskStates());
-    } catch (Throwable t) {
-      LOG.error("Failed to commit dataset", t);
-      setTaskFailureException(datasetState.getTaskStates(), t);
-    }
-
-    // Set the dataset state to COMMITTED upon successful commit
-    datasetState.setState(JobState.RunningState.COMMITTED);
-  }
-
-  @SuppressWarnings("unchecked")
-  private Optional<CommitSequence.Builder> generateCommitSequenceBuilder(JobState.DatasetState datasetState) {
-    try (Closer closer = Closer.create()) {
-      Class<? extends CommitSequencePublisher> dataPublisherClass =
-          (Class<? extends CommitSequencePublisher>) Class.forName(datasetState
-              .getProp(ConfigurationKeys.DATA_PUBLISHER_TYPE, ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
-      CommitSequencePublisher publisher =
-          (CommitSequencePublisher) closer.register(DataPublisher.getInstance(dataPublisherClass, this.jobState));
-      publisher.publish(datasetState.getTaskStates());
-      return publisher.getCommitSequenceBuilder();
-    } catch (Throwable t) {
-      LOG.error("Failed to generate commit sequence", t);
-      setTaskFailureException(datasetState.getTaskStates(), t);
-      throw Throwables.propagate(t);
-    }
-  }
-
-  private void buildAndExecuteCommitSequence(Builder builder, DatasetState datasetState, String datasetUrn)
-      throws IOException {
-    CommitSequence commitSequence =
-        builder.addStep(buildDatasetStateCommitStep(datasetUrn, datasetState).get()).build();
-    this.commitSequenceStore.get().put(commitSequence.getJobName(), datasetUrn, commitSequence);
-    commitSequence.execute();
-    this.commitSequenceStore.get().delete(commitSequence.getJobName(), datasetUrn);
-  }
-
-  /**
-   * Persist dataset state of a given dataset identified by the dataset URN.
-   */
-  private void persistDatasetState(String datasetUrn, JobState.DatasetState datasetState) throws IOException {
-    LOG.info("Persisting dataset state for dataset " + datasetUrn);
-    this.datasetStateStore.persistDatasetState(datasetUrn, datasetState);
-  }
-
-  private static Optional<CommitStep> buildDatasetStateCommitStep(String datasetUrn,
-      JobState.DatasetState datasetState) {
-
-    LOG.info("Creating " + DatasetStateCommitStep.class.getSimpleName() + " for dataset " + datasetUrn);
-    return Optional.of(new DatasetStateCommitStep.Builder<>().withProps(datasetState).withDatasetUrn(datasetUrn)
-        .withDatasetState(datasetState).build());
-  }
-
-  private void finalizeDatasetState(JobState.DatasetState datasetState, String datasetUrn) {
-    for (TaskState taskState : datasetState.getTaskStates()) {
-      // Backoff the actual high watermark to the low watermark for each task that has not been committed
-      if (taskState.getWorkingState() != WorkUnitState.WorkingState.COMMITTED) {
-        taskState.backoffActualHighWatermark();
-        if (this.jobCommitPolicy == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS) {
-          // Determine the final dataset state based on the task states (post commit) and the job commit policy.
-          // 1. If COMMIT_ON_FULL_SUCCESS is used, the processing of the dataset is considered failed if any
-          //    task for the dataset failed to be committed.
-          // 2. Otherwise, the processing of the dataset is considered successful even if some tasks for the
-          //    dataset failed to be committed.
-          datasetState.setState(JobState.RunningState.FAILED);
-        }
-      }
-    }
-
-    datasetState.setId(datasetUrn);
-  }
-
-  /**
-   * Sets the {@link ConfigurationKeys#TASK_FAILURE_EXCEPTION_KEY} for each given {@link TaskState} to the given
-   * {@link Throwable}.
-   */
-  private static void setTaskFailureException(Collection<TaskState> taskStates, Throwable t) {
-    for (TaskState taskState : taskStates) {
-      taskState.setTaskFailureException(t);
-    }
-  }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/SafeDatasetCommit.java
@@ -1,0 +1,275 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.concurrent.Callable;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Throwables;
+import com.google.common.io.Closer;
+
+import gobblin.commit.CommitSequence;
+import gobblin.commit.CommitStep;
+import gobblin.commit.DeliverySemantics;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.publisher.CommitSequencePublisher;
+import gobblin.publisher.DataPublisher;
+import gobblin.publisher.UnpublishedHandling;
+import gobblin.runtime.commit.DatasetStateCommitStep;
+import gobblin.source.extractor.JobCommitPolicy;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * {@link Callable} that commits a single dataset. The logic in this class is thread-safe, however, it calls
+ * {@link DataPublisher#publish(Collection)}. This class is thread-safe if and only if the implementation of
+ * {@link DataPublisher} used is also thread-safe.
+ */
+@AllArgsConstructor
+@Slf4j
+final class SafeDatasetCommit implements Callable<Void> {
+
+  private final boolean shouldCommitDataInJob;
+  private final DeliverySemantics deliverySemantics;
+  private final String datasetUrn;
+  private final JobState.DatasetState datasetState;
+  private final boolean isMultithreaded;
+  private final JobContext jobContext;
+
+  @Override
+  public Void call()
+      throws Exception {
+
+    finalizeDatasetStateBeforeCommit(this.datasetState);
+
+    Class<? extends DataPublisher> dataPublisherClass;
+    try (Closer closer = Closer.create()) {
+      dataPublisherClass = JobContext.getJobDataPublisherClass(this.jobContext.getJobState())
+          .or((Class<? extends DataPublisher>) Class.forName(ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
+      if (!canCommitDataset(datasetState)) {
+        log.warn(String.format("Not committing dataset %s of job %s with commit policy %s and state %s",
+            this.datasetUrn, this.jobContext.getJobId(), this.jobContext.getJobCommitPolicy(), this.datasetState.getState()));
+        checkForUnpublishedWUHandling(this.datasetUrn, this.datasetState, dataPublisherClass, closer);
+        throw new RuntimeException(String.format("Not committing dataset %s of job %s with commit policy %s and state %s",
+            this.datasetUrn, this.jobContext.getJobId(), this.jobContext.getJobCommitPolicy(), this.datasetState.getState()));
+      }
+    } catch (ReflectiveOperationException roe) {
+      log.error("Failed to instantiate data publisher for dataset %s of job %s.", this.datasetUrn,
+          this.jobContext.getJobId(), roe);
+      throw new RuntimeException(roe);
+    }
+
+    Optional<CommitSequence.Builder> commitSequenceBuilder = Optional.absent();
+    try (Closer closer = Closer.create()) {
+      if (this.shouldCommitDataInJob) {
+        log.info(String.format("Committing dataset %s of job %s with commit policy %s and state %s", this.datasetUrn,
+            this.jobContext.getJobId(), this.jobContext.getJobCommitPolicy(), this.datasetState.getState()));
+        if (this.deliverySemantics == DeliverySemantics.EXACTLY_ONCE) {
+          generateCommitSequenceBuilder(this.datasetState);
+        } else {
+          DataPublisher publisher = closer.register(DataPublisher.getInstance(dataPublisherClass, this.jobContext.getJobState()));
+          if (this.isMultithreaded && !publisher.isThreadSafe()) {
+            log.warn(String.format("Gobblin is set up to parallelize publishing, however the publisher %s is not thread-safe. "
+                + "Falling back to serial publishing.", publisher.getClass().getName()));
+            safeCommitDataset(this.datasetState, publisher);
+          } else {
+            commitDataset(this.datasetState, publisher);
+          }
+        }
+      } else {
+        if (this.datasetState.getState() == JobState.RunningState.SUCCESSFUL) {
+          this.datasetState.setState(JobState.RunningState.COMMITTED);
+        }
+      }
+    } catch (ReflectiveOperationException roe) {
+      log.error(String.format("Failed to instantiate data publisher for dataset %s of job %s.", this.datasetUrn,
+              this.jobContext.getJobId()), roe);
+      throw new RuntimeException(roe);
+    } catch (IOException ioe) {
+      log.error(String.format("Failed to commit dataset state for dataset %s of job %s", this.datasetUrn,
+          this.jobContext.getJobId()), ioe);
+      throw new RuntimeException(ioe);
+    } finally {
+      try {
+        finalizeDatasetState(datasetState, datasetUrn);
+
+        if (commitSequenceBuilder.isPresent()) {
+          buildAndExecuteCommitSequence(commitSequenceBuilder.get(), datasetState, datasetUrn);
+          datasetState.setState(JobState.RunningState.COMMITTED);
+        } else {
+          persistDatasetState(datasetUrn, datasetState);
+        }
+      } catch (IOException | RuntimeException ioe) {
+        log.error(
+            String.format("Failed to persist dataset state for dataset %s of job %s", datasetUrn, this.jobContext.getJobId()), ioe);
+        throw new RuntimeException(ioe);
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Synchronized version of {@link #commitDataset(JobState.DatasetState, DataPublisher)} used when publisher is not
+   * thread safe.
+   */
+  private synchronized void safeCommitDataset(JobState.DatasetState datasetState, DataPublisher publisher) {
+    commitDataset(datasetState, publisher);
+  }
+
+  /**
+   * Commit the output data of a dataset.
+   */
+  private void commitDataset(JobState.DatasetState datasetState, DataPublisher publisher) {
+
+    try {
+      publisher.publish(datasetState.getTaskStates());
+    } catch (Throwable t) {
+      log.error("Failed to commit dataset", t);
+      setTaskFailureException(datasetState.getTaskStates(), t);
+    }
+
+    // Set the dataset state to COMMITTED upon successful commit
+    datasetState.setState(JobState.RunningState.COMMITTED);
+  }
+
+  private synchronized void buildAndExecuteCommitSequence(CommitSequence.Builder builder, JobState.DatasetState datasetState,
+      String datasetUrn) throws IOException {
+    CommitSequence commitSequence =
+        builder.addStep(buildDatasetStateCommitStep(datasetUrn, datasetState).get()).build();
+    this.jobContext.getCommitSequenceStore().get().put(commitSequence.getJobName(), datasetUrn, commitSequence);
+    commitSequence.execute();
+    this.jobContext.getCommitSequenceStore().get().delete(commitSequence.getJobName(), datasetUrn);
+  }
+
+  /**
+   * Finalize a given {@link JobState.DatasetState} before committing the dataset.
+   *
+   * This method is thread-safe.
+   */
+  private void finalizeDatasetStateBeforeCommit(JobState.DatasetState datasetState) {
+    for (TaskState taskState : datasetState.getTaskStates()) {
+      if (taskState.getWorkingState() != WorkUnitState.WorkingState.SUCCESSFUL
+          && this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS) {
+        // The dataset state is set to FAILED if any task failed and COMMIT_ON_FULL_SUCCESS is used
+        datasetState.setState(JobState.RunningState.FAILED);
+        datasetState.incrementJobFailures();
+        return;
+      }
+    }
+
+    datasetState.setState(JobState.RunningState.SUCCESSFUL);
+    datasetState.setNoJobFailure();
+  }
+
+  /**
+   * Check if it is OK to commit the output data of a dataset.
+   *
+   * <p>
+   *   A dataset can be committed if and only if any of the following conditions is satisfied:
+   *
+   *   <ul>
+   *     <li>The {@link JobCommitPolicy#COMMIT_ON_PARTIAL_SUCCESS} policy is used.</li>
+   *     <li>The {@link JobCommitPolicy#COMMIT_SUCCESSFUL_TASKS} policy is used.</li>
+   *     <li>The {@link JobCommitPolicy#COMMIT_ON_FULL_SUCCESS} policy is used and all of the tasks succeed.</li>
+   *   </ul>
+   * </p>
+   * This method is thread-safe.
+   */
+  private boolean canCommitDataset(JobState.DatasetState datasetState) {
+    // Only commit a dataset if 1) COMMIT_ON_PARTIAL_SUCCESS is used, or 2)
+    // COMMIT_ON_FULL_SUCCESS is used and all of the tasks of the dataset have succeeded.
+    return this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_ON_PARTIAL_SUCCESS
+        || this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_SUCCESSFUL_TASKS
+        || (this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS
+        && datasetState.getState() == JobState.RunningState.SUCCESSFUL);
+  }
+
+  @SuppressWarnings("unchecked")
+  private Optional<CommitSequence.Builder> generateCommitSequenceBuilder(JobState.DatasetState datasetState) {
+    try (Closer closer = Closer.create()) {
+      Class<? extends CommitSequencePublisher> dataPublisherClass =
+          (Class<? extends CommitSequencePublisher>) Class.forName(datasetState
+              .getProp(ConfigurationKeys.DATA_PUBLISHER_TYPE, ConfigurationKeys.DEFAULT_DATA_PUBLISHER_TYPE));
+      CommitSequencePublisher publisher =
+          (CommitSequencePublisher) closer.register(DataPublisher.getInstance(dataPublisherClass, this.jobContext.getJobState()));
+      publisher.publish(datasetState.getTaskStates());
+      return publisher.getCommitSequenceBuilder();
+    } catch (Throwable t) {
+      log.error("Failed to generate commit sequence", t);
+      setTaskFailureException(datasetState.getTaskStates(), t);
+      throw Throwables.propagate(t);
+    }
+  }
+
+  void checkForUnpublishedWUHandling(String datasetUrn, JobState.DatasetState datasetState,
+      Class<? extends DataPublisher> dataPublisherClass, Closer closer)
+      throws ReflectiveOperationException, IOException {
+    if (UnpublishedHandling.class.isAssignableFrom(dataPublisherClass)) {
+      // pass in jobstate to retrieve properties
+      DataPublisher publisher = closer.register(DataPublisher.getInstance(dataPublisherClass, this.jobContext.getJobState()));
+      log.info(String.format("Calling publisher to handle unpublished work units for dataset %s of job %s.",
+          datasetUrn, this.jobContext.getJobId()));
+      ((UnpublishedHandling) publisher).handleUnpublishedWorkUnits(datasetState.getTaskStatesAsWorkUnitStates());
+    }
+  }
+
+  private void finalizeDatasetState(JobState.DatasetState datasetState, String datasetUrn) {
+    for (TaskState taskState : datasetState.getTaskStates()) {
+      // Backoff the actual high watermark to the low watermark for each task that has not been committed
+      if (taskState.getWorkingState() != WorkUnitState.WorkingState.COMMITTED) {
+        taskState.backoffActualHighWatermark();
+        if (this.jobContext.getJobCommitPolicy() == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS) {
+          // Determine the final dataset state based on the task states (post commit) and the job commit policy.
+          // 1. If COMMIT_ON_FULL_SUCCESS is used, the processing of the dataset is considered failed if any
+          //    task for the dataset failed to be committed.
+          // 2. Otherwise, the processing of the dataset is considered successful even if some tasks for the
+          //    dataset failed to be committed.
+          datasetState.setState(JobState.RunningState.FAILED);
+        }
+      }
+    }
+
+    datasetState.setId(datasetUrn);
+  }
+
+  /**
+   * Persist dataset state of a given dataset identified by the dataset URN.
+   */
+  private void persistDatasetState(String datasetUrn, JobState.DatasetState datasetState) throws IOException {
+    log.info("Persisting dataset state for dataset " + datasetUrn);
+    this.jobContext.getDatasetStateStore().persistDatasetState(datasetUrn, datasetState);
+  }
+
+  /**
+   * Sets the {@link ConfigurationKeys#TASK_FAILURE_EXCEPTION_KEY} for each given {@link TaskState} to the given
+   * {@link Throwable}.
+   */
+  private static void setTaskFailureException(Collection<TaskState> taskStates, Throwable t) {
+    for (TaskState taskState : taskStates) {
+      taskState.setTaskFailureException(t);
+    }
+  }
+
+  private static Optional<CommitStep> buildDatasetStateCommitStep(String datasetUrn,
+      JobState.DatasetState datasetState) {
+
+    log.info("Creating " + DatasetStateCommitStep.class.getSimpleName() + " for dataset " + datasetUrn);
+    return Optional.of(new DatasetStateCommitStep.Builder<>().withProps(datasetState).withDatasetUrn(datasetUrn)
+        .withDatasetState(datasetState).build());
+  }
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/DummyJobContext.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/DummyJobContext.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+
+import gobblin.commit.CommitSequenceStore;
+import gobblin.commit.DeliverySemantics;
+import gobblin.metastore.JobHistoryStore;
+import gobblin.source.Source;
+
+
+public class DummyJobContext extends JobContext {
+
+  private final Map<String, JobState.DatasetState> datasetStateMap;
+
+  public DummyJobContext(Properties jobProps, Logger logger, Map<String, JobState.DatasetState> datasetStateMap)
+      throws Exception {
+    super(jobProps, logger);
+    this.datasetStateMap = datasetStateMap;
+  }
+
+  @Override
+  protected FsDatasetStateStore createStateStore(Properties jobProps, Configuration conf)
+      throws IOException {
+    return new NoopDatasetStateStore(FileSystem.getLocal(new Configuration()), "");
+  }
+
+  @Override
+  protected Optional<JobHistoryStore> createJobHistoryStore(Properties jobProps) {
+    return Optional.absent();
+  }
+
+  @Override
+  protected Optional<CommitSequenceStore> createCommitSequenceStore()
+      throws IOException {
+    return Optional.absent();
+  }
+
+  @Override
+  protected Source<?, ?> createSource(Properties jobProps)
+      throws ClassNotFoundException, InstantiationException, IllegalAccessException {
+    return null;
+  }
+
+  @Override
+  protected void setTaskStagingAndOutputDirs() {
+    // nothing
+  }
+
+  @Override
+  protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob,
+      DeliverySemantics deliverySemantics, String datasetUrn, JobState.DatasetState datasetState,
+      boolean isMultithreaded, JobContext jobContext) {
+    return new Callable<Void>() {
+      @Override
+      public Void call()
+          throws Exception {
+        return null;
+      }
+    };
+  }
+
+  @Override
+  protected Map<String, JobState.DatasetState> computeDatasetStatesByUrns() {
+    return this.datasetStateMap;
+  }
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobContextTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobContextTest.java
@@ -1,0 +1,268 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Queue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.common.collect.Queues;
+
+import gobblin.commit.DeliverySemantics;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.Either;
+
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+
+@Slf4j
+public class JobContextTest {
+
+  @Test
+  public void testNonParallelCommit() throws Exception {
+
+    Properties jobProps = new Properties();
+
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, "test");
+    jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, "id");
+    jobProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "false");
+
+    Map<String, JobState.DatasetState> datasetStateMap = Maps.newHashMap();
+    for (int i = 0; i < 2; i++) {
+      datasetStateMap.put(Integer.toString(i), new JobState.DatasetState());
+    }
+
+    final BlockingQueue<ControllableCallable<Void>> callables = Queues.newLinkedBlockingQueue();
+
+    final JobContext jobContext = new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
+      @Override
+      public boolean apply(@Nullable String input) {
+        return true;
+      }
+    }, callables);
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    Future future = executorService.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          jobContext.commit();
+        } catch (IOException ioe) {
+          throw new RuntimeException(ioe);
+        }
+      }
+    });
+
+    // Not parallelized, should only one commit running
+    ControllableCallable<Void> callable = callables.poll(1, TimeUnit.SECONDS);
+    Assert.assertNotNull(callable);
+    Assert.assertNull(callables.poll(200, TimeUnit.MILLISECONDS));
+
+    // unblock first commit, should see a second commit
+    callable.unblock();
+    callable = callables.poll(1, TimeUnit.SECONDS);
+    Assert.assertNotNull(callable);
+    Assert.assertNull(callables.poll(200, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(future.isDone());
+
+    // unblock second commit, commit should complete
+    callable.unblock();
+    future.get(1, TimeUnit.SECONDS);
+    Assert.assertEquals(jobContext.getJobState().getState(), JobState.RunningState.COMMITTED);
+  }
+
+  @Test
+  public void testParallelCommit() throws Exception {
+
+    Properties jobProps = new Properties();
+
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, "test");
+    jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, "id");
+    jobProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "false");
+    jobProps.setProperty(ConfigurationKeys.PARALLELIZE_DATASET_COMMIT, "true");
+
+    Map<String, JobState.DatasetState> datasetStateMap = Maps.newHashMap();
+    for (int i = 0; i < 5; i++) {
+      datasetStateMap.put(Integer.toString(i), new JobState.DatasetState());
+    }
+
+    final BlockingQueue<ControllableCallable<Void>> callables = Queues.newLinkedBlockingQueue();
+
+    final JobContext jobContext = new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
+      @Override
+      public boolean apply(@Nullable String input) {
+        return true;
+      }
+    }, callables);
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    Future future = executorService.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          jobContext.commit();
+        } catch (IOException ioe) {
+          throw new RuntimeException(ioe);
+        }
+      }
+    });
+
+    // Parallelized, should be able to get all 5 commits running
+    Queue<ControllableCallable<Void>> drainedCallables = Lists.newLinkedList();
+    Assert.assertEquals(Queues.drain(callables, drainedCallables, 5, 1, TimeUnit.SECONDS), 5);
+    Assert.assertFalse(future.isDone());
+
+    // unblock all commits
+    for (ControllableCallable<Void> callable : drainedCallables) {
+      callable.unblock();
+    }
+
+    // check that future is done
+    future.get(1, TimeUnit.SECONDS);
+
+    // check that no more commits were added
+    Assert.assertTrue(callables.isEmpty());
+    Assert.assertEquals(jobContext.getJobState().getState(), JobState.RunningState.COMMITTED);
+  }
+
+  @Test
+  public void testSingleExceptionSemantics() throws Exception {
+
+    Properties jobProps = new Properties();
+
+    jobProps.setProperty(ConfigurationKeys.JOB_NAME_KEY, "test");
+    jobProps.setProperty(ConfigurationKeys.JOB_ID_KEY, "id");
+    jobProps.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "false");
+
+    Map<String, JobState.DatasetState> datasetStateMap = Maps.newHashMap();
+    for (int i = 0; i < 3; i++) {
+      datasetStateMap.put(Integer.toString(i), new JobState.DatasetState());
+    }
+
+    final BlockingQueue<ControllableCallable<Void>> callables = Queues.newLinkedBlockingQueue();
+
+    // There are three datasets, "0", "1", and "2", middle one will fail
+    final JobContext jobContext = new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
+      @Override
+      public boolean apply(@Nullable String input) {
+        return !input.equals("1");
+      }
+    }, callables);
+
+    ExecutorService executorService = Executors.newSingleThreadExecutor();
+    Future future = executorService.submit(new Runnable() {
+      @Override
+      public void run() {
+        try {
+          jobContext.commit();
+        } catch (IOException ioe) {
+          throw new RuntimeException(ioe);
+        }
+      }
+    });
+
+    // All three commits should be run (even though second one fails)
+    callables.poll(1, TimeUnit.SECONDS).unblock();
+    callables.poll(1, TimeUnit.SECONDS).unblock();
+    callables.poll(1, TimeUnit.SECONDS).unblock();
+
+    try {
+      // check future is done
+      future.get(1, TimeUnit.SECONDS);
+      Assert.fail();
+    } catch (ExecutionException ee) {
+      // future should fail
+    }
+    // job failed
+    Assert.assertEquals(jobContext.getJobState().getState(), JobState.RunningState.FAILED);
+  }
+
+  /**
+   * A {@link Callable} that blocks until a different thread calls {@link #unblock()}.
+   */
+  private class ControllableCallable<T> implements Callable<T> {
+
+    private final BlockingQueue<Boolean> queue;
+    private final Either<T, Exception> toReturn;
+    private final String name;
+
+    public ControllableCallable(Either<T, Exception> toReturn, String name) {
+      this.queue = Queues.newArrayBlockingQueue(1);
+      this.queue.add(true);
+      this.toReturn = toReturn;
+      this.name = name;
+    }
+
+    public void unblock() {
+      if (!this.queue.isEmpty()) {
+        this.queue.poll();
+      }
+    }
+
+    @Override
+    public T call()
+        throws Exception {
+      this.queue.put(false);
+      if (this.toReturn instanceof Either.Left) {
+        return ((Either.Left<T, Exception>) this.toReturn).getLeft();
+      } else {
+        throw ((Either.Right<T, Exception>) this.toReturn).getRight();
+      }
+    }
+  }
+
+  private class ControllableCommitJobContext extends DummyJobContext {
+
+    private final Predicate<String> successPredicate;
+    private final Queue<ControllableCallable<Void>> callablesQueue;
+
+    public ControllableCommitJobContext(Properties jobProps, Logger logger,
+        Map<String, JobState.DatasetState> datasetStateMap, Predicate<String> successPredicate,
+        Queue<ControllableCallable<Void>> callablesQueue)
+        throws Exception {
+      super(jobProps, logger, datasetStateMap);
+      this.successPredicate = successPredicate;
+      this.callablesQueue = callablesQueue;
+    }
+
+    @Override
+    protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob,
+        DeliverySemantics deliverySemantics, String datasetUrn, JobState.DatasetState datasetState,
+        boolean isMultithreaded, JobContext jobContext) {
+      ControllableCallable<Void> callable;
+      if (this.successPredicate.apply(datasetUrn)) {
+        callable = new ControllableCallable<>(Either.<Void, Exception>left(null), datasetUrn);
+      } else {
+        callable = new ControllableCallable<>(Either.<Void, Exception>right(new RuntimeException("Fail!")), datasetUrn);
+      }
+      this.callablesQueue.add(callable);
+      return callable;
+    }
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/Either.java
+++ b/gobblin-utility/src/main/java/gobblin/util/Either.java
@@ -51,7 +51,7 @@ public abstract class Either<S, T> {
      * @return value of type {@link S}.
      */
     public S getLeft() {
-      return this.s.get();
+      return this.s.orNull();
     }
   }
 
@@ -67,7 +67,7 @@ public abstract class Either<S, T> {
      * @return value of type {@link T}.
      */
     public T getRight() {
-      return this.t.get();
+      return this.t.orNull();
     }
   }
 

--- a/gobblin-utility/src/main/java/gobblin/util/Either.java
+++ b/gobblin-utility/src/main/java/gobblin/util/Either.java
@@ -44,7 +44,7 @@ public abstract class Either<S, T> {
    */
   public static class Left<S, T> extends Either<S, T> {
     public Left(S s) {
-      super(Optional.of(s), Optional.<T> absent());
+      super(Optional.fromNullable(s), Optional.<T>absent());
     }
 
     /**
@@ -60,7 +60,7 @@ public abstract class Either<S, T> {
    */
   public static class Right<S, T> extends Either<S, T> {
     public Right(T t) {
-      super(Optional.<S> absent(), Optional.of(t));
+      super(Optional.<S>absent(), Optional.fromNullable(t));
     }
 
     /**
@@ -95,10 +95,10 @@ public abstract class Either<S, T> {
    * @return value as an instance of {@link Object}.
    */
   public Object get() {
-    if (this.s.isPresent()) {
-      return this.s.get();
+    if (this instanceof Left) {
+      return this.s.orNull();
     }
-    return this.t.get();
+    return this.t.orNull();
   }
 
 }

--- a/gobblin-utility/src/main/java/gobblin/util/executors/IteratorExecutor.java
+++ b/gobblin-utility/src/main/java/gobblin/util/executors/IteratorExecutor.java
@@ -16,6 +16,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorCompletionService;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -23,11 +24,16 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 
+import gobblin.util.Either;
 import gobblin.util.ExecutorsUtils;
 
+import javax.annotation.Nullable;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -54,6 +60,13 @@ public class IteratorExecutor<T> {
 
   /**
    * Execute the tasks in the task {@link Iterator}. Blocks until all tasks are completed.
+   *
+   * <p>
+   *  Note: this method only guarantees tasks have finished, not that they have finished successfully. It is the caller's
+   *  responsibility to verify the returned futures are successful. Also see {@link #executeAndGetResults()} for different
+   *  semantics.
+   * </p>
+   *
    * @return a list of completed futures.
    * @throws InterruptedException
    */
@@ -85,6 +98,40 @@ public class IteratorExecutor<T> {
     }
 
     return futures;
+  }
+
+  /**
+   * Execute the tasks in the task {@link Iterator}. Blocks until all tasks are completed. Gets the results of each
+   * task, and for each task returns either its result or the thrown {@link ExecutionException}.
+   *
+   * @return a list containing for each task either its result or the {@link ExecutionException} thrown, in the same
+   *        order as the input {@link Iterator}.
+   * @throws InterruptedException
+   */
+  public List<Either<T, ExecutionException>> executeAndGetResults() throws InterruptedException {
+    List<Either<T, ExecutionException>> results = Lists.newArrayList();
+    List<Future<T>> futures = execute();
+    for (Future<T> future : futures) {
+      try {
+        results.add(Either.<T, ExecutionException>left(future.get()));
+      } catch (ExecutionException ee) {
+        results.add(Either.<T, ExecutionException>right(ee));
+      }
+    }
+    return results;
+  }
+
+  /**
+   * Utility method that checks whether all tasks succeeded from the output of {@link #executeAndGetResults()}.
+   * @return true if all tasks succeeded.
+   */
+  public static <T> boolean verifyAllSuccessful(List<Either<T, ExecutionException>> results) {
+    return Iterables.all(results, new Predicate<Either<T, ExecutionException>>() {
+      @Override
+      public boolean apply(@Nullable Either<T, ExecutionException> input) {
+        return input instanceof Either.Left;
+      }
+    });
   }
 
 }


### PR DESCRIPTION
Guide to this PR:
* Created a class `SafeDatasetCommit`. Refactored a lot of the commit logic from `JobContext` to this class.
* `JobContext` creates an `IteratorExecutor` to execute dataset commits in parallel.
* Added a `isThreadSafe` method to `DataPublisher`. If this is false (default), Gobblin will automatically fall back to serial commit even if user choses parallel commit.
* Added a unit test to ensure `JobContext` handles publisher failure semantics correctly.