### PR TITLE
Hive Based Retention

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableHiveDataset.java
@@ -1,0 +1,159 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.dataset;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.apache.thrift.TException;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.typesafe.config.Config;
+
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.policy.SelectBeforeTimeBasedPolicy;
+import gobblin.data.management.policy.VersionSelectionPolicy;
+import gobblin.data.management.version.HiveDatasetVersion;
+import gobblin.data.management.version.finder.DatePartitionHiveVersionFinder;
+import gobblin.data.management.version.finder.AbstractHiveDatasetVersionFinder;
+import gobblin.hive.HiveMetastoreClientPool;
+import gobblin.util.AutoReturnableObject;
+import gobblin.util.ConfigUtils;
+import gobblin.util.reflection.GobblinConstructorUtils;
+
+/**
+ * <p>
+ * A {@link HiveDataset} used for Retention. A {@link HiveDataset} represents a hive table and a {@link HiveDatasetVersion}
+ * represents a hive partition of this table.
+ * </p>
+ *
+ * <ul>
+ * <li>A version finder at {@value #VERSION_FINDER_CLASS_KEY} is used to find all the partitions the dataset
+ * <li>A selection policy at {@value #SELECTION_POLICY_CLASS_KEY} is appliced on all these partitions to get the partitions to be deleted.
+ * <li>These selected partitions are dropped in the hive metastore and all the data on FileSystem is also deleted
+ * </ul>
+ *
+ */
+@Slf4j
+@SuppressWarnings({ "rawtypes", "unchecked" })
+public class CleanableHiveDataset extends HiveDataset implements CleanableDataset {
+
+  private static final String SHOULD_DELETE_DATA_KEY = "gobblin.retention.hive.shouldDeleteData";
+  private static final String SHOULD_DELETE_DATA_DEFAULT = Boolean.toString(true);
+
+  private static final String VERSION_FINDER_CLASS_KEY = "version.finder.class";
+  private static final String DEFAULT_VERSION_FINDER_CLASS = DatePartitionHiveVersionFinder.class.getName();
+
+  private static final String SELECTION_POLICY_CLASS_KEY = "selection.policy.class";
+  private static final String DEFAULT_SELECTION_POLICY_CLASS = SelectBeforeTimeBasedPolicy.class.getName();
+
+  private final VersionSelectionPolicy hiveSelectionPolicy;
+  private final AbstractHiveDatasetVersionFinder hiveDatasetVersionFinder;
+
+  private final boolean simulate;
+  private final boolean shouldDeleteData;
+  private final FsCleanableHelper fsCleanableHelper;
+
+  public CleanableHiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Properties jobProps, Config datasetConfig) throws IOException {
+    super(fs, clientPool, table, jobProps, datasetConfig);
+
+    try {
+      this.hiveSelectionPolicy =
+          (VersionSelectionPolicy) GobblinConstructorUtils.invokeFirstConstructor(
+              Class.forName(ConfigUtils.getString(datasetConfig, SELECTION_POLICY_CLASS_KEY, DEFAULT_SELECTION_POLICY_CLASS)),
+              ImmutableList.<Object> of(datasetConfig, jobProps), ImmutableList.<Object> of(datasetConfig), ImmutableList.<Object> of(jobProps));
+
+      this.hiveDatasetVersionFinder =
+          (AbstractHiveDatasetVersionFinder) GobblinConstructorUtils.invokeFirstConstructor(
+              Class.forName(ConfigUtils.getString(datasetConfig, VERSION_FINDER_CLASS_KEY, DEFAULT_VERSION_FINDER_CLASS)),
+              ImmutableList.<Object> of(this.fs, datasetConfig), ImmutableList.<Object> of(this.fs, jobProps));
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException | ClassNotFoundException e) {
+      throw new IllegalArgumentException(e);
+    }
+
+    this.fsCleanableHelper = new FsCleanableHelper(fs, jobProps, datasetConfig, log);
+
+    this.shouldDeleteData = Boolean.valueOf(jobProps.getProperty(SHOULD_DELETE_DATA_KEY, SHOULD_DELETE_DATA_DEFAULT));
+    this.simulate = Boolean.valueOf(jobProps.getProperty(FsCleanableHelper.SIMULATE_KEY, FsCleanableHelper.SIMULATE_DEFAULT));
+  }
+
+  /**
+   * Drops the partitions selected by {@link #hiveSelectionPolicy}. Also deletes the data associated with it.
+   * <p>
+   * If an {@link Exception} occurs while processing a {@link Partition}, other {@link Partition}s will still be deleted.
+   * However, a {@link RuntimeException} is thrown at the end if there was at least one {@link Exception}.
+   * </p>
+   */
+  @Override
+  public void clean() throws IOException {
+
+    List versions = Lists.newArrayList(this.hiveDatasetVersionFinder.findDatasetVersions(this));
+
+    if (versions.isEmpty()) {
+      log.warn(String.format("No dataset version can be found. Ignoring %s", this.getTable().getCompleteName()));
+      return;
+    }
+
+    Collections.sort(versions, Collections.reverseOrder());
+
+    Collection<HiveDatasetVersion> deletableVersions = this.hiveSelectionPolicy.listSelectedVersions(versions);
+
+    List<Exception> exceptions = Lists.newArrayList();
+    Set<Path> possiblyEmptyDirectories = new HashSet<>();
+
+    try (AutoReturnableObject<IMetaStoreClient> client = this.clientPool.getClient()) {
+
+      for (HiveDatasetVersion hiveDatasetVersion : deletableVersions) {
+        Partition partition = hiveDatasetVersion.getPartition();
+        try {
+          if (!this.simulate) {
+            client.get().dropPartition(partition.getTable().getDbName(), partition.getTable().getTableName(), partition.getValues(), false);
+            log.info("Successfully dropped partition " + partition.getCompleteName());
+          } else {
+            log.info("Simulating drop partition " + partition.getCompleteName());
+          }
+          if (this.shouldDeleteData) {
+            this.fsCleanableHelper.clean(hiveDatasetVersion, possiblyEmptyDirectories);
+          }
+        } catch (TException | IOException e) {
+          log.warn(String.format("Failed to completely delete partition %s.", partition.getCompleteName()), e);
+          exceptions.add(e);
+        }
+      }
+
+      this.fsCleanableHelper.cleanEmptyDirectories(possiblyEmptyDirectories, this);
+    }
+
+    if (!exceptions.isEmpty()) {
+      throw new RuntimeException(String.format("Deletion failed for %s partitions", exceptions.size()));
+    }
+  }
+
+  @Override
+  public Path datasetRoot() {
+    return super.getTable().getDataLocation();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/FsCleanableHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/FsCleanableHelper.java
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.dataset;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.Properties;
+import java.util.Set;
+
+import lombok.Getter;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+
+import com.typesafe.config.Config;
+
+import gobblin.data.management.trash.ProxiedTrash;
+import gobblin.data.management.trash.TrashFactory;
+import gobblin.data.management.version.FileSystemDatasetVersion;
+import gobblin.dataset.FileSystemDataset;
+import gobblin.util.PathUtils;
+
+/**
+ * A helper class to delete {@link Path}s of a FileSystemDatasetVersion.
+ * <p>
+ * Supports the following job level settings:
+ * <ul>
+ * <li> Simulate Mode - Only log paths to be deleted without deleting data by setting {@value #SIMULATE_KEY} to true.
+ * <li> Skip Trash - Delete permanent by setting {@value #SKIP_TRASH_KEY} to true.
+ * <li> Auto delete empty parent directories - By setting {@value #DELETE_EMPTY_DIRECTORIES_KEY} to true.
+ * <li> Proxy as owner and delete - By setting {@value #DELETE_AS_OWNER_KEY} to true.
+ * </ul>
+ * </p>
+ */
+public class FsCleanableHelper {
+
+  public static final String CONFIGURATION_KEY_PREFIX = "gobblin.retention.";
+
+  public static final String SIMULATE_KEY = CONFIGURATION_KEY_PREFIX + "simulate";
+  public static final String SIMULATE_DEFAULT = Boolean.toString(false);
+
+  public static final String SKIP_TRASH_KEY = CONFIGURATION_KEY_PREFIX + "skip.trash";
+  public static final String SKIP_TRASH_DEFAULT = Boolean.toString(false);
+
+  public static final String DELETE_EMPTY_DIRECTORIES_KEY = CONFIGURATION_KEY_PREFIX + "delete.empty.directories";
+  public static final String DELETE_EMPTY_DIRECTORIES_DEFAULT = Boolean.toString(true);
+
+  public static final String DELETE_AS_OWNER_KEY = CONFIGURATION_KEY_PREFIX + "delete.as.owner";
+  public static final String DELETE_AS_OWNER_DEFAULT = Boolean.toString(true);
+
+  protected final FileSystem fs;
+  @Getter
+  protected final ProxiedTrash trash;
+  protected final boolean simulate;
+  protected final boolean skipTrash;
+  protected final boolean deleteEmptyDirectories;
+  protected final boolean deleteAsOwner;
+  protected final Logger log;
+
+  public FsCleanableHelper(FileSystem fs, Properties properties, boolean simulate, boolean skipTrash, boolean deleteEmptyDirectories, boolean deleteAsOwner,
+      Logger log) throws IOException {
+    this.log = log;
+    this.fs = fs;
+    this.simulate = simulate;
+    this.skipTrash = skipTrash;
+    this.deleteEmptyDirectories = deleteEmptyDirectories;
+    Properties thisProperties = new Properties();
+    thisProperties.putAll(properties);
+    if (this.simulate) {
+      thisProperties.setProperty(TrashFactory.SIMULATE, Boolean.toString(true));
+    }
+    if (this.skipTrash) {
+      thisProperties.setProperty(TrashFactory.SKIP_TRASH, Boolean.toString(true));
+    }
+    this.trash = TrashFactory.createProxiedTrash(this.fs, thisProperties);
+    this.deleteAsOwner = deleteAsOwner;
+  }
+
+  public FsCleanableHelper(final FileSystem fs, final Properties props, Config config, Logger log) throws IOException {
+    this(fs, props, Boolean.valueOf(props.getProperty(SIMULATE_KEY, SIMULATE_DEFAULT)),
+        Boolean.valueOf(props.getProperty(SKIP_TRASH_KEY, SKIP_TRASH_DEFAULT)),
+        Boolean.valueOf(props.getProperty(DELETE_EMPTY_DIRECTORIES_KEY, DELETE_EMPTY_DIRECTORIES_DEFAULT)),
+        Boolean.valueOf(props.getProperty(DELETE_AS_OWNER_KEY, DELETE_AS_OWNER_DEFAULT)), log);
+  }
+
+  /**
+   * Delete a single {@link FileSystemDatasetVersion}. All the parent {@link Path}s are after deletion, are
+   * added to <code>possiblyEmptyDirectories</code>. Caller need to call {@link #cleanEmptyDirectories(Set, FileSystemDataset)}
+   * to delete empty parent directories if any.
+   */
+  public void clean(final FileSystemDatasetVersion versionToDelete, final Set<Path> possiblyEmptyDirectories) throws IOException {
+    log.info("Deleting dataset version " + versionToDelete);
+
+    Set<Path> pathsToDelete = versionToDelete.getPaths();
+    log.info("Deleting paths: " + Arrays.toString(pathsToDelete.toArray()));
+
+    boolean deletedAllPaths = true;
+
+    for (Path path : pathsToDelete) {
+
+      if (!this.fs.exists(path)) {
+        log.info(String.format("Path %s in dataset version %s does not exist", path, versionToDelete));
+        continue;
+      }
+
+      boolean successfullyDeleted = deleteAsOwner ? trash.moveToTrashAsOwner(path) : trash.moveToTrash(path);
+
+      if (successfullyDeleted) {
+        possiblyEmptyDirectories.add(path.getParent());
+      } else {
+        log.error("Failed to delete path " + path + " in dataset version " + versionToDelete);
+        deletedAllPaths = false;
+      }
+    }
+
+    if (!deletedAllPaths) {
+      log.error("Failed to delete some paths in dataset version " + versionToDelete);
+    }
+  }
+
+  /**
+   * Delete all {@link FileSystemDatasetVersion}s <code>deletableVersions</code> and also delete any empty parent directories.
+   *
+   * @param fsDataset to which the version belongs.
+   */
+  public void clean(final Collection<? extends FileSystemDatasetVersion> deletableVersions, final FileSystemDataset fsDataset) throws IOException {
+    if (deletableVersions.isEmpty()) {
+      log.warn("No deletable dataset version can be found. Ignoring.");
+      return;
+    }
+    Set<Path> possiblyEmptyDirectories = new HashSet<>();
+    for (FileSystemDatasetVersion fsdv : deletableVersions) {
+      clean(fsdv, possiblyEmptyDirectories);
+    }
+    cleanEmptyDirectories(possiblyEmptyDirectories, fsDataset);
+  }
+
+  /**
+   * Deletes any empty paths in <code>possiblyEmptyDirectories</code> all the way upto the {@link FileSystemDataset#datasetRoot()}.
+   */
+  public void cleanEmptyDirectories(final Set<Path> possiblyEmptyDirectories, final FileSystemDataset fsDataset) throws IOException {
+    if (this.deleteEmptyDirectories && !this.simulate) {
+      for (Path parentDirectory : possiblyEmptyDirectories) {
+        PathUtils.deleteEmptyParentDirectories(fs, fsDataset.datasetRoot(), parentDirectory);
+      }
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/finder/CleanableHiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/finder/CleanableHiveDatasetFinder.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.dataset.finder;
+
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.Table;
+
+import com.typesafe.config.Config;
+
+import gobblin.config.client.ConfigClient;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.data.management.retention.dataset.CleanableHiveDataset;
+import gobblin.data.management.retention.dataset.ConfigurableCleanableDataset;
+
+
+public class CleanableHiveDatasetFinder extends HiveDatasetFinder {
+
+  public CleanableHiveDatasetFinder(FileSystem fs, Properties properties) throws IOException {
+    super(fs, setConfigPrefix(properties));
+  }
+
+  public CleanableHiveDatasetFinder(FileSystem fs, Properties properties, ConfigClient configClient) throws IOException {
+    super(fs, setConfigPrefix(properties), configClient);
+  }
+
+  protected CleanableHiveDataset createHiveDataset(Table table, Config datasetConfig) throws IOException {
+    return new CleanableHiveDataset(super.fs, super.clientPool, new org.apache.hadoop.hive.ql.metadata.Table(table), super.properties, datasetConfig);
+  }
+
+  private static Properties setConfigPrefix(Properties props) {
+    if (!props.containsKey(HIVE_DATASET_CONFIG_PREFIX_KEY)) {
+      props.setProperty(HIVE_DATASET_CONFIG_PREFIX_KEY, ConfigurableCleanableDataset.RETENTION_CONFIGURATION_KEY);
+    }
+    return props;
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/HiveDatasetVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/HiveDatasetVersion.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+/**
+ * Represents a {@link DatasetVersion} for hive partition
+ */
+public interface HiveDatasetVersion extends FileSystemDatasetVersion {
+
+  /**
+   * The partition associated with this {@link DatasetVersion}
+   * @return
+   */
+  public Partition getPartition();
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/TimestampedHiveDatasetVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/TimestampedHiveDatasetVersion.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version;
+
+import lombok.EqualsAndHashCode;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.joda.time.DateTime;
+
+/**
+ * A {@link HiveDatasetVersion} where the version is a timestamp associated with the {@link Partition}. Usually this
+ * is the create time or modification time.
+ */
+public class TimestampedHiveDatasetVersion extends TimestampedDatasetVersion implements HiveDatasetVersion {
+
+  private final Partition partition;
+
+  public TimestampedHiveDatasetVersion(DateTime version, Partition partition) {
+    super(version, partition.getDataLocation());
+    this.partition = partition;
+  }
+
+  @Override
+  public Partition getPartition() {
+    return this.partition;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    return super.equals(obj) && obj instanceof TimestampedHiveDatasetVersion && compareTo((TimestampedHiveDatasetVersion) obj) == 0;
+  }
+
+  @Override
+  public int hashCode() {
+    return this.partition.hashCode() + super.hashCode();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/AbstractHiveDatasetVersionFinder.java
@@ -1,0 +1,95 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version.finder;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveUtils;
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.data.management.version.HiveDatasetVersion;
+import gobblin.dataset.Dataset;
+import gobblin.util.AutoReturnableObject;
+
+
+/**
+ * An abstract {@link VersionFinder} to create {@link HiveDatasetVersion}s for all {@link Partition}s of a {@link HiveDataset}.
+ * Calls {@link #getDatasetVersion(Partition)} for every {@link Partition} found.
+ */
+@Slf4j
+public abstract class AbstractHiveDatasetVersionFinder implements VersionFinder<HiveDatasetVersion> {
+
+  @Override
+  public Class<? extends DatasetVersion> versionClass() {
+    return HiveDatasetVersion.class;
+  }
+
+  /**
+   * Create {@link HiveDatasetVersion}s for all {@link Partition}s of a {@link HiveDataset}.
+   * Calls {@link #getDatasetVersion(Partition)} for every {@link Partition} found.
+   * <p>
+   * Note: If an exception occurs while processing a partition, that partition will be ignored in the returned collection
+   * </p>
+   *
+   * @throws IllegalArgumentException if <code>dataset</code> is not a {@link HiveDataset}. Or if {@link HiveDataset#getTable()}
+   * is not partitioned.
+   */
+  @Override
+  public Collection<HiveDatasetVersion> findDatasetVersions(Dataset dataset) throws IOException {
+    if (!(dataset instanceof HiveDataset)) {
+      throw new IllegalArgumentException("HiveDatasetVersionFinder is only compatible with HiveDataset");
+    }
+    final HiveDataset hiveDataset = (HiveDataset) dataset;
+
+    if (!HiveUtils.isPartitioned(hiveDataset.getTable())) {
+      throw new IllegalArgumentException("HiveDatasetVersionFinder is only compatible with partitioned hive tables");
+    }
+
+    try (AutoReturnableObject<IMetaStoreClient> client = hiveDataset.getClientPool().getClient()) {
+
+      List<Partition> partitions = HiveUtils.getPartitions(client.get(), hiveDataset.getTable(), Optional.<String> absent());
+      return Lists.newArrayList(Iterables.filter(Iterables.transform(partitions, new Function<Partition, HiveDatasetVersion>() {
+
+        @Override
+        public HiveDatasetVersion apply(Partition partition) {
+          try {
+            return getDatasetVersion(partition);
+          } catch (Throwable e) {
+            log.warn(String.format("Failed to get DatasetVersion %s. Skipping.", partition.getCompleteName()), e);
+            return null;
+          }
+        }
+      }), Predicates.notNull()));
+    }
+  }
+
+  /**
+   *
+   * Create a {@link HiveDatasetVersion} for the {@link Partition}
+   * @param partition for which a {@link HiveDatasetVersion} is created
+   */
+  protected abstract HiveDatasetVersion getDatasetVersion(Partition partition);
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/DatePartitionHiveVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/DatePartitionHiveVersionFinder.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version.finder;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+
+import com.google.common.base.Predicate;
+import com.google.common.collect.Iterables;
+import com.typesafe.config.Config;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.version.TimestampedHiveDatasetVersion;
+import gobblin.util.ConfigUtils;
+
+
+/**
+ * A Hive Partition finder where the the version is the partition value.
+ * <p>
+ * The hive table needs to be date partitioned by prop value {@value #PARTITION_KEY_NAME_KEY}. The value of this key must be
+ * a date pattern as per prop value {@value #PARTITION_VALUE_DATE_TIME_PATTERN_KEY}.
+ * </p>
+ * <p>
+ * E.g if the hive partition is datepartition=2016-01-10-22/field1=f1Value.
+ * The {@value #PARTITION_KEY_NAME_KEY}=datepartiton and {@value #PARTITION_VALUE_DATE_TIME_PATTERN_KEY}=yyyy-MM-dd-HH
+ *
+ * </p>
+ */
+public class DatePartitionHiveVersionFinder extends AbstractHiveDatasetVersionFinder {
+
+  public static final String PARTITION_VALUE_DATE_TIME_PATTERN_KEY = "hive.partition.value.datetime.pattern";
+  public static final String DEFAULT_PARTITION_VALUE_DATE_TIME_PATTERN = "yyyy-MM-dd-HH";
+
+  public static final String PARTITION_VALUE_DATE_TIME_TIMEZONE_KEY = "hive.partition.value.datetime.timezone";
+  public static final String DEFAULT_PARTITION_VALUE_DATE_TIME_TIMEZONE = ConfigurationKeys.PST_TIMEZONE_NAME;
+
+  public static final String PARTITION_KEY_NAME_KEY = "hive.partition.key.name";
+  public static final String DEFAULT_PARTITION_KEY_NAME = "datepartition";
+
+  protected final DateTimeFormatter formatter;
+  private final String partitionKeyName;
+  private final Predicate<FieldSchema> partitionKeyNamePredicate;
+
+  public DatePartitionHiveVersionFinder(FileSystem fs, Config config) {
+
+    String pattern = ConfigUtils.getString(config, PARTITION_VALUE_DATE_TIME_PATTERN_KEY, DEFAULT_PARTITION_VALUE_DATE_TIME_PATTERN);
+
+    if (config.hasPath(PARTITION_VALUE_DATE_TIME_TIMEZONE_KEY)) {
+      this.formatter = DateTimeFormat.forPattern(pattern).withZone(DateTimeZone.forID(config.getString(PARTITION_VALUE_DATE_TIME_TIMEZONE_KEY)));
+    } else {
+      this.formatter = DateTimeFormat.forPattern(pattern).withZone(DateTimeZone.forID(DEFAULT_PARTITION_VALUE_DATE_TIME_TIMEZONE));
+    }
+
+    this.partitionKeyName = ConfigUtils.getString(config, PARTITION_KEY_NAME_KEY, DEFAULT_PARTITION_KEY_NAME);
+    this.partitionKeyNamePredicate = new Predicate<FieldSchema>() {
+
+      @Override
+      public boolean apply(FieldSchema input) {
+        return StringUtils.equalsIgnoreCase(input.getName(), DatePartitionHiveVersionFinder.this.partitionKeyName);
+      }
+    };
+
+  }
+
+  /**
+   * Create a {@link TimestampedHiveDatasetVersion} from a {@link Partition}. The hive table is expected
+   * to be date partitioned by {@link #partitionKeyName}. The partition value format must be {@link #partitionValueDatePattern}
+   *
+   * @throws IllegalArgumentException when {@link #partitionKeyName} is not found in the <code></code>
+   * @throws IllegalArgumentException when a value can not be found for {@link #partitionKeyName} in the <code>partition</code>
+   * @throws IllegalArgumentException if the partition value can not be parsed with {@link #partitionValueDatePattern}
+   * {@inheritDoc}
+   */
+  @Override
+  protected TimestampedHiveDatasetVersion getDatasetVersion(Partition partition) {
+
+    int index = Iterables.indexOf(partition.getTable().getPartitionKeys(), this.partitionKeyNamePredicate);
+
+    if (index == -1) {
+      throw new IllegalArgumentException(String.format("Failed to find partition key %s in the table %s", this.partitionKeyName, partition.getTable()
+          .getCompleteName()));
+    }
+
+    if (index >= partition.getValues().size()) {
+      throw new IllegalArgumentException(String.format("Failed to find partition value for key %s in the partition %s", this.partitionKeyName,
+          partition.getName()));
+    }
+    return new TimestampedHiveDatasetVersion(this.formatter.parseDateTime(partition.getValues().get(index).trim()), partition);
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestHelper.java
+++ b/gobblin-data-management/src/main/java/gobblin/util/test/RetentionTestHelper.java
@@ -24,6 +24,8 @@ import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
@@ -33,29 +35,36 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.data.management.retention.DatasetCleaner;
 import gobblin.data.management.retention.dataset.CleanableDataset;
 import gobblin.data.management.retention.dataset.CleanableDatasetBase;
-import gobblin.data.management.retention.profile.ManagedCleanableDatasetFinder;
 import gobblin.data.management.retention.profile.MultiCleanableDatasetFinder;
 import gobblin.dataset.Dataset;
 import gobblin.dataset.DatasetsFinder;
 import gobblin.util.PathUtils;
+import gobblin.util.reflection.GobblinConstructorUtils;
 
 /**
  * Helper methods for Retention integration tests
  */
 public class RetentionTestHelper {
 
-  /**
-  *
-  * Does gobblin retention for test data. {@link DatasetCleaner} which does retention in production can not be directly called as we need to resolve some
-  * runtime properties like ${testNameTempPath}. This directory contains all the setup data created for a test by {@link RetentionTestDataGenerator#setup()}.
-  * It is unique for each test.
-  * The default {@link ConfigClient} used by {@link DatasetCleaner} connects to config store configs. We need to provide a
-  * mock {@link ConfigClient} since the configs are in classpath and not on config store.
-  *
-  * @param retentionConfigClasspathResource this is the same jobProps/config files used while running a real retention job
-  * @param testNameTempPath temp path for this test where test data is generated
-  */
- public static void clean(FileSystem fs, Path retentionConfigClasspathResource, Path testNameTempPath) throws Exception {
+ /**
+ *
+ * Does gobblin retention for test data. {@link DatasetCleaner} which does retention in production can not be directly called as we need to resolve some
+ * runtime properties like ${testNameTempPath}. This directory contains all the setup data created for a test by {@link RetentionTestDataGenerator#setup()}.
+ * It is unique for each test.
+ * The default {@link ConfigClient} used by {@link DatasetCleaner} connects to config store configs. We need to provide a
+ * mock {@link ConfigClient} since the configs are in classpath and not on config store.
+ *
+ * @param retentionConfigClasspathResource this is the same jobProps/config files used while running a real retention job
+ * @param testNameTempPath temp path for this test where test data is generated
+ */
+ public static void clean(FileSystem fs, Path retentionConfigClasspathResource, Optional<Path> additionalJobPropsClasspathResource, Path testNameTempPath) throws Exception {
+
+   Properties additionalJobProps = new Properties();
+   if (additionalJobPropsClasspathResource.isPresent()) {
+     try (final InputStream stream = RetentionTestHelper.class.getClassLoader().getResourceAsStream(additionalJobPropsClasspathResource.get().toString())) {
+       additionalJobProps.load(stream);
+     }
+   }
 
    if (retentionConfigClasspathResource.getName().endsWith(".job")) {
 
@@ -66,6 +75,7 @@ public class RetentionTestHelper {
          jobProps.put(entry.getKey(), StringUtils.replace((String)entry.getValue(), "${testNameTempPath}", testNameTempPath.toString()));
        }
      }
+
      MultiCleanableDatasetFinder finder = new MultiCleanableDatasetFinder(fs, jobProps);
      for (Dataset dataset : finder.findDatasets()) {
        ((CleanableDataset)dataset).clean();
@@ -80,14 +90,24 @@ public class RetentionTestHelper {
      jobProps.setProperty(CleanableDatasetBase.SKIP_TRASH_KEY, Boolean.toString(true));
      jobProps.setProperty(ConfigurationKeys.CONFIG_MANAGEMENT_STORE_URI, "dummy");
 
-     @SuppressWarnings("unchecked")
-     DatasetsFinder<CleanableDataset> finder =
-         (DatasetsFinder<CleanableDataset>) ConstructorUtils.invokeConstructor(
-             Class.forName(testConfig.getString(MultiCleanableDatasetFinder.DATASET_FINDER_CLASS_KEY)),
-             new Object[] { fs, jobProps, testConfig, client });
+     jobProps.putAll(additionalJobProps);
+
+      @SuppressWarnings("unchecked")
+      DatasetsFinder<CleanableDataset> finder =
+          (DatasetsFinder<CleanableDataset>) GobblinConstructorUtils.invokeFirstConstructor(
+              Class.forName(testConfig.getString(MultiCleanableDatasetFinder.DATASET_FINDER_CLASS_KEY)), ImmutableList.of(fs, jobProps, testConfig, client),
+              ImmutableList.of(fs, jobProps, client));
+
      for (CleanableDataset dataset : finder.findDatasets()) {
        dataset.clean();
      }
    }
  }
+
+
+ public static void clean(FileSystem fs, Path retentionConfigClasspathResource, Path testNameTempPath) throws Exception {
+   clean(fs, retentionConfigClasspathResource, Optional.<Path>absent(), testNameTempPath);
+ }
+
 }
+

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/CleanableDatasetBaseTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/CleanableDatasetBaseTest.java
@@ -50,6 +50,7 @@ public class CleanableDatasetBaseTest {
     DatasetVersion dataset1Version2 = new StringDatasetVersion("version2", new Path(datasetRoot, "version2"));
 
     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
+    when(fs.exists(any(Path.class))).thenReturn(true);
 
     DatasetImpl dataset = new DatasetImpl(fs, false, false, false, false, datasetRoot);
 
@@ -77,7 +78,7 @@ public class CleanableDatasetBaseTest {
 
     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
     when(trash.moveToTrash(any(Path.class))).thenReturn(true);
-
+    when(fs.exists(any(Path.class))).thenReturn(true);
     DatasetImpl dataset = new DatasetImpl(fs, false, true, false, false, datasetRoot);
 
     when(dataset.versionFinder.findDatasetVersions(dataset)).
@@ -106,7 +107,7 @@ public class CleanableDatasetBaseTest {
 
     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
     when(trash.moveToTrash(any(Path.class))).thenReturn(true);
-
+    when(fs.exists(any(Path.class))).thenReturn(true);
     DatasetImpl dataset = new DatasetImpl(fs, true, false, false, false, datasetRoot);
 
     when(dataset.versionFinder.findDatasetVersions(dataset)).
@@ -134,7 +135,7 @@ public class CleanableDatasetBaseTest {
 
     when(fs.delete(any(Path.class), anyBoolean())).thenReturn(true);
     when(trash.moveToTrash(any(Path.class))).thenReturn(true);
-
+    when(fs.exists(any(Path.class))).thenReturn(true);
     DatasetImpl dataset = new DatasetImpl(fs, false, false, true, false, datasetRoot);
 
     when(dataset.versionFinder.findDatasetVersions(dataset)).

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/FsCleanableHelperTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/FsCleanableHelperTest.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Sets;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.data.management.retention.dataset.FsCleanableHelper;
+import gobblin.data.management.trash.MockTrash;
+import gobblin.data.management.version.FileSystemDatasetVersion;
+import gobblin.dataset.FileSystemDataset;
+
+
+@Slf4j
+@Test(groups = { "gobblin.data.management.retention" })
+public class FsCleanableHelperTest {
+  private FileSystem fs;
+  private Path testTempPath;
+
+  @BeforeClass
+  public void setup() throws Exception {
+    this.fs = FileSystem.getLocal(new Configuration());
+    this.testTempPath = new Path(this.getClass().getClassLoader().getResource("").getFile(), "FsCleanableHelperTest");
+    this.fs.mkdirs(this.testTempPath);
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    try {
+      fs.delete(this.testTempPath, true);
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+
+  @Test
+  public void testSimulateTrash() throws Exception {
+
+    Properties props = new Properties();
+    props.setProperty(FsCleanableHelper.SIMULATE_KEY, Boolean.toString(true));
+    FsCleanableHelper fsCleanableHelper = new FsCleanableHelper(this.fs, props, ConfigFactory.empty(), log);
+
+    assertThat(fsCleanableHelper.getTrash(), instanceOf(MockTrash.class));
+  }
+
+  @Test
+  public void testDeleteEmptyDirs() throws Exception {
+    Properties props = new Properties();
+    props.setProperty(FsCleanableHelper.SKIP_TRASH_KEY, Boolean.toString(true));
+    FsCleanableHelper fsCleanableHelper = new FsCleanableHelper(this.fs, props, ConfigFactory.empty(), log);
+    FileSystemDataset fsDataset = mock(FileSystemDataset.class);
+    Path datasetRoot = new Path(testTempPath, "dataset1");
+    when(fsDataset.datasetRoot()).thenReturn(datasetRoot);
+
+    // To delete
+    Path deleted1 = new Path(datasetRoot, "2016/01/01/13");
+    Path deleted2 = new Path(datasetRoot, "2016/01/01/14");
+    Path deleted3 = new Path(datasetRoot, "2016/01/02/15");
+
+    // Do not delete
+    Path notDeleted1 = new Path(datasetRoot, "2016/01/02/16");
+
+    this.fs.mkdirs(deleted1);
+    this.fs.mkdirs(deleted2);
+    this.fs.mkdirs(deleted3);
+    this.fs.mkdirs(notDeleted1);
+
+    // Make sure all paths are created
+    Assert.assertTrue(this.fs.exists(deleted1));
+    Assert.assertTrue(this.fs.exists(deleted2));
+    Assert.assertTrue(this.fs.exists(deleted3));
+    Assert.assertTrue(this.fs.exists(notDeleted1));
+
+    List<FileSystemDatasetVersion> deletableVersions = ImmutableList.<FileSystemDatasetVersion> of(
+            new MockFileSystemDatasetVersion(deleted1),
+            new MockFileSystemDatasetVersion(deleted2),
+            new MockFileSystemDatasetVersion(deleted3));
+
+    fsCleanableHelper.clean(deletableVersions, fsDataset);
+
+    // Verify versions are deleted
+    Assert.assertFalse(this.fs.exists(deleted1));
+    Assert.assertFalse(this.fs.exists(deleted2));
+    Assert.assertFalse(this.fs.exists(deleted3));
+
+    // Verify versions are not deleted
+    Assert.assertTrue(this.fs.exists(notDeleted1));
+
+    // Verify empty parent dir "2016/01/01" is deleted
+    Assert.assertFalse(this.fs.exists(deleted1.getParent()));
+
+    // Verify non empty parent dir "2016/01/02" exists
+    Assert.assertTrue(this.fs.exists(notDeleted1.getParent()));
+  }
+
+  @AllArgsConstructor
+  private static class MockFileSystemDatasetVersion implements FileSystemDatasetVersion {
+
+    @Getter
+    private final Path path;
+
+    @Override
+    public Object getVersion() {
+      return null;
+    }
+
+    @Override
+    public int compareTo(FileSystemDatasetVersion o) {
+      return 0;
+    }
+
+    @Override
+    public Set<Path> getPaths() {
+      return Sets.newHashSet(this.path);
+    }
+
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/HiveRetentionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/HiveRetentionTest.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.integration;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+
+import java.util.List;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.joda.time.DateTimeUtils;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.conversion.hive.LocalHiveMetastoreTestUtils;
+import gobblin.util.PathUtils;
+import gobblin.util.test.RetentionTestDataGenerator.FixedThreadLocalMillisProvider;
+import gobblin.util.test.RetentionTestHelper;
+
+
+public class HiveRetentionTest {
+
+  private FileSystem fs;
+  private Path testTempPath;
+
+  private LocalHiveMetastoreTestUtils hiveMetastoreTestUtils;
+  private static final DateTimeFormatter FORMATTER = DateTimeFormat.forPattern("yyyy-MM-dd-HH").withZone(
+      DateTimeZone.forID(ConfigurationKeys.PST_TIMEZONE_NAME));
+
+  @BeforeClass
+  public void setup() throws Exception {
+    this.hiveMetastoreTestUtils = LocalHiveMetastoreTestUtils.getInstance();
+    fs = FileSystem.getLocal(new Configuration());
+    testTempPath = new Path(this.getClass().getClassLoader().getResource("").getFile(), "HiveRetentionTest");
+    fs.mkdirs(testTempPath);
+  }
+
+  private void testTimeBasedHiveRetention(String dbName, String tableName, String configFileName) throws Exception {
+
+    DateTimeUtils.setCurrentMillisProvider(new FixedThreadLocalMillisProvider(FORMATTER.parseDateTime("2016-01-10-00").getMillis()));
+
+    // Setup 4 partitions. 2 will be deleted and 2 will be retained
+    String tableSdLoc = new Path(testTempPath, dbName + tableName).toString();
+    this.hiveMetastoreTestUtils.dropDatabaseIfExists(dbName);
+    final Table tbl = this.hiveMetastoreTestUtils.createTestTable(dbName, tableName, tableSdLoc, ImmutableList.of("datepartition"), false);
+
+    String deleted1 = "2016-01-01-00";
+    String deleted2 = "2016-01-02-02";
+
+    String retained1 = "2016-01-03-04";
+    String retained2 = "2016-01-07-06";
+
+    Partition pDeleted1 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(deleted1), (int) System.currentTimeMillis());
+    Partition pDeleted2 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(deleted2), (int) System.currentTimeMillis());
+    Partition pRetained1 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(retained1), (int) System.currentTimeMillis());
+    Partition pRetained2 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(retained2), (int) System.currentTimeMillis());
+
+    this.fs.mkdirs(new Path(pDeleted1.getSd().getLocation()));
+    this.fs.mkdirs(new Path(pDeleted2.getSd().getLocation()));
+    this.fs.mkdirs(new Path(pRetained1.getSd().getLocation()));
+    this.fs.mkdirs(new Path(pRetained2.getSd().getLocation()));
+
+    List<Partition> partitions = this.hiveMetastoreTestUtils.getLocalMetastoreClient().listPartitions(dbName, tableName, (short) 10);
+    Assert.assertEquals(partitions.size(), 4);
+
+    RetentionTestHelper.clean(fs, PathUtils.combinePaths(RetentionIntegrationTest.TEST_PACKAGE_RESOURCE_NAME, "testHiveTimeBasedRetention", configFileName),
+        Optional.of(PathUtils.combinePaths(RetentionIntegrationTest.TEST_PACKAGE_RESOURCE_NAME, "testHiveTimeBasedRetention", "jobProps.properties")),
+        testTempPath);
+
+    partitions = this.hiveMetastoreTestUtils.getLocalMetastoreClient().listPartitions(dbName, tableName, (short) 10);
+
+    Assert.assertEquals(partitions.size(), 2);
+
+    assertThat(FluentIterable.from(partitions).transform(new Function<Partition, String>() {
+
+      @Override
+      public String apply(Partition input) {
+        return getQlPartition(tbl, input).getName();
+      }
+    }).toList(), containsInAnyOrder(getQlPartition(tbl, pRetained1).getName(), getQlPartition(tbl, pRetained2).getName()));
+
+
+    Assert.assertTrue(this.fs.exists(new Path(pRetained1.getSd().getLocation())));
+    Assert.assertTrue(this.fs.exists(new Path(pRetained2.getSd().getLocation())));
+    Assert.assertFalse(this.fs.exists(new Path(pDeleted1.getSd().getLocation())));
+    Assert.assertFalse(this.fs.exists(new Path(pDeleted2.getSd().getLocation())));
+  }
+
+
+  @Test(dependsOnMethods = { "testTimeBasedHiveRetentionWithJobProps" })
+  public void testTimeBasedHiveRetentionWithConfigStore() throws Exception {
+    String dbName = "hiveTestDbConfigStore";
+    String tableName = "testTable";
+    this.testTimeBasedHiveRetention(dbName, tableName, "selection.conf");
+  }
+
+  @Test
+  public void testTimeBasedHiveRetentionWithJobProps() throws Exception {
+    String dbName = "hiveTestDb";
+    String tableName = "testTable";
+    this.testTimeBasedHiveRetention(dbName, tableName, "hive-retention.job");
+  }
+
+  private static org.apache.hadoop.hive.ql.metadata.Partition getQlPartition(final Table table, final Partition partition) {
+    try {
+      return new org.apache.hadoop.hive.ql.metadata.Partition(new org.apache.hadoop.hive.ql.metadata.Table(table), partition);
+    } catch (HiveException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    try {
+      fs.delete(this.testTempPath, true);
+    } catch (Exception e) {
+      // ignore
+    }
+  }
+
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/RetentionIntegrationTest.java
@@ -57,7 +57,7 @@ public class RetentionIntegrationTest {
   private FileSystem fs;
   private Path testClassTempPath;
   private static final String SETUP_VALIDATE_CONFIG_CLASSPATH_FILENAME = "setup_validate.conf";
-  private static final String TEST_PACKAGE_RESOURCE_NAME = "retentionIntegrationTest";
+  static final String TEST_PACKAGE_RESOURCE_NAME = "retentionIntegrationTest";
   private static final String TEST_DATA_DIR_NAME = "retentionIntegrationTestData";
 
   @BeforeClass

--- a/gobblin-data-management/src/test/java/gobblin/data/management/version/finder/DatePartitionedHiveVersionFinderTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/version/finder/DatePartitionedHiveVersionFinderTest.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version.finder;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.is;
+
+import java.net.URLDecoder;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.joda.time.format.DateTimeFormatter;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.conversion.hive.LocalHiveMetastoreTestUtils;
+import gobblin.data.management.version.TimestampedHiveDatasetVersion;
+
+
+@Test(groups = { "gobblin.data.management.version" })
+public class DatePartitionedHiveVersionFinderTest {
+
+  private FileSystem fs;
+  private LocalHiveMetastoreTestUtils hiveMetastoreTestUtils;
+  private DateTimeFormatter formatter = DateTimeFormat.forPattern("yyyy/MM/dd/HH").withZone(DateTimeZone.forID(ConfigurationKeys.PST_TIMEZONE_NAME));
+  private String dbName = "VfDb1";
+
+  @BeforeClass
+  public void setup() throws Exception {
+    this.fs = FileSystem.getLocal(new Configuration());
+    this.hiveMetastoreTestUtils = LocalHiveMetastoreTestUtils.getInstance();
+    this.hiveMetastoreTestUtils.dropDatabaseIfExists(this.dbName);
+    this.hiveMetastoreTestUtils.createTestDb(this.dbName);
+  }
+
+  @AfterClass
+  public void cleanUp() {
+    try {
+      this.hiveMetastoreTestUtils.dropDatabaseIfExists(this.dbName);
+    } catch (Exception e) {
+      // Will get cleaned up next run of test
+    }
+  }
+
+  @Test
+  public void testDefaults() throws Exception {
+
+    DatePartitionHiveVersionFinder versionFinder = new DatePartitionHiveVersionFinder(this.fs, ConfigFactory.empty());
+    String tableName = "VfTb1";
+
+    Table tbl = this.hiveMetastoreTestUtils.createTestTable(dbName, tableName, ImmutableList.of("datepartition"));
+    org.apache.hadoop.hive.metastore.api.Partition tp =
+        this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of("2016-01-01-20"), (int) System.currentTimeMillis());
+    Partition partition = new Partition(new org.apache.hadoop.hive.ql.metadata.Table(tbl), tp);
+
+    assertThat(partition.getName(), is("datepartition=2016-01-01-20"));
+    TimestampedHiveDatasetVersion dv = versionFinder.getDatasetVersion(partition);
+    Assert.assertEquals(dv.getDateTime(), formatter.parseDateTime("2016/01/01/20"));
+
+  }
+
+  @Test
+  public void testUserDefinedDatePattern() throws Exception {
+    String tableName = "VfTb2";
+    Config conf =
+        ConfigFactory.parseMap(ImmutableMap.<String, String> of(DatePartitionHiveVersionFinder.PARTITION_KEY_NAME_KEY, "field1",
+            DatePartitionHiveVersionFinder.PARTITION_VALUE_DATE_TIME_PATTERN_KEY, "yyyy/MM/dd/HH"));
+
+    DatePartitionHiveVersionFinder versionFinder = new DatePartitionHiveVersionFinder(this.fs, conf);
+
+    Table tbl = this.hiveMetastoreTestUtils.createTestTable(dbName, tableName, ImmutableList.of("field1"));
+    org.apache.hadoop.hive.metastore.api.Partition tp =
+        this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of("2016/01/01/20"), (int) System.currentTimeMillis());
+    Partition partition = new Partition(new org.apache.hadoop.hive.ql.metadata.Table(tbl), tp);
+    Assert.assertEquals(URLDecoder.decode(partition.getName(), "UTF-8"), "field1=2016/01/01/20");
+    TimestampedHiveDatasetVersion dv = versionFinder.getDatasetVersion(partition);
+    Assert.assertEquals(dv.getDateTime(), formatter.parseDateTime("2016/01/01/20"));
+  }
+
+  @Test
+  public void testMultiplePartitionFields() throws Exception {
+    DatePartitionHiveVersionFinder versionFinder = new DatePartitionHiveVersionFinder(this.fs, ConfigFactory.empty());
+    String tableName = "VfTb3";
+
+    Table tbl = this.hiveMetastoreTestUtils.createTestTable(dbName, tableName, ImmutableList.of("datepartition", "field1"));
+    org.apache.hadoop.hive.metastore.api.Partition tp =
+        this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of("2016-01-01-20", "f1"), (int) System.currentTimeMillis());
+    Partition partition = new Partition(new org.apache.hadoop.hive.ql.metadata.Table(tbl), tp);
+
+    assertThat(partition.getName(), anyOf(is("field1=f1/datepartition=2016-01-01-20"), is("datepartition=2016-01-01-20/field1=f1")));
+    TimestampedHiveDatasetVersion dv = versionFinder.getDatasetVersion(partition);
+    Assert.assertEquals(dv.getDateTime(), formatter.parseDateTime("2016/01/01/20"));
+
+  }
+}

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/hive-retention.job
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/hive-retention.job
@@ -1,0 +1,11 @@
+hive.dataset.whitelist=hiveTestDb.testTable
+
+gobblin.retention.dataset.finder.class=gobblin.data.management.retention.dataset.finder.CleanableHiveDatasetFinder
+
+gobblin.retention.selection.policy.class=gobblin.data.management.policy.SelectBeforeTimeBasedPolicy
+gobblin.retention.selection.timeBased.lookbackTime=7d
+gobblin.retention.version.finder.class=gobblin.data.management.version.finder.DatePartitionHiveVersionFinder
+
+gobblin.retention.hive.partition.key.name=datepartition
+gobblin.retention.hive.partition.value.datetime.pattern=yyyy-MM-dd-HH
+gobblin.retention.hive.partition.value.datetime.timezone=America/Los_Angeles

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/jobProps.properties
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/jobProps.properties
@@ -1,0 +1,1 @@
+hive.dataset.whitelist=hiveTestDbConfigStore.testTable

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/selection.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/selection.conf
@@ -1,0 +1,23 @@
+gobblin.retention : {
+
+    is.blacklisted=false
+
+    dataset : {
+      finder.class=gobblin.data.management.retention.dataset.finder.CleanableHiveDatasetFinder
+    }
+
+    selection : {
+      policy.class=gobblin.data.management.policy.SelectBeforeTimeBasedPolicy
+      timeBased.lookbackTime=7d
+    }
+
+    version.finder.class=gobblin.data.management.version.finder.DatePartitionHiveVersionFinder
+
+    hive {
+      partition {
+        key.name=datepartition
+        value.datetime.pattern=yyyy-MM-dd-HH
+        value.datetime.timezone=America/Los_Angeles
+      }
+    }
+}


### PR DESCRIPTION
- Added time based retention for hive partitions.
- In the context of hive retention a ```Dataset``` is a ```Table``` and a ```DatasetVersion``` is a ```Partition```
- ```AbstractHiveDatasetVersionFinder``` and its subclasses can be used outside of retention as well.
- Moved some common logic from ```MultiVersionCleanableDatasetBase``` to ```FsCleanableHelper``` as it needs to be used by the ```CleanableHiveDataset``` too.
- Added tests

@ydai1124 and @ibuenros can you review?