### PR TITLE
Add a backfill hive source that does not check watermarks

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/BackfillHiveSource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/BackfillHiveSource.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.source;
+
+import gobblin.source.extractor.extract.LongWatermark;
+
+/**
+ * A {@link HiveSource} used to create workunits without a watermark check.
+ * {@link #shouldCreateWorkunit(long, LongWatermark)} will always return <code>true</code>
+ */
+public class BackfillHiveSource extends HiveSource {
+
+  @Override
+  public boolean shouldCreateWorkunit(long updateTime, LongWatermark lowWatermark) {
+    return true;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -9,7 +9,7 @@
  * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied.
  */
-package gobblin.data.management.conversion.hive;
+package gobblin.data.management.conversion.hive.source;
 
 import java.io.IOException;
 import java.util.Iterator;
@@ -35,6 +35,7 @@ import gobblin.annotation.Alpha;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.SourceState;
 import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.AvroSchemaManager;
 import gobblin.data.management.conversion.hive.entities.SerializableHivePartition;
 import gobblin.data.management.conversion.hive.entities.SerializableHiveTable;
 import gobblin.data.management.conversion.hive.events.EventConstants;
@@ -220,8 +221,7 @@ public class HiveSource implements Source {
     }
   }
 
-  @VisibleForTesting
-  public boolean shouldCreateWorkunit(long updateTime, LongWatermark lowWatermark) {
+  protected boolean shouldCreateWorkunit(long updateTime, LongWatermark lowWatermark) {
     return new DateTime(updateTime).isAfter(lowWatermark.getValue());
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveSourceUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveSourceUtils.java
@@ -19,9 +19,9 @@ import org.apache.hadoop.hive.ql.metadata.Table;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.data.management.conversion.hive.AvroSchemaManager;
-import gobblin.data.management.conversion.hive.HiveSource;
 import gobblin.data.management.conversion.hive.entities.SerializableHivePartition;
 import gobblin.data.management.conversion.hive.entities.SerializableHiveTable;
+import gobblin.data.management.conversion.hive.source.HiveSource;
 import gobblin.metrics.event.sla.SlaEventKeys;
 import gobblin.source.workunit.WorkUnit;
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/HiveSourceTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/HiveSourceTest.java
@@ -42,6 +42,7 @@ import gobblin.configuration.SourceState;
 import gobblin.configuration.WorkUnitState;
 import gobblin.data.management.conversion.hive.entities.SerializableHivePartition;
 import gobblin.data.management.conversion.hive.entities.SerializableHiveTable;
+import gobblin.data.management.conversion.hive.source.HiveSource;
 import gobblin.data.management.conversion.hive.util.HiveSourceUtils;
 import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.hive.avro.HiveAvroSerDeManager;


### PR DESCRIPTION
A backfill source will be used to re run avro to orc conversion for all partitions starting from ```lookBackDays```

@abti can you review?