### PR TITLE
Change Hive Avro to ORC publish to use Gobblin constructs instead of Hive exchange partition query

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -165,7 +165,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
 
     // Partition dir hint helps create different directory for hourly and daily partition with same timestamp, such as:
     // .. daily_2016-01-01-00 and hourly_2016-01-01-00
-    // This helps existing hourly data from not being delete at the time of roll up, and so Hive queries in flight
+    // This helps existing hourly data from not being deleted at the time of roll up, and so Hive queries in flight
     // .. do not fail
     List<String> partitionDirPrefixHint = getConversionConfig().getPartitionDirPrefixHint();
 
@@ -235,7 +235,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     // TODO: Split this method into two (conversion and publish)
     // Addition to WUS for Staging publish:
     // A. Evolution turned on:
-    //    1. If table does not exists: simply create it
+    //    1. If table does not exists: simply create it (now it should exist)
     //    2. If table exists:
     //      2.1 Evolve table (alter table)
     //      2.2 If snapshot table:
@@ -248,7 +248,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     //          2.3.3 Create partition with location
     //          2.3.4 Drop this staging table and delete directories
     // B. Evolution turned off:
-    //    1. If table does not exists: simply create it
+    //    1. If table does not exists: simply create it (now it should exist)
     //    2. If table exists:
     //      2.1 Do not evolve table
     //      2.2 If snapshot table:
@@ -292,7 +292,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     }
 
     // Step:
-    // A.2.1: If table exists, evolve table
+    // A.2.1: If table pre-exists (destinationTableMeta would be present), evolve table
     // B.2.1: No-op
     List<String> evolutionDDLs = HiveAvroORCQueryGenerator.generateEvolutionDDL(orcStagingTableName,
         orcTableName,
@@ -313,7 +313,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
       // Step:
       // A.2.2.1, B.2.2.1: Delete data in final table directory
       // A.2.2.2, B.2.2.2: Move data from staging to final table directory
-      log.info("Partition directory to move: " + orcStagingDataLocation + " to: " + orcDataLocation);
+      log.info("Snapshot directory to move: " + orcStagingDataLocation + " to: " + orcDataLocation);
       publishDirectories.put(orcStagingDataLocation, orcDataLocation);
 
       // Step:

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -140,6 +140,15 @@ public class ConvertibleHiveDataset extends HiveDataset {
     public static final String HIVE_VERSION_KEY = "hiveVersion";
     private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
 
+    /***
+     * Comma separated list of string that should be used as prefix for destination table partition location dir name
+     * .. if present in the location path string of source destination
+     * This helps with rollup situations where hourly partitions roll up to 0th hour for daily but we do not want to
+     * .. to overwrite data so that the queries in flight do not fail; instead the Hive metadata is updated to new
+     * .. directory location
+     */
+    private static final String PARTITION_DIR_PREFIX_LOCATION_HINT = "partitionDir.prefixLocationHint";
+
     private final String destinationFormat;
     private final String destinationTableName;
     private final String destinationStagingTableName;
@@ -151,6 +160,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private final boolean evolutionEnabled;
     private final Optional<Integer> rowLimit;
     private final Optional<String> hiveVersion;
+    private final List<String> partitionDirPrefixHint;
 
     private ConversionConfig(Config config, Table table, String destinationFormat) {
 
@@ -174,7 +184,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
       this.rowLimit = Optional.fromNullable(ConfigUtils.getInt(config, ROW_LIMIT_KEY, null));
       this.hiveVersion = Optional.fromNullable(ConfigUtils.getString(config, HIVE_VERSION_KEY, null));
-
+      this.partitionDirPrefixHint = ConfigUtils.getStringList(config, PARTITION_DIR_PREFIX_LOCATION_HINT);
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/entities/QueryBasedHivePublishEntity.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/entities/QueryBasedHivePublishEntity.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.entities;
+
+import java.util.List;
+import java.util.Map;
+
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.ToString;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+
+/**
+ * Entity to carry Hive queries to publish table and partitions from writer to publisher.
+ * This entity also holds references to directories to be moved or deleted while publishing.
+ */
+@ToString
+@EqualsAndHashCode
+@Getter
+public class QueryBasedHivePublishEntity {
+  // Hive queries to execute to publish table and / or partitions.
+  private List<String> publishQueries;
+  // Directories to move: key is source, value is destination.
+  private Map<String, String> publishDirectories;
+
+  // Hive queries to cleanup after publish step.
+  private List<String> cleanupQueries;
+  // Directories to delete after publish step.
+  private List<String> cleanupDirectories;
+
+  public QueryBasedHivePublishEntity() {
+    this.publishQueries = Lists.newArrayList();
+    this.publishDirectories = Maps.newHashMap();
+
+    this.cleanupQueries = Lists.newArrayList();
+    this.cleanupDirectories = Lists.newArrayList();
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
@@ -16,6 +16,7 @@ import java.net.URI;
 import java.sql.SQLException;
 import java.util.Collection;
 import java.util.List;
+import java.util.Map;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -23,17 +24,19 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Predicate;
-import com.google.common.base.Splitter;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.WorkUnitState.WorkingState;
 import gobblin.data.management.conversion.hive.AvroSchemaManager;
+import gobblin.data.management.conversion.hive.entities.QueryBasedHivePublishEntity;
 import gobblin.data.management.conversion.hive.events.EventConstants;
 import gobblin.data.management.conversion.hive.query.HiveAvroORCQueryGenerator;
 import gobblin.data.management.conversion.hive.watermarker.TableLevelWatermarker;
@@ -45,6 +48,7 @@ import gobblin.metrics.event.sla.SlaEventSubmitter;
 import gobblin.publisher.DataPublisher;
 import gobblin.source.extractor.extract.LongWatermark;
 import gobblin.util.HadoopUtils;
+import gobblin.util.WriterUtils;
 
 
 /**
@@ -87,42 +91,37 @@ public class HiveConvertPublisher extends DataPublisher {
   @Override
   public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
 
-    String cleanupCommands = StringUtils.EMPTY;
-    boolean isFirst = true;
+    List<String> cleanUpQueries = Lists.newArrayList();
+    List<String> directoriesToDelete = Lists.newArrayList();
+
     if (Iterables.tryFind(states, UNSUCCESSFUL_WORKUNIT).isPresent()) {
       for (WorkUnitState wus : states) {
-        if (isFirst) {
-          // Get cleanup staging table commands
-          cleanupCommands = HiveAvroORCQueryGenerator.deserializeCleanupCommands(wus);
-          isFirst = false;
-        }
+        QueryBasedHivePublishEntity publishEntity = HiveAvroORCQueryGenerator.deserializePublishCommands(wus);
+
+        // Add cleanup commands - to be executed later
+        cleanUpQueries.addAll(publishEntity.getCleanupQueries());
+        directoriesToDelete.addAll(publishEntity.getCleanupDirectories());
+
         wus.setWorkingState(WorkingState.FAILED);
         new SlaEventSubmitter(eventSubmitter, EventConstants.CONVERSION_FAILED_EVENT, wus.getProperties()).submit();
       }
     } else {
-      String publishTableCommands = StringUtils.EMPTY;
       for (WorkUnitState wus : states) {
-        if (isFirst) {
-          // Get publish table commands
-          publishTableCommands = HiveAvroORCQueryGenerator.deserializePublishTableCommands(wus);
+        QueryBasedHivePublishEntity publishEntity = HiveAvroORCQueryGenerator.deserializePublishCommands(wus);
 
-          // Execute publish table commands
-          executeQueries(publishTableCommands);
+        // Add cleanup commands - to be executed later
+        cleanUpQueries.addAll(publishEntity.getCleanupQueries());
+        directoriesToDelete.addAll(publishEntity.getCleanupDirectories());
 
-          // Get cleanup staging table commands
-          cleanupCommands = HiveAvroORCQueryGenerator.deserializeCleanupCommands(wus);
-          isFirst = false;
+        // Publish snapshot / partition directories
+        Map<String, String> publishDirectories = publishEntity.getPublishDirectories();
+        for (Map.Entry<String, String> publishDir : publishDirectories.entrySet()) {
+          moveDirectory(publishDir.getKey(), publishDir.getValue());
         }
 
-        // Get directory to delete before publish partition if any
-        String dirToDelete = HiveAvroORCQueryGenerator.deserializeDirToDeleteBeforePartitionPublish(wus);
-
-        // Get publish partition commands if any
-        String publishPartitionCommands = HiveAvroORCQueryGenerator.deserializePublishPartitionCommands(wus);
-
-        // Execute publish partition commands if any
-        deleteDirectory(dirToDelete);
-        executeQueries(publishPartitionCommands);
+        // Register snapshot / partition
+        List<String> publishQueries = publishEntity.getPublishQueries();
+        executeQueries(publishQueries);
 
         wus.setWorkingState(WorkingState.COMMITTED);
         wus.setActualHighWatermark(TableLevelWatermarker.GSON.fromJson(wus.getWorkunit().getExpectedHighWatermark(),
@@ -131,9 +130,32 @@ public class HiveConvertPublisher extends DataPublisher {
         new SlaEventSubmitter(eventSubmitter, EventConstants.CONVERSION_SUCCESSFUL_SLA_EVENT, wus.getProperties())
             .submit();
       }
+
     }
-    // Execute cleanup staging table commands
-    executeQueries(cleanupCommands);
+    // Execute cleanup commands
+    executeQueries(cleanUpQueries);
+    for (String directory : directoriesToDelete) {
+      deleteDirectory(directory);
+    }
+  }
+
+  private void moveDirectory(String sourceDir, String targetDir)
+      throws IOException {
+    // If targetDir exists, delete it
+    if (this.fs.exists(new Path(targetDir))) {
+      deleteDirectory(targetDir);
+    }
+
+    // Create parent directories of targetDir
+    WriterUtils.mkdirsWithRecursivePermission(this.fs, new Path(targetDir).getParent(),
+        FsPermission.getCachePoolDefault());
+
+    // Move directory
+    log.info("Moving directory: " + sourceDir + " to: " + targetDir);
+    if (!this.fs.rename(new Path(sourceDir), new Path(targetDir))) {
+      throw new IOException(
+          String.format("Unable to move %s to %s", sourceDir, targetDir));
+    }
   }
 
   private void deleteDirectory(String dirToDelete) throws IOException {
@@ -145,13 +167,12 @@ public class HiveConvertPublisher extends DataPublisher {
     this.fs.delete(new Path(dirToDelete), true);
   }
 
-  private void executeQueries(String queries) {
-    if (StringUtils.isBlank(queries)) {
+  private void executeQueries(List<String> queries) {
+    if (null == queries || queries.size() == 0) {
       return;
     }
     try {
-      List<String> queryList = Splitter.on("\n").omitEmptyStrings().trimResults().splitToList(queries);
-      this.hiveJdbcConnector.executeStatements(queryList.toArray(new String[queryList.size()]));
+      this.hiveJdbcConnector.executeStatements(queries.toArray(new String[queries.size()]));
     } catch (SQLException e) {
       throw new RuntimeException(e);
     }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -335,7 +335,13 @@ public class HiveAvroORCQueryGenerator {
 
     return ddls;
   }
-  
+
+  /***
+   * Generate DDL query to drop a Hive table.
+   * @param dbName Hive database name.
+   * @param tableName Hive table name.
+   * @return Command to drop the table.
+   */
   public static String generateDropTableDDL(String dbName, String tableName) {
     return String.format("DROP TABLE IF EXISTS `%s`.`%s`", dbName, tableName);
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -13,6 +13,7 @@
 package gobblin.data.management.conversion.hive.query;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -34,12 +35,14 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 
 import gobblin.configuration.State;
+import gobblin.data.management.conversion.hive.entities.QueryBasedHivePublishEntity;
 import gobblin.data.management.conversion.hive.entities.SchemaAwareHivePartition;
 
 
@@ -50,9 +53,6 @@ import gobblin.data.management.conversion.hive.entities.SchemaAwareHivePartition
 public class HiveAvroORCQueryGenerator {
 
   private static final String SERIALIZED_PUBLISH_TABLE_COMMANDS = "serialized.publish.table.commands";
-  private static final String SERIALIZED_DIR_TO_DELETE_BEFORE_PARTITION_PUBLISH = "serialized.publish.partition.preCleanup";
-  private static final String SERIALIZED_PUBLISH_PARTITION_COMMANDS = "serialized.publish.partition.commands";
-  private static final String SERIALIZED_CLEANUP_COMMANDS = "serialized.cleanup.commands";
   private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 
   // Table properties keys
@@ -294,6 +294,53 @@ public class HiveAvroORCQueryGenerator {
   }
 
   /***
+   * Generate DDL query to create a Hive partition pointing at specific location.
+   * @param dbName Hive database name.
+   * @param tableName Hive table name.
+   * @param partitionLocation Physical location of partition.
+   * @param partitionsDMLInfo Partitions DML info - a map of partition name and partition value.
+   * @return Commands to create a partition.
+   */
+  public static List<String> generateCreatePartitionDDL(String dbName,
+      String tableName,
+      String partitionLocation,
+      Map<String, String> partitionsDMLInfo) {
+
+    if (null == partitionsDMLInfo || partitionsDMLInfo.size() == 0) {
+      return Collections.emptyList();
+    }
+
+    // Partition details
+    StringBuilder partitionSpecs = new StringBuilder();
+    partitionSpecs.append("PARTITION (");
+    boolean isFirstPartitionSpec = true;
+    for (Map.Entry<String, String> partition : partitionsDMLInfo.entrySet()) {
+      if (isFirstPartitionSpec) {
+        isFirstPartitionSpec = false;
+      } else {
+        partitionSpecs.append(", ");
+      }
+      partitionSpecs.append(String.format("`%s`='%s'", partition.getKey(), partition.getValue()));
+    }
+    partitionSpecs.append(") \n");
+
+    // Create statement
+    List<String> ddls = Lists.newArrayList();
+    // Note: Hive does not support fully qualified Hive table names such as db.table for ALTER TABLE in v0.13
+    // .. hence specifying 'use dbName' as a precursor to rename
+    // Refer: HIVE-2496
+    ddls.add(String.format("USE %s%n", dbName));
+    ddls.add(String.format("ALTER TABLE `%s` ADD IF NOT EXISTS %s LOCATION '%s' ", tableName, partitionSpecs,
+        partitionLocation));
+
+    return ddls;
+  }
+  
+  public static String generateDropTableDDL(String dbName, String tableName) {
+    return String.format("DROP TABLE IF EXISTS `%s`.`%s`", dbName, tableName);
+  }
+
+  /***
    * Adapt Avro schema / types to Hive column types
    * @param schema Schema to adapt and generate Hive columns with corresponding types
    * @param hiveColumns Optional Map to populate with the generated hive columns for reference of caller
@@ -519,7 +566,13 @@ public class HiveAvroORCQueryGenerator {
     if (optionalPartitionDMLInfo.isPresent()) {
       if (optionalPartitionDMLInfo.get().size()  > 0) {
         dmlQuery.append("PARTITION (");
+        boolean isFirstPartitionSpec = true;
         for (Map.Entry<String, String> partition : optionalPartitionDMLInfo.get().entrySet()) {
+          if (isFirstPartitionSpec) {
+            isFirstPartitionSpec = false;
+          } else {
+            dmlQuery.append(", ");
+          }
           dmlQuery.append(String.format("`%s`='%s'", partition.getKey(), partition.getValue()));
         }
         dmlQuery.append(") \n");
@@ -645,7 +698,7 @@ public class HiveAvroORCQueryGenerator {
    * @param destinationTableMeta Destination table metadata.
    * @return DDLs to evolve final destination table.
    */
-  public static String generateEvolutionDDL(String stagingTableName,
+  public static List<String> generateEvolutionDDL(String stagingTableName,
       String finalTableName,
       Optional<String> optionalStagingDbName,
       Optional<String> optionalFinalDbName,
@@ -656,13 +709,13 @@ public class HiveAvroORCQueryGenerator {
     // If schema evolution is disabled, then do nothing OR
     // If destination table does not exists, then do nothing
     if (!isEvolutionEnabled || !destinationTableMeta.isPresent()) {
-      return StringUtils.EMPTY;
+      return Collections.emptyList();
     }
 
     String stagingDbName = optionalStagingDbName.isPresent() ? optionalStagingDbName.get() : DEFAULT_DB_NAME;
     String finalDbName = optionalFinalDbName.isPresent() ? optionalFinalDbName.get() : DEFAULT_DB_NAME;
 
-    StringBuilder ddl = new StringBuilder();
+    List<String> ddl = Lists.newArrayList();
 
     // Evolve schema
     Table destinationTable = destinationTableMeta.get();
@@ -674,9 +727,9 @@ public class HiveAvroORCQueryGenerator {
           // If evolved column is found, but type is evolved - evolve it
           // .. if incompatible, isTypeEvolved will throw an exception
           if (isTypeEvolved(evolvedColumn.getValue(), destinationField.getType())) {
-            ddl.append(String.format("ALTER TABLE `%s`.`%s` CHANGE COLUMN %s %s %s COMMENT '%s'",
+            ddl.add(String.format("ALTER TABLE `%s`.`%s` CHANGE COLUMN %s %s %s COMMENT '%s'",
                 finalDbName, finalTableName, evolvedColumn.getKey(), evolvedColumn.getKey(), evolvedColumn.getValue(),
-                destinationField.getComment())).append("\n");
+                destinationField.getComment()));
           }
           found = true;
           break;
@@ -688,12 +741,12 @@ public class HiveAvroORCQueryGenerator {
         if (StringUtils.isBlank(flattenSource)) {
           flattenSource = evolvedSchema.getField(evolvedColumn.getKey()).name();
         }
-        ddl.append(String.format("ALTER TABLE `%s`.`%s` ADD COLUMNS (%s %s COMMENT 'from flatten_source %s')",
-            finalDbName, finalTableName, evolvedColumn.getKey(), evolvedColumn.getValue(), flattenSource)).append("\n");
+        ddl.add(String.format("ALTER TABLE `%s`.`%s` ADD COLUMNS (%s %s COMMENT 'from flatten_source %s')", finalDbName,
+            finalTableName, evolvedColumn.getKey(), evolvedColumn.getValue(), flattenSource));
       }
     }
 
-    return ddl.toString();
+    return ddl;
   }
 
   /***
@@ -705,13 +758,13 @@ public class HiveAvroORCQueryGenerator {
    * @param destinationTableMeta Existing final table metadata if any.
    * @return DDL to publish to final destination table from staging table.
    */
-  public static String generatePublishTableDDL(
+  public static List<String> generatePublishTableDDL(
       String stagingTableName,
       String finalTableName,
       Optional<String> optionalStagingDbName,
       Optional<String> optionalFinalDbName,
       Optional<Table> destinationTableMeta) {
-    StringBuilder ddl = new StringBuilder();
+    List<String> ddl = Lists.newArrayList();
 
     String stagingDbName = optionalStagingDbName.isPresent() ? optionalStagingDbName.get() : DEFAULT_DB_NAME;
     String finalDbName = optionalFinalDbName.isPresent() ? optionalFinalDbName.get() : DEFAULT_DB_NAME;
@@ -720,17 +773,15 @@ public class HiveAvroORCQueryGenerator {
 
     // If new table, then create table
     if (!destinationTableMeta.isPresent()) {
-      ddl.append(String.format("DROP TABLE IF EXISTS `%s`.`%s`", finalDbName, finalTableName)).append("\n");
+      ddl.add(String.format("DROP TABLE IF EXISTS `%s`.`%s`", finalDbName, finalTableName));
       // Note: Hive does not support fully qualified Hive table names such as db.table for 'RENAME' in v0.13
       // .. hence specifying 'use dbName' as a precursor to rename
       // Refer: HIVE-2496
-      ddl.append(String.format("USE `%s`", finalDbName)).append("\n");
-      ddl.append(String.format("ALTER TABLE `%s` RENAME TO `%s`", stagingTableName, finalTableName)).append("\n");
-
-      return ddl.toString();
+      ddl.add(String.format("USE `%s`", finalDbName));
+      ddl.add(String.format("ALTER TABLE `%s` RENAME TO `%s`", stagingTableName, finalTableName));
     }
 
-    return StringUtils.EMPTY;
+    return ddl;
   }
 
   /***
@@ -744,7 +795,7 @@ public class HiveAvroORCQueryGenerator {
    * @param hiveVersion Hive version for compatibility.
    * @return DDL to publish to final destination table from staging table.
    */
-  public static String generatePublishPartitionDDL(String stagingTableName,
+  public static List<String> generatePublishPartitionDDL(String stagingTableName,
       String finalTableName,
       Optional<String> optionalStagingDbName,
       Optional<String> optionalFinalDbName,
@@ -752,11 +803,11 @@ public class HiveAvroORCQueryGenerator {
       Optional<Table> destinationTableMeta,
       Optional<String> hiveVersion) {
     if (!destinationTableMeta.isPresent() || partitionsDMLInfo.size() == 0) {
-      return StringUtils.EMPTY;
+      return Collections.emptyList();
     }
 
     // Format: alter table t4 exchange partition (ds='3') with table t3
-    StringBuilder ddl = new StringBuilder();
+    List<String> ddl = Lists.newArrayList();
 
     String stagingDbName = optionalStagingDbName.isPresent() ? optionalStagingDbName.get() : DEFAULT_DB_NAME;
     String finalDbName = optionalFinalDbName.isPresent() ? optionalFinalDbName.get() : DEFAULT_DB_NAME;
@@ -769,24 +820,24 @@ public class HiveAvroORCQueryGenerator {
       // Note: Hive does not support fully qualified Hive table names such as db.table for ALTER TABLE in v0.13
       // .. hence specifying 'use dbName' as a precursor to rename
       // Refer: HIVE-2496
-      ddl.append(String.format("USE `%s`", finalDbName)).append("\n");
-      ddl.append(String.format("ALTER TABLE `%s` DROP IF EXISTS PARTITION (%s='%s')", finalTableName,
-          partition.getKey(), partition.getValue())).append("\n");
+      ddl.add(String.format("USE `%s`", finalDbName));
+      ddl.add(String.format("ALTER TABLE `%s` DROP IF EXISTS PARTITION (%s='%s')", finalTableName, partition.getKey(),
+          partition.getValue()));
 
       if (hiveVersion.isPresent()
           && !"0.13".equalsIgnoreCase(hiveVersion.get())
           && !"0.12".equalsIgnoreCase(hiveVersion.get())) {
         // Newer versions have the bug fixed
-        ddl.append(String.format("ALTER TABLE `%s`.`%s` EXCHANGE PARTITION (%s='%s') WITH TABLE `%s`.`%s`", stagingDbName,
-            stagingTableName, partition.getKey(), partition.getValue(), finalDbName, finalTableName)).append("\n");
+        ddl.add(String.format("ALTER TABLE `%s`.`%s` EXCHANGE PARTITION (%s='%s') WITH TABLE `%s`.`%s`", stagingDbName,
+            stagingTableName, partition.getKey(), partition.getValue(), finalDbName, finalTableName));
       } else {
         // By default assume it is 0.13 or 0.12 with the bug (pre 0.12 versions did not support exchange partitions)
-        ddl.append(String.format("ALTER TABLE `%s`.`%s` EXCHANGE PARTITION (%s='%s') WITH TABLE `%s`.`%s`", finalDbName,
-            finalTableName, partition.getKey(), partition.getValue(), stagingDbName, stagingTableName)).append("\n");
+        ddl.add(String.format("ALTER TABLE `%s`.`%s` EXCHANGE PARTITION (%s='%s') WITH TABLE `%s`.`%s`", finalDbName,
+            finalTableName, partition.getKey(), partition.getValue(), stagingDbName, stagingTableName));
       }
     }
 
-    return ddl.toString();
+    return ddl;
   }
 
   /***
@@ -823,9 +874,50 @@ public class HiveAvroORCQueryGenerator {
    * @param optionalStagingDbName Optional staging database name, defaults to default.
    * @return DDL to clean up temporary staging table.
    */
-  public static String generateCleanupDDL(String stagingTableName, Optional<String> optionalStagingDbName) {
+  public static List<String> generateCleanupDDL(String stagingTableName, Optional<String> optionalStagingDbName) {
+    List<String> ddls = Lists.newArrayList();
+
     String stagingDbName = optionalStagingDbName.isPresent() ? optionalStagingDbName.get() : DEFAULT_DB_NAME;
-    return String.format("DROP TABLE IF EXISTS `%s`.`%s`", stagingDbName, stagingTableName) + "\n";
+    ddls.add(String.format("DROP TABLE IF EXISTS `%s`.`%s`", stagingDbName, stagingTableName));
+
+    return ddls;
+  }
+
+  /**
+   * Generate DDL for dropping partitions of a table.
+   * <p>
+   * ALTER TABLE finalTableName DROP IF EXISTS PARTITION partition_spec, PARTITION partition_spec, ...;
+   * </p>
+   * @param finalTableName Table name where partitions are dropped
+   * @param partitionsDMLInfo Partitions to be dropped
+   * @return DDL to drop partitions in <code>finalTableName</code>
+   */
+  public static List<String> generateDropPartitionsDDL(final String dbName, final String finalTableName,
+      final Map<String, String> partitionsDMLInfo) {
+
+    if (null == partitionsDMLInfo || partitionsDMLInfo.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    // Partition details
+    StringBuilder partitionSpecs = new StringBuilder();
+    partitionSpecs.append("PARTITION (");
+    boolean isFirstPartitionSpec = true;
+    for (Map.Entry<String, String> partition : partitionsDMLInfo.entrySet()) {
+      if (isFirstPartitionSpec) {
+        isFirstPartitionSpec = false;
+      } else {
+        partitionSpecs.append(", ");
+      }
+      partitionSpecs.append(String.format("`%s`='%s'", partition.getKey(), partition.getValue()));
+    }
+    partitionSpecs.append(") ");
+
+    List<String> ddls = Lists.newArrayList();
+    ddls.add(String.format("USE %s%n", dbName));
+    ddls.add(String.format("ALTER TABLE %s DROP IF EXISTS %s", finalTableName, partitionSpecs));
+
+    return ddls;
   }
 
   /**
@@ -837,106 +929,40 @@ public class HiveAvroORCQueryGenerator {
    * @param partitionDMLInfos list of Partition to be dropped
    * @return DDL to drop partitions in <code>finalTableName</code>
    */
-  public static String generateDropPartitionsDDL(final String dbName, final String finalTableName,
+  public static List<String> generateDropPartitionsDDL(final String dbName, final String finalTableName,
       final List<Map<String, String>> partitionDMLInfos) {
 
     if (partitionDMLInfos.isEmpty()) {
-      return StringUtils.EMPTY;
+      return Collections.emptyList();
     }
 
-    StringBuilder ddl = new StringBuilder(String.format("USE %s%n", dbName));
-    ddl.append(String.format("ALTER TABLE %s DROP IF EXISTS ", finalTableName));
-
+    List<String> ddls = Lists.newArrayList();
+    ddls.add(String.format("USE %s %n", dbName));
     // Join the partition specs
-    ddl.append(Joiner.on(",").join(Iterables.transform(partitionDMLInfos, PARTITION_SPEC_GENERATOR)));
-    ddl.append("\n");
-    return ddl.toString();
+    ddls.add(String.format("ALTER TABLE %s DROP IF EXISTS %s", finalTableName,
+        Joiner.on(",").join(Iterables.transform(partitionDMLInfos, PARTITION_SPEC_GENERATOR))));
+
+    return ddls;
   }
 
   /***
-   * Serialize a {@link String} of publish table commands into a {@link State} at
-   * {@link #SERIALIZED_PUBLISH_TABLE_COMMANDS}.
-   * @param state {@link State} to serialize commands into.
-   * @param commands Publish table commands to serialize.
+   * Serialize a {@link QueryBasedHivePublishEntity} into a {@link State} at {@link #SERIALIZED_PUBLISH_TABLE_COMMANDS}.
+   * @param state {@link State} to serialize entity into.
+   * @param queryBasedHivePublishEntity to carry to publisher.
    */
-  public static void serializePublishTableCommands(State state, String commands) {
+  public static void serializePublishCommands(State state, QueryBasedHivePublishEntity queryBasedHivePublishEntity) {
     state.setProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_TABLE_COMMANDS,
-        GSON.toJson(commands));
+        GSON.toJson(queryBasedHivePublishEntity));
   }
 
   /***
-   * Serialize a {@link String} of dir to delete before partition publish into a {@link State} at
-   * {@link #SERIALIZED_DIR_TO_DELETE_BEFORE_PARTITION_PUBLISH}.
-   * @param state {@link State} to serialize dir into.
-   * @param dirName Dir to delete before partition publish.
+   * Deserialize the publish entity from a {@link State} at {@link #SERIALIZED_PUBLISH_TABLE_COMMANDS}.
+   * @param state {@link State} to look into for serialized entity.
+   * @return Publish table entity.
    */
-  public static void serializeDirToDeleteBeforePartitionPublish(State state, Optional<String> dirName) {
-    if (dirName.isPresent()) {
-      state.setProp(HiveAvroORCQueryGenerator.SERIALIZED_DIR_TO_DELETE_BEFORE_PARTITION_PUBLISH,
-          GSON.toJson(dirName.get()));
-    } else {
-      state.setProp(HiveAvroORCQueryGenerator.SERIALIZED_DIR_TO_DELETE_BEFORE_PARTITION_PUBLISH,
-          GSON.toJson(StringUtils.EMPTY));
-    }
-  }
-
-  /***
-   * Serialize a {@link String} of publish partition commands into a {@link State} at
-   * {@link #SERIALIZED_PUBLISH_PARTITION_COMMANDS}.
-   * @param state {@link State} to serialize commands into.
-   * @param commands Publish partition commands to serialize.
-   */
-  public static void serializePublishPartitionCommands(State state, String commands) {
-    state.setProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_PARTITION_COMMANDS,
-        GSON.toJson(commands));
-  }
-
-  /***
-   * Serialize a {@link String} of cleanup commands into a {@link State} at {@link #SERIALIZED_CLEANUP_COMMANDS}.
-   * @param state {@link State} to serialize commands into.
-   * @param commands Cleanup commands to serialize.
-   */
-  public static void serializedCleanupCommands(State state, String commands) {
-    state.setProp(HiveAvroORCQueryGenerator.SERIALIZED_CLEANUP_COMMANDS,
-        GSON.toJson(commands));
-  }
-
-  /***
-   * Deserialize the publish table commands from a {@link State} at {@link #SERIALIZED_PUBLISH_TABLE_COMMANDS}.
-   * @param state {@link State} to look into for serialized commands.
-   * @return Publish table commands.
-   */
-  public static String deserializePublishTableCommands(State state) {
-    return GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_TABLE_COMMANDS), String.class);
-  }
-
-  /***
-   * Deserialize the dir to delete before partition publish from a {@link State} at
-   * {@link #SERIALIZED_DIR_TO_DELETE_BEFORE_PARTITION_PUBLISH}
-   * @param state {@link State} to look into for dir name.
-   * @return Dir to delete before partition publish.
-   */
-  public static String deserializeDirToDeleteBeforePartitionPublish(State state) {
-    return GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_DIR_TO_DELETE_BEFORE_PARTITION_PUBLISH),
-        String.class);
-  }
-
-  /***
-   * Deserialize the publish partition commands from a {@link State} at {@link #SERIALIZED_PUBLISH_PARTITION_COMMANDS}.
-   * @param state {@link State} to look into for serialized commands.
-   * @return Publish partition commands.
-   */
-  public static String deserializePublishPartitionCommands(State state) {
-    return GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_PARTITION_COMMANDS), String.class);
-  }
-
-  /***
-   * Deserialize the cleanup commands from a {@link State} at {@link #SERIALIZED_CLEANUP_COMMANDS}.
-   * @param state {@link State} to look into for serialized commands.
-   * @return Cleanup commands.
-   */
-  public static String deserializeCleanupCommands(State state) {
-    return GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_CLEANUP_COMMANDS), String.class);
+  public static QueryBasedHivePublishEntity deserializePublishCommands(State state) {
+    return GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_TABLE_COMMANDS),
+        QueryBasedHivePublishEntity.class);
   }
 
   private static boolean isTypeEvolved(String evolvedType, String destinationType) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveValidationQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveValidationQueryGenerator.java
@@ -18,8 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 
 import org.apache.hadoop.hive.ql.metadata.Partition;
 
-import com.beust.jcommander.internal.Lists;
 import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
 
 import gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset;
 import gobblin.data.management.copy.hive.HiveDataset;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/validation/ValidationJob.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/validation/ValidationJob.java
@@ -30,9 +30,9 @@ import org.joda.time.DateTime;
 
 import azkaban.jobExecutor.AbstractJob;
 
-import com.beust.jcommander.internal.Maps;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveAvroToOrcConverterTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveAvroToOrcConverterTest.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.util.List;
 
 import org.apache.avro.Schema;
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.hive.metastore.api.FieldSchema;
 import org.apache.hadoop.hive.metastore.api.Partition;
 import org.apache.hadoop.hive.metastore.api.Table;
@@ -67,17 +68,17 @@ public class HiveAvroToOrcConverterTest {
 
     try (HiveAvroToFlattenedOrcConverter converter = new HiveAvroToFlattenedOrcConverter();) {
 
-      Config config = ConfigFactory.parseMap(ImmutableMap.<String, String> builder()
-          .put("destinationFormats", "flattenedOrc")
-          .put("flattenedOrc.destination.dbName",dbName)
-          .put("flattenedOrc.destination.tableName", tableName + "_orc")
-          .put("flattenedOrc.destination.dataPath","file:" + tableSdLoc + "_orc")
-          .build());
+      Config config = ConfigFactory.parseMap(
+          ImmutableMap.<String, String>builder().put("destinationFormats", "flattenedOrc")
+              .put("flattenedOrc.destination.dbName", dbName)
+              .put("flattenedOrc.destination.tableName", tableName + "_orc")
+              .put("flattenedOrc.destination.dataPath", "file:" + tableSdLoc + "_orc").build());
 
       ConvertibleHiveDataset cd = ConvertibleHiveDatasetTest.createTestConvertibleDataset(config);
 
       List<QueryBasedHiveConversionEntity> conversionEntities =
-          Lists.newArrayList(converter.convertRecord(converter.convertSchema(schema, wus), new QueryBasedHiveConversionEntity(cd, new SchemaAwareHiveTable(table, schema)), wus));
+          Lists.newArrayList(converter.convertRecord(converter.convertSchema(schema, wus),
+              new QueryBasedHiveConversionEntity(cd, new SchemaAwareHiveTable(table, schema)), wus));
 
       Assert.assertEquals(conversionEntities.size(), 1, "Only one query entity should be returned");
 
@@ -86,10 +87,17 @@ public class HiveAvroToOrcConverterTest {
 
       Assert.assertEquals(queries.size(), 2, "One DDL and one DML query should be returned");
 
-      Assert.assertEquals(queries.get(0).trim().replaceAll(" ", ""),
-          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.ddl").replaceAll(" ", ""));
-      Assert.assertEquals(queries.get(1).trim().replaceAll(" ", ""),
-          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.dml").replaceAll(" ", ""));
+      // Ignoring part before first bracket in DDL and 'select' clause in DML because staging table has
+      // .. a random name component
+      String actualDDLQuery = StringUtils.substringAfter("(", queries.get(0).trim());
+      String actualDMLQuery = StringUtils.substringAfter("SELECT", queries.get(0).trim());
+      String expectedDDLQuery = StringUtils.substringAfter("(",
+          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.ddl"));
+      String expectedDMLQuery = StringUtils.substringAfter("SELECT",
+          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_flattened.dml"));
+
+      Assert.assertEquals(actualDDLQuery, expectedDDLQuery);
+      Assert.assertEquals(actualDMLQuery, expectedDMLQuery);
     }
 
   }
@@ -132,10 +140,17 @@ public class HiveAvroToOrcConverterTest {
 
       Assert.assertEquals(queries.size(), 2, "One DDL and one DML query should be returned");
 
-      Assert.assertEquals(queries.get(0).trim().replaceAll(" ", ""),
-          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.ddl").replaceAll(" ", ""));
-      Assert.assertEquals(queries.get(1).trim().replaceAll(" ", ""),
-          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.dml").replaceAll(" ", ""));
+      // Ignoring part before first bracket in DDL and 'select' clause in DML because staging table has
+      // .. a random name component
+      String actualDDLQuery = StringUtils.substringAfter("(", queries.get(0).trim());
+      String actualDMLQuery = StringUtils.substringAfter("SELECT", queries.get(0).trim());
+      String expectedDDLQuery = StringUtils.substringAfter("(",
+          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.ddl"));
+      String expectedDMLQuery = StringUtils.substringAfter("SELECT",
+          ConversionHiveTestUtils.readQueryFromFile(resourceDir, "recordWithinRecordWithinRecord_nested.dml"));
+
+      Assert.assertEquals(actualDDLQuery, expectedDDLQuery);
+      Assert.assertEquals(actualDMLQuery, expectedDMLQuery);
     }
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/converter/HiveSchemaEvolutionTest.java
@@ -216,7 +216,7 @@ public class HiveSchemaEvolutionTest {
     Assert.assertEquals(generateEvolutionDDL.size(), 1);
     Assert.assertEquals(generateEvolutionDDL.get(0),
         "ALTER TABLE `hiveDb`.`sourceSchema` ADD COLUMNS (parentFieldRecord__nestedFieldInt int "
-            + "COMMENT 'from flatten_source parentFieldRecord.nestedFieldInt')\n",
+            + "COMMENT 'from flatten_source parentFieldRecord.nestedFieldInt')",
         "Generated evolution DDL did not match for evolution enabled");
 
     // Destination table does not exists
@@ -225,7 +225,7 @@ public class HiveSchemaEvolutionTest {
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
             outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
     // No DDL should be generated, because create table will take care of destination table
-    Assert.assertEquals(generateEvolutionDDL.get(0), "",
+    Assert.assertEquals(generateEvolutionDDL.size(), 0,
         "Generated evolution DDL did not match for evolution enabled");
   }
 
@@ -249,7 +249,7 @@ public class HiveSchemaEvolutionTest {
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
             outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
     // No DDL should be generated, because select based on destination table will selectively project columns
-    Assert.assertEquals(generateEvolutionDDL.get(0), "",
+    Assert.assertEquals(generateEvolutionDDL.size(), 0,
         "Generated evolution DDL did not match for evolution disabled");
 
     // Destination table does not exists
@@ -258,7 +258,7 @@ public class HiveSchemaEvolutionTest {
         .generateEvolutionDDL(orcStagingTableName, orcTableName, Optional.of(hiveDbName), Optional.of(hiveDbName),
             outputSchema, isEvolutionEnabled, hiveColumns, destinationTableMeta);
     // No DDL should be generated, because create table will take care of destination table
-    Assert.assertEquals(generateEvolutionDDL.get(0), "",
+    Assert.assertEquals(generateEvolutionDDL.size(), 0,
         "Generated evolution DDL did not match for evolution disabled");
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
@@ -223,14 +223,17 @@ public class HiveAvroORCQueryGeneratorTest {
     partitionDMLInfos.add(ImmutableMap.of("datepartition", "2016-01-02", "sizepartition", "20"));
     partitionDMLInfos.add(ImmutableMap.of("datepartition", "2016-01-03", "sizepartition", "30"));
 
-    String ddl = HiveAvroORCQueryGenerator.generateDropPartitionsDDL("db1", "table1", partitionDMLInfos);
+    List<String> ddl = HiveAvroORCQueryGenerator.generateDropPartitionsDDL("db1", "table1", partitionDMLInfos);
 
-    Assert.assertEquals(ddl, "USE db1\n"
-        + "ALTER TABLE table1 DROP IF EXISTS  PARTITION (datepartition='2016-01-01',sizepartition='10'), "
+    Assert.assertEquals(ddl.size(), 2);
+    Assert.assertEquals(ddl.get(0), "USE db1 \n");
+    Assert.assertEquals(ddl.get(1),
+          "ALTER TABLE table1 DROP IF EXISTS  PARTITION (datepartition='2016-01-01',sizepartition='10'), "
         + "PARTITION (datepartition='2016-01-02',sizepartition='20'), "
-        + "PARTITION (datepartition='2016-01-03',sizepartition='30')\n");
+        + "PARTITION (datepartition='2016-01-03',sizepartition='30')");
 
     // Check empty partitions
-    Assert.assertEquals(HiveAvroORCQueryGenerator.generateDropPartitionsDDL("db1", "table1", Collections.<Map<String, String>> emptyList()), "");
+    Assert.assertEquals(HiveAvroORCQueryGenerator.generateDropPartitionsDDL("db1", "table1",
+        Collections.<Map<String, String>>emptyList()), Collections.emptyList());
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
@@ -236,4 +236,23 @@ public class HiveAvroORCQueryGeneratorTest {
     Assert.assertEquals(HiveAvroORCQueryGenerator.generateDropPartitionsDDL("db1", "table1",
         Collections.<Map<String, String>>emptyList()), Collections.emptyList());
   }
+
+  @Test
+  public void testCreatePartitionDDL() throws Exception {
+    List<String> ddl = HiveAvroORCQueryGenerator.generateCreatePartitionDDL("db1", "table1", "/tmp",
+        ImmutableMap.of("datepartition", "2016-01-01", "sizepartition", "10"));
+
+    Assert.assertEquals(ddl.size(), 2);
+    Assert.assertEquals(ddl.get(0), "USE db1\n");
+    Assert.assertEquals(ddl.get(1),
+        "ALTER TABLE `table1` ADD IF NOT EXISTS PARTITION (`datepartition`='2016-01-01', `sizepartition`='10') \n"
+            + " LOCATION '/tmp' ");
+  }
+
+  @Test
+  public void testDropTableDDL() throws Exception {
+    String ddl = HiveAvroORCQueryGenerator.generateDropTableDDL("db1", "table1");
+
+    Assert.assertEquals(ddl, "DROP TABLE IF EXISTS `db1`.`table1`");
+  }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/predicates/RegistrationTimeSkipPredicateTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/predicates/RegistrationTimeSkipPredicateTest.java
@@ -19,12 +19,12 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.mockito.Mockito;
 
-import com.beust.jcommander.internal.Maps;
 import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
 
 import gobblin.data.management.copy.CopyConfiguration;
 import gobblin.data.management.copy.CopyContext;


### PR DESCRIPTION
Change Hive Avro to ORC publish to use Gobblin constructs instead of Hive exchange partition query: 
- Hive exchange partition query was being used to move partitions from staging to final table
- However, this can fail queries in flight because the current model overwrites data location
- To overcome this, we have changed the publish module to use Gobblin constructs 

New publish works as follows: 
- Staging table partition is created in a directory under Gobblin control (dir name prefix is derived from source partition location string; such as if partitionDir.prefixLocationHint is set to 'hourly,daily' and 'hourly' exists as substring in source partition path, then 'hourly' string is prefixed to dir name of the partition) 
- At the time of publish, first the staging partition directory is moved as ORC final table sub directory (if previously any dir existed, its deleted; however here hourly / daily hint helps)
- Previous partition is dropped if any from the destination table, and new partition is created with new partition directory location
- Old partition directory (if different) is left over for retention to clean up

Also, other minor changes: 
- Each staging partition gets it own staging table 
- Code refactoring 