### PR TITLE
Initial commit for hive retention

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -61,9 +61,9 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
   private static final String DATASET_ERROR = "DatasetError";
   private static final String FAILURE_CONTEXT = "FailureContext";
 
-  private final Properties properties;
-  private final HiveMetastoreClientPool clientPool;
-  private final FileSystem fs;
+  protected final Properties properties;
+  protected final HiveMetastoreClientPool clientPool;
+  protected final FileSystem fs;
   private final WhitelistBlacklist whitelistBlacklist;
   private final Optional<EventSubmitter> eventSubmitter;
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/HiveCleanableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/HiveCleanableDataset.java
@@ -1,0 +1,115 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.dataset;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.thrift.TException;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.retention.policy.CombineRetentionPolicy;
+import gobblin.data.management.retention.policy.HiveTablePartitionInvalidDataLocRetentionPolicy;
+import gobblin.data.management.retention.policy.HiveTablePartitionTimeBasedRetentionPolicy;
+import gobblin.data.management.retention.policy.RetentionPolicy;
+import gobblin.data.management.version.HiveTablePartitionVersion;
+import gobblin.data.management.version.finder.HiveDatasetVersionFinder;
+import gobblin.data.management.version.finder.VersionFinder;
+import gobblin.hive.HiveMetastoreClientPool;
+import gobblin.util.AutoReturnableObject;
+import gobblin.util.Either;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Extends {@link HiveDataset} and also is cleanable. It uses {@link CombineRetentionPolicy} of {@link HiveTablePartitionTimeBasedRetentionPolicy}
+ * and {@link HiveTablePartitionInvalidDataLocRetentionPolicy} to decide the deletable versions.
+ */
+@Slf4j
+public class HiveCleanableDataset extends HiveDataset implements CleanableDataset {
+  private final VersionFinder<HiveTablePartitionVersion> versionFinder;
+  private final CombineRetentionPolicy<HiveTablePartitionVersion> retentionPolicy;
+  private final boolean simulate;
+
+  public HiveCleanableDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Properties properties)
+      throws IOException {
+    super(fs, clientPool, table, properties);
+    this.versionFinder = new HiveDatasetVersionFinder(fs, properties);
+    List<RetentionPolicy<HiveTablePartitionVersion>> policies = Lists
+        .newArrayList(new HiveTablePartitionInvalidDataLocRetentionPolicy(fs),
+            new HiveTablePartitionTimeBasedRetentionPolicy(properties, fs));
+    this.retentionPolicy = new CombineRetentionPolicy<HiveTablePartitionVersion>(policies,
+        CombineRetentionPolicy.DeletableCombineOperation.UNION);
+    this.simulate = Boolean.valueOf(properties
+        .getProperty(MultiVersionCleanableDatasetBase.SIMULATE_KEY, MultiVersionCleanableDatasetBase.SIMULATE_DEFAULT));
+  }
+
+  @Override
+  public void clean()
+      throws IOException {
+    Iterable<Either<Table, Partition>> deletableTableOrPartitions = Iterables.transform(
+        this.retentionPolicy.listDeletableVersions(new ArrayList<>(this.versionFinder.findDatasetVersions(this))),
+        new Function<HiveTablePartitionVersion, Either<Table, Partition>>() {
+          @Override
+          public Either<Table, Partition> apply(HiveTablePartitionVersion input) {
+            return input.getVersion();
+          }
+        });
+    for (Either<Table, Partition> tableOrPartitionToDelete : deletableTableOrPartitions) {
+      this.cleanImpl(tableOrPartitionToDelete);
+    }
+  }
+
+  protected void cleanImpl(Either<Table, Partition> tableOrPartition)
+      throws IOException {
+    try (AutoReturnableObject<IMetaStoreClient> client = this.clientPool.getClient()) {
+      if (tableOrPartition instanceof Either.Right) {
+        Partition paritionToDrop = ((Partition) ((Either.Right) tableOrPartition).getRight());
+        if (this.simulate) {
+          log.info("Simulate mode: will delete partition " + paritionToDrop.getValues() + " for table " + paritionToDrop
+              .getTable().getTableName());
+        }
+
+        client.get().dropPartition(this.table.getDbName(), this.table.getTableName(), paritionToDrop.getValues(), true);
+      } else {
+        Table tableToDrop = ((Table) ((Either.Left) tableOrPartition).getLeft());
+        if (this.simulate) {
+          log.info("Simulate mode: will delete table " + tableToDrop.getTableName());
+        }
+        client.get().dropTable(tableToDrop.getDbName(), tableToDrop.getTableName(), true, true);
+      }
+    } catch (NoSuchObjectException e) {
+      // Partition or table does not exist. Nothing to do
+    } catch (TException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public Path datasetRoot() {
+    return this.tableRootPath.isPresent() ? tableRootPath.get() : null;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/finder/HiveCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/finder/HiveCleanableDatasetFinder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.dataset.finder;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.data.management.retention.dataset.HiveCleanableDataset;
+
+
+/**
+ * Extends {@link HiveDatasetFinder} and finds {@link HiveCleanableDatasetFinder}.
+ */
+public class HiveCleanableDatasetFinder extends HiveDatasetFinder {
+  public HiveCleanableDatasetFinder(FileSystem fs, Properties properties)
+      throws IOException {
+    super(fs, properties);
+  }
+
+  @Override
+  protected HiveDataset createHiveDataset(Table table)
+      throws IOException {
+    return new HiveCleanableDataset(this.fs, this.clientPool, new org.apache.hadoop.hive.ql.metadata.Table(table),
+        this.properties);
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/HiveTablePartitionInvalidDataLocRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/HiveTablePartitionInvalidDataLocRetentionPolicy.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.policy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.data.management.version.HiveTablePartitionVersion;
+import gobblin.util.Either;
+
+import lombok.AllArgsConstructor;
+
+
+/**
+ * List deletable {@link HiveTablePartitionVersion}s by checking if the data location pointed by {@link Table} or {@link Partition} exists.
+ */
+@AllArgsConstructor
+public class HiveTablePartitionInvalidDataLocRetentionPolicy implements RetentionPolicy<HiveTablePartitionVersion> {
+  private final FileSystem fs;
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return HiveTablePartitionVersion.class;
+  }
+
+  @Override
+  public Collection<HiveTablePartitionVersion> listDeletableVersions(List<HiveTablePartitionVersion> allVersions) {
+    List<HiveTablePartitionVersion> deletableVersions = new ArrayList<>();
+    for (HiveTablePartitionVersion hiveTablePartitionVersion : allVersions) {
+      Either<Table, Partition> version = hiveTablePartitionVersion.getVersion();
+      Path dataLoc = version instanceof Either.Left ? ((Table) ((Either.Left) version).getLeft()).getDataLocation()
+          : ((Partition) ((Either.Right) version).getRight()).getDataLocation();
+      try {
+        if (!this.fs.exists(dataLoc)) {
+          deletableVersions.add(hiveTablePartitionVersion);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to determine deletable versions", e);
+      }
+    }
+    return deletableVersions;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/HiveTablePartitionTimeBasedRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/HiveTablePartitionTimeBasedRetentionPolicy.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.retention.policy;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.joda.time.DateTime;
+import org.joda.time.Duration;
+
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.data.management.version.HiveTablePartitionVersion;
+import gobblin.util.Either;
+
+
+/**
+ * List deletable {@link HiveTablePartitionVersion}s by checking if the modification timestamp of the data location older than currentTime minus {@link #retention}.
+ * This can be overridden by getting the time information from other ways, e.g., the datetime pattern along the path.
+ */
+public class HiveTablePartitionTimeBasedRetentionPolicy implements RetentionPolicy<HiveTablePartitionVersion> {
+
+  private final Duration retention;
+  private final FileSystem fs;
+
+  public HiveTablePartitionTimeBasedRetentionPolicy(Properties props, FileSystem fs) {
+    this.retention = Duration.standardMinutes(Long.parseLong(props
+        .getProperty(TimeBasedRetentionPolicy.RETENTION_MINUTES_KEY,
+            TimeBasedRetentionPolicy.RETENTION_MINUTES_DEFAULT)));
+    this.fs = fs;
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return HiveTablePartitionVersion.class;
+  }
+
+  @Override
+  public Collection<HiveTablePartitionVersion> listDeletableVersions(List<HiveTablePartitionVersion> allVersions) {
+    List<HiveTablePartitionVersion> deletableVersions = new ArrayList<>();
+    for (HiveTablePartitionVersion hiveTablePartitionVersion : allVersions) {
+      Either<Table, Partition> version = hiveTablePartitionVersion.getVersion();
+      try {
+        if (this.shouldDeleteTableOrPartition(version)) {
+          deletableVersions.add(hiveTablePartitionVersion);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to determine deletable versions", e);
+      }
+    }
+    return deletableVersions;
+  }
+
+  public boolean shouldDeleteTableOrPartition(Either<Table, Partition> tableOrPartition)
+      throws IOException {
+    Path dataLoc =
+        tableOrPartition instanceof Either.Left ? ((Table) ((Either.Left) tableOrPartition).getLeft()).getDataLocation()
+            : ((Partition) ((Either.Right) tableOrPartition).getRight()).getDataLocation();
+    if (this.fs.exists(dataLoc) && new DateTime(this.fs.getFileStatus(dataLoc).getModificationTime()).plus(retention)
+        .isBeforeNow()) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/TimeBasedRetentionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/policy/TimeBasedRetentionPolicy.java
@@ -103,7 +103,7 @@ public class TimeBasedRetentionPolicy implements RetentionPolicy<TimestampedData
    * @param periodString
    * @return duration for this period.
    */
-  private static Duration parseDuration(String periodString) {
+  protected static Duration parseDuration(String periodString) {
     DateTime zeroEpoc = new DateTime(0);
     return new Duration(zeroEpoc, zeroEpoc.plus(ISOPeriodFormat.standard().parsePeriod(periodString)));
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/HiveTablePartitionVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/HiveTablePartitionVersion.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.version;
+
+import gobblin.util.Either;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+/**
+ * Denotes the version for a hive table or partition.
+ */
+@AllArgsConstructor
+public class HiveTablePartitionVersion implements DatasetVersion{
+  @Getter
+  private final Either<Table, Partition> version;
+
+  @Override
+  public Either<Table, Partition> getVersion() {
+    return version;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/HiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/HiveDatasetVersionFinder.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.version.finder;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.data.management.copy.hive.HiveUtils;
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.data.management.version.HiveTablePartitionVersion;
+import gobblin.dataset.Dataset;
+import gobblin.util.Either;
+
+
+/**
+ * Find {@link HiveTablePartitionVersion}s for {@link HiveDataset}. If the hive table is partitioned, then versions will
+ * be partitions. Otherwise, it is a single version using table itself.
+ */
+public class HiveDatasetVersionFinder extends HiveDatasetFinder implements VersionFinder<HiveTablePartitionVersion> {
+  public HiveDatasetVersionFinder(FileSystem fs, Properties properties)
+      throws IOException {
+    super(fs, properties);
+  }
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return HiveTablePartitionVersion.class;
+  }
+
+  @Override
+  public Collection<HiveTablePartitionVersion> findDatasetVersions(Dataset dataset)
+      throws IOException {
+    Preconditions.checkArgument(dataset instanceof HiveDataset);
+    List<HiveTablePartitionVersion> hiveDatasetVersions = new ArrayList<>();
+    HiveDataset hiveDataset = (HiveDataset) dataset;
+
+    if (!hiveDataset.getTable().isPartitioned()) {
+      hiveDatasetVersions.add(new HiveTablePartitionVersion(Either.<Table, Partition>left(hiveDataset.getTable())));
+    } else {
+      for (Partition partition : HiveUtils
+          .getPartitions(hiveDataset.getClientPool().getClient().get(), hiveDataset.getTable(),
+              Optional.<String>absent())) {
+        hiveDatasetVersions.add(new HiveTablePartitionVersion(Either.<Table, Partition>right(partition)));
+      }
+    }
+
+    return hiveDatasetVersions;
+  }
+}


### PR DESCRIPTION
Implementation of hive retention. It uses `HiveCleanableDatasetFinder` to find `HiveCleanableDataset`. Each `HiveCleanableDataset` will contain `HiveTablePartitionVersions`. If a table is not partitioned, it will be single version. Otherwise, it will contain partitions as versions. 
Currently, there are two retention policies. One is `HiveTablePartitionInvalidDataLocRetentionPolicy`, which is based on if the data location exists on filesystem. Another one is `HiveTablePartitionTimeBasedRetentionPolicy`, which is based on some timestamp. Now the default behavior is based on modified timestamp. But it can be overridden. 

Tested on holdem, I have created RB: https://rb.corp.linkedin.com/r/756706/ for sample job configs I used.