### PR TITLE
Implemented a commit step database to reduce size of copy work units.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -141,7 +141,7 @@ ext.externalDependency = [
   "avroMapredH2": "org.apache.avro:avro-mapred:" + avroVersion + ":hadoop2",
   "commonsCli": "commons-cli:commons-cli:1.3.1",
   "commonsCodec": "commons-codec:commons-codec:1.10",
-  "commonsDbcp": "commons-dbcp:commons-dbcp:1.4",
+  "commonsDbcp": "org.apache.commons:commons-dbcp2:2.1.1",
   "commonsEmail": "org.apache.commons:commons-email:1.4",
   "commonsLang": "commons-lang:commons-lang:2.6",
   "commonsLang3": "org.apache.commons:commons-lang3:3.4",

--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -486,9 +486,9 @@ public class State implements Writable {
 
     while (numEntries-- > 0) {
       txt.readFields(in);
-      String key = txt.toString();
+      String key = txt.toString().intern();
       txt.readFields(in);
-      String value = txt.toString();
+      String value = txt.toString().intern();
 
       this.properties.put(key, value);
     }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcProvider.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcProvider.java
@@ -13,10 +13,11 @@
 package gobblin.source.extractor.extract.jdbc;
 
 import gobblin.tunnel.Tunnel;
-import org.apache.commons.dbcp.BasicDataSource;
 
 import java.io.IOException;
 import java.sql.SQLException;
+
+import org.apache.commons.dbcp2.BasicDataSource;
 
 
 /**
@@ -74,7 +75,7 @@ public class JdbcProvider extends BasicDataSource {
     this.setUrl(connectionUrl);
     this.setInitialSize(0);
     this.setMaxIdle(numconn);
-    this.setMaxWait(timeout);
+    this.setMaxWaitMillis(timeout);
   }
 
   @Override

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyEntity.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyEntity.java
@@ -121,7 +121,7 @@ public class CopyEntity implements HasGuid {
   /**
    * Used for simulate runs. Should explain what this copy entity will do.
    */
-  public String explain() {
+  public String explain() throws IOException {
     return toString();
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepCopyEntity.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepCopyEntity.java
@@ -15,6 +15,7 @@ package gobblin.data.management.copy.entities;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
+import java.io.IOException;
 import java.util.Map;
 
 import gobblin.commit.CommitStep;
@@ -27,20 +28,25 @@ import gobblin.data.management.copy.CopyEntity;
 @EqualsAndHashCode(callSuper = true)
 public class CommitStepCopyEntity extends CopyEntity {
 
-  @Getter
-  private final CommitStep step;
   /** A priority value that can be used for sorting {@link CommitStepCopyEntity}s. Lower values are higher priority.*/
   @Getter
   private final int priority;
+  private final String key;
 
-  public CommitStepCopyEntity(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority) {
+  public CommitStepCopyEntity(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority,
+      CommitStepDB commitStepDB, String stepKey) throws IOException {
     super(fileSet, additionalMetadata);
-    this.step = step;
+    commitStepDB.put(stepKey, step);
+    this.key = stepKey;
     this.priority = priority;
   }
 
+  public CommitStep getStep(CommitStepDB commitStepDB) throws IOException {
+    return commitStepDB.get(this.key);
+  }
+
   @Override
-  public String explain() {
-    return this.step.toString();
+  public String explain() throws IOException {
+    return this.getStep(new CommitStepDB()).toString();
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepCopyEntity.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepCopyEntity.java
@@ -34,19 +34,19 @@ public class CommitStepCopyEntity extends CopyEntity {
   private final String key;
 
   public CommitStepCopyEntity(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority,
-      CommitStepDB commitStepDB, String stepKey) throws IOException {
+      String stepKey) throws IOException {
     super(fileSet, additionalMetadata);
-    commitStepDB.put(stepKey, step);
+    CommitStepDB.put(stepKey, step);
     this.key = stepKey;
     this.priority = priority;
   }
 
-  public CommitStep getStep(CommitStepDB commitStepDB) throws IOException {
-    return commitStepDB.get(this.key);
+  public CommitStep getStep() throws IOException {
+    return CommitStepDB.get(this.key);
   }
 
   @Override
   public String explain() throws IOException {
-    return this.getStep(new CommitStepDB()).toString();
+    return this.getStep().toString();
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepDB.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/CommitStepDB.java
@@ -1,0 +1,206 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.entities;
+
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.SQLIntegrityConstraintViolationException;
+import java.sql.Statement;
+import java.util.NoSuchElementException;
+import java.util.Properties;
+
+import org.apache.commons.io.IOUtils;
+
+import com.google.common.base.Charsets;
+
+import gobblin.commit.CommitStep;
+import gobblin.data.management.copy.CopyEntity;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A DB that stores {@link CommitStep}s. Implementation is transparent to the user, but currently uses Derby.
+ */
+@Slf4j
+public class CommitStepDB implements Closeable {
+
+  public static final String COMMIT_STEP_DB_NAME = "gobblinCommitStepDB";
+  private static final String protocol = "jdbc:derby:";
+  private static final String ALREADY_EXISTS_STATE = "X0Y32";
+
+  private static final String INSERT_STEP_STATEMENT = "INSERT INTO steps VALUES (?, ?)";
+  private static final String GET_STEP_STATEMENT = "SELECT step FROM steps WHERE step_key = ?";
+
+  static {
+    Runtime.getRuntime().addShutdownHook(new Thread() {
+      @Override
+      public void run() {
+        try {
+          dropTable();
+          try {
+            DriverManager.getConnection(protocol + COMMIT_STEP_DB_NAME + ";shutdown=true", new Properties());
+          } catch (SQLException se) {
+            if (((se.getErrorCode() == 45000)
+                && ("08006".equals(se.getSQLState())))) {
+              // we got the expected exception
+              System.out.println("Derby shut down normally");
+            } else {
+              throw se;
+            }
+          }
+          DriverManager.getConnection(protocol + COMMIT_STEP_DB_NAME + ";drop=true", new Properties());
+        } catch (SQLException sqle) {
+          System.out.println("Error dropping commit steps DB");
+          printSQLException(sqle);
+        }
+      }
+    });
+  }
+
+  private final Connection conn;
+
+  public CommitStepDB() throws IOException {
+    try {
+      String driver = "org.apache.derby.jdbc.EmbeddedDriver";
+      Class.forName(driver);
+    } catch (ReflectiveOperationException roe) {
+      throw new RuntimeException("Derby is not in the classpath", roe);
+    }
+
+    try {
+      this.conn = DriverManager.getConnection(protocol + COMMIT_STEP_DB_NAME + ";create=true", new Properties());
+      ensureTableExists();
+    } catch (SQLException se) {
+      throw new IOException(se);
+    }
+  }
+
+  private void ensureTableExists() throws SQLException {
+    try (Statement statement = this.conn.createStatement()) {
+      statement.execute("CREATE TABLE steps(step_key VARCHAR(200) NOT NULL, step CLOB(500K), PRIMARY KEY (step_key))");
+    } catch (SQLException sqle) {
+      if (!sqle.getSQLState().equals(ALREADY_EXISTS_STATE)) {
+        throw sqle;
+      }
+    }
+  }
+
+  private static void dropTable() throws SQLException {
+    try (Connection conn = DriverManager.getConnection(protocol + COMMIT_STEP_DB_NAME + ";create=true", new Properties());
+        Statement statement = conn.createStatement()) {
+      statement.execute("DROP TABLE steps");
+      conn.commit();
+    } catch (SQLException sqle) {
+      if (!sqle.getSQLState().equals(ALREADY_EXISTS_STATE)) {
+        throw sqle;
+      }
+    }
+  }
+
+  /**
+   * Put a {@link CommitStep} into the DB.
+   * @param key key to indentify the {@link CommitStep}
+   * @param step {@link CommitStep} to store.
+   * @throws IOException for SQL errors.
+   * @throws IllegalStateException if a {@link CommitStep} with that key already exists.
+   */
+  public void put(String key, CommitStep step) throws IOException {
+    String serializedStep = CopyEntity.GSON.toJson(step);
+    try (PreparedStatement statement = this.conn.prepareStatement(INSERT_STEP_STATEMENT)) {
+      statement.setString(1, key);
+      statement.setAsciiStream(2, new ByteArrayInputStream(serializedStep.getBytes(Charsets.UTF_8)));
+      statement.execute();
+      this.conn.commit();
+    } catch (SQLIntegrityConstraintViolationException se) {
+      String existingStep = getRaw(key);
+      if (!serializedStep.equals(existingStep)) {
+        throw new IllegalStateException(
+            String.format("A step with key %s is already present in the commit step DB.", key));
+      }
+    } catch (SQLException se) {
+      throw new IOException(se);
+    }
+  }
+
+  /**
+   * Get the {@link CommitStep} stored under this key.
+   * @param key
+   * @return {@link CommitStep} stored under input key.
+   * @throws NoSuchElementException if no {@link CommitStep} with that key exists.
+   * @throws IOException for SQL errors.
+   */
+  public CommitStep get(String key) throws IOException {
+    return CopyEntity.GSON.fromJson(getRaw(key), CommitStep.class);
+  }
+
+  private String getRaw(String key) throws IOException {
+    try (PreparedStatement statement = this.conn.prepareStatement(GET_STEP_STATEMENT)) {
+      statement.setString(1, key);
+      ResultSet rs = statement.executeQuery();
+      this.conn.commit();
+
+      if (!rs.next()) {
+        throw new NoSuchElementException("No step with key " + key);
+      }
+
+      InputStream is = rs.getAsciiStream(1);
+      return IOUtils.toString(is, Charsets.UTF_8);
+    } catch (SQLException se) {
+      throw new IOException(se);
+    }
+  }
+
+  /**
+   * Closes the connection to the DB.
+   * @throws IOException
+   */
+  @Override
+  public void close()
+      throws IOException {
+    try {
+      this.conn.close();
+    } catch (SQLException sqle) {
+      log.error("Failed to close SQL connection.");
+      printSQLException(sqle);
+    }
+  }
+
+  /**
+   * Prints details of an SQLException chain to <code>System.err</code>.
+   * Details included are SQL State, Error code, Exception message.
+   *
+   * @param e the SQLException from which to print details.
+   */
+  public static void printSQLException(SQLException e) {
+    // Unwraps the entire exception chain to unveil the real cause of the
+    // Exception.
+    while (e != null) {
+      System.err.println("\n----- SQLException -----");
+      System.err.println("  SQL State:  " + e.getSQLState());
+      System.err.println("  Error Code: " + e.getErrorCode());
+      System.err.println("  Message:    " + e.getMessage());
+      // for stack traces, refer to derby.log or uncomment this:
+      //e.printStackTrace(System.err);
+      e = e.getNextException();
+    }
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PostPublishStep.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PostPublishStep.java
@@ -12,6 +12,7 @@
 
 package gobblin.data.management.copy.entities;
 
+import java.io.IOException;
 import java.util.Map;
 
 import gobblin.commit.CommitStep;
@@ -23,12 +24,15 @@ import gobblin.commit.CommitStep;
  */
 public class PostPublishStep extends CommitStepCopyEntity {
 
-  public PostPublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority) {
-    super(fileSet, additionalMetadata, step, priority);
+  public PostPublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority,
+      CommitStepDB commitStepDB, String stepKey)
+      throws IOException {
+    super(fileSet, additionalMetadata, step, priority, commitStepDB, stepKey);
   }
 
   @Override
-  public String explain() {
-    return String.format("Post publish step with priority %s: %s", this.getPriority(), getStep().toString());
+  public String explain() throws IOException {
+    return String.format("Post publish step with priority %s: %s", this.getPriority(),
+        getStep(new CommitStepDB()).toString());
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PostPublishStep.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PostPublishStep.java
@@ -24,15 +24,14 @@ import gobblin.commit.CommitStep;
  */
 public class PostPublishStep extends CommitStepCopyEntity {
 
-  public PostPublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority,
-      CommitStepDB commitStepDB, String stepKey)
+  public PostPublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority, String stepKey)
       throws IOException {
-    super(fileSet, additionalMetadata, step, priority, commitStepDB, stepKey);
+    super(fileSet, additionalMetadata, step, priority, stepKey);
   }
 
   @Override
   public String explain() throws IOException {
     return String.format("Post publish step with priority %s: %s", this.getPriority(),
-        getStep(new CommitStepDB()).toString());
+        getStep().toString());
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PrePublishStep.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PrePublishStep.java
@@ -24,15 +24,14 @@ import gobblin.commit.CommitStep;
  */
 public class PrePublishStep extends CommitStepCopyEntity {
 
-  public PrePublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority,
-      CommitStepDB commitStepDB, String stepKey)
+  public PrePublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority, String stepKey)
       throws IOException {
-    super(fileSet, additionalMetadata, step, priority, commitStepDB, stepKey);
+    super(fileSet, additionalMetadata, step, priority, stepKey);
   }
 
   @Override
   public String explain() throws IOException {
     return String.format("Pre publish step with priority %s: %s", this.getPriority(),
-        getStep(new CommitStepDB()).toString());
+        getStep().toString());
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PrePublishStep.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/entities/PrePublishStep.java
@@ -12,6 +12,7 @@
 
 package gobblin.data.management.copy.entities;
 
+import java.io.IOException;
 import java.util.Map;
 
 import gobblin.commit.CommitStep;
@@ -23,12 +24,15 @@ import gobblin.commit.CommitStep;
  */
 public class PrePublishStep extends CommitStepCopyEntity {
 
-  public PrePublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority) {
-    super(fileSet, additionalMetadata, step, priority);
+  public PrePublishStep(String fileSet, Map<String, Object> additionalMetadata, CommitStep step, int priority,
+      CommitStepDB commitStepDB, String stepKey)
+      throws IOException {
+    super(fileSet, additionalMetadata, step, priority, commitStepDB, stepKey);
   }
 
   @Override
-  public String explain() {
-    return String.format("Pre publish step with priority %s: %s", this.getPriority(), getStep().toString());
+  public String explain() throws IOException {
+    return String.format("Pre publish step with priority %s: %s", this.getPriority(),
+        getStep(new CommitStepDB()).toString());
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -40,7 +40,6 @@ import gobblin.data.management.copy.CopyableDataset;
 import gobblin.data.management.copy.CopyableDatasetMetadata;
 import gobblin.data.management.copy.CopyableFile;
 import gobblin.data.management.copy.entities.CommitStepCopyEntity;
-import gobblin.data.management.copy.entities.CommitStepDB;
 import gobblin.data.management.copy.entities.PostPublishStep;
 import gobblin.data.management.copy.entities.PrePublishStep;
 import gobblin.data.management.copy.recovery.RecoveryHelper;
@@ -72,7 +71,6 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
   private final FileSystem fs;
   protected final EventSubmitter eventSubmitter;
   protected final RecoveryHelper recoveryHelper;
-  protected final CommitStepDB commitStepDB;
 
   /**
    * Build a new {@link CopyDataPublisher} from {@link State}. The constructor expects the following to be set in the
@@ -101,7 +99,6 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
 
     this.recoveryHelper = new RecoveryHelper(this.fs, state);
     this.recoveryHelper.purgeOldPersistedFile();
-    this.commitStepDB = new CommitStepDB();
   }
 
   @Override
@@ -171,8 +168,8 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     log.info(String.format("[%s] Publishing fileSet from %s for dataset %s", datasetAndPartition.identifier(),
         datasetWriterOutputPath, metadata.getDatasetURN()));
 
-    List<CommitStep> prePublish = getCommitSequence(datasetWorkUnitStates, PrePublishStep.class, this.commitStepDB);
-    List<CommitStep> postPublish = getCommitSequence(datasetWorkUnitStates, PostPublishStep.class, this.commitStepDB);
+    List<CommitStep> prePublish = getCommitSequence(datasetWorkUnitStates, PrePublishStep.class);
+    List<CommitStep> postPublish = getCommitSequence(datasetWorkUnitStates, PostPublishStep.class);
     log.info(String.format("[%s] Found %d prePublish steps and %d postPublish steps.", datasetAndPartition.identifier(),
         prePublish.size(), postPublish.size()));
 
@@ -209,8 +206,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
         Long.toString(datasetOriginTimestamp), Long.toString(datasetUpstreamTimestamp));
   }
 
-  private static List<CommitStep> getCommitSequence(Collection<WorkUnitState> workUnits, Class<?> baseClass,
-      CommitStepDB commitStepDB)
+  private static List<CommitStep> getCommitSequence(Collection<WorkUnitState> workUnits, Class<?> baseClass)
       throws IOException {
     List<CommitStepCopyEntity> steps = Lists.newArrayList();
     for (WorkUnitState wus : workUnits) {
@@ -230,7 +226,7 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
     Collections.sort(steps, commitStepSorter);
     List<CommitStep> sequence = Lists.newArrayList();
     for (CommitStepCopyEntity entity : steps) {
-      sequence.add(entity.getStep(commitStepDB));
+      sequence.add(entity.getStep());
     }
 
     return sequence;

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepCopyEntityTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepCopyEntityTest.java
@@ -31,9 +31,9 @@ public class CommitStepCopyEntityTest {
   public void test() throws Exception {
     TestStep step = new TestStep("myStep");
     CommitStepCopyEntity ce =
-        new CommitStepCopyEntity("fileset", Maps.<String, Object>newHashMap(), step, 1, new CommitStepDB(), "step");
+        new CommitStepCopyEntity("fileset", Maps.<String, Object>newHashMap(), step, 1, "step");
 
-    Assert.assertEquals(step, ce.getStep(new CommitStepDB()));
+    Assert.assertEquals(step, ce.getStep());
   }
 
   @AllArgsConstructor

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepCopyEntityTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepCopyEntityTest.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.entities;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Maps;
+
+import gobblin.commit.CommitStep;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+
+public class CommitStepCopyEntityTest {
+
+  @Test
+  public void test() throws Exception {
+    TestStep step = new TestStep("myStep");
+    CommitStepCopyEntity ce =
+        new CommitStepCopyEntity("fileset", Maps.<String, Object>newHashMap(), step, 1, new CommitStepDB(), "step");
+
+    Assert.assertEquals(step, ce.getStep(new CommitStepDB()));
+  }
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  private class TestStep implements CommitStep {
+    private final String name;
+
+    @Override
+    public boolean isCompleted()
+        throws IOException {
+      return true;
+    }
+
+    @Override
+    public void execute()
+        throws IOException {
+
+    }
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepDBTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepDBTest.java
@@ -30,14 +30,10 @@ public class CommitStepDBTest {
 
     String key = "testBasic";
 
-    CommitStepDB stepDB = new CommitStepDB();
-
     CommitStep commitStep = new TestStep("myData");
-    stepDB.put(key, commitStep);
-    CommitStep recoveredStep = stepDB.get(key);
+    CommitStepDB.put(key, commitStep);
+    CommitStep recoveredStep = CommitStepDB.get(key);
     Assert.assertEquals(commitStep, recoveredStep);
-
-    stepDB.close();
 
   }
 
@@ -53,12 +49,9 @@ public class CommitStepDBTest {
 
     CommitStep commitStep = new TestStep(reallyLongString);
 
-    CommitStepDB stepDB = new CommitStepDB();
-    stepDB.put(key, commitStep);
-    CommitStep recoveredStep = stepDB.get(key);
+    CommitStepDB.put(key, commitStep);
+    CommitStep recoveredStep = CommitStepDB.get(key);
     Assert.assertEquals(commitStep, recoveredStep);
-
-    stepDB.close();
 
   }
 
@@ -67,42 +60,20 @@ public class CommitStepDBTest {
 
     String key = "testRepeatedKeys";
 
-    CommitStepDB stepDB = new CommitStepDB();
-
     CommitStep commitStepa = new TestStep("aaa");
-    stepDB.put(key, commitStepa);
+    CommitStepDB.put(key, commitStepa);
 
     // putting the same step will not throw exception
-    stepDB.put(key, commitStepa);
+    CommitStepDB.put(key, commitStepa);
 
     // trying to store a different step under the same key will throw exception
     try {
       CommitStep commitStepb = new TestStep("bbb");
-      stepDB.put(key, commitStepb);
+      CommitStepDB.put(key, commitStepb);
       Assert.fail();
     } catch (IllegalStateException exc) {
       // expected
     }
-
-    stepDB.close();
-  }
-
-  @Test
-  public void testReadInDifferentInstance() throws Exception {
-
-    String key = "testReadInDifferentInstance";
-
-    CommitStepDB writeStepDB = new CommitStepDB();
-
-    CommitStep commitStep = new TestStep("myData");
-    writeStepDB.put(key, commitStep);
-
-    CommitStepDB readStepDB = new CommitStepDB();
-    CommitStep recoveredStep = readStepDB.get(key);
-    Assert.assertEquals(commitStep, recoveredStep);
-
-    writeStepDB.close();
-    readStepDB.close();
 
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepDBTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/entities/CommitStepDBTest.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.data.management.copy.entities;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.commit.CommitStep;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+
+
+public class CommitStepDBTest {
+
+  @Test
+  public void testBasic() throws Exception {
+
+    String key = "testBasic";
+
+    CommitStepDB stepDB = new CommitStepDB();
+
+    CommitStep commitStep = new TestStep("myData");
+    stepDB.put(key, commitStep);
+    CommitStep recoveredStep = stepDB.get(key);
+    Assert.assertEquals(commitStep, recoveredStep);
+
+    stepDB.close();
+
+  }
+
+  @Test
+  public void testReallyLongStep() throws Exception {
+
+    String key = "testReallyLongStep";
+
+    String reallyLongString = "long";
+    for (int i = 0; i < 10; i++) {
+      reallyLongString = reallyLongString + reallyLongString;
+    }
+
+    CommitStep commitStep = new TestStep(reallyLongString);
+
+    CommitStepDB stepDB = new CommitStepDB();
+    stepDB.put(key, commitStep);
+    CommitStep recoveredStep = stepDB.get(key);
+    Assert.assertEquals(commitStep, recoveredStep);
+
+    stepDB.close();
+
+  }
+
+  @Test
+  public void testRepeatedKeys() throws Exception {
+
+    String key = "testRepeatedKeys";
+
+    CommitStepDB stepDB = new CommitStepDB();
+
+    CommitStep commitStepa = new TestStep("aaa");
+    stepDB.put(key, commitStepa);
+
+    // putting the same step will not throw exception
+    stepDB.put(key, commitStepa);
+
+    // trying to store a different step under the same key will throw exception
+    try {
+      CommitStep commitStepb = new TestStep("bbb");
+      stepDB.put(key, commitStepb);
+      Assert.fail();
+    } catch (IllegalStateException exc) {
+      // expected
+    }
+
+    stepDB.close();
+  }
+
+  @Test
+  public void testReadInDifferentInstance() throws Exception {
+
+    String key = "testReadInDifferentInstance";
+
+    CommitStepDB writeStepDB = new CommitStepDB();
+
+    CommitStep commitStep = new TestStep("myData");
+    writeStepDB.put(key, commitStep);
+
+    CommitStepDB readStepDB = new CommitStepDB();
+    CommitStep recoveredStep = readStepDB.get(key);
+    Assert.assertEquals(commitStep, recoveredStep);
+
+    writeStepDB.close();
+    readStepDB.close();
+
+  }
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  public static class TestStep implements CommitStep {
+
+    private final String data;
+
+    @Override
+    public boolean isCompleted()
+        throws IOException {
+      return false;
+    }
+
+    @Override
+    public void execute()
+        throws IOException {
+
+    }
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -22,6 +22,7 @@ import java.util.Properties;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
@@ -35,7 +36,6 @@ import com.google.common.collect.Maps;
 
 import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyEntity;
-import gobblin.data.management.copy.entities.CommitStepDB;
 import gobblin.data.management.copy.entities.PostPublishStep;
 import gobblin.data.management.copy.hive.HiveCopyEntityHelper.DeregisterFileDeleteMethod;
 import gobblin.hive.HiveRegProps;
@@ -156,10 +156,9 @@ public class HiveCopyEntityHelperTest {
         Mockito.any(org.apache.hadoop.hive.ql.metadata.Table.class))).thenCallRealMethod();
 
     org.apache.hadoop.hive.ql.metadata.Table meta_table = Mockito.mock(org.apache.hadoop.hive.ql.metadata.Table.class);
-    org.apache.hadoop.hive.metastore.api.Table api_table =
-        Mockito.mock(org.apache.hadoop.hive.metastore.api.Table.class);
-    Mockito.when(api_table.getDbName()).thenReturn("TestDB");
-    Mockito.when(api_table.getTableName()).thenReturn("TestTable");
+    org.apache.hadoop.hive.metastore.api.Table api_table = new Table();
+    api_table.setDbName("TestDB");
+    api_table.setTableName("TestTable");
     Mockito.when(meta_table.getTTable()).thenReturn(api_table);
 
     List<CopyEntity> copyEntities = new ArrayList<CopyEntity>();
@@ -172,7 +171,7 @@ public class HiveCopyEntityHelperTest {
     Assert.assertTrue(copyEntities.get(0) instanceof PostPublishStep);
     PostPublishStep p = (PostPublishStep) (copyEntities.get(0));
     Assert
-        .assertTrue(p.getStep(new CommitStepDB()).toString().
+        .assertTrue(p.getStep().toString().
             contains("Deregister table TestDB.TestTable on Hive metastore /targetURI"));
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveCopyEntityHelperTest.java
@@ -35,8 +35,8 @@ import com.google.common.collect.Maps;
 
 import gobblin.configuration.State;
 import gobblin.data.management.copy.CopyEntity;
+import gobblin.data.management.copy.entities.CommitStepDB;
 import gobblin.data.management.copy.entities.PostPublishStep;
-import gobblin.data.management.copy.entities.PrePublishStep;
 import gobblin.data.management.copy.hive.HiveCopyEntityHelper.DeregisterFileDeleteMethod;
 import gobblin.hive.HiveRegProps;
 import gobblin.metrics.event.MultiTimingEvent;
@@ -172,7 +172,8 @@ public class HiveCopyEntityHelperTest {
     Assert.assertTrue(copyEntities.get(0) instanceof PostPublishStep);
     PostPublishStep p = (PostPublishStep) (copyEntities.get(0));
     Assert
-        .assertTrue(p.getStep().toString().contains("Deregister table TestDB.TestTable on Hive metastore /targetURI"));
+        .assertTrue(p.getStep(new CommitStepDB()).toString().
+            contains("Deregister table TestDB.TestTable on Hive metastore /targetURI"));
   }
 
   @Test public void testReplacedPrefix() throws Exception {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobState.java
@@ -352,9 +352,9 @@ public class JobState extends SourceState {
   public void readFields(DataInput in) throws IOException {
     Text text = new Text();
     text.readFields(in);
-    this.jobName = text.toString();
+    this.jobName = text.toString().intern();
     text.readFields(in);
-    this.jobId = text.toString();
+    this.jobId = text.toString().intern();
     this.setId(this.jobId);
     this.startTime = in.readLong();
     this.endTime = in.readLong();
@@ -366,7 +366,7 @@ public class JobState extends SourceState {
     for (int i = 0; i < numTaskStates; i++) {
       TaskState taskState = new TaskState();
       taskState.readFields(in);
-      this.taskStates.put(taskState.getTaskId(), taskState);
+      this.taskStates.put(taskState.getTaskId().intern(), taskState);
     }
     super.readFields(in);
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -282,9 +282,9 @@ public class TaskState extends WorkUnitState {
   public void readFields(DataInput in) throws IOException {
     Text text = new Text();
     text.readFields(in);
-    this.jobId = text.toString();
+    this.jobId = text.toString().intern();
     text.readFields(in);
-    this.taskId = text.toString();
+    this.taskId = text.toString().intern();
     this.setId(this.taskId);
     this.startTime = in.readLong();
     this.endTime = in.readLong();

--- a/gobblin-utility/src/main/java/gobblin/util/jdbc/DataSourceBuilder.java
+++ b/gobblin-utility/src/main/java/gobblin/util/jdbc/DataSourceBuilder.java
@@ -98,7 +98,7 @@ public class DataSourceBuilder {
     }
 
     if (this.maxActiveConnections != null) {
-      properties.setProperty(DataSourceProvider.MAX_ACTIVE_CONNS, this.maxActiveConnections.toString());
+      properties.setProperty(DataSourceProvider.MAX_TOTAL_CONNS, this.maxActiveConnections.toString());
     }
 
     if (this.useStrongEncryption != null) {

--- a/gobblin-utility/src/main/java/gobblin/util/jdbc/DataSourceProvider.java
+++ b/gobblin-utility/src/main/java/gobblin/util/jdbc/DataSourceProvider.java
@@ -14,9 +14,9 @@ package gobblin.util.jdbc;
 
 import java.util.Properties;
 
-import javax.sql.DataSource;
+import org.apache.commons.dbcp2.BasicDataSource;
 
-import org.apache.commons.dbcp.BasicDataSource;
+import javax.sql.DataSource;
 
 import com.google.inject.Inject;
 import com.google.inject.Provider;
@@ -37,7 +37,7 @@ public class DataSourceProvider implements Provider<DataSource> {
   public static final String USERNAME = GOBBLIN_UTIL_JDBC_PREFIX + "username";
   public static final String PASSWORD = GOBBLIN_UTIL_JDBC_PREFIX + "password";
   public static final String MAX_IDLE_CONNS = GOBBLIN_UTIL_JDBC_PREFIX + "max.idle.connections";
-  public static final String MAX_ACTIVE_CONNS = GOBBLIN_UTIL_JDBC_PREFIX + "max.active.connections";
+  public static final String MAX_TOTAL_CONNS = GOBBLIN_UTIL_JDBC_PREFIX + "max.total.connections";
   public static final String DEFAULT_CONN_DRIVER = "com.mysql.jdbc.Driver";
 
   protected final BasicDataSource basicDataSource;
@@ -55,8 +55,8 @@ public class DataSourceProvider implements Provider<DataSource> {
     if (properties.containsKey(MAX_IDLE_CONNS)) {
       this.basicDataSource.setMaxIdle(Integer.parseInt(properties.getProperty(MAX_IDLE_CONNS)));
     }
-    if (properties.containsKey(MAX_ACTIVE_CONNS)) {
-      this.basicDataSource.setMaxActive(Integer.parseInt(properties.getProperty(MAX_ACTIVE_CONNS)));
+    if (properties.containsKey(MAX_TOTAL_CONNS)) {
+      this.basicDataSource.setMaxTotal(Integer.parseInt(properties.getProperty(MAX_TOTAL_CONNS)));
     }
   }
 


### PR DESCRIPTION
- Implemented `CommitStepDB` class using Derby as backing store.
- Added tests for `CommitStepDB` and `CommitStepCopyEntity`.
- Changes required to use `CommitStepDB`.
