### PR TITLE
Initial commit for a skeleton GobblinInstanceDriver

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstanceLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstanceLauncher.java
@@ -25,4 +25,7 @@ public interface GobblinInstanceLauncher extends Service {
    * Creates a new Gobblin instance to run Gobblin jobs.
    * @throws IllegalStateException if {@link #isRunning()} is false.*/
   GobblinInstanceDriver getDriver() throws IllegalStateException;
+
+  /** The instance name (for debugging/logging purposes) */
+  String getName();
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionState.java
@@ -11,18 +11,28 @@
  */
 package gobblin.runtime.api;
 
+import java.util.HashMap;
 import java.util.Map;
 
+import lombok.Getter;
+
 /**
- * @author cbotev
+ * TODO
  *
  */
 public class JobExecutionState extends JobExecutionStatus {
-  final JobSpec jobSpec;
+  @Getter final JobSpec jobSpec;
   Map<String, Object> executionMetadata;
 
   public JobExecutionState(JobSpec jobSpec, JobExecution jobExecution) {
     super(jobExecution);
     this.jobSpec = jobSpec;
+    // TODO default implementation
+    this.executionMetadata = new HashMap<>();
   }
+
+  public Map<String, Object> getExecutionMetadata() {
+    return this.executionMetadata;
+  }
+
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionState.java
@@ -11,6 +11,7 @@
  */
 package gobblin.runtime.api;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,7 +33,7 @@ public class JobExecutionState extends JobExecutionStatus {
   }
 
   public Map<String, Object> getExecutionMetadata() {
-    return this.executionMetadata;
+    return Collections.unmodifiableMap(this.executionMetadata);
   }
 
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionStatus.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionStatus.java
@@ -11,23 +11,23 @@
  */
 package gobblin.runtime.api;
 
-import java.util.List;
-
 import gobblin.runtime.JobState;
 
+import lombok.Getter;
+
 public class JobExecutionStatus {
-  final JobExecution jobExecution;
+  @Getter final JobExecution jobExecution;
+
+  @Getter JobState.RunningState status;
+  /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
+  @Getter String stage;
+
+  // TODO commented out to avoid FindBugs warning
+  // transient List<JobExecutionStateListener> changeListeners;
 
   public JobExecutionStatus(JobExecution jobExecution) {
     this.jobExecution = jobExecution;
     this.status = JobState.RunningState.PENDING;
   }
-
-  /** SUBMITTED, STARTED, SUCCEEDED, FAILED */
-  JobState.RunningState status;
-  /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
-  String stage;
-
-  transient List<JobExecutionStateListener> changeListeners;
 
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionStatus.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionStatus.java
@@ -16,8 +16,9 @@ import gobblin.runtime.JobState;
 import lombok.Getter;
 
 public class JobExecutionStatus {
-  @Getter final JobExecution jobExecution;
+  public static final String UKNOWN_STAGE = "unkown";
 
+  @Getter final JobExecution jobExecution;
   @Getter JobState.RunningState status;
   /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
   @Getter String stage;
@@ -28,6 +29,7 @@ public class JobExecutionStatus {
   public JobExecutionStatus(JobExecution jobExecution) {
     this.jobExecution = jobExecution;
     this.status = JobState.RunningState.PENDING;
+    this.stage = UKNOWN_STAGE;
   }
 
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionStatus.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionStatus.java
@@ -15,13 +15,14 @@ import gobblin.runtime.JobState;
 
 import lombok.Getter;
 
+@Getter
 public class JobExecutionStatus {
   public static final String UKNOWN_STAGE = "unkown";
 
-  @Getter final JobExecution jobExecution;
-  @Getter JobState.RunningState status;
+  final JobExecution jobExecution;
+  JobState.RunningState status;
   /** Arbitrary execution stage, e.g. setup, workUnitGeneration, taskExecution, publishing */
-  @Getter String stage;
+  String stage;
 
   // TODO commented out to avoid FindBugs warning
   // transient List<JobExecutionStateListener> changeListeners;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobSpec.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobSpec.java
@@ -56,6 +56,19 @@ public class JobSpec implements Configurable {
     return new Builder(jobSpecUri);
   }
 
+  public String toShortString() {
+    return getUri().toString() + "/" + getVersion();
+  }
+
+  public String toLongString() {
+    return getUri().toString() + "/" + getVersion() + "[" + getDescription() + "]";
+  }
+
+  @Override
+  public String toString() {
+    return toShortString();
+  }
+
   public static class Builder {
     private Optional<Config> config = Optional.absent();
     private Optional<Properties> configAsProperties = Optional.absent();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance_driver/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance_driver/DefaultGobblinInstanceDriverImpl.java
@@ -23,7 +23,6 @@ import gobblin.runtime.api.GobblinInstanceDriver;
 import gobblin.runtime.api.JobCatalog;
 import gobblin.runtime.api.JobExecutionLauncher;
 import gobblin.runtime.api.JobExecutionState;
-import gobblin.runtime.api.JobExecutionStateListener;
 import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.api.JobSpecMonitorFactory;
 import gobblin.runtime.api.JobSpecScheduler;
@@ -88,7 +87,11 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
     }
   }
 
-  class ExecutionStateListener implements JobExecutionStateListener {
+  class ExecutionStateListener extends DefaultJobExecutionStateListenerImpl {
+
+    public ExecutionStateListener() {
+      super(DefaultGobblinInstanceDriverImpl.this._log);
+    }
 
     @Override
     public void onStatusChange(JobExecutionState state, RunningState previousStatus, RunningState newStatus) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance_driver/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance_driver/DefaultGobblinInstanceDriverImpl.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.instance_driver;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.util.concurrent.AbstractIdleService;
+
+import gobblin.runtime.JobState.RunningState;
+import gobblin.runtime.api.GobblinInstanceDriver;
+import gobblin.runtime.api.JobCatalog;
+import gobblin.runtime.api.JobExecutionLauncher;
+import gobblin.runtime.api.JobExecutionState;
+import gobblin.runtime.api.JobExecutionStateListener;
+import gobblin.runtime.api.JobSpec;
+import gobblin.runtime.api.JobSpecMonitorFactory;
+import gobblin.runtime.api.JobSpecScheduler;
+import gobblin.runtime.std.DefaultJobCatalogListenerImpl;
+import gobblin.runtime.std.DefaultJobExecutionStateListenerImpl;
+
+/**
+ * A default implementation of {@link GobblinInstanceDriver}. It accepts already instantiated
+ * {@link JobCatalog}, {@link JobSpecMonitorFactory}, {@link JobSpecScheduler},
+ * {@link JobExecutionLauncher}. It is responsibility of the caller to manage those (e.g. start,
+ * shutdown, etc.)
+ *
+ */
+public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
+       implements GobblinInstanceDriver {
+  protected final Logger _log;
+  protected final JobCatalog _jobCatalog;
+  protected final JobSpecScheduler _jobScheduler;
+  protected final JobExecutionLauncher _jobLauncher;
+  protected JobSpecListener _jobSpecListener;
+
+  public DefaultGobblinInstanceDriverImpl(JobCatalog jobCatalog, JobSpecScheduler jobScheduler,
+      JobExecutionLauncher jobLauncher, Optional<Logger> log) {
+    Preconditions.checkNotNull(jobCatalog);
+    Preconditions.checkNotNull(jobScheduler);
+    Preconditions.checkNotNull(jobLauncher);
+
+    _jobCatalog = jobCatalog;
+    _jobScheduler = jobScheduler;
+    _jobLauncher = jobLauncher;
+    _log = log.isPresent() ? log.get() : LoggerFactory.getLogger(getClass());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public JobCatalog getJobCatalog() {
+    return _jobCatalog;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public JobSpecScheduler getJobScheduler() {
+    return _jobScheduler;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public JobExecutionLauncher getJobLauncher() {
+    return _jobLauncher;
+  }
+
+  @Override
+  protected void startUp() throws Exception {
+    _jobSpecListener = new JobSpecListener();
+    _jobCatalog.addListener(_jobSpecListener);
+  }
+
+  @Override
+  protected void shutDown() throws Exception {
+    if (null != _jobSpecListener) {
+      _jobCatalog.removeListener(_jobSpecListener);
+    }
+  }
+
+  class ExecutionStateListener implements JobExecutionStateListener {
+
+    @Override
+    public void onStatusChange(JobExecutionState state, RunningState previousStatus, RunningState newStatus) {
+      // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void onStageTransition(JobExecutionState state, String previousStage, String newStage) {
+      // TODO Auto-generated method stub
+
+    }
+
+    @Override
+    public void onMetadataChange(JobExecutionState state, String key, Object oldValue, Object newValue) {
+      // TODO Auto-generated method stub
+
+    }
+
+  }
+
+  /** Keeps track of a job execution */
+  class JobExecutionListener extends DefaultJobExecutionStateListenerImpl {
+
+    public JobExecutionListener() {
+      super(LoggerFactory.getLogger(DefaultGobblinInstanceDriverImpl.this._log.getName() +
+                                  "_jobExecutionListener"));
+    }
+
+    @Override public String toString() {
+      return _log.get().getName();
+    }
+
+  }
+
+  /** The runnable invoked by the Job scheduler */
+  class JobSpecRunnable implements Runnable {
+    private final JobSpec _jobSpec;
+
+    public JobSpecRunnable(JobSpec jobSpec) {
+      _jobSpec = jobSpec;
+    }
+
+    @Override
+    public void run() {
+       _jobLauncher.launchJob(_jobSpec, new JobExecutionListener());
+    }
+  }
+
+  /** Listens to changes in the Job catalog and schedules/un-schedules jobs. */
+  class JobSpecListener extends DefaultJobCatalogListenerImpl {
+
+    public JobSpecListener() {
+      super(LoggerFactory.getLogger(DefaultGobblinInstanceDriverImpl.this._log.getName() +
+                                  "_jobSpecListener"));
+    }
+
+    @Override public String toString() {
+      return _log.get().getName();
+    }
+
+    @Override public void onAddJob(JobSpec addedJob) {
+      super.onAddJob(addedJob);
+      _jobScheduler.scheduleJob(addedJob, new JobSpecRunnable(addedJob));
+    }
+
+    @Override public void onDeleteJob(JobSpec deletedJob) {
+      super.onDeleteJob(deletedJob);
+      _jobScheduler.unscheduleJob(deletedJob.getUri());
+    }
+
+    @Override public void onUpdateJob(JobSpec originalJob, JobSpec updatedJob) {
+      super.onUpdateJob(originalJob, updatedJob);
+      _jobScheduler.scheduleJob(updatedJob, new JobSpecRunnable(updatedJob));
+    }
+
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/scheduler/ImmediateJobSpecScheduler.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/scheduler/ImmediateJobSpecScheduler.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.scheduler;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ThreadFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import gobblin.runtime.api.JobSpec;
+import gobblin.runtime.api.JobSpecSchedule;
+import gobblin.runtime.api.JobSpecScheduler;
+import gobblin.runtime.std.DefaultJobSpecScheduleImpl;
+import gobblin.util.LoggingUncaughtExceptionHandler;
+
+/**
+ * A simple implementation of a {@link JobSpecScheduler} which schedules the job immediately.
+ * Note that job runnable is scheduled immediately but this happens in a separate thread so it is
+ * asynchronous.
+ */
+public class ImmediateJobSpecScheduler implements JobSpecScheduler {
+  private final Logger _log;
+  private final ThreadFactory _jobRunnablesThreadFactory;
+
+  public ImmediateJobSpecScheduler(Optional<Logger> log) {
+    _log = log.isPresent() ? log.get() : LoggerFactory.getLogger(getClass());
+    _jobRunnablesThreadFactory = (new ThreadFactoryBuilder())
+        .setDaemon(false)
+        .setNameFormat(_log.getName() + "-%d")
+        .setUncaughtExceptionHandler(new LoggingUncaughtExceptionHandler(Optional.of(_log)))
+        .build();
+  }
+
+  /** {@inheritDoc} */
+  @Override public JobSpecSchedule scheduleJob(JobSpec jobSpec, Runnable jobRunnable) {
+    Thread runThread = _jobRunnablesThreadFactory.newThread(jobRunnable);
+    _log.info("Starting JobSpec " + jobSpec + " in thread " + runThread.getName());
+    JobSpecSchedule schedule =
+        DefaultJobSpecScheduleImpl.createImmediateSchedule(jobSpec, jobRunnable);
+    runThread.start();
+    return schedule;
+  }
+
+  /** {@inheritDoc} */
+  @Override public void unscheduleJob(URI jobSpecURI) {
+    // No-op since no future schedules are maintained
+  }
+
+  /** {@inheritDoc} */
+  @Override public Map<URI, JobSpecSchedule> getSchedules() {
+    // No future schedules
+    return Collections.emptyMap();
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobCatalogListenerImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobCatalogListenerImpl.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.std;
+
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+
+import gobblin.runtime.api.JobCatalogListener;
+import gobblin.runtime.api.JobSpec;
+
+/**
+ * Default NOOP implementation for {@link JobCatalogListener}. It can log the callbacks. Other
+ * implementing classes can use this as a base to override only the methods they care about.
+ */
+public class DefaultJobCatalogListenerImpl implements JobCatalogListener {
+  protected final Optional<Logger> _log;
+
+  /**
+   * Constructor
+   * @param log   if no log is specified, the logging will be done. Logging level is INFO.
+   */
+  public DefaultJobCatalogListenerImpl(Optional<Logger> log) {
+    _log = log;
+  }
+
+  public DefaultJobCatalogListenerImpl(Logger log) {
+    this(Optional.of(log));
+  }
+
+  /** Constructor with no logging */
+  public DefaultJobCatalogListenerImpl() {
+    this(Optional.<Logger>absent());
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onAddJob(JobSpec addedJob) {
+    if (_log.isPresent()) {
+      _log.get().info("New JobSpec detected: " + addedJob.toShortString());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onDeleteJob(JobSpec deletedJob) {
+    if (_log.isPresent()) {
+      _log.get().info("JobSpec deleted: " + deletedJob.toShortString());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onUpdateJob(JobSpec originalJob, JobSpec updatedJob) {
+    if (_log.isPresent()) {
+      _log.get().info("JobSpec changed: " + originalJob.toShortString() + " --> " +
+             updatedJob.toShortString());
+    }
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobExecutionStateListenerImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobExecutionStateListenerImpl.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.std;
+
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+
+import gobblin.runtime.JobState.RunningState;
+import gobblin.runtime.api.JobExecutionState;
+import gobblin.runtime.api.JobExecutionStateListener;
+
+/**
+ * Default NOOP implementation for a {@link JobExecutionStateListener}. The implementation can
+ * optionally log the callbacks.
+ */
+public class DefaultJobExecutionStateListenerImpl implements JobExecutionStateListener {
+  protected final Optional<Logger> _log;
+
+  /**
+   * Constructor
+   * @param log   if present, the implementation will log each callback at INFO level
+   */
+  public DefaultJobExecutionStateListenerImpl(Optional<Logger> log) {
+    _log = log;
+  }
+
+  public DefaultJobExecutionStateListenerImpl(Logger log) {
+    this(Optional.of(log));
+  }
+
+  /** Constructor with no logging */
+  public DefaultJobExecutionStateListenerImpl() {
+    this(Optional.<Logger>absent());
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onStatusChange(JobExecutionState state, RunningState previousStatus, RunningState newStatus) {
+    if (_log.isPresent()) {
+      _log.get().info("JobExection status change for " + state.getJobSpec().toShortString() +
+                      ": " + previousStatus + " --> " + newStatus);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onStageTransition(JobExecutionState state, String previousStage, String newStage) {
+    if (_log.isPresent()) {
+      _log.get().info("JobExection stage change for " + state.getJobSpec().toShortString() +
+                      ": " + previousStage + " --> " + newStage);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onMetadataChange(JobExecutionState state, String key, Object oldValue,
+                               Object newValue) {
+    if (_log.isPresent()) {
+      _log.get().info("JobExection metadata change for " + state.getJobSpec().toShortString() +
+                      key + ": '" + oldValue + "' --> '" + newValue + "'");
+    }
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobSpecScheduleImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobSpecScheduleImpl.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.std;
+
+import com.google.common.base.Optional;
+
+import gobblin.runtime.api.JobSpec;
+import gobblin.runtime.api.JobSpecSchedule;
+
+import lombok.Data;
+
+/**
+ * Simple POJO implementation of {@link JobSpecSchedule}
+ */
+@Data
+public class DefaultJobSpecScheduleImpl implements JobSpecSchedule {
+  private final JobSpec jobSpec;
+  private final Runnable jobRunnable;
+  private final Optional<Long> nextRunTimeMillis;
+
+  /** Creates a schedule denoting that the job is to be executed immediately */
+  public static DefaultJobSpecScheduleImpl createImmediateSchedule(JobSpec jobSpec,
+                                                                   Runnable jobRunnable) {
+    return new DefaultJobSpecScheduleImpl(jobSpec, jobRunnable,
+                                          Optional.of(System.currentTimeMillis()));
+  }
+
+  /** Creates a schedule denoting that the job is not to be executed */
+  public static DefaultJobSpecScheduleImpl createNoSchedule(JobSpec jobSpec,
+                                                            Runnable jobRunnable) {
+    return new DefaultJobSpecScheduleImpl(jobSpec, jobRunnable,
+                                          Optional.<Long>absent());
+  }
+
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/instance_driver/TestDefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/instance_driver/TestDefaultGobblinInstanceDriverImpl.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.instance_driver;
+
+import java.util.concurrent.TimeUnit;
+
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+import gobblin.runtime.api.JobExecutionLauncher;
+import gobblin.runtime.api.JobSpec;
+import gobblin.runtime.api.JobSpecScheduler;
+import gobblin.runtime.job_catalog.InMemoryJobCatalog;
+import gobblin.runtime.std.DefaultJobSpecScheduleImpl;
+
+/**
+ * Unit tests for {@link DefaultGobblinInstanceDriverImpl}
+ */
+public class TestDefaultGobblinInstanceDriverImpl {
+
+  @Test
+  public void testScheduling() throws Exception {
+    final Logger log = LoggerFactory.getLogger(getClass().getName() + ".testBasicFlow");
+    final Optional<Logger> loggerOpt = Optional.of(log);
+    InMemoryJobCatalog jobCatalog = new InMemoryJobCatalog(loggerOpt);
+
+    JobSpecScheduler scheduler = Mockito.mock(JobSpecScheduler.class);
+    JobExecutionLauncher jobLauncher = Mockito.mock(JobExecutionLauncher.class);
+
+    DefaultGobblinInstanceDriverImpl driver =
+        new DefaultGobblinInstanceDriverImpl(jobCatalog, scheduler, jobLauncher, loggerOpt);
+
+    JobSpec js1_1 = JobSpec.builder("test.job1").withVersion("1").build();
+    JobSpec js1_2 = JobSpec.builder("test.job1").withVersion("2").build();
+    JobSpec js2 = JobSpec.builder("test.job2").withVersion("1").build();
+
+    jobCatalog.put(js1_1);
+
+    driver.startAsync().awaitRunning(100, TimeUnit.MILLISECONDS);
+    jobCatalog.put(js2);
+    jobCatalog.put(js1_2);
+    jobCatalog.remove(js2.getUri());
+
+    Mockito.when(
+        scheduler.scheduleJob(Mockito.eq(js1_1),
+                              Mockito.any(DefaultGobblinInstanceDriverImpl.JobSpecRunnable.class)))
+           .thenReturn(DefaultJobSpecScheduleImpl.createNoSchedule(js1_1, null));
+    Mockito.when(
+        scheduler.scheduleJob(Mockito.eq(js2),
+                              Mockito.any(DefaultGobblinInstanceDriverImpl.JobSpecRunnable.class)))
+           .thenReturn(DefaultJobSpecScheduleImpl.createNoSchedule(js2, null));
+    Mockito.when(
+        scheduler.scheduleJob(Mockito.eq(js1_2),
+                              Mockito.any(DefaultGobblinInstanceDriverImpl.JobSpecRunnable.class)))
+           .thenReturn(DefaultJobSpecScheduleImpl.createNoSchedule(js1_2, null));
+
+    Mockito.verify(scheduler).scheduleJob(Mockito.eq(js1_1),
+        Mockito.any(DefaultGobblinInstanceDriverImpl.JobSpecRunnable.class));
+    Mockito.verify(scheduler).scheduleJob(Mockito.eq(js2),
+        Mockito.any(DefaultGobblinInstanceDriverImpl.JobSpecRunnable.class));
+    Mockito.verify(scheduler).scheduleJob(Mockito.eq(js1_2),
+        Mockito.any(DefaultGobblinInstanceDriverImpl.JobSpecRunnable.class));
+    Mockito.verify(scheduler).unscheduleJob(Mockito.eq(js2.getUri()));
+  }
+
+}

--- a/gobblin-runtime/src/test/java/gobblin/runtime/scheduler/TestImmediateJobSpecScheduler.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/scheduler/TestImmediateJobSpecScheduler.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.scheduler;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+import gobblin.runtime.api.JobSpec;
+
+/**
+ * Unit tests for {@link ImmediateJobSpecScheduler}
+ *
+ */
+public class TestImmediateJobSpecScheduler {
+
+  @Test
+  public void testSchedule() throws Exception {
+    final Logger log = LoggerFactory.getLogger(getClass().getName() + ".testSimpleFlow");
+    final Optional<Logger> logOpt = Optional.of(log);
+    ImmediateJobSpecScheduler scheduler = new ImmediateJobSpecScheduler(logOpt);
+
+    final CountDownLatch expectedCallCount = new CountDownLatch(3);
+
+    Runnable r = new Runnable() {
+      @Override public void run() {
+        expectedCallCount.countDown();
+      }
+    };
+
+    JobSpec js1 = JobSpec.builder("test.job1").build();
+    JobSpec js2 = JobSpec.builder("test.job2").build();
+    JobSpec js3 = JobSpec.builder("test.job3").build();
+
+    scheduler.scheduleJob(js1, r);
+    Assert.assertEquals(scheduler.getSchedules().size(), 0);
+    scheduler.scheduleJob(js2, r);
+    Assert.assertEquals(scheduler.getSchedules().size(), 0);
+    scheduler.scheduleJob(js3, r);
+    Assert.assertEquals(scheduler.getSchedules().size(), 0);
+
+    Assert.assertTrue(expectedCallCount.await(100, TimeUnit.MILLISECONDS));
+  }
+}


### PR DESCRIPTION
Changes:
- A skeleton GobblinInstanceDriver implementation -- DefaultGobblinInstanceDriverImpl
- ImmediateJobSpecScheduler: Simple JobSpecScheduler implementation that puts the tasks immediately in a separate thread.
- Some default listener implementations
- Fix FindBugs in new launcher APIs
- Unit tests

@ibuenros @autumnust Can you review?