### PR TITLE
Made Hive table rename backward compatible with Hive v0.13

### DIFF
--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -285,7 +285,8 @@ public class HiveSchemaEvolutionTest {
         .generatePublishTableDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
             destinationTableMeta);
     Assert.assertEquals(generatePublishDDL, "DROP TABLE IF EXISTS `hiveDb`.`sourceSchema`\n"
-            + "ALTER TABLE `hiveDb`.`sourceSchema_staging` RENAME TO `hiveDb`.`sourceSchema`\n",
+            + "USE `hiveDb`\n"
+            + "ALTER TABLE `sourceSchema_staging` RENAME TO `sourceSchema`\n",
         "Generated publish table DDL did not match for new destination table");
   }
 


### PR DESCRIPTION
Made Hive table rename backward compatible with Hive v0.13
 
In Hive v0.13, Hive does not support fully qualified Hive table names such as db.table for table rename. So, changed publish commands to specify 'use dbName' as a precursor to the rename