### PR TITLE
Support for schema evolution, staging, selective column projection and compatibility check for Avro to ORC

### DIFF
--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -34,6 +34,7 @@ dependencies {
   compile externalDependency.commonsIo
   compile externalDependency.gson
   compile externalDependency.commonsCodec
+  compile externalDependency.mockito
   compile externalDependency.typesafeConfig
   compile externalDependency.findBugsAnnotations
   compile externalDependency.testng
@@ -41,7 +42,6 @@ dependencies {
   testCompile externalDependency.calciteCore
   testCompile externalDependency.calciteAvatica
   testCompile externalDependency.jhyde
-  testCompile externalDependency.mockito
   testCompile externalDependency.joptSimple
   testCompile externalDependency.hamcrest
   testCompile externalDependency.testng

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -127,7 +127,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
 
     // ORC table name and location
     String orcTableName = getConversionConfig().getDestinationTableName();
-    String orcStagingTableName = orcTableName + "_staging"; // Fixed and non-configurable
+    String orcStagingTableName = getConversionConfig().getDestinationStagingTableName();
     String orcTableDatabase = getConversionConfig().getDestinationDbName();
     String orcDataLocation = getOrcDataLocation(workUnit);
     boolean isEvolutionEnabled = getConversionConfig().isEvolutionEnabled();
@@ -212,8 +212,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
         HiveAvroORCQueryUtils.generatePublishTableDDL(orcStagingTableName,
             orcTableName,
             destinationTableMeta)).append("\n");
-    workUnit.setProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_TABLE_COMMANDS,
-        HiveAvroORCQueryUtils.GSON.toJson(publishTableQueries));
+    HiveAvroORCQueryUtils.serializePublishTableCommands(workUnit, publishTableQueries.toString());
     log.debug("Publish table queries: " + publishTableQueries);
 
     StringBuilder publishPartitionQueries = new StringBuilder();
@@ -222,14 +221,12 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
             orcTableName,
             partitionsDMLInfo,
             destinationTableMeta)).append("\n");
-    workUnit.setProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_PARTITION_COMMANDS,
-        HiveAvroORCQueryUtils.GSON.toJson(publishPartitionQueries));
+    HiveAvroORCQueryUtils.serializePublishPartitionCommands(workUnit, publishPartitionQueries.toString());
     log.debug("Publish partition queries: " + publishPartitionQueries);
 
     StringBuilder cleanupQueries = new StringBuilder();
     cleanupQueries.append(HiveAvroORCQueryUtils.generateCleanupDDL(orcStagingTableName)).append("\n");
-    workUnit.setProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS,
-        HiveAvroORCQueryUtils.GSON.toJson(cleanupQueries));
+    HiveAvroORCQueryUtils.serializedCleanupCommands(workUnit, cleanupQueries.toString());
     log.debug("Cleanup queries: " + cleanupQueries);
 
     log.debug("Conversion Query " + conversionEntity.getQueries());

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -135,6 +135,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
     public static final String CLUSTER_BY_KEY = "clusterByList";
     public static final String NUM_BUCKETS_KEY = "numBuckets";
+    public static final String EVOLUTION_ENABLED = "evolution.enabled";
 
     private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
     private final String destinationFormat;
@@ -144,6 +145,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private final List<String> clusterBy;
     private final Optional<Integer> numBuckets;
     private final Properties hiveRuntimeProperties;
+    private final boolean evolutionEnabled;
 
     private ConversionConfig(Config config, Table table, String destinationFormat) {
 
@@ -161,7 +163,9 @@ public class ConvertibleHiveDataset extends HiveDataset {
       // Optional
       this.clusterBy = ConfigUtils.getStringList(config, CLUSTER_BY_KEY);
       this.numBuckets = Optional.fromNullable(ConfigUtils.getInt(config, NUM_BUCKETS_KEY, null));
-      this.hiveRuntimeProperties = ConfigUtils.configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
+      this.hiveRuntimeProperties = ConfigUtils
+          .configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
+      this.evolutionEnabled = config.hasPath(EVOLUTION_ENABLED) && config.getBoolean(EVOLUTION_ENABLED);
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -140,6 +140,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
     private final String destinationFormat;
     private final String destinationTableName;
+    private final String destinationStagingTableName;
     private final String destinationDbName;
     private final String destinationDataPath;
     private final List<String> clusterBy;
@@ -157,6 +158,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
       // Required
       this.destinationFormat = destinationFormat;
       this.destinationTableName = resolveTemplate(config.getString(DESTINATION_TABLE_KEY), table);
+      this.destinationStagingTableName = String.format("%s_%s", this.destinationTableName, "staging"); // Fixed and non-configurable
       this.destinationDbName = resolveTemplate(config.getString(DESTINATION_DB_KEY), table);
       this.destinationDataPath = resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), table);
 
@@ -165,7 +167,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.numBuckets = Optional.fromNullable(ConfigUtils.getInt(config, NUM_BUCKETS_KEY, null));
       this.hiveRuntimeProperties = ConfigUtils
           .configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
-      this.evolutionEnabled = config.hasPath(EVOLUTION_ENABLED) && config.getBoolean(EVOLUTION_ENABLED);
+      this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
@@ -73,8 +73,7 @@ public class HiveConvertPublisher extends DataPublisher {
       for (WorkUnitState wus : states) {
         if (isFirst) {
           // Get cleanup staging table commands
-          cleanupCommands = HiveAvroORCQueryUtils.GSON
-              .fromJson(wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS), String.class);
+          cleanupCommands = HiveAvroORCQueryUtils.deserializeCleanupCommands(wus);
           isFirst = false;
         }
         wus.setWorkingState(WorkingState.FAILED);
@@ -85,21 +84,18 @@ public class HiveConvertPublisher extends DataPublisher {
       for (WorkUnitState wus : states) {
         if (isFirst) {
           // Get publish table commands
-          publishTableCommands = HiveAvroORCQueryUtils.GSON
-              .fromJson(wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_TABLE_COMMANDS), String.class);
+          publishTableCommands = HiveAvroORCQueryUtils.deserializePublishTableCommands(wus);
 
           // Execute publish table commands
           executeQueries(publishTableCommands);
 
           // Get cleanup staging table commands
-          cleanupCommands = HiveAvroORCQueryUtils.GSON
-              .fromJson(wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS), String.class);
+          cleanupCommands = HiveAvroORCQueryUtils.deserializeCleanupCommands(wus);
           isFirst = false;
         }
 
         // Get publish partition commands if any
-        String publishPartitionCommands = HiveAvroORCQueryUtils.GSON.fromJson(
-            wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_PARTITION_COMMANDS), String.class);
+        String publishPartitionCommands = HiveAvroORCQueryUtils.deserializePublishPartitionCommands(wus);
 
         // Execute publish partition commands if any
         executeQueries(publishPartitionCommands);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
@@ -12,8 +12,10 @@
 package gobblin.data.management.conversion.hive.publisher;
 
 import java.io.IOException;
+import java.sql.SQLException;
 import java.util.Collection;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 
 import com.google.common.base.Predicate;
@@ -24,7 +26,9 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.WorkUnitState.WorkingState;
 import gobblin.data.management.conversion.hive.AvroSchemaManager;
 import gobblin.data.management.conversion.hive.events.EventConstants;
+import gobblin.data.management.conversion.hive.util.HiveAvroORCQueryUtils;
 import gobblin.data.management.conversion.hive.watermarker.TableLevelWatermarker;
+import gobblin.hive.util.HiveJdbcConnector;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.event.EventSubmitter;
@@ -40,6 +44,7 @@ import gobblin.util.HadoopUtils;
 public class HiveConvertPublisher extends DataPublisher {
 
   private final AvroSchemaManager avroSchemaManager;
+  private final HiveJdbcConnector hiveJdbcConnector;
   private MetricContext metricContext;
   private EventSubmitter eventSubmitter;
 
@@ -48,6 +53,11 @@ public class HiveConvertPublisher extends DataPublisher {
     this.avroSchemaManager = new AvroSchemaManager(FileSystem.get(HadoopUtils.newConfiguration()), state);
     this.metricContext = Instrumented.getMetricContext(state, HiveConvertPublisher.class);
     this.eventSubmitter = new EventSubmitter.Builder(this.metricContext, EventConstants.CONVERSION_NAMESPACE).build();
+    try {
+      this.hiveJdbcConnector = HiveJdbcConnector.newConnectorWithProps(state.getProperties());
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @Override
@@ -57,13 +67,43 @@ public class HiveConvertPublisher extends DataPublisher {
   @Override
   public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
 
+    String cleanupCommands = StringUtils.EMPTY;
+    boolean isFirst = true;
     if (Iterables.tryFind(states, UNSUCCESSFUL_WORKUNIT).isPresent()) {
       for (WorkUnitState wus : states) {
+        if (isFirst) {
+          // Get cleanup staging table commands
+          cleanupCommands = HiveAvroORCQueryUtils.GSON
+              .fromJson(wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS), String.class);
+          isFirst = false;
+        }
         wus.setWorkingState(WorkingState.FAILED);
         new SlaEventSubmitter(eventSubmitter, EventConstants.CONVERSION_FAILED_EVENT, wus.getProperties()).submit();
       }
     } else {
+      String publishTableCommands = StringUtils.EMPTY;
       for (WorkUnitState wus : states) {
+        if (isFirst) {
+          // Get publish table commands
+          publishTableCommands = HiveAvroORCQueryUtils.GSON
+              .fromJson(wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_TABLE_COMMANDS), String.class);
+
+          // Execute publish table commands
+          executeQueries(publishTableCommands);
+
+          // Get cleanup staging table commands
+          cleanupCommands = HiveAvroORCQueryUtils.GSON
+              .fromJson(wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS), String.class);
+          isFirst = false;
+        }
+
+        // Get publish partition commands if any
+        String publishPartitionCommands = HiveAvroORCQueryUtils.GSON.fromJson(
+            wus.getProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_PARTITION_COMMANDS), String.class);
+
+        // Execute publish partition commands if any
+        executeQueries(publishPartitionCommands);
+
         wus.setWorkingState(WorkingState.COMMITTED);
         wus.setActualHighWatermark(TableLevelWatermarker.GSON.fromJson(wus.getWorkunit().getExpectedHighWatermark(),
             LongWatermark.class));
@@ -71,6 +111,19 @@ public class HiveConvertPublisher extends DataPublisher {
         new SlaEventSubmitter(eventSubmitter, EventConstants.CONVERSION_SUCCESSFUL_SLA_EVENT, wus.getProperties())
             .submit();
       }
+    }
+    // Execute cleanup staging table commands
+    executeQueries(cleanupCommands);
+  }
+
+  private void executeQueries(String queries) {
+    if (StringUtils.isBlank(queries)) {
+      return;
+    }
+    try {
+      this.hiveJdbcConnector.executeStatements(queries);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtils.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtils.java
@@ -34,6 +34,8 @@ import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
+import gobblin.configuration.State;
+
 
 /***
  * Generate Hive queries
@@ -41,10 +43,10 @@ import com.google.gson.GsonBuilder;
 @Slf4j
 public class HiveAvroORCQueryUtils {
 
-  public static final String SERIALIZED_PUBLISH_TABLE_COMMANDS = "serialized.publish.table.commands";
-  public static final String SERIALIZED_PUBLISH_PARTITION_COMMANDS = "serialized.publish.partition.commands";
-  public static final String SERIALIZED_CLEANUP_COMMANDS = "serialized.cleanup.commands";
-  public static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+  private static final String SERIALIZED_PUBLISH_TABLE_COMMANDS = "serialized.publish.table.commands";
+  private static final String SERIALIZED_PUBLISH_PARTITION_COMMANDS = "serialized.publish.partition.commands";
+  private static final String SERIALIZED_CLEANUP_COMMANDS = "serialized.cleanup.commands";
+  private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
   // Table properties keys
   private static final String ORC_COMPRESSION_KEY                 = "orc.compress";
@@ -727,6 +729,65 @@ public class HiveAvroORCQueryUtils {
    */
   public static String generateCleanupDDL(String stagingTableName) {
     return String.format("DROP TABLE IF EXISTS %s;", stagingTableName) + "\n";
+  }
+
+  /***
+   * Serialize a {@link String} of publish table commands into a {@link State} at
+   * {@link #SERIALIZED_PUBLISH_TABLE_COMMANDS}.
+   * @param state {@link State} to serialize commands into.
+   * @param commands Publish table commands to serialize.
+   */
+  public static void serializePublishTableCommands(State state, String commands) {
+    state.setProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_TABLE_COMMANDS,
+        GSON.toJson(commands));
+  }
+
+  /***
+   * Serialize a {@link String} of publish partition commands into a {@link State} at
+   * {@link #SERIALIZED_PUBLISH_PARTITION_COMMANDS}.
+   * @param state {@link State} to serialize commands into.
+   * @param commands Publish partition commands to serialize.
+   */
+  public static void serializePublishPartitionCommands(State state, String commands) {
+    state.setProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_PARTITION_COMMANDS,
+        GSON.toJson(commands));
+  }
+
+  /***
+   * Serialize a {@link String} of cleanup commands into a {@link State} at {@link #SERIALIZED_CLEANUP_COMMANDS}.
+   * @param state {@link State} to serialize commands into.
+   * @param commands Cleanup commands to serialize.
+   */
+  public static void serializedCleanupCommands(State state, String commands) {
+    state.setProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS,
+        GSON.toJson(commands));
+  }
+
+  /***
+   * Deserialize the publish table commands from a {@link State} at {@link #SERIALIZED_PUBLISH_TABLE_COMMANDS}.
+   * @param state {@link State} to look into for serialized commands.
+   * @return Publish table commands.
+   */
+  public static String deserializePublishTableCommands(State state) {
+    return GSON.fromJson(state.getProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_TABLE_COMMANDS), String.class);
+  }
+
+  /***
+   * Deserialize the publish partition commands from a {@link State} at {@link #SERIALIZED_PUBLISH_PARTITION_COMMANDS}.
+   * @param state {@link State} to look into for serialized commands.
+   * @return Publish partition commands.
+   */
+  public static String deserializePublishPartitionCommands(State state) {
+    return GSON.fromJson(state.getProp(HiveAvroORCQueryUtils.SERIALIZED_PUBLISH_PARTITION_COMMANDS), String.class);
+  }
+
+  /***
+   * Deserialize the cleanup commands from a {@link State} at {@link #SERIALIZED_CLEANUP_COMMANDS}.
+   * @param state {@link State} to look into for serialized commands.
+   * @return Cleanup commands.
+   */
+  public static String deserializeCleanupCommands(State state) {
+    return GSON.fromJson(state.getProp(HiveAvroORCQueryUtils.SERIALIZED_CLEANUP_COMMANDS), String.class);
   }
 
   private static boolean isTypeEvolved(String evolvedType, String destinationType) {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -13,6 +13,7 @@ package gobblin.data.management.conversion.hive.converter;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -29,6 +30,7 @@ import org.testng.annotations.Test;
 
 import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Maps;
 
 import gobblin.data.management.ConversionHiveTestUtils;
@@ -76,10 +78,11 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(),
             Optional.<Map<String, String>>absent(),
             isEvolutionEnabled,
-            destinationTableMeta);
+            destinationTableMeta,
+            new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir, 
-        "source_schema_evolution_enabled.ddl"));
+        "source_schema_evolution_enabled.ddl"), "Generated DDL did not match expected for evolution enabled");
 
     String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
         outputSchema,
@@ -94,7 +97,7 @@ public class HiveSchemaEvolutionTest {
         destinationTableMeta);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_evolution_enabled.dml"));
+        "source_schema_evolution_enabled.dml"), "Generated DML did not match expected for evolution enabled");
   }
 
   @Test
@@ -116,10 +119,12 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(),
             Optional.<Map<String, String>>absent(),
             isEvolutionEnabled,
-            destinationTableMeta);
+            destinationTableMeta,
+            new HashMap<String, String>());
 
-    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir, 
-        "source_schema_evolution_enabled.ddl"));
+    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_evolution_enabled.ddl"),
+        "Generated DDL did not match expected for evolution enabled");
 
     String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
         outputSchema,
@@ -134,7 +139,8 @@ public class HiveSchemaEvolutionTest {
         destinationTableMeta);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_evolution_enabled.dml"));
+        "source_schema_evolution_enabled.dml"),
+        "Generated DML did not match expected for evolution enabled");
   }
 
   @Test
@@ -156,10 +162,12 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(),
             Optional.<Map<String, String>>absent(),
             isEvolutionEnabled,
-            destinationTableMeta);
+            destinationTableMeta,
+            new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir, 
-        "source_schema_evolution_disabled.ddl"));
+        "source_schema_evolution_disabled.ddl"),
+        "Generated DDL did not match expected for evolution disabled");
 
     String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
         outputSchema,
@@ -174,7 +182,8 @@ public class HiveSchemaEvolutionTest {
         destinationTableMeta);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_evolution_disabled.dml"));
+        "source_schema_evolution_disabled.dml"),
+        "Generated DML did not match expected for evolution disabled");
   }
 
   @Test
@@ -196,10 +205,12 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(),
             Optional.<Map<String, String>>absent(),
             isEvolutionEnabled,
-            destinationTableMeta);
+            destinationTableMeta,
+            new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_evolution_enabled.ddl"));
+        "source_schema_evolution_enabled.ddl"),
+        "Generated DDL did not match expected for evolution disabled");
 
     String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
         outputSchema,
@@ -214,7 +225,8 @@ public class HiveSchemaEvolutionTest {
         destinationTableMeta);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_evolution_enabled.dml"));
+        "source_schema_evolution_enabled.dml"),
+        "Generated DML did not match expected for evolution disabled");
   }
 
   @Test
@@ -236,10 +248,12 @@ public class HiveSchemaEvolutionTest {
             Optional.<String>absent(),
             Optional.<Map<String, String>>absent(),
             isEvolutionEnabled,
-            destinationTableMeta);
+            destinationTableMeta,
+            new HashMap<String, String>());
 
     Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_lineage_missing.ddl"));
+        "source_schema_lineage_missing.ddl"),
+        "Generated DDL did not match expected for evolution disabled");
 
     String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
         outputSchema,
@@ -254,7 +268,174 @@ public class HiveSchemaEvolutionTest {
         destinationTableMeta);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
-        "source_schema_lineage_missing.dml"));
+        "source_schema_lineage_missing.dml"),
+        "Generated DML did not match expected for evolution disabled");
+  }
+
+  @Test
+  public void testEvolutionEnabledGenerateEvolutionDDL() {
+    String orcStagingTableName = schemaName + "_staging";
+    String orcTableName = schemaName;
+    boolean isEvolutionEnabled = true;
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
+    Map<String, String> hiveColumns = new HashMap<>();
+
+    // Call to help populate hiveColumns via real code path
+    HiveAvroORCQueryUtils.generateCreateTableDDL(outputSchema, schemaName, "/tmp/dummy", Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
+        Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
+        Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, hiveColumns);
+
+    // Destination table exists
+    String generateEvolutionDDL = HiveAvroORCQueryUtils
+        .generateEvolutionDDL(orcStagingTableName,
+            orcTableName,
+            outputSchema,
+            isEvolutionEnabled,
+            hiveColumns,
+            destinationTableMeta);
+    Assert.assertEquals(generateEvolutionDDL,
+        "ALTER TABLE sourceSchema ADD COLUMNS (parentFieldRecord__nestedFieldInt int COMMENT "
+            + "'from flatten_source parentFieldRecord.nestedFieldInt');\n",
+        "Generated evolution DDL did not match for evolution enabled");
+
+    // Destination table does not exists
+    destinationTableMeta = Optional.absent();
+    generateEvolutionDDL = HiveAvroORCQueryUtils
+        .generateEvolutionDDL(orcStagingTableName,
+            orcTableName,
+            outputSchema,
+            isEvolutionEnabled,
+            hiveColumns,
+            destinationTableMeta);
+    // No DDL should be generated, because create table will take care of destination table
+    Assert.assertEquals(generateEvolutionDDL, "",
+        "Generated evolution DDL did not match for evolution enabled");
+  }
+
+  @Test
+  public void testEvolutionDisabledGenerateEvolutionDDL() {
+    String orcStagingTableName = schemaName + "_staging";
+    String orcTableName = schemaName;
+    boolean isEvolutionEnabled = false;
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
+    Map<String, String> hiveColumns = new HashMap<>();
+
+    // Call to help populate hiveColumns via real code path
+    HiveAvroORCQueryUtils.generateCreateTableDDL(outputSchema, schemaName, "/tmp/dummy", Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
+        Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
+        Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, hiveColumns);
+
+    // Destination table exists
+    String generateEvolutionDDL = HiveAvroORCQueryUtils
+        .generateEvolutionDDL(orcStagingTableName,
+            orcTableName,
+            outputSchema,
+            isEvolutionEnabled,
+            hiveColumns,
+            destinationTableMeta);
+    // No DDL should be generated, because select based on destination table will selectively project columns
+    Assert.assertEquals(generateEvolutionDDL, "",
+        "Generated evolution DDL did not match for evolution disabled");
+
+    // Destination table does not exists
+    destinationTableMeta = Optional.absent();
+    generateEvolutionDDL = HiveAvroORCQueryUtils
+        .generateEvolutionDDL(orcStagingTableName,
+            orcTableName,
+            outputSchema,
+            isEvolutionEnabled,
+            hiveColumns,
+            destinationTableMeta);
+    // No DDL should be generated, because create table will take care of destination table
+    Assert.assertEquals(generateEvolutionDDL, "",
+        "Generated evolution DDL did not match for evolution disabled");
+  }
+
+  @Test
+  public void testGeneratePublishTableDDL() {
+    String orcStagingTableName = schemaName + "_staging";
+    String orcTableName = schemaName;
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
+
+    // Destination table exists
+    String generatePublishDDL = HiveAvroORCQueryUtils
+        .generatePublishTableDDL(orcStagingTableName,
+            orcTableName,
+            destinationTableMeta);
+    // No DDL should be generated, because:
+    // 1. If evolution is enabled, alter table DDL will take care of destination table evolution
+    // 2. If evolution is disabled, select based on destination table will selectively project columns
+    // Subsequently partitions from staging will be moved to destination
+    Assert.assertEquals(generatePublishDDL, "",
+        "Generated publish table DDL did not match for existing destination table");
+
+    // Destination table does not exists
+    destinationTableMeta = Optional.absent();
+    generatePublishDDL = HiveAvroORCQueryUtils
+        .generatePublishTableDDL(orcStagingTableName,
+            orcTableName,
+            destinationTableMeta);
+    Assert.assertEquals(generatePublishDDL, "DROP TABLE IF EXISTS sourceSchema;\n"
+        + "ALTER TABLE sourceSchema_staging RENAME TO sourceSchema;\n",
+        "Generated publish table DDL did not match for new destination table");
+  }
+
+  @Test
+  public void testGeneratePublishPartitionDDL() {
+    String orcStagingTableName = schemaName + "_staging";
+    String orcTableName = schemaName;
+    Map<String, String> partitionInfo = ImmutableMap.<String, String>builder().put("datepartition", "20160101").build();
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
+
+    // Destination table exists
+    String generatePublishDDL = HiveAvroORCQueryUtils
+        .generatePublishPartitionDDL(orcStagingTableName,
+            orcTableName,
+            partitionInfo,
+            destinationTableMeta);
+    // Evolution enabled:
+    // - Table exist: Move partition from staging to destination
+    // Evolution disabled:
+    // - Table exist: Move partition from staging to destination
+    Assert.assertEquals(generatePublishDDL,
+        "ALTER TABLE sourceSchema EXCHANGE PARTITION (datepartition='20160101') WITH TABLE sourceSchema_staging;\n",
+        "Generated publish partition DDL did not match");
+
+    destinationTableMeta = Optional.absent();
+    // Destination table does not exists
+    generatePublishDDL = HiveAvroORCQueryUtils
+        .generatePublishPartitionDDL(orcStagingTableName,
+            orcTableName,
+            partitionInfo,
+            destinationTableMeta);
+    // Evolution enabled:
+    // - Table does not exist: no-op (staging is already renamed to final)
+    // Evolution disabled:
+    // - Table does not exist: no op (staging is already renamed to final)
+    Assert.assertEquals(generatePublishDDL, "", "Generated publish partition DDL did not match");
+
+    // Destination table exists but its a snapshot table (no partition)
+    generatePublishDDL = HiveAvroORCQueryUtils
+        .generatePublishPartitionDDL(orcStagingTableName,
+            orcTableName,
+            new HashMap<String, String>(),
+            destinationTableMeta);
+    Assert.assertEquals(generatePublishDDL, "", "Generated publish partition DDL did not match");
+  }
+
+  @Test
+  public void testGenerateCleanupDDL() {
+    String orcStagingTableName = schemaName + "_staging";
+
+    // Destination table exists
+    String generateCleanupDDL = HiveAvroORCQueryUtils.generateCleanupDDL(orcStagingTableName);
+    Assert.assertEquals(generateCleanupDDL,
+        "DROP TABLE IF EXISTS sourceSchema_staging;\n",
+        "Generated cleanup staging DDL did not match");
   }
 
   private Optional<Table> createEvolvedDestinationTable(String tableName, String dbName, String location,
@@ -268,8 +449,9 @@ public class HiveSchemaEvolutionTest {
     cols.add(new FieldSchema("parentFieldRecord__nestedFieldString", "string",
         withComment ? "from flatten_source parentFieldRecord.nestedFieldString" : ""));
     // The following column is skipped (simulating un-evolved schema):
-    // cols.add(new FieldSchema("parentFieldRecord__nestedFieldInt", "int",
-    //   withComment ? "from flatten_source parentFieldRecord.nestedFieldInt" : ""));
+    // Column name   : parentFieldRecord__nestedFieldInt
+    // Column type   : int
+    // Column comment: from flatten_source parentFieldRecord.nestedFieldInt
     cols.add(new FieldSchema("parentFieldInt", "int",
         withComment ? "from flatten_source parentFieldInt" : ""));
     // Extra schema

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -1,0 +1,288 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.converter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.avro.Schema;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.metastore.api.Order;
+import org.apache.hadoop.hive.metastore.api.SerDeInfo;
+import org.apache.hadoop.hive.metastore.api.StorageDescriptor;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+
+import gobblin.data.management.ConversionHiveTestUtils;
+import gobblin.data.management.conversion.hive.util.HiveAvroORCQueryUtils;
+import gobblin.util.AvroFlattener;
+
+
+/**
+ * Test for schema evolution enabled or disabled
+ */
+@Slf4j
+@Test(groups = { "gobblin.data.management.conversion" })
+public class HiveSchemaEvolutionTest {
+  private static String resourceDir = "avroToOrcSchemaEvolutionTest";
+  private static String schemaName = "sourceSchema";
+  private static AvroFlattener avroFlattener = new AvroFlattener();
+  private static Schema inputSchema;
+  private static Schema outputSchema;
+
+  static {
+    try {
+      inputSchema = ConversionHiveTestUtils.readSchemaFromJsonFile(resourceDir, "source_schema.json");
+      outputSchema = avroFlattener.flatten(inputSchema, true);
+    } catch (IOException e) {
+      throw new RuntimeException("Could not initialized tests", e);
+    }
+  }
+
+  @Test
+  public void testEvolutionEnabledForExistingTable() throws IOException {
+    boolean isEvolutionEnabled = true;
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
+
+    String ddl = HiveAvroORCQueryUtils
+        .generateCreateTableDDL(outputSchema,
+            schemaName,
+            "file:/user/hive/warehouse/" + schemaName,
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            Optional.<List<String>>absent(),
+            Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
+            Optional.<Integer>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            isEvolutionEnabled,
+            destinationTableMeta);
+
+    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir, 
+        "source_schema_evolution_enabled.ddl"));
+
+    String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
+        outputSchema,
+        schemaName,
+        schemaName + "_orc",
+        Optional.<String>absent(),
+        Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(),
+        Optional.<Boolean>absent(),
+        Optional.<Boolean>absent(),
+        isEvolutionEnabled,
+        destinationTableMeta);
+
+    Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_evolution_enabled.dml"));
+  }
+
+  @Test
+  public void testEvolutionEnabledForNewTable() throws IOException {
+    boolean isEvolutionEnabled = true;
+    Optional<Table> destinationTableMeta = Optional.absent();
+
+    String ddl = HiveAvroORCQueryUtils
+        .generateCreateTableDDL(outputSchema,
+            schemaName,
+            "file:/user/hive/warehouse/" + schemaName,
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            Optional.<List<String>>absent(),
+            Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
+            Optional.<Integer>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            isEvolutionEnabled,
+            destinationTableMeta);
+
+    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir, 
+        "source_schema_evolution_enabled.ddl"));
+
+    String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
+        outputSchema,
+        schemaName,
+        schemaName + "_orc",
+        Optional.<String>absent(),
+        Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(),
+        Optional.<Boolean>absent(),
+        Optional.<Boolean>absent(),
+        isEvolutionEnabled,
+        destinationTableMeta);
+
+    Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_evolution_enabled.dml"));
+  }
+
+  @Test
+  public void testEvolutionDisabledForExistingTable() throws IOException {
+    boolean isEvolutionEnabled = false;
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", true);
+
+    String ddl = HiveAvroORCQueryUtils
+        .generateCreateTableDDL(outputSchema,
+            schemaName,
+            "file:/user/hive/warehouse/" + schemaName,
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            Optional.<List<String>>absent(),
+            Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
+            Optional.<Integer>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            isEvolutionEnabled,
+            destinationTableMeta);
+
+    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir, 
+        "source_schema_evolution_disabled.ddl"));
+
+    String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
+        outputSchema,
+        schemaName,
+        schemaName + "_orc",
+        Optional.<String>absent(),
+        Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(),
+        Optional.<Boolean>absent(),
+        Optional.<Boolean>absent(),
+        isEvolutionEnabled,
+        destinationTableMeta);
+
+    Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_evolution_disabled.dml"));
+  }
+
+  @Test
+  public void testEvolutionDisabledForNewTable() throws IOException {
+    boolean isEvolutionEnabled = false;
+    Optional<Table> destinationTableMeta = Optional.absent();
+
+    String ddl = HiveAvroORCQueryUtils
+        .generateCreateTableDDL(outputSchema,
+            schemaName,
+            "file:/user/hive/warehouse/" + schemaName,
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            Optional.<List<String>>absent(),
+            Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
+            Optional.<Integer>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            isEvolutionEnabled,
+            destinationTableMeta);
+
+    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_evolution_enabled.ddl"));
+
+    String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
+        outputSchema,
+        schemaName,
+        schemaName + "_orc",
+        Optional.<String>absent(),
+        Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(),
+        Optional.<Boolean>absent(),
+        Optional.<Boolean>absent(),
+        isEvolutionEnabled,
+        destinationTableMeta);
+
+    Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_evolution_enabled.dml"));
+  }
+
+  @Test
+  public void testLineageMissing() throws IOException {
+    boolean isEvolutionEnabled = false;
+    Optional<Table> destinationTableMeta = createEvolvedDestinationTable(schemaName, "default", "", false);
+
+    String ddl = HiveAvroORCQueryUtils
+        .generateCreateTableDDL(outputSchema,
+            schemaName,
+            "file:/user/hive/warehouse/" + schemaName,
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            Optional.<List<String>>absent(),
+            Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
+            Optional.<Integer>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<String>absent(),
+            Optional.<Map<String, String>>absent(),
+            isEvolutionEnabled,
+            destinationTableMeta);
+
+    Assert.assertEquals(ddl, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_lineage_missing.ddl"));
+
+    String dml = HiveAvroORCQueryUtils.generateTableMappingDML(inputSchema,
+        outputSchema,
+        schemaName,
+        schemaName + "_orc",
+        Optional.<String>absent(),
+        Optional.<String>absent(),
+        Optional.<Map<String, String>>absent(),
+        Optional.<Boolean>absent(),
+        Optional.<Boolean>absent(),
+        isEvolutionEnabled,
+        destinationTableMeta);
+
+    Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
+        "source_schema_lineage_missing.dml"));
+  }
+
+  private Optional<Table> createEvolvedDestinationTable(String tableName, String dbName, String location,
+      boolean withComment) {
+    List<FieldSchema> cols = new ArrayList<>();
+    // Existing columns that match avroToOrcSchemaEvolutionTest/source_schema_evolution_enabled.ddl
+    cols.add(new FieldSchema("parentFieldRecord__nestedFieldRecord__superNestedFieldString", "string",
+        withComment ? "from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldString" : ""));
+    cols.add(new FieldSchema("parentFieldRecord__nestedFieldRecord__superNestedFieldInt", "int",
+        withComment ? "from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldInt" : ""));
+    cols.add(new FieldSchema("parentFieldRecord__nestedFieldString", "string",
+        withComment ? "from flatten_source parentFieldRecord.nestedFieldString" : ""));
+    // The following column is skipped (simulating un-evolved schema):
+    // cols.add(new FieldSchema("parentFieldRecord__nestedFieldInt", "int",
+    //   withComment ? "from flatten_source parentFieldRecord.nestedFieldInt" : ""));
+    cols.add(new FieldSchema("parentFieldInt", "int",
+        withComment ? "from flatten_source parentFieldInt" : ""));
+    // Extra schema
+    cols.add(new FieldSchema("parentFieldRecord__nestedFieldString2", "string",
+        withComment ? "from flatten_source parentFieldRecord.nestedFieldString2" : ""));
+
+    String inputFormat = "org.apache.hadoop.hive.ql.io.orc.OrcInputFormat";
+    String outputFormat = "org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat";
+    StorageDescriptor storageDescriptor = new StorageDescriptor(cols, location, inputFormat, outputFormat, false, 0,
+        new SerDeInfo(), null, Lists.<Order>newArrayList(), null);
+    Table table = new Table(tableName, dbName, "ketl_dev", 0, 0, 0, storageDescriptor,
+        Lists.<FieldSchema>newArrayList(), Maps.<String,String>newHashMap(), "", "", "");
+
+    return Optional.of(table);
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtilsTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtilsTest.java
@@ -19,6 +19,7 @@ import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.avro.Schema;
+import org.apache.hadoop.hive.metastore.api.Table;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -33,6 +34,8 @@ import gobblin.util.AvroFlattener;
 public class HiveAvroORCQueryUtilsTest {
 
   private static String resourceDir = "avroToOrcQueryUtilsTest";
+  private static Optional<Table> destinationTableMeta = Optional.absent();
+  private static boolean isEvolutionEnabled = true;
 
   /***
    * Test DDL generation for schema structured as: Array within record within array within record
@@ -48,11 +51,10 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent());
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
 
-    Assert.assertEquals(q.trim().replaceAll(" ", ""),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "arrayWithinRecordWithinArrayWithinRecord_nested.ddl")
-            .replaceAll(" ", ""));
+    Assert.assertEquals(q,
+        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "arrayWithinRecordWithinArrayWithinRecord_nested.ddl"));
   }
 
   /***
@@ -69,11 +71,10 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent());
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
 
-    Assert.assertEquals(q.trim().replaceAll(" ", ""),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "optionWithinOptionWithinRecord_nested.ddl")
-            .replaceAll(" ", ""));
+    Assert.assertEquals(q,
+        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "optionWithinOptionWithinRecord_nested.ddl"));
   }
 
   /***
@@ -90,11 +91,10 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent());
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
 
-    Assert.assertEquals(q.trim().replaceAll(" ", ""),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinOptionWithinRecord_nested.ddl")
-            .replaceAll(" ", ""));
+    Assert.assertEquals(q.trim(),
+        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinOptionWithinRecord_nested.ddl"));
   }
 
   /***
@@ -111,11 +111,10 @@ public class HiveAvroORCQueryUtilsTest {
         "file:/user/hive/warehouse/" + schemaName, Optional.<String>absent(), Optional.<Map<String, String>>absent(),
         Optional.<List<String>>absent(), Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
         Optional.<Integer>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent());
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
 
-    Assert.assertEquals(q.trim().replaceAll(" ", ""),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.ddl")
-            .replaceAll(" ", ""));
+    Assert.assertEquals(q.trim(),
+        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.ddl"));
   }
 
   /***
@@ -134,11 +133,10 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent());
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
 
-    Assert.assertEquals(q.trim().replaceAll(" ", ""),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.ddl")
-            .replaceAll(" ", ""));
+    Assert.assertEquals(q,
+        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.ddl"));
   }
 
   /***
@@ -156,11 +154,11 @@ public class HiveAvroORCQueryUtilsTest {
 
     String q = HiveAvroORCQueryUtils.generateTableMappingDML(schema, flattenedSchema, schemaName,
         schemaName + "_orc", Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(), Optional.<Boolean>absent());
+        Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(), Optional.<Boolean>absent(),
+        isEvolutionEnabled, destinationTableMeta);
 
-    Assert.assertEquals(q.trim().replaceAll(" ", ""),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord.dml")
-            .replaceAll(" ", ""));
+    Assert.assertEquals(q.trim(),
+        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord.dml"));
   }
 
   /***
@@ -176,6 +174,6 @@ public class HiveAvroORCQueryUtilsTest {
         "file:/user/hive/warehouse/" + schemaName, Optional.<String>absent(), Optional.<Map<String, String>>absent(),
         Optional.<List<String>>absent(), Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
         Optional.<Integer>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent());
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtilsTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryUtilsTest.java
@@ -13,6 +13,7 @@
 package gobblin.data.management.conversion.hive.util;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -51,7 +52,7 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q,
         ConversionHiveTestUtils.readQueryFromFile(resourceDir, "arrayWithinRecordWithinArrayWithinRecord_nested.ddl"));
@@ -71,7 +72,7 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q,
         ConversionHiveTestUtils.readQueryFromFile(resourceDir, "optionWithinOptionWithinRecord_nested.ddl"));
@@ -91,7 +92,7 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q.trim(),
         ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinOptionWithinRecord_nested.ddl"));
@@ -111,7 +112,7 @@ public class HiveAvroORCQueryUtilsTest {
         "file:/user/hive/warehouse/" + schemaName, Optional.<String>absent(), Optional.<Map<String, String>>absent(),
         Optional.<List<String>>absent(), Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
         Optional.<Integer>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q.trim(),
         ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.ddl"));
@@ -133,7 +134,7 @@ public class HiveAvroORCQueryUtilsTest {
         Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<List<String>>absent(),
         Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(), Optional.<Integer>absent(),
         Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, new HashMap<String, String>());
 
     Assert.assertEquals(q,
         ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.ddl"));
@@ -174,6 +175,6 @@ public class HiveAvroORCQueryUtilsTest {
         "file:/user/hive/warehouse/" + schemaName, Optional.<String>absent(), Optional.<Map<String, String>>absent(),
         Optional.<List<String>>absent(), Optional.<Map<String, HiveAvroORCQueryUtils.COLUMN_SORT_ORDER>>absent(),
         Optional.<Integer>absent(), Optional.<String>absent(), Optional.<String>absent(), Optional.<String>absent(),
-        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta);
+        Optional.<Map<String, String>>absent(), isEvolutionEnabled, destinationTableMeta, new HashMap<String, String>());
   }
 }

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/arrayWithinRecordWithinArrayWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/arrayWithinRecordWithinArrayWithinRecord_nested.ddl
@@ -1,13 +1,13 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `default.testArrayWithinRecordWithinArrayWithinRecordDDL` (
-  `parentRecordFieldName` array<struct<`nestedRecordFieldName`:array<string>>>)
-ROW FORMAT SERDE
-  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
-STORED AS INPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
-OUTPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
-LOCATION
-  'file:/user/hive/warehouse/testArrayWithinRecordWithinArrayWithinRecordDDL'
-TBLPROPERTIES (
-  'orc.compress'='SNAPPY',
-  'orc.row.index.stride'='268435456')
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.testArrayWithinRecordWithinArrayWithinRecordDDL` ( 
+  `parentRecordFieldName` array<struct<`nestedRecordFieldName`:array<string>>> COMMENT 'from flatten_source parentRecordFieldName') 
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
+LOCATION 
+  'file:/user/hive/warehouse/testArrayWithinRecordWithinArrayWithinRecordDDL' 
+TBLPROPERTIES ( 
+  'orc.compress'='SNAPPY', 
+  'orc.row.index.stride'='268435456') 

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/optionWithinOptionWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/optionWithinOptionWithinRecord_nested.ddl
@@ -1,14 +1,14 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `default.testOptionWithinOptionWithinRecordDDL` (
-  `parentFieldUnion` struct<`unionRecordMemberFieldUnion`:struct<`superNestedFieldString1`:string,`superNestedFieldString2`:string>,`unionRecordMemberFieldString`:string>,
-  `parentFieldInt` int)
-ROW FORMAT SERDE
-  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
-STORED AS INPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
-OUTPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
-LOCATION
-  'file:/user/hive/warehouse/testOptionWithinOptionWithinRecordDDL'
-TBLPROPERTIES (
-  'orc.compress'='SNAPPY',
-  'orc.row.index.stride'='268435456')
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.testOptionWithinOptionWithinRecordDDL` ( 
+  `parentFieldUnion` struct<`unionRecordMemberFieldUnion`:struct<`superNestedFieldString1`:string,`superNestedFieldString2`:string>,`unionRecordMemberFieldString`:string> COMMENT 'from flatten_source parentFieldUnion', 
+  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt') 
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
+LOCATION 
+  'file:/user/hive/warehouse/testOptionWithinOptionWithinRecordDDL' 
+TBLPROPERTIES ( 
+  'orc.compress'='SNAPPY', 
+  'orc.row.index.stride'='268435456') 

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinOptionWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinOptionWithinRecord_nested.ddl
@@ -1,14 +1,14 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinOptionWithinRecordDDL` (
-  `parentFieldUnion` struct<`unionRecordMemberFieldLong`:bigint,`unionRecordMemberFieldString`:string>,
-  `parentFieldInt` int)
-ROW FORMAT SERDE
-  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
-STORED AS INPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
-OUTPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
-LOCATION
-  'file:/user/hive/warehouse/testRecordWithinOptionWithinRecordDDL'
-TBLPROPERTIES (
-  'orc.compress'='SNAPPY',
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinOptionWithinRecordDDL` ( 
+  `parentFieldUnion` struct<`unionRecordMemberFieldLong`:bigint,`unionRecordMemberFieldString`:string> COMMENT 'from flatten_source parentFieldUnion', 
+  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt') 
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
+LOCATION 
+  'file:/user/hive/warehouse/testRecordWithinOptionWithinRecordDDL' 
+TBLPROPERTIES ( 
+  'orc.compress'='SNAPPY', 
   'orc.row.index.stride'='268435456')

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinRecordWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/recordWithinRecordWithinRecord_nested.ddl
@@ -1,14 +1,14 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinRecordWithinRecordDDL` (
-  `parentFieldRecord` struct<`nestedFieldRecord`:struct<`superNestedFieldString`:string,`superNestedFieldInt`:int>,`nestedFieldString`:string,`nestedFieldInt`:int>,
-  `parentFieldInt` int)
-ROW FORMAT SERDE
-  'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
-STORED AS INPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat'
-OUTPUTFORMAT
-  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat'
-LOCATION
-  'file:/user/hive/warehouse/testRecordWithinRecordWithinRecordDDL'
-TBLPROPERTIES (
-  'orc.compress'='SNAPPY',
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinRecordWithinRecordDDL` ( 
+  `parentFieldRecord` struct<`nestedFieldRecord`:struct<`superNestedFieldString`:string,`superNestedFieldInt`:int>,`nestedFieldString`:string,`nestedFieldInt`:int> COMMENT 'from flatten_source parentFieldRecord', 
+  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt') 
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
+LOCATION 
+  'file:/user/hive/warehouse/testRecordWithinRecordWithinRecordDDL' 
+TBLPROPERTIES ( 
+  'orc.compress'='SNAPPY', 
   'orc.row.index.stride'='268435456')

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema.json
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema.json
@@ -1,0 +1,34 @@
+{
+  "type" : "record",
+  "name" : "parentRecordName",
+  "fields" : [ {
+    "name" : "parentFieldRecord",
+    "type" : {
+      "type" : "record",
+      "name" : "nestedRecordName",
+      "fields" : [ {
+        "name" : "nestedFieldRecord",
+        "type" : {
+          "type" : "record",
+          "name" : "superNestedRecordName",
+          "fields" : [ {
+            "name" : "superNestedFieldString",
+            "type" : "string"
+          }, {
+            "name" : "superNestedFieldInt",
+            "type" : "int"
+          }]
+        }
+      }, {
+        "name" : "nestedFieldString",
+        "type" : "string"
+      }, {
+        "name" : "nestedFieldInt",
+        "type" : "int"
+      } ]
+    }
+  }, {
+    "name" : "parentFieldInt",
+    "type" : "int"
+  } ]
+}

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_disabled.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_disabled.ddl
@@ -1,9 +1,9 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinRecordWithinRecordDDL` ( 
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.sourceSchema` ( 
   `parentFieldRecord__nestedFieldRecord__superNestedFieldString` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldString', 
   `parentFieldRecord__nestedFieldRecord__superNestedFieldInt` int COMMENT 'from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldInt', 
   `parentFieldRecord__nestedFieldString` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldString', 
-  `parentFieldRecord__nestedFieldInt` int COMMENT 'from flatten_source parentFieldRecord.nestedFieldInt', 
-  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt') 
+  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt', 
+  `parentFieldRecord__nestedFieldString2` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldString2') 
 ROW FORMAT SERDE 
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
 STORED AS INPUTFORMAT 
@@ -11,7 +11,7 @@ STORED AS INPUTFORMAT
 OUTPUTFORMAT 
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
 LOCATION 
-  'file:/user/hive/warehouse/testRecordWithinRecordWithinRecordDDL' 
+  'file:/user/hive/warehouse/sourceSchema' 
 TBLPROPERTIES ( 
   'orc.compress'='SNAPPY', 
   'orc.row.index.stride'='268435456') 

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_disabled.dml
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_disabled.dml
@@ -1,0 +1,8 @@
+INSERT OVERWRITE TABLE `default.sourceSchema_orc` 
+SELECT 
+  `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldString`, 
+  `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldInt`, 
+  `parentFieldRecord`.`nestedFieldString`, 
+  `parentFieldInt`, 
+  `parentFieldRecord`.`nestedFieldString2` 
+ FROM `default.sourceSchema` 

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_enabled.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_enabled.ddl
@@ -1,4 +1,4 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `default.testRecordWithinRecordWithinRecordDDL` ( 
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.sourceSchema` ( 
   `parentFieldRecord__nestedFieldRecord__superNestedFieldString` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldString', 
   `parentFieldRecord__nestedFieldRecord__superNestedFieldInt` int COMMENT 'from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldInt', 
   `parentFieldRecord__nestedFieldString` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldString', 
@@ -11,7 +11,7 @@ STORED AS INPUTFORMAT
 OUTPUTFORMAT 
   'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
 LOCATION 
-  'file:/user/hive/warehouse/testRecordWithinRecordWithinRecordDDL' 
+  'file:/user/hive/warehouse/sourceSchema' 
 TBLPROPERTIES ( 
   'orc.compress'='SNAPPY', 
   'orc.row.index.stride'='268435456') 

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_enabled.dml
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_evolution_enabled.dml
@@ -1,8 +1,8 @@
-INSERT OVERWRITE TABLE `default.testRecordWithinRecordWithinRecordDDL_orc` 
+INSERT OVERWRITE TABLE `default.sourceSchema_orc` 
 SELECT 
   `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldString`, 
   `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldInt`, 
   `parentFieldRecord`.`nestedFieldString`, 
   `parentFieldRecord`.`nestedFieldInt`, 
   `parentFieldInt` 
- FROM `default.testRecordWithinRecordWithinRecordDDL`
+ FROM `default.sourceSchema` 

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_lineage_missing.ddl
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_lineage_missing.ddl
@@ -1,0 +1,17 @@
+CREATE EXTERNAL TABLE IF NOT EXISTS `default.sourceSchema` ( 
+  `parentFieldRecord__nestedFieldRecord__superNestedFieldString` string COMMENT '', 
+  `parentFieldRecord__nestedFieldRecord__superNestedFieldInt` int COMMENT '', 
+  `parentFieldRecord__nestedFieldString` string COMMENT '', 
+  `parentFieldInt` int COMMENT '', 
+  `parentFieldRecord__nestedFieldString2` string COMMENT '') 
+ROW FORMAT SERDE 
+  'org.apache.hadoop.hive.ql.io.orc.OrcSerde' 
+STORED AS INPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcInputFormat' 
+OUTPUTFORMAT 
+  'org.apache.hadoop.hive.ql.io.orc.OrcOutputFormat' 
+LOCATION 
+  'file:/user/hive/warehouse/sourceSchema' 
+TBLPROPERTIES ( 
+  'orc.compress'='SNAPPY', 
+  'orc.row.index.stride'='268435456') 

--- a/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_lineage_missing.dml
+++ b/gobblin-data-management/src/test/resources/avroToOrcSchemaEvolutionTest/source_schema_lineage_missing.dml
@@ -1,8 +1,7 @@
-INSERT OVERWRITE TABLE `default.testRecordWithinRecordWithinRecordDDL_orc` 
+INSERT OVERWRITE TABLE `default.sourceSchema_orc` 
 SELECT 
   `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldString`, 
   `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldInt`, 
   `parentFieldRecord`.`nestedFieldString`, 
-  `parentFieldRecord`.`nestedFieldInt`, 
   `parentFieldInt` 
- FROM `default.testRecordWithinRecordWithinRecordDDL`
+ FROM `default.sourceSchema` 

--- a/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_flattened.ddl
+++ b/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_flattened.ddl
@@ -1,9 +1,9 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `testdb.testtable_orc` (
-  `parentFieldRecord__nestedFieldRecord__superNestedFieldString` string,
-  `parentFieldRecord__nestedFieldRecord__superNestedFieldInt` int,
-  `parentFieldRecord__nestedFieldString` string,
-  `parentFieldRecord__nestedFieldInt` int,
-  `parentFieldInt` int)
+CREATE EXTERNAL TABLE IF NOT EXISTS `testdb.testtable_orc_staging` (
+  `parentFieldRecord__nestedFieldRecord__superNestedFieldString` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldString',
+  `parentFieldRecord__nestedFieldRecord__superNestedFieldInt` int COMMENT 'from flatten_source parentFieldRecord.nestedFieldRecord.superNestedFieldInt',
+  `parentFieldRecord__nestedFieldString` string COMMENT 'from flatten_source parentFieldRecord.nestedFieldString',
+  `parentFieldRecord__nestedFieldInt` int COMMENT 'from flatten_source parentFieldRecord.nestedFieldInt',
+  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt')
 ROW FORMAT SERDE
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
 STORED AS INPUTFORMAT

--- a/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_flattened.dml
+++ b/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_flattened.dml
@@ -1,4 +1,4 @@
-INSERT OVERWRITE TABLE `testdb.testtable_orc`
+INSERT OVERWRITE TABLE `testdb.testtable_orc_staging`
 SELECT
   `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldString`,
   `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldInt`,

--- a/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_nested.ddl
+++ b/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_nested.ddl
@@ -1,6 +1,6 @@
-CREATE EXTERNAL TABLE IF NOT EXISTS `testdb.testtable_orc_nested` (
-  `parentFieldRecord` struct<`nestedFieldRecord`:struct<`superNestedFieldString`:string,`superNestedFieldInt`:int>,`nestedFieldString`:string,`nestedFieldInt`:int>,
-  `parentFieldInt` int)
+CREATE EXTERNAL TABLE IF NOT EXISTS `testdb.testtable_orc_nested_staging` (
+  `parentFieldRecord` struct<`nestedFieldRecord`:struct<`superNestedFieldString`:string,`superNestedFieldInt`:int>,`nestedFieldString`:string,`nestedFieldInt`:int> COMMENT 'from flatten_source parentFieldRecord',
+  `parentFieldInt` int COMMENT 'from flatten_source parentFieldInt')
 ROW FORMAT SERDE
   'org.apache.hadoop.hive.ql.io.orc.OrcSerde'
 STORED AS INPUTFORMAT

--- a/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_nested.dml
+++ b/gobblin-data-management/src/test/resources/hiveConverterTest/recordWithinRecordWithinRecord_nested.dml
@@ -1,4 +1,4 @@
-INSERT OVERWRITE TABLE `testdb.testtable_orc_nested`
+INSERT OVERWRITE TABLE `testdb.testtable_orc_nested_staging`
 SELECT
   `parentFieldRecord`,
   `parentFieldInt`


### PR DESCRIPTION
Adding support for:
- Schema evolution: Support to evolve destination ORC table for changes in source table schema (Hive / ORC does not support evolution yet, this is being added with hope that Hive / ORC will soon support evolution)
- Staging: Support to first stage converted data in a staging table before publishing / committing it to the final table
- Selective column projection: To counter against schema evolution on source hive table, this feature would help selectively project columns from source that are in destination / ORC table 

