### PR TITLE
Minor text formatting fix for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,5 +43,5 @@ Please refer to the page [Getting Started](http://gobblin.readthedocs.org/en/lat
 
 ## Configuration
 
-Please refer to the page [Configuration Glossary](http://gobblin.readthedocs.org/en/latest/user-guide/Configuration-Properties-Glossary/)in the documentation for an overview on the configuration properties of Gobblin.
+Please refer to the page [Configuration Glossary](http://gobblin.readthedocs.org/en/latest/user-guide/Configuration-Properties-Glossary/) in the documentation for an overview on the configuration properties of Gobblin.
 


### PR DESCRIPTION
Very minor text formatting fix for README.md (added a space). Self approving