### PR TITLE
Added limit clause to Hive query generation to enable conversion validation of sample subset

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -140,6 +140,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
             ? Optional.<List<String>> absent()
             : Optional.of(getConversionConfig().getClusterBy());
     Optional<Integer> numBuckets = getConversionConfig().getNumBuckets();
+    Optional<Integer> rowLimit = getConversionConfig().getRowLimit();
 
     // Populate optional partition info
     Map<String, String> partitionsDDLInfo = Maps.newHashMap();
@@ -186,7 +187,8 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
                 Optional.<Boolean>absent(),
                 Optional.<Boolean>absent(),
                 isEvolutionEnabled,
-                destinationTableMeta);
+                destinationTableMeta,
+                rowLimit);
     conversionEntity.getQueries().add(insertInORCTableDML);
     log.debug("Conversion DML: " + insertInORCTableDML);
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -136,6 +136,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     public static final String CLUSTER_BY_KEY = "clusterByList";
     public static final String NUM_BUCKETS_KEY = "numBuckets";
     public static final String EVOLUTION_ENABLED = "evolution.enabled";
+    public static final String ROW_LIMIT_KEY = "rowLimit";
 
     private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
     private final String destinationFormat;
@@ -147,6 +148,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private final Optional<Integer> numBuckets;
     private final Properties hiveRuntimeProperties;
     private final boolean evolutionEnabled;
+    private final Optional<Integer> rowLimit;
 
     private ConversionConfig(Config config, Table table, String destinationFormat) {
 
@@ -168,6 +170,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.hiveRuntimeProperties = ConfigUtils
           .configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
       this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
+      this.rowLimit = Optional.fromNullable(ConfigUtils.getInt(config, ROW_LIMIT_KEY, null));
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -465,7 +465,9 @@ public class HiveAvroORCQueryGenerator {
    * @param optionalOverwriteTable Optional overwrite table, if not specified it is set to true
    * @param optionalCreateIfNotExists Optional create if not exists, if not specified it is set to false
    * @param isEvolutionEnabled If schema evolution is turned on
-   * @param destinationTableMeta Optional destination table metadata  @return DML query
+   * @param destinationTableMeta Optional destination table metadata
+   * @param rowLimit Optional row limit
+   * @return DML query
    */
   public static String generateTableMappingDML(Schema inputAvroSchema,
       Schema outputOrcSchema,
@@ -477,7 +479,8 @@ public class HiveAvroORCQueryGenerator {
       Optional<Boolean> optionalOverwriteTable,
       Optional<Boolean> optionalCreateIfNotExists,
       boolean isEvolutionEnabled,
-      Optional<Table> destinationTableMeta) {
+      Optional<Table> destinationTableMeta,
+      Optional<Integer> rowLimit) {
     Preconditions.checkNotNull(inputAvroSchema);
     Preconditions.checkNotNull(outputOrcSchema);
     Preconditions.checkArgument(StringUtils.isNotBlank(inputTblName));
@@ -604,6 +607,11 @@ public class HiveAvroORCQueryGenerator {
         }
         dmlQuery.append(" \n");
       }
+    }
+
+    // Limit clause
+    if (rowLimit.isPresent()) {
+      dmlQuery.append(String.format("LIMIT %s", rowLimit.get()));
     }
 
     return dmlQuery.toString();

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -49,6 +49,7 @@ public class HiveSchemaEvolutionTest {
   private static AvroFlattener avroFlattener = new AvroFlattener();
   private static Schema inputSchema;
   private static Schema outputSchema;
+  private static Optional<Integer> rowLimit = Optional.absent();
 
   static {
     try {
@@ -79,7 +80,7 @@ public class HiveSchemaEvolutionTest {
     String dml = HiveAvroORCQueryGenerator
         .generateTableMappingDML(inputSchema, outputSchema, schemaName, schemaName + "_orc", Optional.<String>absent(),
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(),
-            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta);
+            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta, rowLimit);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
         "source_schema_evolution_enabled.dml"), "Generated DML did not match expected for evolution enabled");
@@ -105,7 +106,7 @@ public class HiveSchemaEvolutionTest {
     String dml = HiveAvroORCQueryGenerator
         .generateTableMappingDML(inputSchema, outputSchema, schemaName, schemaName + "_orc", Optional.<String>absent(),
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(),
-            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta);
+            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta, rowLimit);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
         "source_schema_evolution_enabled.dml"),
@@ -132,7 +133,7 @@ public class HiveSchemaEvolutionTest {
     String dml = HiveAvroORCQueryGenerator
         .generateTableMappingDML(inputSchema, outputSchema, schemaName, schemaName + "_orc", Optional.<String>absent(),
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(),
-            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta);
+            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta, rowLimit);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
         "source_schema_evolution_disabled.dml"),
@@ -159,7 +160,7 @@ public class HiveSchemaEvolutionTest {
     String dml = HiveAvroORCQueryGenerator
         .generateTableMappingDML(inputSchema, outputSchema, schemaName, schemaName + "_orc", Optional.<String>absent(),
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(),
-            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta);
+            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta, rowLimit);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
         "source_schema_evolution_enabled.dml"),
@@ -186,7 +187,7 @@ public class HiveSchemaEvolutionTest {
     String dml = HiveAvroORCQueryGenerator
         .generateTableMappingDML(inputSchema, outputSchema, schemaName, schemaName + "_orc", Optional.<String>absent(),
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(),
-            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta);
+            Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta, rowLimit);
 
     Assert.assertEquals(dml, ConversionHiveTestUtils.readQueryFromFile(resourceDir,
         "source_schema_lineage_missing.dml"),

--- a/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/flattenedWithRowLimit.dml
+++ b/gobblin-data-management/src/test/resources/avroToOrcQueryUtilsTest/flattenedWithRowLimit.dml
@@ -1,0 +1,8 @@
+INSERT OVERWRITE TABLE `default.testRecordWithinRecordWithinRecordDDL_orc` 
+SELECT 
+  `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldString`, 
+  `parentFieldRecord`.`nestedFieldRecord`.`superNestedFieldInt`, 
+  `parentFieldRecord`.`nestedFieldString`, 
+  `parentFieldRecord`.`nestedFieldInt`, 
+  `parentFieldInt` 
+ FROM `default.testRecordWithinRecordWithinRecordDDL` LIMIT 1


### PR DESCRIPTION
Added limit clause to Hive query generation to enable conversion on sample data size for validation purposes

With this addition, to run a job that runs sampled conversion on multiple datasets: 
1. Use BackfillHiveSource
2. Configure rest of Avro to ORC conversion job as you normally would 
(by specifying dataset whitelist, etc)
3. Set rowLimit to a low number (say 1)
4. Run the job