### PR TITLE
Add ConvertibleHiveDataset and config store support to HiveDatasetFinder

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -32,7 +32,9 @@ import gobblin.data.management.copy.hive.HiveDataset;
 import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.util.ConfigUtils;
 
-
+/**
+ * A {@link HiveDataset} that can be converted to another {@link HiveDataset}
+ */
 @Getter
 @ToString
 public class ConvertibleHiveDataset extends HiveDataset {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -44,8 +44,8 @@ public class ConvertibleHiveDataset extends HiveDataset {
   public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
   public static final String DESTINATION_CONVERSION_FORMATS_KEY = "destination.formats";
 
-  private static final String DB_NAME_TEMPLATE = "{dbName}";
-  private static final String TABLE_NAME_TEMPLATE = "{tableName}";
+  private static final String DB_NAME_TEMPLATE = "{DB}";
+  private static final String TABLE_NAME_TEMPLATE = "{TABLE}";
 
   private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
   private final Optional<String> destinationTableName;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -17,7 +17,6 @@ import java.util.Properties;
 import lombok.Getter;
 import lombok.ToString;
 
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hive.ql.metadata.Table;
 
@@ -43,9 +42,6 @@ public class ConvertibleHiveDataset extends HiveDataset {
   public static final String DESTINATION_DB_KEY = "destination.dbName";
   public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
   public static final String DESTINATION_CONVERSION_FORMATS_KEY = "destination.formats";
-
-  private static final String DB_NAME_TEMPLATE = "{DB}";
-  private static final String TABLE_NAME_TEMPLATE = "{TABLE}";
 
   private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
   private final Optional<String> destinationTableName;
@@ -74,13 +70,5 @@ public class ConvertibleHiveDataset extends HiveDataset {
 
     this.hiveProperties = ConfigUtils.configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
 
-  }
-
-  /**
-   * Resolve {@value #DB_NAME_TEMPLATE} and {@value #TABLE_NAME_TEMPLATE} in <code>rawString</code> to {@link Table#getDbName()}
-   * and {@link Table#getTableName()}
-   */
-  private static String resolveTemplate(String rawString, Table table) {
-    return StringUtils.replaceEach(rawString, new String[] { DB_NAME_TEMPLATE, TABLE_NAME_TEMPLATE }, new String[] { table.getDbName(), table.getTableName() });
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.dataset;
+
+import java.util.HashSet;
+import java.util.Properties;
+
+import lombok.Getter;
+import lombok.ToString;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.Table;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Sets;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigException;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.hive.HiveMetastoreClientPool;
+import gobblin.util.ConfigUtils;
+
+
+@Getter
+@ToString
+public class ConvertibleHiveDataset extends HiveDataset {
+
+  public static final String DESTINATION_TABLE_KEY = "destination.tableName";
+  public static final String DESTINATION_DB_KEY = "destination.dbName";
+  public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
+  public static final String DESTINATION_CONVERSION_FORMATS_KEY = "destination.formats";
+
+  private static final String DB_NAME_TEMPLATE = "{dbName}";
+  private static final String TABLE_NAME_TEMPLATE = "{tableName}";
+
+  private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
+  private final Optional<String> destinationTableName;
+  private final Optional<String> destinationDbName;
+  private final Optional<String> destinationDataPath;
+  private final Optional<HashSet<String>> formats;
+  private final Properties hiveProperties;
+
+  public ConvertibleHiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Config config) {
+    super(fs, clientPool, table, config);
+    this.destinationTableName = Optional.fromNullable(resolveTemplate(ConfigUtils.getString(config, DESTINATION_TABLE_KEY, null), table));
+    this.destinationDbName = Optional.fromNullable(resolveTemplate(ConfigUtils.getString(config, DESTINATION_DB_KEY, null), table));
+    this.destinationDataPath = Optional.fromNullable(resolveTemplate(ConfigUtils.getString(config, DESTINATION_DATA_PATH_KEY, null), table));
+
+    if (config.hasPath(DESTINATION_CONVERSION_FORMATS_KEY)) {
+      this.formats = Optional.of(Sets.<String> newHashSet());
+      try {
+        this.formats.get().addAll(config.getStringList(DESTINATION_CONVERSION_FORMATS_KEY));
+      } catch (ConfigException.WrongType e) {
+        Splitter tokenSplitter = Splitter.on(",").omitEmptyStrings().trimResults();
+        this.formats.get().addAll(tokenSplitter.splitToList(config.getString(DESTINATION_CONVERSION_FORMATS_KEY)));
+      }
+    } else {
+      this.formats = Optional.absent();
+    }
+
+    this.hiveProperties = ConfigUtils.configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
+
+  }
+
+  /**
+   * Resolve {@value #DB_NAME_TEMPLATE} and {@value #TABLE_NAME_TEMPLATE} in <code>rawString</code> to {@link Table#getDbName()}
+   * and {@link Table#getTableName()}
+   */
+  private static String resolveTemplate(String rawString, Table table) {
+    return StringUtils.replaceEach(rawString, new String[] { DB_NAME_TEMPLATE, TABLE_NAME_TEMPLATE }, new String[] { table.getDbName(), table.getTableName() });
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetFinder.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.dataset;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import com.typesafe.config.Config;
+
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.metrics.event.EventSubmitter;
+
+
+public class ConvertibleHiveDatasetFinder extends HiveDatasetFinder {
+
+  public ConvertibleHiveDatasetFinder(FileSystem fs, Properties properties, EventSubmitter eventSubmitter) throws IOException {
+    super(fs, properties, eventSubmitter);
+  }
+
+  protected ConvertibleHiveDataset createHiveDataset(Table table, Config config) {
+    return new ConvertibleHiveDataset(super.fs, super.clientPool, new org.apache.hadoop.hive.ql.metadata.Table(table),
+        config);
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetFinder.java
@@ -23,6 +23,9 @@ import gobblin.data.management.copy.hive.HiveDatasetFinder;
 import gobblin.metrics.event.EventSubmitter;
 
 
+/**
+ * A {@link HiveDatasetFinder} to create {@link ConvertibleHiveDataset}s
+ */
 public class ConvertibleHiveDatasetFinder extends HiveDatasetFinder {
 
   public ConvertibleHiveDatasetFinder(FileSystem fs, Properties properties, EventSubmitter eventSubmitter) throws IOException {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -16,7 +16,10 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.Properties;
 
+import lombok.Getter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
+
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.metadata.Table;
@@ -24,6 +27,8 @@ import org.apache.hadoop.hive.ql.metadata.Table;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import gobblin.annotation.Alpha;
 import gobblin.configuration.State;
@@ -31,15 +36,13 @@ import gobblin.data.management.copy.CopyConfiguration;
 import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.CopyableDataset;
 import gobblin.data.management.copy.IterableCopyableDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder.DbAndTable;
 import gobblin.data.management.partition.FileSet;
 import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.Tag;
 import gobblin.util.PathUtils;
-
-import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -56,30 +59,43 @@ public class HiveDataset implements IterableCopyableDataset {
   public static final String DATABASE = "Database";
   public static final String TABLE = "Table";
 
-  protected final Properties properties;
-  protected final FileSystem fs;
-  protected final HiveMetastoreClientPool clientPool;
-  @Getter
-  protected final Table table;
+  // Will not be serialized/de-serialized
+  protected transient final Properties properties;
+  protected transient final FileSystem fs;
+  protected transient final HiveMetastoreClientPool clientPool;
+  private transient final MetricContext metricContext;
+  protected transient final Table table;
+  protected transient final Config datasetConfig;
+
 
   // Only set if table has exactly one location
   protected final Optional<Path> tableRootPath;
-
   protected final String tableIdentifier;
-  @Getter
-  private final MetricContext metricContext;
+  protected final DbAndTable dbAndTable;
 
   public HiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Properties properties) {
+    this(fs, clientPool, table, properties, ConfigFactory.empty());
+  }
+
+  public HiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Config datasetConfig) {
+    this(fs, clientPool, table, new Properties(), datasetConfig);
+  }
+
+  public HiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Properties properties, Config datasetConfig) {
     this.fs = fs;
     this.clientPool = clientPool;
     this.table = table;
     this.properties = properties;
+    this.datasetConfig = datasetConfig;
 
-    this.tableRootPath = PathUtils.isGlob(this.table.getDataLocation()) ? Optional.<Path> absent()
-        : Optional.of(this.table.getDataLocation());
+    System.out.println(this.table.getDataLocation());
+    System.out.println(PathUtils.isGlob(this.table.getDataLocation()));
+    this.tableRootPath = PathUtils.isGlob(this.table.getDataLocation()) ? Optional.<Path> absent() : Optional.of(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     log.info("Created Hive dataset for table " + this.tableIdentifier);
+
+    this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());
 
     this.metricContext = Instrumented.getMetricContext(new State(properties), HiveDataset.class,
         Lists.<Tag<?>> newArrayList(new Tag<>(DATABASE, table.getDbName()), new Tag<>(TABLE, table.getTableName())));

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -20,6 +20,7 @@ import lombok.Getter;
 import lombok.ToString;
 import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.metadata.Table;
@@ -58,6 +59,9 @@ public class HiveDataset implements IterableCopyableDataset {
   public static final String REGISTRATION_GENERATION_TIME_MILLIS = "registrationGenerationTimeMillis";
   public static final String DATABASE = "Database";
   public static final String TABLE = "Table";
+
+  public static final String DATABASE_TOKEN = "$DB";
+  public static final String TABLE_TOKEN = "$TABLE";
 
   // Will not be serialized/de-serialized
   protected transient final Properties properties;
@@ -119,4 +123,11 @@ public class HiveDataset implements IterableCopyableDataset {
     return this.table.getCompleteName();
   }
 
+  /**
+   * Resolve {@value #DATABASE_TOKEN} and {@value #TABLE_TOKEN} in <code>rawString</code> to {@link Table#getDbName()}
+   * and {@link Table#getTableName()}
+   */
+  public static String resolveTemplate(String rawString, Table table) {
+    return StringUtils.replaceEach(rawString, new String[] { DATABASE_TOKEN, TABLE_TOKEN }, new String[] { table.getDbName(), table.getTableName() });
+  }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -88,8 +88,6 @@ public class HiveDataset implements IterableCopyableDataset {
     this.properties = properties;
     this.datasetConfig = datasetConfig;
 
-    System.out.println(this.table.getDataLocation());
-    System.out.println(PathUtils.isGlob(this.table.getDataLocation()));
     this.tableRootPath = PathUtils.isGlob(this.table.getDataLocation()) ? Optional.<Path> absent() : Optional.of(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDatasetFinder.java
@@ -223,7 +223,7 @@ public class HiveDatasetFinder implements IterableDatasetFinder<HiveDataset> {
 
 
   /**
-   * Deprecated. Use {@link #createHiveDataset(Table, Config)} instead
+   * @deprecated Use {@link #createHiveDataset(Table, Config)} instead
    */
   @Deprecated
   protected HiveDataset createHiveDataset(Table table) throws IOException {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveTargetPathHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveTargetPathHelper.java
@@ -60,8 +60,6 @@ public class HiveTargetPathHelper {
   public static final String RELOCATE_DATA_FILES_KEY =
       HiveDatasetFinder.HIVE_DATASET_PREFIX + ".copy.relocate.data.files";
   public static final String DEFAULT_RELOCATE_DATA_FILES = Boolean.toString(false);
-  private static final String databaseToken = "$DB";
-  private static final String tableToken = "$TABLE";
   private final boolean relocateDataFiles;
   private final Optional<Path> targetTableRoot;
   private final Optional<Path> targetTablePrefixTobeReplaced;
@@ -101,9 +99,9 @@ public class HiveTargetPathHelper {
    * resolved to /data/myDatabase/myTable.
    */
   protected static Path resolvePath(String pattern, String database, String table) {
-    pattern = pattern.replace(databaseToken, database);
-    if (pattern.contains(tableToken)) {
-      pattern = pattern.replace(tableToken, table);
+    pattern = pattern.replace(HiveDataset.DATABASE_TOKEN, database);
+    if (pattern.contains(HiveDataset.TABLE_TOKEN)) {
+      pattern = pattern.replace(HiveDataset.TABLE_TOKEN, table);
       return new Path(pattern);
     } else {
       return new Path(pattern, table);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/hive/HiveConfigClientUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/hive/HiveConfigClientUtils.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.hive;
+
+import org.apache.hadoop.fs.Path;
+
+import gobblin.data.management.copy.hive.HiveDatasetFinder.DbAndTable;
+
+
+public class HiveConfigClientUtils {
+
+  private static final String HIVE_DATASETS_CONFIG_PREFIX = "hive/";
+
+  public static String getDatasetUri(DbAndTable dbAndTable) {
+    return HIVE_DATASETS_CONFIG_PREFIX + dbAndTable.getDb() + Path.SEPARATOR + dbAndTable.getTable();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/hive/HiveConfigClientUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/hive/HiveConfigClientUtils.java
@@ -13,13 +13,21 @@ package gobblin.data.management.hive;
 
 import org.apache.hadoop.fs.Path;
 
+import gobblin.config.client.ConfigClient;
+import gobblin.data.management.copy.hive.HiveDataset;
 import gobblin.data.management.copy.hive.HiveDatasetFinder.DbAndTable;
 
-
+/**
+ * Utility methods to for a {@link HiveDataset} to communicate with {@link ConfigClient}
+ */
 public class HiveConfigClientUtils {
 
   private static final String HIVE_DATASETS_CONFIG_PREFIX = "hive/";
 
+  /**
+   * Get the dataset uri for a hive db and table. The uri is relative to the store uri .
+   * @param dbAndTable
+   */
   public static String getDatasetUri(DbAndTable dbAndTable) {
     return HIVE_DATASETS_CONFIG_PREFIX + dbAndTable.getDb() + Path.SEPARATOR + dbAndTable.getTable();
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -53,9 +53,9 @@ public class ConvertibleHiveDatasetTest {
   @Test
   public void testSubstitution() throws Exception {
     Config config =
-        ConfigFactory.parseMap(ImmutableMap.of(ConvertibleHiveDataset.DESTINATION_DB_KEY, "dest_{DB}",
-            ConvertibleHiveDataset.DESTINATION_TABLE_KEY, "dest_{TABLE}",
-            ConvertibleHiveDataset.DESTINATION_DATA_PATH_KEY,"dest_data/{DB}/{TABLE}"));
+        ConfigFactory.parseMap(ImmutableMap.of(ConvertibleHiveDataset.DESTINATION_DB_KEY, "dest_$DB",
+            ConvertibleHiveDataset.DESTINATION_TABLE_KEY, "dest_$TABLE",
+            ConvertibleHiveDataset.DESTINATION_DATA_PATH_KEY,"dest_data/$DB/$TABLE"));
 
     Table table = getTestTable("db1", "tb1");
     ConvertibleHiveDataset cd =

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -53,9 +53,9 @@ public class ConvertibleHiveDatasetTest {
   @Test
   public void testSubstitution() throws Exception {
     Config config =
-        ConfigFactory.parseMap(ImmutableMap.of(ConvertibleHiveDataset.DESTINATION_DB_KEY, "dest_{dbName}",
-            ConvertibleHiveDataset.DESTINATION_TABLE_KEY, "dest_{tableName}",
-            ConvertibleHiveDataset.DESTINATION_DATA_PATH_KEY,"dest_data/{dbName}/{tableName}"));
+        ConfigFactory.parseMap(ImmutableMap.of(ConvertibleHiveDataset.DESTINATION_DB_KEY, "dest_{DB}",
+            ConvertibleHiveDataset.DESTINATION_TABLE_KEY, "dest_{TABLE}",
+            ConvertibleHiveDataset.DESTINATION_DATA_PATH_KEY,"dest_data/{DB}/{TABLE}"));
 
     Table table = getTestTable("db1", "tb1");
     ConvertibleHiveDataset cd =

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.dataset;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.hive.HiveMetastoreClientPool;
+
+
+public class ConvertibleHiveDatasetTest {
+
+  @Test
+  public void testConstructor() throws Exception {
+    Config config =
+        ConfigFactory.parseMap(ImmutableMap.of(ConvertibleHiveDataset.DESTINATION_DB_KEY, "dest_db",
+            ConvertibleHiveDataset.DESTINATION_TABLE_KEY, "dest_tb",
+            ConvertibleHiveDataset.DESTINATION_DATA_PATH_KEY, "dest_data",
+            ConvertibleHiveDataset.DESTINATION_CONVERSION_FORMATS_KEY, "a,b"));
+
+    Table table = getTestTable("db1", "tb1");
+    ConvertibleHiveDataset cd =
+        new ConvertibleHiveDataset(Mockito.mock(FileSystem.class), Mockito.mock(HiveMetastoreClientPool.class), new org.apache.hadoop.hive.ql.metadata.Table(
+            table), config);
+    Assert.assertEquals(cd.getDestinationDbName().get(), "dest_db");
+    Assert.assertEquals(cd.getDestinationTableName().get(), "dest_tb");
+    Assert.assertEquals(cd.getDestinationDataPath().get(), "dest_data");
+    Assert.assertEquals(cd.getFormats().get(), ImmutableSet.of("a", "b"));
+  }
+
+  /**
+   * Test to make sure {dbName} and {tableName} are resolved
+   * @throws Exception
+   */
+  @Test
+  public void testSubstitution() throws Exception {
+    Config config =
+        ConfigFactory.parseMap(ImmutableMap.of(ConvertibleHiveDataset.DESTINATION_DB_KEY, "dest_{dbName}",
+            ConvertibleHiveDataset.DESTINATION_TABLE_KEY, "dest_{tableName}",
+            ConvertibleHiveDataset.DESTINATION_DATA_PATH_KEY,"dest_data/{dbName}/{tableName}"));
+
+    Table table = getTestTable("db1", "tb1");
+    ConvertibleHiveDataset cd =
+        new ConvertibleHiveDataset(Mockito.mock(FileSystem.class), Mockito.mock(HiveMetastoreClientPool.class), new org.apache.hadoop.hive.ql.metadata.Table(
+            table), config);
+    Assert.assertEquals(cd.getDestinationDbName().get(), "dest_db1");
+    Assert.assertEquals(cd.getDestinationTableName().get(), "dest_tb1");
+    Assert.assertEquals(cd.getDestinationDataPath().get(), "dest_data/db1/tb1");
+  }
+
+  private Table getTestTable(String dbName, String tableName) {
+    Table table = new Table();
+    table.setDbName(dbName);
+    table.setTableName(tableName);
+    StorageDescriptor sd = new StorageDescriptor();
+    sd.setLocation("/tmp/test");
+    table.setSd(sd);
+    return table;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -136,6 +136,20 @@ public class ConfigUtils {
   }
 
   /**
+   * Return {@link Config} value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
+   *
+   * @param config in which the path may be present
+   * @param path key to look for in the config object
+   * @return config value at <code>path</code> if <code>config</code> has path. If not return <code>def</code>
+   */
+  public static Config getConfig(Config config, String path, Config def) {
+    if (config.hasPath(path)) {
+      return config.getConfig(path);
+    }
+    return def;
+  }
+
+  /**
    * Check if the given <code>key</code> exists in <code>config</code> and it is not null or empty
    * Uses {@link StringUtils#isNotBlank(CharSequence)}
    * @param config which may have the key


### PR DESCRIPTION
1. Added ```ConvertibleHiveDataset``` used in conversion jobs
2. Added support for reading dataset configs from gobblin config store if available. If config store is not configured, job configs with a prefix are used as dataset config.  By default the prefix is empty string. But by setting ```hive.dataset.configPrefix``` only configs with this prefix is passed to the ```HiveDataset```'s``` ```datasetConfig```.<br>

**Some Example**<br>
**a. Retention jobs**
<pre>
hive.dataset.configPrefix=hive.dataset.retention
hive.dataset.retention.is.blacklisted=true
hive.dataset.retention.selection.policy=blah
</pre>
```CleanableHiveDataset``` will be initialized with
<pre>
is.blacklisted=true
selection.policy=blah
</pre>

**b. Avro to Orc Conversion jobs**
<pre>
hive.dataset.configPrefix=hive.dataset.conversion.avro.orc
hive.dataset.conversion.avro.orc.is.blacklisted=true
hive.dataset.conversion.avro.orc.destination.tableName=blah
</pre>
```ConvertibleHiveDataset``` will be initialized with
<pre>
is.blacklisted=true
destination.tableName=blah
</pre>

Note that ```is.blacklisted``` is a key in local scope which is used to blacklist a dataset in any context.

@ibuenros and @abti can you review?

Here is the [design doc](https://docs.google.com/document/d/1IH9XzY93wiDf6-rzRuFuC6KZSOufulpQSCP5O9eSUUU/edit#heading=h.q4hfu3do5xv3) 
