### PR TITLE
Fix SchedulerUtils bugs for loading config file on hdfs

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -189,6 +189,7 @@ public class JobContext {
 
     Preconditions.checkState(this.jobState.contains(FsCommitSequenceStore.GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_DIR));
 
+    // TODO: Filesystem should not be in try-with-resource block
     try (FileSystem fs = FileSystem.get(URI.create(this.jobState
         .getProp(FsCommitSequenceStore.GOBBLIN_RUNTIME_COMMIT_SEQUENCE_STORE_FS_URI, ConfigurationKeys.LOCAL_FS_URI)),
         HadoopUtils.getConfFromState(this.jobState))) {

--- a/gobblin-utility/src/main/java/gobblin/util/filesystem/FileStatusEntry.java
+++ b/gobblin-utility/src/main/java/gobblin/util/filesystem/FileStatusEntry.java
@@ -37,29 +37,28 @@ public class FileStatusEntry extends FileStatus {
 
   public boolean refresh(final Path path)
       throws IOException {
-    try (FileSystem fs = path.getFileSystem(new Configuration())) {
-      if (_fileStatus.isPresent()) {
-        Optional<FileStatus> oldStatus = this._fileStatus;
-        try {
-          Optional<FileStatus> newStatus = Optional.of(fs.getFileStatus(path));
-          this.exists = newStatus.isPresent();
-          return (oldStatus.isPresent() != this._fileStatus.isPresent()
-              || oldStatus.get().getModificationTime() != newStatus.get().getModificationTime()
-              || oldStatus.get().isDirectory() != newStatus.get().isDirectory() || oldStatus.get().getLen() != newStatus
-              .get()
-              .getLen());
-        } catch (FileNotFoundException e) {
-          _fileStatus = Optional.absent();
-          this.exists = false;
-          return true;
-        }
+    FileSystem fs = FileSystem.get(new Configuration());
+    if (_fileStatus.isPresent()) {
+      Optional<FileStatus> oldStatus = this._fileStatus;
+      try {
+        Optional<FileStatus> newStatus = Optional.of(fs.getFileStatus(path));
+        this.exists = newStatus.isPresent();
+        return (oldStatus.isPresent() != this._fileStatus.isPresent()
+            || oldStatus.get().getModificationTime() != newStatus.get().getModificationTime()
+            || oldStatus.get().isDirectory() != newStatus.get().isDirectory() || oldStatus.get().getLen() != newStatus
+            .get()
+            .getLen());
+      } catch (FileNotFoundException e) {
+        _fileStatus = Optional.absent();
+        this.exists = false;
+        return true;
+      }
+    } else {
+      if (path.getFileSystem(new Configuration()).exists(path)) {
+        _fileStatus = Optional.of(fs.getFileStatus(path));
+        return true;
       } else {
-        if (path.getFileSystem(new Configuration()).exists(path)) {
-          _fileStatus = Optional.of(fs.getFileStatus(path));
-          return true;
-        } else {
-          return false;
-        }
+        return false;
       }
     }
   }


### PR DESCRIPTION
bugs appeared when testing on Azkaban. (try-with-resources one and loading a single config file one) Could you help for the review? @ibuenros   

--- 
Bugs detail: 
- In `SchedulerUtils.java: loadGenericJobConfig `  method, the loading of single configuration file process is buggy, as it hard coded  "file://" prefix which is not compatible for file system except local fs. The solution is to change it to use `PropertiesConfiguration` object for loading a `inputStream` instead. 

- The instance of FileSystem will be closed with try-with-resources implementation, which is not expected for periodically running scenario. May need to redesign this later.
