### PR TITLE
Removing originalJob from JobCatalogListener.onUpdatedJob(); Adding J…

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstanceDriver.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstanceDriver.java
@@ -22,8 +22,14 @@ import gobblin.annotation.Alpha;
  * {@link JobSpec}s and run them.
  * */
 @Alpha
-public interface GobblinInstanceDriver extends Service {
+public interface GobblinInstanceDriver extends Service, JobLifecycleListenersContainer {
   JobCatalog getJobCatalog();
+  /**
+   * Returns a mutable instance of the job catalog
+   * (if it implements the {@link MutableJobCatalog} interface). Implementation will throw
+   * ClassCastException if the current catalog is not mutable.
+   */
+  MutableJobCatalog getMutableJobCatalog();
   JobSpecScheduler getJobScheduler();
   JobExecutionLauncher getJobLauncher();
   Logger getLog();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalogListener.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalogListener.java
@@ -33,7 +33,7 @@ public interface JobCatalogListener {
   /**
    * Invoked when the contents of a JobSpec gets updated in the catalog.
    */
-  public void onUpdateJob(JobSpec originalJob, JobSpec updatedJob);
+  public void onUpdateJob(JobSpec updatedJob);
 
   /** A standard implementation of onAddJob as a functional object */
   public static class AddJobCallback extends Callback<JobCatalogListener, Void> {
@@ -65,18 +65,16 @@ public interface JobCatalogListener {
   }
 
   public static class UpdateJobCallback extends Callback<JobCatalogListener, Void> {
-    private final JobSpec _originalJob;
     private final JobSpec _updatedJob;
-    public UpdateJobCallback(JobSpec originalJob, JobSpec updatedJob) {
-      super(Objects.toStringHelper("onUpdateJob").add("originalJob", originalJob)
+    public UpdateJobCallback(JobSpec updatedJob) {
+      super(Objects.toStringHelper("onUpdateJob")
                    .add("updatedJob", updatedJob).toString());
-      _originalJob = originalJob;
       _updatedJob = updatedJob;
     }
 
     @Override
     public Void apply(JobCatalogListener listener) {
-      listener.onUpdateJob(_originalJob, _updatedJob);
+      listener.onUpdateJob(_updatedJob);
       return null;
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalogListener.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalogListener.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.api;
 
+import java.net.URI;
+
 import com.google.common.base.Objects;
 
 import gobblin.annotation.Alpha;
@@ -28,7 +30,7 @@ public interface JobCatalogListener {
   /**
    * Invoked when a JobSpec gets removed from the catalog.
    */
-  public void onDeleteJob(JobSpec deletedJob);
+  public void onDeleteJob(URI deletedJobURI, String deletedJobVersion);
 
   /**
    * Invoked when the contents of a JobSpec gets updated in the catalog.
@@ -51,15 +53,20 @@ public interface JobCatalogListener {
 
   /** A standard implementation of onDeleteJob as a functional object */
   public static class DeleteJobCallback extends Callback<JobCatalogListener, Void> {
-    private final JobSpec _deletedJob;
+    private final URI _deletedJobURI;
+    private final String _deletedJobVersion;
 
-    public DeleteJobCallback(JobSpec deletedJob) {
-      super(Objects.toStringHelper("onDeleteJob").add("deletedJob", deletedJob).toString());
-      _deletedJob = deletedJob;
+    public DeleteJobCallback(URI deletedJobURI, String deletedJobVersion) {
+      super(Objects.toStringHelper("onDeleteJob")
+                   .add("deletedJobURI", deletedJobURI)
+                   .add("deletedJobVersion", deletedJobVersion)
+                   .toString());
+      _deletedJobURI = deletedJobURI;
+      _deletedJobVersion = deletedJobVersion;
     }
 
     @Override public Void apply(JobCatalogListener listener) {
-      listener.onDeleteJob(_deletedJob);
+      listener.onDeleteJob(_deletedJobURI, _deletedJobVersion);
       return null;
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobLifecycleListener.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobLifecycleListener.java
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.api;
+
+import gobblin.annotation.Alpha;
+
+/**
+ * A listener that can track the full lifecycle of a job: from the registering of the jobspec to
+ * completion of any of the job executions.
+ */
+@Alpha
+public interface JobLifecycleListener extends JobCatalogListener, JobExecutionStateListener {
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobLifecycleListenersContainer.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobLifecycleListenersContainer.java
@@ -1,0 +1,23 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.api;
+
+import java.util.List;
+
+/**
+ * An interface for managing instances of {@link JobLifecycleListener}.
+ */
+public interface JobLifecycleListenersContainer {
+  void registerJobLifecycleListener(JobLifecycleListener listener);
+  void unregisterJobLifecycleListener(JobLifecycleListener listener);
+  List<JobLifecycleListener> getJobLifecycleListeners();
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.instance;
 
+import java.util.List;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,11 +28,14 @@ import gobblin.runtime.api.JobCatalog;
 import gobblin.runtime.api.JobExecutionDriver;
 import gobblin.runtime.api.JobExecutionLauncher;
 import gobblin.runtime.api.JobExecutionState;
+import gobblin.runtime.api.JobLifecycleListener;
 import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.api.JobSpecMonitorFactory;
 import gobblin.runtime.api.JobSpecScheduler;
+import gobblin.runtime.api.MutableJobCatalog;
 import gobblin.runtime.std.DefaultJobCatalogListenerImpl;
 import gobblin.runtime.std.DefaultJobExecutionStateListenerImpl;
+import gobblin.runtime.std.JobLifecycleListenersList;
 
 /**
  * A default implementation of {@link GobblinInstanceDriver}. It accepts already instantiated
@@ -47,8 +52,8 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
   protected final JobSpecScheduler _jobScheduler;
   protected final JobExecutionLauncher _jobLauncher;
   protected final ConfigAccessor _instanceCfg;
+  protected final JobLifecycleListenersList _dispatcher;
   protected JobSpecListener _jobSpecListener;
-
 
   public DefaultGobblinInstanceDriverImpl(Configurable sysConfig, JobCatalog jobCatalog, JobSpecScheduler jobScheduler,
       JobExecutionLauncher jobLauncher, Optional<Logger> log) {
@@ -63,11 +68,17 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
     _sysConfig = sysConfig;
     _instanceCfg = ConfigAccessor.createFromGlobalConfig(_sysConfig.getConfig());
     _log = log.isPresent() ? log.get() : LoggerFactory.getLogger(getClass());
+    _dispatcher = new JobLifecycleListenersList(_log);
   }
 
   /** {@inheritDoc} */
   @Override public JobCatalog getJobCatalog() {
     return _jobCatalog;
+  }
+
+  /** {@inheritDoc} */
+  @Override public MutableJobCatalog getMutableJobCatalog() {
+    return (MutableJobCatalog)_jobCatalog;
   }
 
   /** {@inheritDoc} */
@@ -183,8 +194,8 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
       _jobScheduler.unscheduleJob(deletedJob.getUri());
     }
 
-    @Override public void onUpdateJob(JobSpec originalJob, JobSpec updatedJob) {
-      super.onUpdateJob(originalJob, updatedJob);
+    @Override public void onUpdateJob(JobSpec updatedJob) {
+      super.onUpdateJob(updatedJob);
       _jobScheduler.scheduleJob(updatedJob, new JobSpecRunnable(updatedJob));
     }
 
@@ -192,6 +203,21 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
 
   ConfigAccessor getInstanceCfg() {
     return _instanceCfg;
+  }
+
+  @Override
+  public void registerJobLifecycleListener(JobLifecycleListener listener) {
+    _dispatcher.registerJobLifecycleListener(listener);
+  }
+
+  @Override
+  public void unregisterJobLifecycleListener(JobLifecycleListener listener) {
+    _dispatcher.unregisterJobLifecycleListener(listener);
+  }
+
+  @Override
+  public List<JobLifecycleListener> getJobLifecycleListeners() {
+    return _dispatcher.getJobLifecycleListeners();
   }
 
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
@@ -11,6 +11,7 @@
  */
 package gobblin.runtime.instance;
 
+import java.net.URI;
 import java.util.List;
 
 import org.slf4j.Logger;
@@ -189,9 +190,9 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
       _jobScheduler.scheduleJob(addedJob, new JobSpecRunnable(addedJob));
     }
 
-    @Override public void onDeleteJob(JobSpec deletedJob) {
-      super.onDeleteJob(deletedJob);
-      _jobScheduler.unscheduleJob(deletedJob.getUri());
+    @Override public void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
+      super.onDeleteJob(deletedJobURI, deletedJobVersion);
+      _jobScheduler.unscheduleJob(deletedJobURI);
     }
 
     @Override public void onUpdateJob(JobSpec updatedJob) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance/StandardGobblinInstanceDriver.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance/StandardGobblinInstanceDriver.java
@@ -72,8 +72,7 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
 
   }
 
-  @Override
-  protected void shutDown() throws Exception {
+  @Override protected void shutDown() throws Exception {
     getLog().info("Shutting down driver ...");
     super.shutDown();
     if (null != _subservices) {
@@ -180,6 +179,11 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
       return _jobCatalog.get();
     }
 
+    public Builder withJobCatalog(JobCatalog jobCatalog) {
+      _jobCatalog = Optional.of(jobCatalog);
+      return this;
+    }
+
     public JobSpecScheduler getDefaultJobScheduler() {
       return new ImmediateJobSpecScheduler(Optional.of(getLog()));
     }
@@ -191,7 +195,7 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
       return _jobScheduler.get();
     }
 
-    public Builder setJobScheduler(JobSpecScheduler jobScheduler) {
+    public Builder withJobScheduler(JobSpecScheduler jobScheduler) {
       _jobScheduler = Optional.of(jobScheduler);
       return this;
     }
@@ -207,7 +211,7 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
       return _jobLauncher.get();
     }
 
-    public Builder setJobLauncher(JobExecutionLauncher jobLauncher) {
+    public Builder withJobLauncher(JobExecutionLauncher jobLauncher) {
       _jobLauncher = Optional.of(jobLauncher);
       return this;
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/CachingJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/CachingJobCatalog.java
@@ -78,8 +78,8 @@ public class CachingJobCatalog implements JobCatalog {
     }
 
     @Override
-    public void onDeleteJob(JobSpec deletedJob) {
-      _cache.remove(deletedJob.getUri());
+    public void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
+      _cache.remove(deletedJobURI);
     }
 
     @Override

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/CachingJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/CachingJobCatalog.java
@@ -83,7 +83,7 @@ public class CachingJobCatalog implements JobCatalog {
     }
 
     @Override
-    public void onUpdateJob(JobSpec originalJob, JobSpec updatedJob) {
+    public void onUpdateJob(JobSpec updatedJob) {
       _cache.put(updatedJob);
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/InMemoryJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/InMemoryJobCatalog.java
@@ -99,7 +99,7 @@ public class InMemoryJobCatalog implements MutableJobCatalog {
     Preconditions.checkNotNull(uri);
     JobSpec jobSpec = this.jobSpecs.remove(uri);
     if (null != jobSpec) {
-      this.listeners.onDeleteJob(jobSpec);
+      this.listeners.onDeleteJob(jobSpec.getUri(), jobSpec.getVersion());
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/InMemoryJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/InMemoryJobCatalog.java
@@ -90,7 +90,7 @@ public class InMemoryJobCatalog implements MutableJobCatalog {
       this.listeners.onAddJob(jobSpec);
     }
     else {
-      this.listeners.onUpdateJob(oldSpec, jobSpec);
+      this.listeners.onUpdateJob(jobSpec);
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/JobCatalogListenersList.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/JobCatalogListenersList.java
@@ -1,5 +1,6 @@
 package gobblin.runtime.job_catalog;
 
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -57,10 +58,11 @@ public class JobCatalogListenersList implements JobCatalogListener, JobCatalogLi
   }
 
   @Override
-  public synchronized void onDeleteJob(JobSpec deletedJob) {
-    Preconditions.checkNotNull(deletedJob);
+  public synchronized void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
+    Preconditions.checkNotNull(deletedJobURI);
+
     try {
-      _disp.execCallbacks(new DeleteJobCallback(deletedJob));
+      _disp.execCallbacks(new DeleteJobCallback(deletedJobURI, deletedJobVersion));
     } catch (InterruptedException e) {
       getLog().warn("onDeleteJob interrupted.");
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/JobCatalogListenersList.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/JobCatalogListenersList.java
@@ -67,11 +67,10 @@ public class JobCatalogListenersList implements JobCatalogListener, JobCatalogLi
   }
 
   @Override
-  public synchronized void onUpdateJob(JobSpec originalJob, JobSpec updatedJob) {
-    Preconditions.checkNotNull(originalJob);
+  public synchronized void onUpdateJob(JobSpec updatedJob) {
     Preconditions.checkNotNull(updatedJob);
     try {
-      _disp.execCallbacks(new UpdateJobCallback(originalJob, updatedJob));
+      _disp.execCallbacks(new UpdateJobCallback(updatedJob));
     } catch (InterruptedException e) {
       getLog().warn("onUpdateJob interrupted.");
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobCatalogListenerImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobCatalogListenerImpl.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.std;
 
+import java.net.URI;
+
 import org.slf4j.Logger;
 
 import com.google.common.base.Optional;
@@ -50,9 +52,9 @@ public class DefaultJobCatalogListenerImpl implements JobCatalogListener {
   }
 
   /** {@inheritDoc} */
-  @Override public void onDeleteJob(JobSpec deletedJob) {
+  @Override public void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
     if (_log.isPresent()) {
-      _log.get().info("JobSpec deleted: " + deletedJob.toShortString());
+      _log.get().info("JobSpec deleted: " + deletedJobURI + "/" + deletedJobVersion);
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobCatalogListenerImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobCatalogListenerImpl.java
@@ -57,10 +57,9 @@ public class DefaultJobCatalogListenerImpl implements JobCatalogListener {
   }
 
   /** {@inheritDoc} */
-  @Override public void onUpdateJob(JobSpec originalJob, JobSpec updatedJob) {
+  @Override public void onUpdateJob(JobSpec updatedJob) {
     if (_log.isPresent()) {
-      _log.get().info("JobSpec changed: " + originalJob.toShortString() + " --> " +
-             updatedJob.toShortString());
+      _log.get().info("JobSpec changed: " + updatedJob.toShortString());
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobLifecycleListenerImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobLifecycleListenerImpl.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.std;
 
+import java.net.URI;
+
 import org.slf4j.Logger;
 
 import com.google.common.base.Optional;
@@ -52,9 +54,9 @@ public class DefaultJobLifecycleListenerImpl implements JobLifecycleListener {
   }
 
   /** {@inheritDoc} */
-  @Override public void onDeleteJob(JobSpec deletedJob) {
+  @Override public void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
     if (_log.isPresent()) {
-      _log.get().info("JobSpec deleted: " + deletedJob.toShortString());
+      _log.get().info("JobSpec deleted: " + deletedJobURI + "/" + deletedJobVersion);
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobLifecycleListenerImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/DefaultJobLifecycleListenerImpl.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.std;
+
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+
+import gobblin.runtime.JobState.RunningState;
+import gobblin.runtime.api.JobExecutionState;
+import gobblin.runtime.api.JobLifecycleListener;
+import gobblin.runtime.api.JobSpec;
+
+/**
+ * Default NOOP implementation for {@link JobLifecycleListener}. It can log the callbacks. Other
+ * implementing classes can use this as a base to override only the methods they care about.
+ */
+public class DefaultJobLifecycleListenerImpl implements JobLifecycleListener {
+  protected final Optional<Logger> _log;
+
+  /**
+   * Constructor
+   * @param log   if no log is specified, the logging will be done. Logging level is INFO.
+   */
+  public DefaultJobLifecycleListenerImpl(Optional<Logger> log) {
+    _log = log;
+  }
+
+  public DefaultJobLifecycleListenerImpl(Logger log) {
+    this(Optional.of(log));
+  }
+
+  /** Constructor with no logging */
+  public DefaultJobLifecycleListenerImpl() {
+    this(Optional.<Logger>absent());
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onAddJob(JobSpec addedJob) {
+    if (_log.isPresent()) {
+      _log.get().info("New JobSpec detected: " + addedJob.toShortString());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onDeleteJob(JobSpec deletedJob) {
+    if (_log.isPresent()) {
+      _log.get().info("JobSpec deleted: " + deletedJob.toShortString());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onUpdateJob(JobSpec updatedJob) {
+    if (_log.isPresent()) {
+      _log.get().info("JobSpec changed: " +  updatedJob.toShortString());
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onStatusChange(JobExecutionState state, RunningState previousStatus,
+                                       RunningState newStatus) {
+    if (_log.isPresent()) {
+      _log.get().info("JobExection status change for " + state.getJobSpec().toShortString() +
+                      ": " + previousStatus + " --> " + newStatus);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onStageTransition(JobExecutionState state, String previousStage, String newStage) {
+    if (_log.isPresent()) {
+      _log.get().info("JobExection stage change for " + state.getJobSpec().toShortString() +
+                      ": " + previousStage + " --> " + newStage);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onMetadataChange(JobExecutionState state, String key, Object oldValue, Object newValue) {
+    if (_log.isPresent()) {
+      _log.get().info("JobExection metadata change for " + state.getJobSpec().toShortString() +
+                      key + ": '" + oldValue + "' --> '" + newValue + "'");
+    }
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/FilteredJobLifecycleListener.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/FilteredJobLifecycleListener.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.std;
+
+import com.google.common.base.Predicate;
+
+import gobblin.runtime.JobState.RunningState;
+import gobblin.runtime.api.JobExecutionState;
+import gobblin.runtime.api.JobLifecycleListener;
+import gobblin.runtime.api.JobSpec;
+
+import lombok.AllArgsConstructor;
+
+/**
+ * A listener that can delegate to another {@link JobLifecycleListener} only callbacks that
+ * are relevant to a specific Jobs.
+ *
+ */
+@AllArgsConstructor
+public class FilteredJobLifecycleListener implements JobLifecycleListener {
+  private final Predicate<JobSpec> filter;
+  private final JobLifecycleListener delegate;
+
+  /** {@inheritDoc} */
+  @Override public void onAddJob(JobSpec addedJob) {
+    if (this.filter.apply(addedJob)) {
+      this.delegate.onAddJob(addedJob);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onDeleteJob(JobSpec deletedJob) {
+    if (this.filter.apply(deletedJob)) {
+      this.delegate.onDeleteJob(deletedJob);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onUpdateJob(JobSpec updatedJob) {
+    if (this.filter.apply(updatedJob)) {
+      this.delegate.onUpdateJob(updatedJob);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onStatusChange(JobExecutionState state, RunningState previousStatus, RunningState newStatus) {
+    if (this.filter.apply(state.getJobSpec())) {
+      this.delegate.onStatusChange(state, previousStatus, newStatus);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override public void onStageTransition(JobExecutionState state, String previousStage, String newStage) {
+    if (this.filter.apply(state.getJobSpec())) {
+      this.delegate.onStageTransition(state, previousStage, newStage);
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onMetadataChange(JobExecutionState state, String key, Object oldValue, Object newValue) {
+    if (this.filter.apply(state.getJobSpec())) {
+      this.delegate.onMetadataChange(state, key, oldValue, newValue);
+    }
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/FilteredJobLifecycleListener.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/FilteredJobLifecycleListener.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.std;
 
+import java.net.URI;
+
 import com.google.common.base.Predicate;
 
 import gobblin.runtime.JobState.RunningState;
@@ -37,10 +39,15 @@ public class FilteredJobLifecycleListener implements JobLifecycleListener {
     }
   }
 
-  /** {@inheritDoc} */
-  @Override public void onDeleteJob(JobSpec deletedJob) {
-    if (this.filter.apply(deletedJob)) {
-      this.delegate.onDeleteJob(deletedJob);
+  /**
+   * {@inheritDoc}
+   *
+   *  NOTE: For this callback only conditions on the URI and version will be used.
+   * */
+  @Override public void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
+    JobSpec fakeJobSpec = JobSpec.builder(deletedJobURI).withVersion(deletedJobVersion).build();
+    if (this.filter.apply(fakeJobSpec)) {
+      this.delegate.onDeleteJob(deletedJobURI, deletedJobVersion);
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/JobLifecycleListenersList.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/JobLifecycleListenersList.java
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.std;
+
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.runtime.JobState.RunningState;
+import gobblin.runtime.api.JobExecutionState;
+import gobblin.runtime.api.JobLifecycleListener;
+import gobblin.runtime.api.JobLifecycleListenersContainer;
+import gobblin.runtime.api.JobSpec;
+import gobblin.util.callbacks.CallbacksDispatcher;
+
+/**
+ * A default implementation to manage a list of {@link JobLifecycleListener}
+ *
+ */
+public class JobLifecycleListenersList implements JobLifecycleListener, JobLifecycleListenersContainer {
+  private final CallbacksDispatcher<JobLifecycleListener> _dispatcher;
+
+  public JobLifecycleListenersList(Optional<ExecutorService> execService,
+                                    Optional<Logger> log) {
+    _dispatcher = new CallbacksDispatcher<>(execService, log);
+  }
+
+  public JobLifecycleListenersList(Logger log) {
+    _dispatcher = new CallbacksDispatcher<>(log);
+  }
+
+  public JobLifecycleListenersList() {
+    _dispatcher = new CallbacksDispatcher<>();
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onAddJob(JobSpec addedJob) {
+    Preconditions.checkNotNull(addedJob);
+    try {
+      _dispatcher.execCallbacks(new AddJobCallback(addedJob));
+    } catch (InterruptedException e) {
+      _dispatcher.getLog().warn("onAddJob interrupted.");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onDeleteJob(JobSpec deletedJob) {
+    Preconditions.checkNotNull(deletedJob);
+    try {
+      _dispatcher.execCallbacks(new DeleteJobCallback(deletedJob));
+    } catch (InterruptedException e) {
+      _dispatcher.getLog().warn("onDeleteJob interrupted.");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onUpdateJob(JobSpec updatedJob) {
+    Preconditions.checkNotNull(updatedJob);
+    try {
+      _dispatcher.execCallbacks(new UpdateJobCallback(updatedJob));
+    } catch (InterruptedException e) {
+      _dispatcher.getLog().warn("onUpdateJob interrupted.");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onStatusChange(JobExecutionState state, RunningState previousStatus,
+      RunningState newStatus) {
+    try {
+      _dispatcher.execCallbacks(new StatusChangeCallback(state, previousStatus, newStatus));
+    } catch (InterruptedException e) {
+      _dispatcher.getLog().warn("onStatusChange interrupted.");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onStageTransition(JobExecutionState state, String previousStage, String newStage) {
+    try {
+      _dispatcher.execCallbacks(new StageTransitionCallback(state, previousStage, newStage));
+    } catch (InterruptedException e) {
+      _dispatcher.getLog().warn("onStageTransition interrupted.");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void onMetadataChange(JobExecutionState state, String key, Object oldValue, Object newValue) {
+    try {
+      _dispatcher.execCallbacks(new MetadataChangeCallback(state, key, oldValue, newValue));
+    } catch (InterruptedException e) {
+      _dispatcher.getLog().warn("onMetadataChange interrupted.");
+    }
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void registerJobLifecycleListener(JobLifecycleListener listener) {
+    _dispatcher.addListener(listener);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public void unregisterJobLifecycleListener(JobLifecycleListener listener) {
+    _dispatcher.removeListener(listener);
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public List<JobLifecycleListener> getJobLifecycleListeners() {
+    return _dispatcher.getListeners();
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/JobLifecycleListenersList.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/JobLifecycleListenersList.java
@@ -11,6 +11,7 @@
  */
 package gobblin.runtime.std;
 
+import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -59,10 +60,10 @@ public class JobLifecycleListenersList implements JobLifecycleListener, JobLifec
 
   /** {@inheritDoc} */
   @Override
-  public void onDeleteJob(JobSpec deletedJob) {
-    Preconditions.checkNotNull(deletedJob);
+  public void onDeleteJob(URI deletedJobURI, String deletedJobVersion) {
+    Preconditions.checkNotNull(deletedJobURI);
     try {
-      _dispatcher.execCallbacks(new DeleteJobCallback(deletedJob));
+      _dispatcher.execCallbacks(new DeleteJobCallback(deletedJobURI, deletedJobVersion));
     } catch (InterruptedException e) {
       _dispatcher.getLog().warn("onDeleteJob interrupted.");
     }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestInMemoryJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestInMemoryJobCatalog.java
@@ -36,7 +36,7 @@ public class TestInMemoryJobCatalog {
     Mockito.verify(l).onUpdateJob(Mockito.eq(js1_2));
     Mockito.verify(l).onAddJob(Mockito.eq(js2));
     Mockito.verify(l).onUpdateJob(Mockito.eq(js1_3));
-    Mockito.verify(l).onDeleteJob(Mockito.eq(js2));
+    Mockito.verify(l).onDeleteJob(Mockito.eq(js2.getUri()), Mockito.eq(js2.getVersion()));
 
     Mockito.verifyNoMoreInteractions(l);
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestInMemoryJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestInMemoryJobCatalog.java
@@ -7,7 +7,6 @@ import org.testng.annotations.Test;
 
 import gobblin.runtime.api.JobCatalogListener;
 import gobblin.runtime.api.JobSpec;
-import gobblin.runtime.job_catalog.InMemoryJobCatalog;
 
 /** Unit tests for {@link InMemoryJobCatalog} */
 public class TestInMemoryJobCatalog {
@@ -34,9 +33,9 @@ public class TestInMemoryJobCatalog {
     cat.remove(js1_3.getUri());
 
     Mockito.verify(l).onAddJob(Mockito.eq(js1_1));
-    Mockito.verify(l).onUpdateJob(Mockito.eq(js1_1), Mockito.eq(js1_2));
+    Mockito.verify(l).onUpdateJob(Mockito.eq(js1_2));
     Mockito.verify(l).onAddJob(Mockito.eq(js2));
-    Mockito.verify(l).onUpdateJob(Mockito.eq(js1_2), Mockito.eq(js1_3));
+    Mockito.verify(l).onUpdateJob(Mockito.eq(js1_3));
     Mockito.verify(l).onDeleteJob(Mockito.eq(js2));
 
     Mockito.verifyNoMoreInteractions(l);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestJobCatalogListenersList.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestJobCatalogListenersList.java
@@ -5,7 +5,6 @@ import org.testng.annotations.Test;
 
 import gobblin.runtime.api.JobCatalogListener;
 import gobblin.runtime.api.JobSpec;
-import gobblin.runtime.job_catalog.JobCatalogListenersList;
 
 /** Unit tests for {@link JobCatalogListenersList} */
 public class TestJobCatalogListenersList {
@@ -22,7 +21,7 @@ public class TestJobCatalogListenersList {
     Mockito.doThrow(new RuntimeException("injected l1 failure")).when(l1).onDeleteJob(Mockito.eq(js2));
 
     JobCatalogListener l2 = Mockito.mock(JobCatalogListener.class);
-    Mockito.doThrow(new RuntimeException("injected l2 failure")).when(l2).onUpdateJob(Mockito.eq(js1_1), Mockito.eq(js1_2));
+    Mockito.doThrow(new RuntimeException("injected l2 failure")).when(l2).onUpdateJob(Mockito.eq(js1_2));
 
     JobCatalogListener l3 = Mockito.mock(JobCatalogListener.class);
     Mockito.doThrow(new RuntimeException("injected l3 failure")).when(l3).onAddJob(Mockito.eq(js2));
@@ -33,22 +32,22 @@ public class TestJobCatalogListenersList {
 
     ll.onAddJob(js1_1);
     ll.onAddJob(js2);
-    ll.onUpdateJob(js1_1, js1_2);
+    ll.onUpdateJob(js1_2);
     ll.onDeleteJob(js2);
 
     Mockito.verify(l1).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l1).onAddJob(Mockito.eq(js2));
-    Mockito.verify(l1).onUpdateJob(Mockito.eq(js1_1), Mockito.eq(js1_2));
+    Mockito.verify(l1).onUpdateJob(Mockito.eq(js1_2));
     Mockito.verify(l1).onDeleteJob(Mockito.eq(js2));
 
     Mockito.verify(l2).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l2).onAddJob(Mockito.eq(js2));
-    Mockito.verify(l2).onUpdateJob(Mockito.eq(js1_1), Mockito.eq(js1_2));
+    Mockito.verify(l2).onUpdateJob(Mockito.eq(js1_2));
     Mockito.verify(l2).onDeleteJob(Mockito.eq(js2));
 
     Mockito.verify(l3).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l3).onAddJob(Mockito.eq(js2));
-    Mockito.verify(l3).onUpdateJob(Mockito.eq(js1_1), Mockito.eq(js1_2));
+    Mockito.verify(l3).onUpdateJob(Mockito.eq(js1_2));
     Mockito.verify(l3).onDeleteJob(Mockito.eq(js2));
 
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestJobCatalogListenersList.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestJobCatalogListenersList.java
@@ -18,7 +18,8 @@ public class TestJobCatalogListenersList {
     JobSpec js2 = JobSpec.builder("test:job2").build();
 
     JobCatalogListener l1 = Mockito.mock(JobCatalogListener.class);
-    Mockito.doThrow(new RuntimeException("injected l1 failure")).when(l1).onDeleteJob(Mockito.eq(js2));
+    Mockito.doThrow(new RuntimeException("injected l1 failure")).when(l1)
+        .onDeleteJob(Mockito.eq(js2.getUri()), Mockito.eq(js2.getVersion()));
 
     JobCatalogListener l2 = Mockito.mock(JobCatalogListener.class);
     Mockito.doThrow(new RuntimeException("injected l2 failure")).when(l2).onUpdateJob(Mockito.eq(js1_2));
@@ -33,22 +34,22 @@ public class TestJobCatalogListenersList {
     ll.onAddJob(js1_1);
     ll.onAddJob(js2);
     ll.onUpdateJob(js1_2);
-    ll.onDeleteJob(js2);
+    ll.onDeleteJob(js2.getUri(), js2.getVersion());
 
     Mockito.verify(l1).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l1).onAddJob(Mockito.eq(js2));
     Mockito.verify(l1).onUpdateJob(Mockito.eq(js1_2));
-    Mockito.verify(l1).onDeleteJob(Mockito.eq(js2));
+    Mockito.verify(l1).onDeleteJob(Mockito.eq(js2.getUri()), Mockito.eq(js2.getVersion()));
 
     Mockito.verify(l2).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l2).onAddJob(Mockito.eq(js2));
     Mockito.verify(l2).onUpdateJob(Mockito.eq(js1_2));
-    Mockito.verify(l2).onDeleteJob(Mockito.eq(js2));
+    Mockito.verify(l2).onDeleteJob(Mockito.eq(js2.getUri()), Mockito.eq(js2.getVersion()));
 
     Mockito.verify(l3).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l3).onAddJob(Mockito.eq(js2));
     Mockito.verify(l3).onUpdateJob(Mockito.eq(js1_2));
-    Mockito.verify(l3).onDeleteJob(Mockito.eq(js2));
+    Mockito.verify(l3).onDeleteJob(Mockito.eq(js2.getUri()), Mockito.eq(js2.getVersion()));
 
 
     Mockito.verifyNoMoreInteractions(l1, l2, l3);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
@@ -82,7 +82,7 @@ public class TestMutableCachingJobCatalog {
 
     Mockito.verify(l).onAddJob(Mockito.eq(js1_1));
     Mockito.verify(l).onUpdateJob(Mockito.eq(js1_2));
-    Mockito.verify(l).onDeleteJob(Mockito.eq(js1_2));
+    Mockito.verify(l).onDeleteJob(Mockito.eq(js1_2.getUri()), Mockito.eq(js1_2.getVersion()));
 
     Mockito.verifyNoMoreInteractions(l);
   }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
@@ -24,9 +24,6 @@ import com.google.common.base.Optional;
 import gobblin.runtime.api.JobCatalogListener;
 import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.api.JobSpecNotFoundException;
-import gobblin.runtime.job_catalog.CachingJobCatalog;
-import gobblin.runtime.job_catalog.InMemoryJobCatalog;
-import gobblin.runtime.job_catalog.MutableCachingJobCatalog;
 
 /** Unit tests for {@link CachingJobCatalog} and {@link MutableCachingJobCatalog} */
 public class TestMutableCachingJobCatalog {
@@ -84,7 +81,7 @@ public class TestMutableCachingJobCatalog {
     }
 
     Mockito.verify(l).onAddJob(Mockito.eq(js1_1));
-    Mockito.verify(l).onUpdateJob(Mockito.eq(js1_1), Mockito.eq(js1_2));
+    Mockito.verify(l).onUpdateJob(Mockito.eq(js1_2));
     Mockito.verify(l).onDeleteJob(Mockito.eq(js1_2));
 
     Mockito.verifyNoMoreInteractions(l);

--- a/gobblin-utility/src/main/java/gobblin/util/callbacks/CallbacksDispatcher.java
+++ b/gobblin-utility/src/main/java/gobblin/util/callbacks/CallbacksDispatcher.java
@@ -95,7 +95,7 @@ public class CallbacksDispatcher<L> {
   public Logger getLog() {
     return _log;
   }
-  public <R> CallbackResults<L, R> execCallbacks(Function<L, R> callback, L listener)
+  public <R> CallbackResults<L, R> execCallbacks(Function<? super L, R> callback, L listener)
          throws InterruptedException {
     Preconditions.checkNotNull(listener);
     List<L> listenerList = new ArrayList<>(1);
@@ -104,7 +104,7 @@ public class CallbacksDispatcher<L> {
     return execCallbacks(callback, listenerList);
   }
 
-  public <R> CallbackResults<L, R> execCallbacks(Function<L, R> callback)
+  public <R> CallbackResults<L, R> execCallbacks(Function<? super L, R> callback)
          throws InterruptedException {
     Preconditions.checkNotNull(callback);
     List<L> listeners = getListeners();
@@ -112,7 +112,8 @@ public class CallbacksDispatcher<L> {
     return execCallbacks(callback, listeners);
   }
 
-  private <R> CallbackResults<L, R> execCallbacks(Function<L, R> callback, List<L> listeners)
+  private <R> CallbackResults<L, R> execCallbacks(Function<? super L, R> callback,
+                                                          List<L> listeners)
       throws InterruptedException {
     List<Callable<R>> callbacks = new ArrayList<>(listeners.size());
     for (L listener: listeners) {
@@ -142,7 +143,7 @@ public class CallbacksDispatcher<L> {
 
   @AllArgsConstructor
   public class CallbackCallable<R> implements Callable<R> {
-    final Function<L, R> _callback;
+    final Function<? super L, R> _callback;
     final L _listener;
 
     @Override public R call() throws Exception {

--- a/gobblin-utility/src/test/java/gobblin/util/callbacks/TestCallbacksDispatcher.java
+++ b/gobblin-utility/src/test/java/gobblin/util/callbacks/TestCallbacksDispatcher.java
@@ -59,7 +59,8 @@ public class TestCallbacksDispatcher {
     disp1.addListener(l3);
 
     final VoidCallback voidCallback = new VoidCallback();
-    CallbacksDispatcher.CallbackResults<MyListener, Void> voidRes = disp1.execCallbacks(voidCallback);
+    CallbacksDispatcher.CallbackResults<MyListener, Void> voidRes =
+        disp1.execCallbacks(voidCallback);
     Assert.assertEquals(voidRes.getSuccesses().size(), 2);
     Assert.assertEquals(voidRes.getFailures().size(), 1);
     Assert.assertEquals(voidRes.getCancellations().size(), 0);


### PR DESCRIPTION
* Removing originalJob from JobCatalogListener.onUpdatedJob() -- this touches a lot of files
* Adding JobLifecycleListener interface and related classes
  - JobLifecycleListenersContainer interface
  - Extending GobblinInstanceDriver with the JobLifecycleListenersContainer interface
  - DefaultJobLifecycleListenerImpl - default no-op implementation
  - JobLifecycleListenersList - default JobLifecycleListenersContainer implementation

@ibuenros @autumnust can you review?