### PR TITLE
Make sure maven central repo is first; bug fixes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,18 @@
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.locks.ReentrantLock
 
+// Setup environment
+ext.build_script_dir = "${projectDir.path}/build_script"
+ext.isDefaultEnvironment = !project.hasProperty('overrideBuildEnvironment')
+
+File getEnvironmentScript() {
+  final File env = file(isDefaultEnvironment ? 'defaultEnvironment.gradle' : project.overrideBuildEnvironment)
+  assert env.isFile() : "The environment script [$env] does not exists or is not a file."
+  return env
+}
+
+apply from: environmentScript
+
 buildscript {
   repositories {
     maven {
@@ -34,18 +46,6 @@ idea.project {
   ext.languageLevel = JavaVersion.VERSION_1_7
   languageLevel = JavaVersion.VERSION_1_7
 }
-
-ext.build_script_dir = "${projectDir.path}/build_script"
-ext.isDefaultEnvironment = !project.hasProperty('overrideBuildEnvironment')
-
-File getEnvironmentScript()
-{
-  final File env = file(isDefaultEnvironment ? 'defaultEnvironment.gradle' : project.overrideBuildEnvironment)
-  assert env.isFile() : "The environment script [$env] does not exists or is not a file."
-  return env
-}
-
-apply from: environmentScript
 
 // Maven POM generation is not thread safe, so serialize all the Upload tasks we can use `--parallel`.
 // https://issues.gradle.org/browse/GRADLE-2492

--- a/defaultEnvironment.gradle
+++ b/defaultEnvironment.gradle
@@ -8,6 +8,10 @@
 // under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
 // CONDITIONS OF ANY KIND, either express or implied.
 
+repositories {
+  mavenCentral()
+}
+
 subprojects {
   repositories {
     mavenCentral()

--- a/gobblin-compaction/src/test/java/gobblin/compaction/mapreduce/MRCompactorJobRunnerFilenameRecordCountProviderTest.java
+++ b/gobblin-compaction/src/test/java/gobblin/compaction/mapreduce/MRCompactorJobRunnerFilenameRecordCountProviderTest.java
@@ -39,7 +39,7 @@ public class MRCompactorJobRunnerFilenameRecordCountProviderTest {
     String originalFilename = "test.123.avro";
     String suffixPattern = Pattern.quote(".late") + "[\\d]*";
 
-    Path testDir = new Path("gobblin-compaction/src/test/resources/compactorFilenameRecordCountProviderTest");
+    Path testDir = new Path("/tmp/compactorFilenameRecordCountProviderTest");
     FileSystem fs = FileSystem.getLocal(new Configuration());
     try {
       if (fs.exists(testDir)) {

--- a/gobblin-rest-service/gobblin-rest-server/build.gradle
+++ b/gobblin-rest-service/gobblin-rest-server/build.gradle
@@ -57,4 +57,5 @@ buildscript {
 
 test {
     workingDir rootProject.rootDir
+    jvmArgs '-Dlog4j.configuration=gobblin-rest-server-test-log4j.properties'
 }

--- a/gobblin-rest-service/gobblin-rest-server/src/test/resources/gobblin-rest-server-test-log4j.properties
+++ b/gobblin-rest-service/gobblin-rest-server/src/test/resources/gobblin-rest-server-test-log4j.properties
@@ -1,0 +1,24 @@
+#
+# Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+
+log4j.rootLogger=ERROR, stdout
+log4j.appender.stdout=org.apache.log4j.ConsoleAppender
+log4j.appender.stdout.Target=System.out
+log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
+log4j.appender.stdout.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss z} %-5p [%t] %c{2} - %m%n
+
+
+log4j.logger.gobblin=INFO, verboselog
+log4j.appender.verboselog=org.apache.log4j.FileAppender
+log4j.appender.verboselog.file=/tmp/gobblin-rest-server-test.log
+log4j.appender.verboselog.layout=org.apache.log4j.PatternLayout
+log4j.appender.verboselog.layout.ConversionPattern=%d{yyyy-MM-dd HH:mm:ss z} %-5p [%t] %c{2} - %m%n


### PR DESCRIPTION
* We've been seeing gobblin-core failures on Travis. It seems related to aws-java-sdk-1.7.4 being needed by hadoop-aws . It seems like the artifact was being pulled from jcenter rather than Maven Central and there might be an issue with the former. I've reordered the repositoriy registration so Maven comes first.
* I think I've finally figured out an issue with intermittently failing :gobblin-compaction:test . MRCompactorJobRunnerFilenameRecordCountProviderTest was creating a directory under source code tree which was confusing gradle. Moved the directory to /tmp/
* Added log4j configuration for gobblin-rest-server tests to write test output to /tmp/gobblin-rest-server-test.log . Hopefully that helps with intermittent failures.

@abti can you review ?