### PR TITLE
Rename init method in BackfillHiveSource

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/BackfillHiveSource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/BackfillHiveSource.java
@@ -46,7 +46,7 @@ public class BackfillHiveSource extends HiveAvroToOrcSource {
   private Set<String> partitionsWhitelist;
 
   @VisibleForTesting
-  public void initialize(SourceState state) {
+  public void initBackfillHiveSource(SourceState state) {
     this.partitionsWhitelist =
         Sets.newHashSet(Splitter.on(",").omitEmptyStrings().trimResults().split(state.getProp(BACKFILL_SOURCE_PARTITION_WHITELIST_KEY,
             StringUtils.EMPTY)));
@@ -54,7 +54,7 @@ public class BackfillHiveSource extends HiveAvroToOrcSource {
 
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {
-    initialize(state);
+    initBackfillHiveSource(state);
     return super.getWorkunits(state);
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/BackfillHiveSourceTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/BackfillHiveSourceTest.java
@@ -29,7 +29,7 @@ public class BackfillHiveSourceTest {
 
     BackfillHiveSource backfillHiveSource = new BackfillHiveSource();
     SourceState state = new SourceState();
-    backfillHiveSource.initialize(state);
+    backfillHiveSource.initBackfillHiveSource(state);
 
     Partition sourcePartition = Mockito.mock(Partition.class, Mockito.RETURNS_SMART_NULLS);
     Assert.assertTrue(backfillHiveSource.shouldCreateWorkunit(sourcePartition, new LongWatermark(0)));
@@ -42,7 +42,7 @@ public class BackfillHiveSourceTest {
     SourceState state = new SourceState();
     state.setProp(BackfillHiveSource.BACKFILL_SOURCE_PARTITION_WHITELIST_KEY,
         "service@logEvent@datepartition=2016-08-04-00,service@logEvent@datepartition=2016-08-05-00");
-    backfillHiveSource.initialize(state);
+    backfillHiveSource.initBackfillHiveSource(state);
 
     Partition pass1 = Mockito.mock(Partition.class, Mockito.RETURNS_SMART_NULLS);
     Mockito.when(pass1.getCompleteName()).thenReturn("service@logEvent@datepartition=2016-08-04-00");


### PR DESCRIPTION
Simple rename of ```initialize``` method to ```initBackfillHiveSource``` since the name conflicts with method in super class