### PR TITLE
Added CURRENTMINUTE and CURRENTSECOND options for watermark cutoff

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/AppendMaxLimitType.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/AppendMaxLimitType.java
@@ -13,5 +13,5 @@
 package gobblin.source.extractor.partition;
 
 public enum AppendMaxLimitType {
-  CURRENTDATE, CURRENTHOUR;
+  CURRENTDATE, CURRENTHOUR, CURRENTMINUTE, CURRENTSECOND;
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -279,18 +279,28 @@ public class Partitioner {
       switch (limitType) {
         case CURRENTDATE:
           format = "yyyyMMdd";
-          limitDelta = limitDelta * 24;
+          limitDelta = limitDelta * 24 * 60 * 60;
           seconds = 86399; // 23:59:59
           break;
         case CURRENTHOUR:
           format = "yyyyMMddHH";
+          limitDelta = limitDelta * 60 * 60;
           seconds = 3599; // x:59:59
+          break;
+        case CURRENTMINUTE:
+          format = "yyyyMMddHHmm";
+          limitDelta = limitDelta * 60;
+          seconds = 59;
+          break;
+        case CURRENTSECOND:
+          format = "yyyyMMddHHmmss";
+          seconds = 0;
           break;
         default:
           break;
       }
 
-      DateTime deltaTime = Utils.getCurrentTime(timeZone).minusHours(limitDelta);
+      DateTime deltaTime = Utils.getCurrentTime(timeZone).minusSeconds(limitDelta);
       DateTime previousTime =
           Utils.toDateTime(Utils.dateTimeToString(deltaTime, format, timeZone), format, timeZone).plusSeconds(seconds);
       highWatermark = Long.parseLong(Utils.dateTimeToString(previousTime, WATERMARKTIMEFORMAT, timeZone));


### PR DESCRIPTION
When watermark type is TIMESTAMP, we wanted to extract data up to past few seconds or minutes. But there were only CURRENTDATE and CURRENTHOUR cutoff options. So I added CURRENTMINUTE and CURRENTSECOND to AppendMaxLimitType.
Can someone please review and accept this feature?
