### PR TITLE
Disable flattening for complex types other than nested records and union

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/HiveAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/HiveAvroToOrcConverter.java
@@ -65,7 +65,7 @@ public class HiveAvroToOrcConverter
     Preconditions.checkNotNull(workUnit, "Workunit state must not be null");
     Preconditions.checkNotNull(conversionEntity.getHiveTable(), "Hive table within conversion entity must not be null");
 
-    Schema flattenedSchema = AVRO_FLATTENER.flatten(outputSchema, true);
+    Schema flattenedSchema = AVRO_FLATTENER.flatten(outputSchema, false);
 
     // Create flattened table if not exists
     // ORC Hive tables are named as   : {avro_table_name}_orc


### PR DESCRIPTION
Disable flattening for complex types other than nested records and union, since ORC does not support predicate pushdown for complex types, so even if we flatten nested structure within a map or array - it will not help and complicates conversion process.