### PR TITLE
Escape Hive queries column, partition and tables

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtils.java
@@ -271,7 +271,7 @@ public class HiveAvroORCQueryUtils {
               columns.append(",");
             }
             String type = generateAvroToHiveColumnMapping(field.schema(), hiveColumns, false);
-            columns.append(field.name()).append(":").append(type);
+            columns.append("`").append(field.name()).append("`").append(":").append(type);
           }
           columns.append(">");
         }
@@ -442,7 +442,10 @@ public class HiveAvroORCQueryUtils {
       } else {
         dmlQuery.append(", \n");
       }
-      dmlQuery.append(String.format("  %s", colName));
+      // Escape the column name
+      colName = colName.replaceAll("\\.", "`.`");
+
+      dmlQuery.append(String.format("  `%s`", colName));
     }
     dmlQuery.append(String.format(" %n FROM `%s.%s` ", originalDbName, originalTblName));
 
@@ -451,7 +454,7 @@ public class HiveAvroORCQueryUtils {
       if (optionalPartitionDMLInfo.get().size()  > 0) {
         dmlQuery.append("WHERE ");
         for (Map.Entry<String, String> partition : optionalPartitionDMLInfo.get().entrySet()) {
-          dmlQuery.append(String.format("%s='%s'",
+          dmlQuery.append(String.format("`%s`='%s'",
               partition.getKey(), partition.getValue()));
         }
         dmlQuery.append(" \n");

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/arrayWithinRecordWithinArrayWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/arrayWithinRecordWithinArrayWithinRecord_nested.ddl
@@ -1,5 +1,5 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS `default.testArrayWithinRecordWithinArrayWithinRecordDDL` (
-  `parentRecordFieldName` array<struct<nestedRecordFieldName:array<string>>>)
+  `parentRecordFieldName` array<struct<`nestedRecordFieldName`:array<string>>>)
 ROW FORMAT SERDE
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
 STORED AS INPUTFORMAT

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/optionWithinOptionWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/optionWithinOptionWithinRecord_nested.ddl
@@ -1,5 +1,5 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS `default.testOptionWithinOptionWithinRecordDDL` (
-  `parentFieldUnion` struct<unionRecordMemberFieldUnion:struct<superNestedFieldString1:string,superNestedFieldString2:string>,unionRecordMemberFieldString:string>,
+  `parentFieldUnion` struct<`unionRecordMemberFieldUnion`:struct<`superNestedFieldString1`:string,`superNestedFieldString2`:string>,`unionRecordMemberFieldString`:string>,
   `parentFieldInt` int)
 ROW FORMAT SERDE
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinOptionWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinOptionWithinRecord_nested.ddl
@@ -1,5 +1,5 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinOptionWithinRecordDDL` (
-  `parentFieldUnion` struct<unionRecordMemberFieldLong:bigint,unionRecordMemberFieldString:string>,
+  `parentFieldUnion` struct<`unionRecordMemberFieldLong`:bigint,`unionRecordMemberFieldString`:string>,
   `parentFieldInt` int)
 ROW FORMAT SERDE
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinRecordWithinRecord.dml
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinRecordWithinRecord.dml
@@ -1,8 +1,8 @@
 INSERT OVERWRITE TABLE `default.testRecordWithinRecordWithinRecordDDL_orc`
 SELECT
-  parentFieldRecord.nestedFieldRecord.superNestedFieldString,
-  parentFieldRecord.nestedFieldRecord.superNestedFieldInt,
-  parentFieldRecord.nestedFieldString,
-  parentFieldRecord.nestedFieldInt,
-  parentFieldInt
+  `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldString`,
+  `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldInt`,
+  `parentFieldRecord`.`nestedFieldString`,
+  `parentFieldRecord`.`nestedFieldInt`,
+  `parentFieldInt`
 FROM `default.testRecordWithinRecordWithinRecordDDL`

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinRecordWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinRecordWithinRecord_nested.ddl
@@ -1,5 +1,5 @@
 CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinRecordWithinRecordDDL` (
-  `parentFieldRecord` struct<nestedFieldRecord:struct<superNestedFieldString:string,superNestedFieldInt:int>,nestedFieldString:string,nestedFieldInt:int>,
+  `parentFieldRecord` struct<`nestedFieldRecord`:struct<`superNestedFieldString`:string,`superNestedFieldInt`:int>,`nestedFieldString`:string,`nestedFieldInt`:int>,
   `parentFieldInt` int)
 ROW FORMAT SERDE
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'


### PR DESCRIPTION
Escape Hive queries column, partition and tables to avoid pitfall against users making use of Hive reserver words for column / partition names