### PR TITLE
extension of loading config file from general file system

### DIFF
--- a/conf/gobblin-standalone.properties
+++ b/conf/gobblin-standalone.properties
@@ -25,6 +25,7 @@ data.publisher.replace.final.dir=false
 
 # Directory where job configuration files are stored
 jobconf.dir=${env:GOBBLIN_JOB_CONFIG_DIR}
+jobconf.fullyQualifiedPath=file://${env:GOBBLIN_JOB_CONFIG_DIR}
 
 # Directory where job/task state files are stored
 state.store.dir=${env:GOBBLIN_WORK_DIR}/state-store

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -57,8 +57,11 @@ public class ConfigurationKeys {
   // Job configuration file monitor polling interval in milliseconds
   public static final String JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY = "jobconf.monitor.interval";
   public static final long DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL = 300000;
-  // Directory where all job configuration files are stored
+  // Directory where all job configuration files are stored WHEN ALL confs reside in local FS.
   public static final String JOB_CONFIG_FILE_DIR_KEY = "jobconf.dir";
+
+  // Path where all job configuration files stored
+  public static final String JOB_CONFIG_FILE_GENERAL_PATH_KEY = "jobconf.fullyQualifiedPath" ;
   // Job configuration file extensions
   public static final String JOB_CONFIG_FILE_EXTENSIONS_KEY = "jobconf.extensions";
   public static final String DEFAULT_JOB_CONFIG_FILE_EXTENSIONS = "pull,job";
@@ -66,6 +69,7 @@ public class ConfigurationKeys {
   // Note this only applies to jobs scheduled by the built-in Quartz-based job scheduler.
   public static final String SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY = "scheduler.wait.for.job.completion";
   public static final String DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION = Boolean.TRUE.toString();
+
 
   /**
    * Task executor and state tracker configuration properties.

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinDaemon.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinDaemon.java
@@ -1,0 +1,35 @@
+package gobblin.azkaban;
+
+import java.util.Properties;
+import org.apache.log4j.Logger;
+import gobblin.scheduler.SchedulerDaemon;
+import azkaban.jobExecutor.AbstractJob;
+
+
+/**
+ * Wrapper of {@link SchedulerDaemon}, specially used by Azkaban to launch a job scheduler daemon.
+ */
+
+public class AzkabanGobblinDaemon extends AbstractJob {
+
+  private static final Logger LOG = Logger.getLogger(AzkabanGobblinDaemon.class);
+
+  private SchedulerDaemon daemon;
+
+  public AzkabanGobblinDaemon(String jobId, Properties props) throws Exception {
+    super(jobId, LOG);
+    this.daemon = new SchedulerDaemon(props);
+  }
+
+  @Override
+  public void run()
+      throws Exception {
+    this.daemon.start();
+  }
+
+  @Override
+  public void cancel()
+      throws Exception {
+    this.daemon.stop();
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
@@ -33,7 +33,7 @@ public class SchedulerDaemon extends ServiceBasedAppLauncher {
     this(PropertiesUtils.combineProperties(defaultProperties, customProperties));
   }
 
-  private SchedulerDaemon(Properties properties) throws Exception {
+  public SchedulerDaemon(Properties properties) throws Exception {
     super(properties, getAppName(properties));
     addService(new JobScheduler(properties));
   }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobLauncherTestHelper.java
@@ -73,6 +73,7 @@ public class JobLauncherTestHelper {
     Assert.assertEquals(datasetState.getState(), JobState.RunningState.COMMITTED);
     Assert.assertEquals(datasetState.getCompletedTasks(), 4);
     Assert.assertEquals(datasetState.getJobFailures(), 0);
+
     for (TaskState taskState : datasetState.getTaskStates()) {
       Assert.assertEquals(taskState.getWorkingState(), WorkUnitState.WorkingState.COMMITTED);
       Assert.assertEquals(taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN),

--- a/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/local/LocalJobLauncherTest.java
@@ -23,6 +23,7 @@ import org.testng.annotations.Test;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
+
 import gobblin.metastore.testing.ITestMetastoreDatabase;
 import gobblin.metastore.testing.TestMetastoreDatabaseFactory;
 import gobblin.runtime.JobLauncherTestHelper;

--- a/gobblin-utility/src/main/java/gobblin/util/SchedulerUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/SchedulerUtils.java
@@ -12,12 +12,11 @@
 
 package gobblin.util;
 
-import gobblin.configuration.ConfigurationKeys;
-
 import java.io.File;
 import java.io.FileFilter;
 import java.io.FilenameFilter;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Properties;
 import java.util.Set;
@@ -28,9 +27,15 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.monitor.FileAlterationListener;
 import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.apache.commons.io.monitor.FileAlterationObserver;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PathFilter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Splitter;
@@ -38,6 +43,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
+
+import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -68,13 +75,22 @@ public class SchedulerUtils {
     }
   };
 
-  /**
-   * Load job configurations from job configuration files stored under the
-   * root job configuration file directory.
-   *
-   * @param properties Gobblin framework configuration properties
-   * @return a list of job configurations in the form of {@link java.util.Properties}
-   */
+  private static final PathFilter PROPERTIES_PATH_FILTER = new PathFilter() {
+    @Override
+    public boolean accept(Path path) {
+      String fileExtension = path.getName().substring(path.getName().lastIndexOf('.') + 1);
+      return fileExtension.equalsIgnoreCase(JOB_PROPS_FILE_EXTENSION);
+    }
+  };
+
+  private static final PathFilter NON_PROPERTIES_PATH_FILTER = new PathFilter() {
+    @Override
+    public boolean accept(Path path) {
+      return !PROPERTIES_PATH_FILTER.accept(path);
+    }
+  };
+
+  @Deprecated
   public static List<Properties> loadJobConfigs(Properties properties)
       throws ConfigurationException {
     Preconditions.checkArgument(properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY),
@@ -83,6 +99,20 @@ public class SchedulerUtils {
     List<Properties> jobConfigs = Lists.newArrayList();
     loadJobConfigsRecursive(jobConfigs, properties, getJobConfigurationFileExtensions(properties),
         new File(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY)));
+    return jobConfigs;
+  }
+
+  /**
+   * Load job configuration from job configuration files stored in general file system,
+   * located by Path
+   * @param properties Gobblin framework configuration properties
+   * @return a list of job configurations in the form of {@link java.util.Properties}
+   */
+  public static List<Properties> loadGenericJobConfigs(Properties properties)
+      throws ConfigurationException, IOException {
+    List<Properties> jobConfigs = Lists.newArrayList();
+    loadGenericJobConfigsRecursive(jobConfigs, properties, getJobConfigurationFileExtensions(properties),
+        new Path(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY)));
     return jobConfigs;
   }
 
@@ -178,6 +208,80 @@ public class SchedulerUtils {
   }
 
   /**
+   * Recursively load job configuration files under given URI of directory of config files folder
+   */
+  private static void loadGenericJobConfigsRecursive(List<Properties> jobConfigs, Properties rootProps,
+      Set<String> jobConfigFileExtensions, Path configDirPath)
+      throws ConfigurationException, IOException {
+
+    Configuration conf = new Configuration();
+    try (FileSystem filesystem = configDirPath.getFileSystem(conf)) {
+      if (!filesystem.exists(configDirPath)) {
+        throw new RuntimeException(
+            "The specified job configurations directory was not found: " + configDirPath.toString());
+      }
+
+      FileStatus[] propertiesFilesStatus = filesystem.listStatus(configDirPath, PROPERTIES_PATH_FILTER);
+      if ( propertiesFilesStatus != null && propertiesFilesStatus.length > 0) {
+        // There should be a single properties file in each directory (or sub directory)
+        if (propertiesFilesStatus.length != 1) {
+          throw new RuntimeException("Found more than one .properties file in directory: " + configDirPath);
+        }
+
+        // Load the properties, which may overwrite the same properties defined in the parent or ancestor directories.
+        // Open the inputStream, construct a reader and send to the loader for constructing propertiesConfiguration.
+        PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+        Path uniqueConfigFilePath = propertiesFilesStatus[0].getPath();
+        try (InputStreamReader inputStreamReader = new InputStreamReader(filesystem.open(uniqueConfigFilePath),
+            Charsets.UTF_8)) {
+          propertiesConfiguration.load(inputStreamReader);
+          rootProps.putAll(ConfigurationConverter.getProperties(propertiesConfiguration));
+        }
+      }
+
+      // Get all non-properties files
+      FileStatus[] nonPropFiles = filesystem.listStatus(configDirPath, NON_PROPERTIES_PATH_FILTER);
+      if ( nonPropFiles == null || nonPropFiles.length == 0 ) {
+        return;
+      }
+
+      for (FileStatus nonPropFile : nonPropFiles) {
+        Path configFilePath = nonPropFile.getPath();
+        if (nonPropFile.isDirectory()) {
+          Properties rootPropsCopy = new Properties();
+          rootPropsCopy.putAll(rootProps);
+          loadGenericJobConfigsRecursive(jobConfigs, rootPropsCopy, jobConfigFileExtensions, configFilePath);
+        } else {
+          if (!jobConfigFileExtensions.contains(
+              configFilePath.getName().substring(configFilePath.getName().lastIndexOf('.') + 1).toLowerCase())) {
+            LOGGER.warn("Skipped file " + configFilePath + " that has an unsupported extension");
+            continue;
+          }
+
+          Path doneFilePath = configFilePath.suffix(".done");
+          if (filesystem.exists(doneFilePath)) {
+            LOGGER.info("Skipped job configuration file " + doneFilePath + " for which a .done file exists");
+            continue;
+          }
+
+          Properties jobProps = new Properties();
+          // Put all parent/ancestor properties first
+          jobProps.putAll(rootProps);
+          // Then load the job configuration properties defined in the job configuration file
+          PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+          try (InputStreamReader inputStreamReader = new InputStreamReader(filesystem.open(configFilePath),
+              Charsets.UTF_8)) {
+            propertiesConfiguration.load(inputStreamReader);
+            jobProps.putAll(ConfigurationConverter.getProperties(propertiesConfiguration));
+            jobProps.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY, configFilePath.toString());
+            jobConfigs.add(jobProps);
+          }
+        }
+      }
+    }
+  }
+
+  /**
    * Recursively load job configuration files under the given directory.
    */
   private static void loadJobConfigsRecursive(List<Properties> jobConfigs, Properties rootProps,
@@ -193,8 +297,8 @@ public class SchedulerUtils {
       }
 
       // Load the properties, which may overwrite the same properties defined in the parent or ancestor directories.
-      rootProps.putAll(ConfigurationConverter
-          .getProperties(new PropertiesConfiguration(new File(jobConfigDir, propertiesFiles[0]))));
+      rootProps.putAll(ConfigurationConverter.getProperties(
+          new PropertiesConfiguration(new File(jobConfigDir, propertiesFiles[0]))));
     }
 
     // Get all non-properties files
@@ -236,7 +340,9 @@ public class SchedulerUtils {
   }
 
   private static Set<String> getJobConfigurationFileExtensions(Properties properties) {
-    Iterable<String> jobConfigFileExtensionsIterable = Splitter.on(",").omitEmptyStrings().trimResults()
+    Iterable<String> jobConfigFileExtensionsIterable = Splitter.on(",")
+        .omitEmptyStrings()
+        .trimResults()
         .split(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_EXTENSIONS_KEY,
             ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_EXTENSIONS));
     return ImmutableSet.copyOf(Iterables.transform(jobConfigFileExtensionsIterable, new Function<String, String>() {

--- a/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/SchedulerUtilsTest.java
@@ -17,21 +17,13 @@ import java.io.FileWriter;
 import java.io.IOException;
 import java.util.List;
 import java.util.Properties;
-import java.util.Set;
-import java.util.concurrent.Semaphore;
 
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.monitor.FileAlterationListener;
-import org.apache.commons.io.monitor.FileAlterationListenerAdaptor;
-import org.apache.commons.io.monitor.FileAlterationMonitor;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import com.google.common.collect.Sets;
-import com.google.common.io.Files;
 
 import gobblin.configuration.ConfigurationKeys;
 
@@ -42,6 +34,8 @@ import gobblin.configuration.ConfigurationKeys;
 @Test(groups = {"gobblin.util"})
 public class SchedulerUtilsTest {
 
+  // For general type of File system
+
   private File jobConfigDir;
   private File subDir1;
   private File subDir11;
@@ -51,7 +45,7 @@ public class SchedulerUtilsTest {
   public void setUp()
       throws IOException {
     this.jobConfigDir = java.nio.file.Files.createTempDirectory(
-            String.format("gobblin-test_%s_job-conf", this.getClass().getSimpleName())).toFile();
+        String.format("gobblin-test_%s_job-conf", this.getClass().getSimpleName())).toFile();
     FileUtils.forceDeleteOnExit(this.jobConfigDir);
     this.subDir1 = new File(this.jobConfigDir, "test1");
     this.subDir11 = new File(this.subDir1, "test11");
@@ -106,16 +100,18 @@ public class SchedulerUtilsTest {
 
   @Test
   public void testLoadJobConfigs()
-      throws ConfigurationException {
+      throws ConfigurationException, IOException {
     Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    List<Properties> jobConfigs = SchedulerUtils.loadJobConfigs(properties);
+    System.err.println(" LEI :  " + this.jobConfigDir.getAbsolutePath() );
+    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, this.jobConfigDir.getAbsolutePath());
+    List<Properties> jobConfigs = SchedulerUtils.loadGenericJobConfigs(properties);
     Assert.assertEquals(jobConfigs.size(), 4);
 
     // test-job-conf-dir/test1/test11/test111.pull
     Properties jobProps1 = getJobConfigForFile(jobConfigs, "test111.pull");
     Assert.assertEquals(jobProps1.stringPropertyNames().size(), 7);
-    Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY) || jobProps1.containsKey(
+        ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps1.getProperty("k1"), "d1");
     Assert.assertEquals(jobProps1.getProperty("k2"), "a2");
@@ -126,7 +122,8 @@ public class SchedulerUtilsTest {
     // test-job-conf-dir/test1/test11.pull
     Properties jobProps2 = getJobConfigForFile(jobConfigs, "test11.pull");
     Assert.assertEquals(jobProps2.stringPropertyNames().size(), 6);
-    Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY) || jobProps1.containsKey(
+        ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps2.getProperty("k1"), "c1");
     Assert.assertEquals(jobProps2.getProperty("k2"), "a2");
@@ -136,7 +133,8 @@ public class SchedulerUtilsTest {
     // test-job-conf-dir/test1/test12.PULL
     Properties jobProps3 = getJobConfigForFile(jobConfigs, "test12.PULL");
     Assert.assertEquals(jobProps3.stringPropertyNames().size(), 6);
-    Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY) || jobProps1.containsKey(
+        ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps3.getProperty("k1"), "b1");
     Assert.assertEquals(jobProps3.getProperty("k2"), "a2");
@@ -146,154 +144,12 @@ public class SchedulerUtilsTest {
     // test-job-conf-dir/test2/test21.PULL
     Properties jobProps4 = getJobConfigForFile(jobConfigs, "test21.PULL");
     Assert.assertEquals(jobProps4.stringPropertyNames().size(), 5);
-    Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
+    Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY) || jobProps1.containsKey(
+        ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY));
     Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
     Assert.assertEquals(jobProps4.getProperty("k1"), "a1");
     Assert.assertEquals(jobProps4.getProperty("k2"), "b2");
     Assert.assertEquals(jobProps4.getProperty("k5"), "b5");
-  }
-
-  @Test(dependsOnMethods = {"testLoadJobConfigs"})
-  public void testLoadJobConfigsWithDoneFile()
-      throws ConfigurationException, IOException {
-    // Create a .done file for test21.pull so it should not be loaded
-    Files.copy(new File(this.subDir2, "test21.PULL"), new File(this.subDir2, "test21.PULL.done"));
-
-    Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    List<Properties> jobConfigs = SchedulerUtils.loadJobConfigs(properties);
-    Assert.assertEquals(jobConfigs.size(), 3);
-
-    // test-job-conf-dir/test1/test11/test111.pull
-    Properties jobProps1 = getJobConfigForFile(jobConfigs, "test111.pull");
-    Assert.assertEquals(jobProps1.stringPropertyNames().size(), 7);
-    Assert.assertEquals(jobProps1.getProperty("k1"), "d1");
-    Assert.assertEquals(jobProps1.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps1.getProperty("k3"), "a3");
-    Assert.assertEquals(jobProps1.getProperty("k8"), "a8");
-    Assert.assertEquals(jobProps1.getProperty("k9"), "a8");
-
-    // test-job-conf-dir/test1/test11.pull
-    Properties jobProps2 = getJobConfigForFile(jobConfigs, "test11.pull");
-    Assert.assertEquals(jobProps2.stringPropertyNames().size(), 6);
-    Assert.assertEquals(jobProps2.getProperty("k1"), "c1");
-    Assert.assertEquals(jobProps2.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps2.getProperty("k3"), "b3");
-    Assert.assertEquals(jobProps2.getProperty("k6"), "a6");
-
-    // test-job-conf-dir/test1/test12.PULL
-    Properties jobProps3 = getJobConfigForFile(jobConfigs, "test12.PULL");
-    Assert.assertEquals(jobProps3.stringPropertyNames().size(), 6);
-    Assert.assertEquals(jobProps3.getProperty("k1"), "b1");
-    Assert.assertEquals(jobProps3.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps3.getProperty("k3"), "a3");
-    Assert.assertEquals(jobProps3.getProperty("k7"), "a7");
-
-    Assert.assertNull(getJobConfigForFile(jobConfigs, "test21.PULL"));
-  }
-
-  @Test
-  public void testLoadJobConfigsForCommonPropsFile()
-      throws ConfigurationException, IOException {
-    File commonPropsFile = new File(this.subDir1, "test.properties");
-
-    Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    List<Properties> jobConfigs =
-        SchedulerUtils.loadJobConfigs(properties, commonPropsFile, this.jobConfigDir);
-    Assert.assertEquals(jobConfigs.size(), 3);
-
-    // test-job-conf-dir/test1/test11/test111.pull
-    Properties jobProps1 = getJobConfigForFile(jobConfigs, "test111.pull");
-    Assert.assertEquals(jobProps1.stringPropertyNames().size(), 7);
-    Assert.assertEquals(jobProps1.getProperty("k1"), "d1");
-    Assert.assertEquals(jobProps1.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps1.getProperty("k3"), "a3");
-    Assert.assertEquals(jobProps1.getProperty("k8"), "a8");
-    Assert.assertEquals(jobProps1.getProperty("k9"), "a8");
-
-    // test-job-conf-dir/test1/test11.pull
-    Properties jobProps2 = getJobConfigForFile(jobConfigs, "test11.pull");
-    Assert.assertEquals(jobProps2.stringPropertyNames().size(), 6);
-    Assert.assertEquals(jobProps2.getProperty("k1"), "c1");
-    Assert.assertEquals(jobProps2.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps2.getProperty("k3"), "b3");
-    Assert.assertEquals(jobProps2.getProperty("k6"), "a6");
-
-    // test-job-conf-dir/test1/test12.PULL
-    Properties jobProps3 = getJobConfigForFile(jobConfigs, "test12.PULL");
-    Assert.assertEquals(jobProps3.stringPropertyNames().size(), 6);
-    Assert.assertEquals(jobProps3.getProperty("k1"), "b1");
-    Assert.assertEquals(jobProps3.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps3.getProperty("k3"), "a3");
-    Assert.assertEquals(jobProps3.getProperty("k7"), "a7");
-  }
-
-  @Test
-  public void testLoadJobConfig()
-      throws ConfigurationException, IOException {
-    File jobConfigFile = new File(this.subDir11, "test111.pull");
-    Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY, this.jobConfigDir.getAbsolutePath());
-    Properties jobProps = SchedulerUtils.loadJobConfig(properties, jobConfigFile, this.jobConfigDir);
-
-    Assert.assertEquals(jobProps.stringPropertyNames().size(), 7);
-    Assert.assertTrue(jobProps.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY));
-    Assert.assertTrue(jobProps.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
-    Assert.assertEquals(jobProps.getProperty("k1"), "d1");
-    Assert.assertEquals(jobProps.getProperty("k2"), "a2");
-    Assert.assertEquals(jobProps.getProperty("k3"), "a3");
-    Assert.assertEquals(jobProps.getProperty("k8"), "a8");
-    Assert.assertEquals(jobProps.getProperty("k9"), "a8");
-  }
-
-  @Test(dependsOnMethods = {
-      "testLoadJobConfigsWithDoneFile",
-      "testLoadJobConfigsForCommonPropsFile",
-      "testLoadJobConfig"})
-  public void testFileAlterationObserver() throws Exception {
-    FileAlterationMonitor monitor = new FileAlterationMonitor(3000);
-    final Set<File> fileAltered = Sets.newHashSet();
-    final Semaphore semaphore = new Semaphore(0);
-    FileAlterationListener listener = new FileAlterationListenerAdaptor() {
-
-      @Override
-      public void onFileCreate(File file) {
-        fileAltered.add(file);
-        semaphore.release();
-      }
-
-      @Override
-      public void onFileChange(File file) {
-        fileAltered.add(file);
-        semaphore.release();
-      }
-    };
-
-    SchedulerUtils.addFileAlterationObserver(monitor, listener, this.jobConfigDir);
-
-    try {
-      monitor.start();
-      // Give the monitor some time to start
-      Thread.sleep(1000);
-
-      File jobConfigFile = new File(this.subDir11, "test111.pull");
-      Files.touch(jobConfigFile);
-
-      File commonPropsFile = new File(this.subDir1, "test.properties");
-      Files.touch(commonPropsFile);
-
-      File newJobConfigFile = new File(this.subDir11, "test112.pull");
-      Files.append("k1=v1", newJobConfigFile, ConfigurationKeys.DEFAULT_CHARSET_ENCODING);
-
-      semaphore.acquire(3);
-      Assert.assertEquals(fileAltered.size(), 3);
-      Assert.assertTrue(fileAltered.contains(jobConfigFile));
-      Assert.assertTrue(fileAltered.contains(commonPropsFile));
-      Assert.assertTrue(fileAltered.contains(newJobConfigFile));
-    } finally {
-      monitor.stop();
-    }
   }
 
   @AfterClass


### PR DESCRIPTION
- Added new class `AzkabanGobblinDaemon` for deployment on Azkaban .
- Rewrite the original `loadJobConfig` and related method into general form which is compatible for general file system. 

---

- Temporarily remove some parts of SchedulerUtilsTest.java as there's also no counterpart in SchedulerUtils.java(for general file system, most of them are monitor-related), which leads to decrease in the coverage report.