### PR TITLE
Made changes to handle Hive-6129 (inverted exchange partition bug) and corresponding support for backward incompatible changes in Hive

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -141,6 +141,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
             : Optional.of(getConversionConfig().getClusterBy());
     Optional<Integer> numBuckets = getConversionConfig().getNumBuckets();
     Optional<Integer> rowLimit = getConversionConfig().getRowLimit();
+    Optional<String> hiveVersion = getConversionConfig().getHiveVersion();
 
     // Populate optional partition info
     Map<String, String> partitionsDDLInfo = Maps.newHashMap();
@@ -153,7 +154,6 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     }
 
     // Create DDL statement
-
     Map<String, String> hiveColumns = new HashMap<String, String>();
     String createTargetTableDDL =
         HiveAvroORCQueryGenerator.generateCreateTableDDL(outputAvroSchema,
@@ -233,7 +233,8 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
                 Optional.of(orcTableDatabase),
                 Optional.of(orcTableDatabase),
                 partitionsDMLInfo,
-                destinationTableMeta)).append("\n");
+                destinationTableMeta,
+                hiveVersion)).append("\n");
     HiveAvroORCQueryGenerator.serializePublishPartitionCommands(workUnit, publishPartitionQueries.toString());
     log.debug("Publish partition queries: " + publishPartitionQueries);
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -137,6 +137,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     public static final String NUM_BUCKETS_KEY = "numBuckets";
     public static final String EVOLUTION_ENABLED = "evolution.enabled";
     public static final String ROW_LIMIT_KEY = "rowLimit";
+    public static final String HIVE_VERSION_KEY = "hiveVersion";
 
     private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
     private final String destinationFormat;
@@ -149,6 +150,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private final Properties hiveRuntimeProperties;
     private final boolean evolutionEnabled;
     private final Optional<Integer> rowLimit;
+    private final Optional<String> hiveVersion;
 
     private ConversionConfig(Config config, Table table, String destinationFormat) {
 
@@ -171,6 +173,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
           .configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
       this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
       this.rowLimit = Optional.fromNullable(ConfigUtils.getInt(config, ROW_LIMIT_KEY, null));
+      this.hiveVersion = Optional.fromNullable(ConfigUtils.getString(config, HIVE_VERSION_KEY, null));
     }
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -300,7 +300,7 @@ public class HiveSchemaEvolutionTest {
     // Destination table exists
     String generatePublishDDL = HiveAvroORCQueryGenerator
         .generatePublishPartitionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName),
-            Optional.of(hiveDbName),partitionInfo, destinationTableMeta);
+            Optional.of(hiveDbName),partitionInfo, destinationTableMeta, Optional.of("0.13"));
     // Evolution enabled:
     // - Table exist: Move partition from staging to destination
     // Evolution disabled:
@@ -314,7 +314,7 @@ public class HiveSchemaEvolutionTest {
     // Destination table does not exists
     generatePublishDDL = HiveAvroORCQueryGenerator
         .generatePublishPartitionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName),
-            Optional.of(hiveDbName),partitionInfo, destinationTableMeta);
+            Optional.of(hiveDbName),partitionInfo, destinationTableMeta, Optional.of("0.13"));
     // Evolution enabled:
     // - Table does not exist: no-op (staging is already renamed to final)
     // Evolution disabled:
@@ -324,7 +324,7 @@ public class HiveSchemaEvolutionTest {
     // Destination table exists but its a snapshot table (no partition)
     generatePublishDDL = HiveAvroORCQueryGenerator
         .generatePublishPartitionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName),
-            Optional.of(hiveDbName),new HashMap<String, String>(), destinationTableMeta);
+            Optional.of(hiveDbName),new HashMap<String, String>(), destinationTableMeta, Optional.of("0.13"));
     Assert.assertEquals(generatePublishDDL, "", "Generated publish partition DDL did not match");
   }
 


### PR DESCRIPTION
Made changes to handle Hive-6129 (inverted exchange partition bug) and corresponding support for backward incompatible changes in Hive: 

- Hive-4095 introduced the partition exchange feature for first time in v0.12
- HIVE-6129 found out that the advertised behavior was inverse (source was being treated as target and vice-versa) and a backward incompatible fix was introduced

So, changed Gobblin code to handle all versions of Hive by taking hint from config about the Hive version and creating the correct corresponding Hive statement 

Also, added a few javadocs