### PR TITLE
Make kafka buffer size configurable

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -371,6 +371,12 @@ public class ConfigurationKeys {
   public static final String ERROR_MESSAGE_UNDECODABLE_COUNT = "error.message.undecodable.count";
 
   /**
+   * Configuration properties used by both KakfaSource and KafkaExtractor
+   */
+  public static final String KAFKA_BUFFER_SIZE = "kafka.buffer.size";
+  public static final int DEFAULT_KAFKA_BUFFER_SIZE = 1024 * 1024;
+
+  /**
    * Configuration properties for source connection.
    */
   public static final String SOURCE_CONN_USE_AUTHENTICATION = "source.conn.use.authentication";

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaPartition.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaPartition.java
@@ -13,6 +13,7 @@
 package gobblin.source.extractor.extract.kafka;
 
 import com.google.common.net.HostAndPort;
+import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -25,6 +26,7 @@ import com.google.common.net.HostAndPort;
 public final class KafkaPartition {
   private final int id;
   private final String topicName;
+  private final int bufferSize;
   private KafkaLeader leader;
 
   public static class Builder {
@@ -32,7 +34,7 @@ public final class KafkaPartition {
     private String topicName = "";
     private int leaderId = 0;
     private HostAndPort leaderHostAndPort;
-
+    private int bufferSize = ConfigurationKeys.DEFAULT_KAFKA_BUFFER_SIZE;
     public Builder withId(int id) {
       this.id = id;
       return this;
@@ -45,6 +47,11 @@ public final class KafkaPartition {
 
     public Builder withLeaderId(int leaderId) {
       this.leaderId = leaderId;
+      return this;
+    }
+
+    public Builder withBufferSize(int bufferSize){
+      this.bufferSize = bufferSize;
       return this;
     }
 
@@ -67,12 +74,14 @@ public final class KafkaPartition {
     this.topicName = other.topicName;
     this.id = other.id;
     this.leader = new KafkaLeader(other.leader.id, other.leader.hostAndPort);
+    this.bufferSize = other.bufferSize;
   }
 
   private KafkaPartition(Builder builder) {
     this.id = builder.id;
     this.topicName = builder.topicName;
     this.leader = new KafkaLeader(builder.leaderId, builder.leaderHostAndPort);
+    this.bufferSize = builder.bufferSize;
   }
 
   public KafkaLeader getLeader() {
@@ -85,6 +94,10 @@ public final class KafkaPartition {
 
   public int getId() {
     return this.id;
+  }
+
+  public int getBufferSize() {
+    return this.bufferSize;
   }
 
   public void setLeader(int leaderId, String leaderHost, int leaderPort) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaUtils.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/KafkaUtils.java
@@ -12,6 +12,7 @@
 
 package gobblin.source.extractor.extract.kafka;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 
 import java.util.List;
@@ -48,7 +49,9 @@ public class KafkaUtils {
         "Missing configuration property " + KafkaSource.PARTITION_ID);
 
     KafkaPartition.Builder builder = new KafkaPartition.Builder().withTopicName(state.getProp(KafkaSource.TOPIC_NAME))
-        .withId(state.getPropAsInt(KafkaSource.PARTITION_ID));
+        .withId(state.getPropAsInt(KafkaSource.PARTITION_ID))
+        .withBufferSize(state.getPropAsInt(ConfigurationKeys.KAFKA_BUFFER_SIZE,
+                ConfigurationKeys.DEFAULT_KAFKA_BUFFER_SIZE));
     if (state.contains(KafkaSource.LEADER_ID)) {
       builder = builder.withLeaderId(state.getPropAsInt(KafkaSource.LEADER_ID));
     }


### PR DESCRIPTION
As mentioned in the mailing list, the existing gobblin configuration means that if any topic configured to have a larger buffer size than the default of 1mb will silently fail to be consumed when a large message is read. The silence is mostly Kafka's fault, but Gobblin should be able to be to support topics with large messages through a configuration parameter.

I am sending this as a preliminary patch, expecting you guys might have problems with it, because to be fair, the situation is a bit tricky: The KafkaOldAPI is the piece that needs this configuration, but it receives no configuration information.

Given that this is theoretically different by topic (although for some reason, KafkaTopicMetaData won't produce this information), I thought it really should be handled as something done by topic, although, for the time being, I am feeding the data from the work unit.

For the call that we make to get the list of kafka topics, I am using the defaults instead, because it doesn't seem like a place where one would change message topics, and trickling that up to a point that can read the configuration seems like quite a few changes.

I'd be happy to take a different approach, but then I'd like guidance on what would make the PR approvable.
