### PR TITLE
Bug fix - Retention does not blacklist dataset

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/ConfigurableCleanableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/ConfigurableCleanableDataset.java
@@ -103,7 +103,7 @@ public class ConfigurableCleanableDataset<T extends FileSystemDatasetVersion>
   public ConfigurableCleanableDataset(FileSystem fs, Properties jobProps, Path datasetRoot, Config config, Logger log)
       throws IOException {
 
-    super(fs, jobProps, log);
+    super(fs, jobProps, config, log);
     this.datasetRoot = datasetRoot;
     this.versionFindersAndPolicies = Lists.newArrayList();
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import org.apache.hadoop.fs.FileSystem;
 import org.slf4j.Logger;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
@@ -138,6 +139,8 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
   @Deprecated
   protected final ProxiedTrash trash;
 
+  @Getter
+  @VisibleForTesting
   protected final boolean isDatasetBlacklisted;
 
   private final FsCleanableHelper fsCleanableHelper;
@@ -179,8 +182,11 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
   }
 
   public MultiVersionCleanableDatasetBase(final FileSystem fs, final Properties props, Logger log) throws IOException {
-    this(fs, props, ConfigFactory
-        .parseMap(ImmutableMap.<String, String> of(IS_DATASET_BLACKLISTED_KEY, IS_DATASET_BLACKLISTED_DEFAULT)), log);
+    // This constructor is used by retention jobs configured through job configs and do not use dataset configs from config store.
+    // IS_DATASET_BLACKLISTED_KEY is only available with dataset config. Hence set IS_DATASET_BLACKLISTED_KEY to default
+    // ...false for jobs running with job configs
+    this(fs, props, ConfigFactory.parseMap(ImmutableMap.<String, String> of(IS_DATASET_BLACKLISTED_KEY,
+        IS_DATASET_BLACKLISTED_DEFAULT)), log);
   }
 
   /**

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/ConfigurableCleanableDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/ConfigurableCleanableDatasetTest.java
@@ -54,6 +54,7 @@ public class ConfigurableCleanableDatasetTest {
 
     Assert.assertEquals(dataset.getVersionFindersAndPolicies().get(0).getVersionSelectionPolicy().getClass(), EmbeddedRetentionSelectionPolicy.class);
     Assert.assertEquals(dataset.getVersionFindersAndPolicies().get(0).getVersionFinder().getClass(), WatermarkDatasetVersionFinder.class);
+    Assert.assertEquals(dataset.isDatasetBlacklisted(), false);
   }
 
   @Test
@@ -72,6 +73,7 @@ public class ConfigurableCleanableDatasetTest {
 
     Assert.assertEquals(dataset.getVersionFindersAndPolicies().get(0).getVersionSelectionPolicy().getClass(), NewestKSelectionPolicy.class);
     Assert.assertEquals(dataset.getVersionFindersAndPolicies().get(0).getVersionFinder().getClass(), WatermarkDatasetVersionFinder.class);
+    Assert.assertEquals(dataset.isDatasetBlacklisted(), false);
   }
 
   @Test
@@ -93,5 +95,24 @@ public class ConfigurableCleanableDatasetTest {
 
     Assert.assertEquals(dataset.getVersionFindersAndPolicies().get(1).getVersionSelectionPolicy().getClass(), NewestKSelectionPolicy.class);
     Assert.assertEquals(dataset.getVersionFindersAndPolicies().get(1).getVersionFinder().getClass(), WatermarkDatasetVersionFinder.class);
+    Assert.assertEquals(dataset.isDatasetBlacklisted(), false);
+  }
+
+  @Test
+  public void testDatasetIsBlacklisted() throws Exception {
+
+    Config conf =
+        ConfigFactory.parseMap(ImmutableMap.<String, String> of("gobblin.retention.version.finder.class",
+            "gobblin.data.management.version.finder.WatermarkDatasetVersionFinder",
+            "gobblin.retention.selection.policy.class",
+            "gobblin.data.management.policy.NewestKSelectionPolicy",
+            "gobblin.retention.selection.newestK.versionsSelected", "2",
+            "gobblin.retention.dataset.is.blacklisted", "true"));
+
+    ConfigurableCleanableDataset<FileSystemDatasetVersion> dataset =
+        new ConfigurableCleanableDataset<FileSystemDatasetVersion>(FileSystem.get(new URI(ConfigurationKeys.LOCAL_FS_URI),
+            new Configuration()), new Properties(), new Path("/someroot"), conf, LoggerFactory.getLogger(ConfigurableCleanableDatasetTest.class));
+
+    Assert.assertEquals(dataset.isDatasetBlacklisted(), true);
   }
 }


### PR DESCRIPTION
## Root cause ##
```ConfigurableCleanableDataset``` was calling the incorrect super constructor ```super(fs, jobProps, log)``` instead of ```super(fs, jobProps, config, log)```

## Impact ##
When retention job is configured through config store, each dataset can be blacklisted by setting ```gobblin.retention.is.blacklisted=true```. Since the wrong constructor was being called, this value was never passed to the super class. Hence the dataset was not blacklisted.

@chavdar can you review?