### PR TITLE
Fix for HIVE-11194: exchange partition does not work properly if data directory for destination partitions pre-exists

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -20,10 +20,13 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.NoSuchObjectException;
 import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.thrift.TException;
 
 import com.google.common.base.Optional;
@@ -40,6 +43,7 @@ import gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset.Co
 import gobblin.data.management.conversion.hive.entities.QueryBasedHiveConversionEntity;
 import gobblin.data.management.conversion.hive.query.HiveAvroORCQueryGenerator;
 import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.data.management.copy.hive.HiveUtils;
 import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.util.AutoReturnableObject;
 
@@ -132,7 +136,10 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     String orcTableDatabase = getConversionConfig().getDestinationDbName();
     String orcDataLocation = getOrcDataLocation(workUnit);
     boolean isEvolutionEnabled = getConversionConfig().isEvolutionEnabled();
-    Optional<Table> destinationTableMeta = getDestinationTableMeta(orcTableDatabase, orcTableName, workUnit);
+    Pair<Optional<Table>, Optional<List<Partition>>> destinationMeta = getDestinationTableMeta(orcTableDatabase,
+        orcTableName, workUnit);
+    Optional<Table> destinationTableMeta = destinationMeta.getLeft();
+    Optional<List<Partition>> destinationPartitionsMeta = destinationMeta.getRight();
 
     // Optional
     Optional<List<String>> clusterBy =
@@ -225,6 +232,15 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     HiveAvroORCQueryGenerator.serializePublishTableCommands(workUnit, publishTableQueries.toString());
     log.debug("Publish table queries: " + publishTableQueries);
 
+    Optional<String> dirToDeleteBeforePartitionPublish = HiveAvroORCQueryGenerator
+            .findDirToDeleteBeforePartitionPublish(conversionEntity.getHivePartition(), destinationPartitionsMeta);
+    HiveAvroORCQueryGenerator.serializeDirToDeleteBeforePartitionPublish(workUnit, dirToDeleteBeforePartitionPublish);
+    if (dirToDeleteBeforePartitionPublish.isPresent()) {
+      log.info("Directory to delete before publish partition: " + dirToDeleteBeforePartitionPublish.get());
+    } else {
+      log.info("No pre-existing partition directory to delete before publish partition.");
+    }
+
     StringBuilder publishPartitionQueries = new StringBuilder();
     publishPartitionQueries.append(
         HiveAvroORCQueryGenerator
@@ -292,22 +308,31 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     }
   }
 
-  private Optional<Table> getDestinationTableMeta(String dbName, String tableName, WorkUnitState state)
+  private Pair<Optional<Table>, Optional<List<Partition>>> getDestinationTableMeta(String dbName,
+      String tableName, WorkUnitState state)
       throws DataConversionException {
+
     Optional<Table> table = Optional.<Table>absent();
+    Optional<List<Partition>> partitions = Optional.<List<Partition>>absent();
 
     try {
       HiveMetastoreClientPool pool = HiveMetastoreClientPool.get(state.getJobState().getProperties(),
           Optional.fromNullable(state.getJobState().getProp(HiveDatasetFinder.HIVE_METASTORE_URI_KEY)));
       try (AutoReturnableObject<IMetaStoreClient> client = pool.getClient()) {
         table = Optional.of(client.get().getTable(dbName, tableName));
+        if (table.isPresent()) {
+          org.apache.hadoop.hive.ql.metadata.Table qlTable = new org.apache.hadoop.hive.ql.metadata.Table(table.get());
+          if (HiveUtils.isPartitioned(qlTable)) {
+            partitions = Optional.of(HiveUtils.getPartitions(client.get(), qlTable, Optional.<String>absent()));
+          }
+        }
       }
     } catch (NoSuchObjectException e) {
-      return Optional.<Table>absent();
+      return ImmutablePair.of(table, partitions);
     } catch (IOException | TException e) {
       throw new DataConversionException("Could not fetch destination table metadata", e);
     }
 
-    return table;
+    return ImmutablePair.of(table, partitions);
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
@@ -12,17 +12,24 @@
 package gobblin.data.management.conversion.hive.publisher;
 
 import java.io.IOException;
+import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
 
-import org.apache.commons.lang.StringUtils;
-import org.apache.hadoop.fs.FileSystem;
+import lombok.extern.slf4j.Slf4j;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.WorkUnitState.WorkingState;
@@ -43,18 +50,29 @@ import gobblin.util.HadoopUtils;
 /**
  * A simple {@link DataPublisher} updates the watermark and working state
  */
+@Slf4j
 public class HiveConvertPublisher extends DataPublisher {
 
   private final AvroSchemaManager avroSchemaManager;
   private final HiveJdbcConnector hiveJdbcConnector;
   private MetricContext metricContext;
   private EventSubmitter eventSubmitter;
+  private final FileSystem fs;
 
   public HiveConvertPublisher(State state) throws IOException {
     super(state);
     this.avroSchemaManager = new AvroSchemaManager(FileSystem.get(HadoopUtils.newConfiguration()), state);
     this.metricContext = Instrumented.getMetricContext(state, HiveConvertPublisher.class);
     this.eventSubmitter = new EventSubmitter.Builder(this.metricContext, EventConstants.CONVERSION_NAMESPACE).build();
+
+    Configuration conf = new Configuration();
+    Optional<String> uri = Optional.fromNullable(this.state.getProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI));
+    if (uri.isPresent()) {
+      this.fs = FileSystem.get(URI.create(uri.get()), conf);
+    } else {
+      this.fs = FileSystem.get(conf);
+    }
+
     try {
       this.hiveJdbcConnector = HiveJdbcConnector.newConnectorWithProps(state.getProperties());
     } catch (SQLException e) {
@@ -96,10 +114,14 @@ public class HiveConvertPublisher extends DataPublisher {
           isFirst = false;
         }
 
+        // Get directory to delete before publish partition if any
+        String dirToDelete = HiveAvroORCQueryGenerator.deserializeDirToDeleteBeforePartitionPublish(wus);
+
         // Get publish partition commands if any
         String publishPartitionCommands = HiveAvroORCQueryGenerator.deserializePublishPartitionCommands(wus);
 
         // Execute publish partition commands if any
+        deleteDirectory(dirToDelete);
         executeQueries(publishPartitionCommands);
 
         wus.setWorkingState(WorkingState.COMMITTED);
@@ -112,6 +134,15 @@ public class HiveConvertPublisher extends DataPublisher {
     }
     // Execute cleanup staging table commands
     executeQueries(cleanupCommands);
+  }
+
+  private void deleteDirectory(String dirToDelete) throws IOException {
+    if (StringUtils.isBlank(dirToDelete)) {
+      return;
+    }
+
+    log.info("Going to delete existing partition data: " + dirToDelete);
+    this.fs.delete(new Path(dirToDelete), true);
   }
 
   private void executeQueries(String queries) {

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -306,7 +306,8 @@ public class HiveSchemaEvolutionTest {
     // Evolution disabled:
     // - Table exist: Move partition from staging to destination
     Assert.assertEquals(generatePublishDDL,
-        "ALTER TABLE `hiveDb`.`sourceSchema` EXCHANGE PARTITION (datepartition='20160101') "
+        "USE `hiveDb`\n" + "ALTER TABLE `sourceSchema` DROP IF EXISTS PARTITION (datepartition='20160101')\n"
+            + "ALTER TABLE `hiveDb`.`sourceSchema` EXCHANGE PARTITION (datepartition='20160101') "
             + "WITH TABLE `hiveDb`.`sourceSchema_staging`\n",
         "Generated publish partition DDL did not match");
 


### PR DESCRIPTION
If a partition is being exchanged into a table but the data directory location for the partition already exists, Hive moves data within a sub-directory of it rather than cleanly overwriting it.

More details here: HIVE-11194

So, adding a pre publish hook to cleanup the existing directory (if any) of an existing partition in destination table before issuing exchange partition from staging to destination.