### PR TITLE
Support for distcp-ng registration time in isOlderThanLookback check and minor refactoring

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -122,7 +122,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
 
   /**
    * Get the {@link ConversionConfig} required for building the Avro to ORC conversion query
-   * @return
+   * @return Conversion config
    */
   protected abstract ConversionConfig getConversionConfig();
 
@@ -183,7 +183,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     }
 
     // Create DDL statement for table
-    Map<String, String> hiveColumns = new HashMap<String, String>();
+    Map<String, String> hiveColumns = new HashMap<>();
     String createStagingTableDDL =
         HiveAvroORCQueryGenerator.generateCreateTableDDL(outputAvroSchema,
             orcStagingTableName,

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -908,7 +908,7 @@ public class HiveAvroORCQueryGenerator {
         QueryBasedHivePublishEntity.class);
   }
 
-  private static boolean isTypeEvolved(String evolvedType, String destinationType) {
+  public static boolean isTypeEvolved(String evolvedType, String destinationType) {
     if (evolvedType.equalsIgnoreCase(destinationType)) {
       // Same type, not evolved
       return false;

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
@@ -211,8 +211,7 @@ public class HiveAvroORCQueryGeneratorTest {
             Optional.<String>absent(), Optional.<Map<String, String>>absent(), Optional.<Boolean>absent(),
             Optional.<Boolean>absent(), isEvolutionEnabled, destinationTableMeta, rowLimit);
 
-    Assert.assertEquals(q.trim(),
-        ConversionHiveTestUtils.readQueryFromFile(resourceDir, "flattenedWithRowLimit.dml"));
+    Assert.assertEquals(q.trim(), ConversionHiveTestUtils.readQueryFromFile(resourceDir, "flattenedWithRowLimit.dml"));
   }
 
   @Test
@@ -282,5 +281,23 @@ public class HiveAvroORCQueryGeneratorTest {
     String actualEscapedType = HiveAvroORCQueryGenerator.escapeHiveType(type);
 
     Assert.assertEquals(actualEscapedType, expectedEscapedType);
+  }
+
+  @Test
+  public void testValidTypeEvolution() throws Exception {
+    // Check a few evolved types
+    Assert.assertTrue(HiveAvroORCQueryGenerator.isTypeEvolved("float", "int"));
+    Assert.assertTrue(HiveAvroORCQueryGenerator.isTypeEvolved("double", "float"));
+    Assert.assertTrue(HiveAvroORCQueryGenerator.isTypeEvolved("string", "varchar"));
+    Assert.assertTrue(HiveAvroORCQueryGenerator.isTypeEvolved("double", "string"));
+
+    // Check if type is same
+    Assert.assertFalse(HiveAvroORCQueryGenerator.isTypeEvolved("int", "int"));
+  }
+
+  @Test (expectedExceptions = RuntimeException.class)
+  public void testInvalidTypeEvolution() throws Exception {
+    // Check for in-compatible types
+    HiveAvroORCQueryGenerator.isTypeEvolved("boolean", "int");
   }
 }


### PR DESCRIPTION
Changes: 
- Add support for distcp-ng registration time while running isOlderThanLookback check to counter cases where createTime is not set in Partition metadata
- Added tests for Hive type evolution compatibility check
- Minor code refactoring to make naming convention uniform in Avro to ORC converter and code cleanup

Trivial changes / tested. self approving. 