### PR TITLE
AvroToorc - Implemented a per partition watermark

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -91,7 +91,7 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
   /**
    * list of partitions that a partition has replaced. E.g. list of hourly partitons for a daily partition
    */
-  private static final String REPLACED_PARTITIONS_HIVE_METASTORE_KEY = "gobblin.replaced.partitions";
+  public static final String REPLACED_PARTITIONS_HIVE_METASTORE_KEY = "gobblin.replaced.partitions";
 
   /**
    * The dataset being converted.
@@ -459,21 +459,28 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     return orcDataLocation + Path.SEPARATOR + orcStagingTableName;
   }
 
-  /**
-   * Parse the {@link #REPLACED_PARTITIONS_HIVE_METASTORE_KEY} from partition parameters to returns DDLs for all the partitions to be
-   * dropped.
-   */
+
   @VisibleForTesting
   public static List<Map<String, String>> getDropPartitionsDDLInfo(QueryBasedHiveConversionEntity conversionEntity) {
     if (!conversionEntity.getHivePartition().isPresent()) {
       return Collections.emptyList();
     }
 
-    Table table = conversionEntity.getHiveTable().getTTable();
-    Partition hivePartition = conversionEntity.getHivePartition().get();
+    return getDropPartitionsDDLInfo(conversionEntity.getHivePartition().get());
 
+  }
+
+  /**
+   * Parse the {@link #REPLACED_PARTITIONS_HIVE_METASTORE_KEY} from partition parameters to returns DDLs for all the partitions to be
+   * dropped.
+   *
+   * @return A {@link List} of partitions to be dropped. Each element of the list is a {@link Map} which maps a partition's
+   * key and value.
+   *
+   */
+  public static List<Map<String, String>> getDropPartitionsDDLInfo(Partition hivePartition) {
     List<Map<String, String>> replacedPartitionsDDLInfo = Lists.newArrayList();
-    List<FieldSchema> partitionKeys = table.getPartitionKeys();
+    List<FieldSchema> partitionKeys = hivePartition.getTable().getPartitionKeys();
 
     if (StringUtils.isNotBlank(hivePartition.getParameters().get(REPLACED_PARTITIONS_HIVE_METASTORE_KEY))) {
 
@@ -493,7 +500,6 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
         }
       }
     }
-
     return replacedPartitionsDDLInfo;
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/provider/UpdateNotFoundException.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/provider/UpdateNotFoundException.java
@@ -14,7 +14,7 @@ package gobblin.data.management.conversion.hive.provider;
 /**
  * An exception when {@link HiveUnitUpdateProvider} can not find updates
  */
-public class UpdateNotFoundException extends Exception {
+public class UpdateNotFoundException extends RuntimeException {
 
   private static final long serialVersionUID = -3750962295968867238L;
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/query/HiveAvroORCQueryGenerator.java
@@ -912,8 +912,10 @@ public class HiveAvroORCQueryGenerator {
    * @return Publish table entity.
    */
   public static QueryBasedHivePublishEntity deserializePublishCommands(State state) {
-    return GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_TABLE_COMMANDS),
-        QueryBasedHivePublishEntity.class);
+    QueryBasedHivePublishEntity queryBasedHivePublishEntity =
+        GSON.fromJson(state.getProp(HiveAvroORCQueryGenerator.SERIALIZED_PUBLISH_TABLE_COMMANDS),
+            QueryBasedHivePublishEntity.class);
+    return queryBasedHivePublishEntity == null ? new QueryBasedHivePublishEntity() : queryBasedHivePublishEntity;
   }
 
   public static boolean isTypeEvolved(String evolvedType, String destinationType) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/HiveSourceWatermarker.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/HiveSourceWatermarker.java
@@ -11,10 +11,17 @@
  */
 package gobblin.data.management.conversion.hive.watermarker;
 
+import java.util.List;
+
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.source.HiveSource;
+import gobblin.publisher.DataPublisher;
 import gobblin.source.extractor.extract.LongWatermark;
+import gobblin.source.workunit.WorkUnit;
+
 
 /**
  * An interface to read previous high watermarks and write new high watermarks to state.
@@ -22,13 +29,63 @@ import gobblin.source.extractor.extract.LongWatermark;
 public interface HiveSourceWatermarker {
 
   /**
-   * Get high watermark from previous execution for a {@link Table}
+   * Get high watermark for a {@link Table}. This API is used by the {@link HiveSource} for Non Partitioned hive tables
+   * @param table for which a high watermark needs to be returned
    */
   public LongWatermark getPreviousHighWatermark(Table table);
 
   /**
-   * Get high watermark from previous execution for a {@link Partition}
+   * Get high watermark for a {@link Partition}. This API is used by the {@link HiveSource} for Partitioned hive tables
+   * @param partition for which a high watermark needs to be returned
    */
   public LongWatermark getPreviousHighWatermark(Partition partition);
 
+  /**
+   * Get the expected high watermark for a {@link Table}. This API is used by the {@link HiveSource} to get Expected
+   * high watermark for Non Partitioned hive tables
+   *
+   * @param table for which a high watermark needs to be returned
+   * @param tableProcessTime time at which workunit creation started for this table
+   */
+  public LongWatermark getExpectedHighWatermark(Table table, long tableProcessTime);
+
+  /**
+   * Get the expected high watermark for a {@link Partition}.This API is used by the {@link HiveSource} for Partitioned hive tables
+   *
+   * @param partition for which a high watermark needs to be returned
+   * @param tableProcessTime time at which workunit creation started for table this partition belongs to
+   * @param partitionProcessTime time at which workunit creation started for this partition
+   */
+  public LongWatermark getExpectedHighWatermark(Partition partition, long tableProcessTime, long partitionProcessTime);
+
+  /**
+   * A callback method that {@link HiveSource} executes when workunit creation for a {@link Table} is started.
+   *
+   * @param table for which {@link WorkUnit}s will be created
+   * @param tableProcessTime time at which this callback was called
+   */
+  public void onTableProcessBegin(Table table, long tableProcessTime);
+
+  /**
+   * A callback method that {@link HiveSource} executes when workunit creation for a {@link Partition} is started.
+   *
+   * @param partition for which {@link WorkUnit} will be created
+   * @param partitionProcessTime time at which this callback was executed
+   * @param partitionUpdateTime time at which this partition was updated
+   */
+  public void onPartitionProcessBegin(Partition partition, long partitionProcessTime, long partitionUpdateTime);
+
+  /**
+   * A callback method executed before a list of workunits is returned by the
+   * {@link HiveSource#getWorkunits(gobblin.configuration.SourceState)} to the caller
+   *
+   * @param workunits constructed by {@link HiveSource#getWorkunits(gobblin.configuration.SourceState)}
+   */
+  public void onGetWorkunitsEnd(List<WorkUnit> workunits);
+
+  /**
+   * Sets the actual high watermark after data has been published by the {@link DataPublisher}
+   * @param wus to set the watermark
+   */
+  public void setActualHighWatermark(WorkUnitState wus);
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/HiveSourceWatermarkerFactory.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/HiveSourceWatermarkerFactory.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.watermarker;
+
+import gobblin.configuration.State;
+
+/**
+ * An interface for creating new {@link HiveSourceWatermarker}s
+ */
+public interface HiveSourceWatermarkerFactory {
+  /**
+   * Create new {@link HiveSourceWatermarker} from {@link State}
+   */
+  public HiveSourceWatermarker createFromState(State state);
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/MultiKeyValueLongWatermark.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/MultiKeyValueLongWatermark.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.watermarker;
+
+import java.math.RoundingMode;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
+import com.google.common.math.LongMath;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+import gobblin.source.extractor.Watermark;
+
+
+/**
+ * A {@link Watermark} that holds multiple key value watermarks. Neither the key nor the value can be null
+ * It is backed by a {@link ConcurrentHashMap}.
+ */
+public class MultiKeyValueLongWatermark implements Watermark {
+
+  private static final Gson GSON = new Gson();
+
+  @Getter(AccessLevel.PACKAGE)
+  private final Map<String, Long> watermarks;
+
+  public MultiKeyValueLongWatermark() {
+    this.watermarks = Maps.newConcurrentMap();
+  }
+
+  public MultiKeyValueLongWatermark(Map<String, Long> watermarks) {
+    this.watermarks = watermarks == null ? Maps.<String, Long> newConcurrentMap() : new ConcurrentHashMap<>(watermarks);
+  }
+
+  @Override
+  public JsonElement toJson() {
+    return GSON.toJsonTree(this);
+  }
+
+  @Override
+  public short calculatePercentCompletion(Watermark lowWatermark, Watermark highWatermark) {
+    Preconditions.checkArgument(
+        lowWatermark instanceof MultiKeyValueLongWatermark && highWatermark instanceof MultiKeyValueLongWatermark,
+        String.format("lowWatermark and highWatermark are not instances of %s",
+            MultiKeyValueLongWatermark.class.getSimpleName()));
+    MultiKeyValueLongWatermark low = (MultiKeyValueLongWatermark) lowWatermark;
+    MultiKeyValueLongWatermark high = (MultiKeyValueLongWatermark) highWatermark;
+
+    long total = 0;
+    long pulled = 0;
+    for (Map.Entry<String, Long> entry : low.watermarks.entrySet()) {
+      if (high.watermarks.containsKey(entry.getKey())) {
+        total += (high.watermarks.get(entry.getKey()) - entry.getValue());
+      }
+    }
+
+    for (Map.Entry<String, Long> entry : low.watermarks.entrySet()) {
+      if (this.watermarks.containsKey(entry.getKey())) {
+        pulled += (this.watermarks.get(entry.getKey()) - entry.getValue());
+      }
+    }
+
+    if (pulled > total) {
+      return 100;
+    }
+
+    return (short) LongMath.divide(pulled * 100, total, RoundingMode.CEILING);
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
@@ -1,0 +1,387 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.watermarker;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import javax.annotation.Nonnull;
+
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.joda.time.DateTime;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Function;
+import com.google.common.base.Joiner;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
+import com.google.common.collect.Collections2;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.converter.AbstractAvroToOrcConverter;
+import gobblin.data.management.conversion.hive.provider.HiveUnitUpdateProvider;
+import gobblin.data.management.conversion.hive.provider.UpdateNotFoundException;
+import gobblin.data.management.conversion.hive.provider.UpdateProviderFactory;
+import gobblin.data.management.conversion.hive.source.HiveSource;
+import gobblin.source.extractor.Watermark;
+import gobblin.source.extractor.WatermarkInterval;
+import gobblin.source.extractor.extract.LongWatermark;
+import gobblin.source.workunit.WorkUnit;
+
+
+/**
+ * A {@link HiveSourceWatermarker} that maintains watermarks for each {@link Partition}. For every {@link Table} it creates
+ *  a NoOp {@link WorkUnit} that stores watermarks for all its {@link Partition}s. The Noop workunit is identified by the
+ *  property {@link #IS_WATERMARK_WORKUNIT_KEY} being set to true.
+ *  <p>
+ *  The watermark used is the update time of a {@link Partition} (for partitioned tables)
+ *  or update time of a {@link Table} (for non partitioned tables).
+ *  </p>
+ *  <p>
+ *  The watermark is stored as a {@link MultiKeyValueLongWatermark} which is an extension to {@link Map} that implements
+ *  gobblin's {@link Watermark}. The key is a {@link Partition} identifier and value is the watermark for this {@link Partition}
+ *  </p>
+ *  <p>
+ *  Watermarks for all {@link Partition}s modified after {@link HiveSource#HIVE_SOURCE_MAXIMUM_LOOKBACK_DAYS_KEY} are retained.
+ *  The default is {@link HiveSource#DEFAULT_HIVE_SOURCE_MAXIMUM_LOOKBACK_DAYS}. If a previous watermark is not found for
+ *  as partition, it returns 0 as the watermark
+ *  </p>
+ */
+@Slf4j
+public class PartitionLevelWatermarker implements HiveSourceWatermarker {
+
+  public static final String IS_WATERMARK_WORKUNIT_KEY = "hive.source.watermark.isWatermarkWorkUnit";
+
+  private static final Joiner PARTITION_VALUES_JOINER = Joiner.on(",");
+
+  static final Predicate<WorkUnitState> WATERMARK_WORKUNIT_PREDICATE = new Predicate<WorkUnitState>() {
+    @Override
+    public boolean apply(@Nonnull WorkUnitState input) {
+      return input.contains(IS_WATERMARK_WORKUNIT_KEY);
+    }
+  };
+
+  private final long leastWatermarkToPersistInState;
+  // Keep an additional 2 days of updates
+  private static int BUFFER_WATERMARK_DAYS_TO_PERSIST = 2;
+
+  /**
+   * Watermarks from previous state
+   */
+  @Getter(AccessLevel.PACKAGE)
+  @VisibleForTesting
+  private final TableWatermarks previousWatermarks;
+
+  /**
+   * Current expected watermarks
+   */
+  @Getter(AccessLevel.PACKAGE)
+  @VisibleForTesting
+  private final TableWatermarks expectedHighWatermarks;
+
+  /**
+   * Delegates watermarking logic to {@link TableLevelWatermarker} for Non partitioned tables
+   */
+  private final TableLevelWatermarker tableLevelWatermarker;
+
+  private final HiveUnitUpdateProvider updateProvider;
+
+  /**
+   * Reads and initialized the previous high watermarks from {@link SourceState#getPreviousDatasetStatesByUrns()}
+   */
+  public PartitionLevelWatermarker(State state) {
+
+    this.expectedHighWatermarks = new TableWatermarks();
+    this.previousWatermarks = new TableWatermarks();
+    this.tableLevelWatermarker = new TableLevelWatermarker(state);
+    this.updateProvider = UpdateProviderFactory.create(state);
+
+    int maxLookBackDays =
+        state.getPropAsInt(HiveSource.HIVE_SOURCE_MAXIMUM_LOOKBACK_DAYS_KEY,
+            HiveSource.DEFAULT_HIVE_SOURCE_MAXIMUM_LOOKBACK_DAYS) + BUFFER_WATERMARK_DAYS_TO_PERSIST;
+
+    this.leastWatermarkToPersistInState = new DateTime().minusDays(maxLookBackDays).getMillis();
+
+    // Load previous watermarks in case of sourceState
+    if (state instanceof SourceState) {
+      SourceState sourceState = (SourceState) state;
+
+      for (Map.Entry<String, Iterable<WorkUnitState>> datasetWorkUnitStates : sourceState
+          .getPreviousWorkUnitStatesByDatasetUrns().entrySet()) {
+
+        List<WorkUnitState> watermarkWorkUnits =
+            Lists.newArrayList(Iterables.filter(datasetWorkUnitStates.getValue(), WATERMARK_WORKUNIT_PREDICATE));
+
+        if (watermarkWorkUnits.isEmpty()) {
+          log.info(String.format("No previous partition watermarks for table %s", datasetWorkUnitStates.getKey()));
+          continue;
+        } else if (watermarkWorkUnits.size() > 1) {
+          throw new IllegalStateException(
+              String
+                  .format(
+                      "Each table should have only 1 watermark workunit that contains watermarks for all it's partitions. Found %s",
+                      watermarkWorkUnits.size()));
+        } else {
+          MultiKeyValueLongWatermark multiKeyValueLongWatermark =
+              watermarkWorkUnits.get(0).getActualHighWatermark(MultiKeyValueLongWatermark.class);
+          if (multiKeyValueLongWatermark != null) {
+            this.previousWatermarks.setPartitionWatermarks(datasetWorkUnitStates.getKey(),
+                multiKeyValueLongWatermark.getWatermarks());
+          } else {
+            log.warn(String.format("Previous workunit for %s has %s set but null MultiKeyValueLongWatermark found",
+                datasetWorkUnitStates.getKey(), IS_WATERMARK_WORKUNIT_KEY));
+          }
+        }
+      }
+
+      log.info("Loaded watermarks from previous state " + this.previousWatermarks);
+
+      for (String tableKey : this.previousWatermarks.keySet()) {
+        this.expectedHighWatermarks.setPartitionWatermarks(tableKey,
+            Maps.newHashMap(this.previousWatermarks.getPartitionWatermarks(tableKey)));
+      }
+    }
+
+  }
+
+  /**
+   * Initializes the expected high watermarks for a {@link Table}
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#onTableProcessBegin(org.apache.hadoop.hive.ql.metadata.Table, long)
+   */
+  @Override
+  public void onTableProcessBegin(Table table, long tableProcessTime) {
+
+    Preconditions.checkNotNull(table);
+
+    if (!this.expectedHighWatermarks.hasPartitionWatermarks(tableKey(table))) {
+      this.expectedHighWatermarks.setPartitionWatermarks(tableKey(table), Maps.<String, Long> newHashMap());
+    }
+  }
+
+  /**
+   * Adds an expected high watermark for this {@link Partition}. Also removes any watermarks for partitions being replaced.
+   * Replace partitions are read using partition parameter {@link AbstractAvroToOrcConverter#REPLACED_PARTITIONS_HIVE_METASTORE_KEY}.
+   * Uses the <code>partitionUpdateTime</code> as the high watermark for this <code>partition</code>
+   *
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#onPartitionProcessBegin(org.apache.hadoop.hive.ql.metadata.Partition, long, long)
+   */
+  @Override
+  public void onPartitionProcessBegin(Partition partition, long partitionProcessTime, long partitionUpdateTime) {
+
+    Preconditions.checkNotNull(partition);
+    Preconditions.checkNotNull(partition.getTable());
+
+    if (!this.expectedHighWatermarks.hasPartitionWatermarks(tableKey(partition.getTable()))) {
+      throw new IllegalStateException(String.format(
+          "onPartitionProcessBegin called before onTableProcessBegin for table: %s, partitions: %s",
+          tableKey(partition.getTable()), partitionKey(partition)));
+    }
+
+    // Remove dropped partitions
+    Collection<String> droppedPartitions =
+        Collections2.transform(AbstractAvroToOrcConverter.getDropPartitionsDDLInfo(partition),
+            new Function<Map<String, String>, String>() {
+              @Override
+              public String apply(Map<String, String> input) {
+                return PARTITION_VALUES_JOINER.join(input.values());
+              }
+            });
+
+    this.expectedHighWatermarks.removePartitionWatermarks(tableKey(partition.getTable()), droppedPartitions);
+    this.expectedHighWatermarks.addPartitionWatermark(tableKey(partition.getTable()), partitionKey(partition),
+        partitionUpdateTime);
+  }
+
+  /**
+   * Delegates to {@link TableLevelWatermarker#getPreviousHighWatermark(Table)}
+   *
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#getPreviousHighWatermark(org.apache.hadoop.hive.ql.metadata.Table)
+   */
+  @Override
+  public LongWatermark getPreviousHighWatermark(Table table) {
+    return this.tableLevelWatermarker.getPreviousHighWatermark(table);
+  }
+
+  /**
+   * Return the previous high watermark if found in previous state. Else returns 0
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#getPreviousHighWatermark(org.apache.hadoop.hive.ql.metadata.Partition)
+   */
+  @Override
+  public LongWatermark getPreviousHighWatermark(Partition partition) {
+    if (this.previousWatermarks.hasPartitionWatermarks(tableKey(partition.getTable()))) {
+
+      // If partition has a watermark return.
+      if (this.previousWatermarks.get(tableKey(partition.getTable())).containsKey(partitionKey(partition))) {
+        return new LongWatermark(this.previousWatermarks.getPartitionWatermark(tableKey(partition.getTable()),
+            partitionKey(partition)));
+      }
+    }
+    return new LongWatermark(0);
+
+  }
+
+  /**
+   * Adds watermark workunits to <code>workunits</code>.
+   * <ul>
+   * <li>Add one NoOp watermark workunit for each {@link Table}
+   * <li>The workunit has and identifier property {@link #IS_WATERMARK_WORKUNIT_KEY} set to true.
+   * <li>Watermarks for all {@link Partition}s that belong to this {@link Table} as added as {@link Map}
+   * <li>A maximum of {@link #maxPartitionsPerDataset} most recently modified {@link Partition} watermarks are added.
+   *
+   * </ul>
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#onGetWorkunitsEnd(java.util.List)
+   */
+  @Override
+  public void onGetWorkunitsEnd(List<WorkUnit> workunits) {
+    for (Map.Entry<String, Map<String, Long>> tableWatermark : this.expectedHighWatermarks.entrySet()) {
+
+      String tableKey = tableWatermark.getKey();
+      Map<String, Long> partitionWatermarks = tableWatermark.getValue();
+
+      // We only keep watermarks for partitions that were updated after leastWatermarkToPersistInState
+      Map<String, Long> expectedPartitionWatermarks =
+          ImmutableMap.copyOf(Maps.filterEntries(partitionWatermarks, new Predicate<Map.Entry<String, Long>>() {
+
+            @Override
+            public boolean apply(@Nonnull Map.Entry<String, Long> input) {
+              return Long.compare(input.getValue(), PartitionLevelWatermarker.this.leastWatermarkToPersistInState) >= 0;
+            }
+          }));
+
+      // Create dummy workunit to track all the partition watermarks for this table
+      WorkUnit watermarkWorkunit = WorkUnit.createEmpty();
+      watermarkWorkunit.setProp(IS_WATERMARK_WORKUNIT_KEY, true);
+      watermarkWorkunit.setProp(ConfigurationKeys.DATASET_URN_KEY, tableKey);
+
+      watermarkWorkunit.setWatermarkInterval(new WatermarkInterval(new MultiKeyValueLongWatermark(
+          this.previousWatermarks.get(tableKey)), new MultiKeyValueLongWatermark(expectedPartitionWatermarks)));
+
+      workunits.add(watermarkWorkunit);
+    }
+  }
+
+  /**
+   *
+   * {@inheritDoc}
+   *
+   * Uses the <code>table</code>'s modified time as watermark. The modified time is read using
+   * {@link HiveUnitUpdateProvider#getUpdateTime(Table)}
+   * @throws UpdateNotFoundException if there was an error fetching update time using {@link HiveUnitUpdateProvider#getUpdateTime(Table)}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#getExpectedHighWatermark(org.apache.hadoop.hive.ql.metadata.Table, long)
+   */
+  @Override
+  public LongWatermark getExpectedHighWatermark(Table table, long tableProcessTime) {
+    return new LongWatermark(this.updateProvider.getUpdateTime(table));
+  }
+
+  /**
+   * Get the expected high watermark for this partition
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#getExpectedHighWatermark(org.apache.hadoop.hive.ql.metadata.Partition, long, long)
+   */
+  @Override
+  public LongWatermark getExpectedHighWatermark(Partition partition, long tableProcessTime, long partitionProcessTime) {
+    return new LongWatermark(this.expectedHighWatermarks.getPartitionWatermark(tableKey(partition.getTable()),
+        partitionKey(partition)));
+  }
+
+  /**
+   * Sets the actual high watermark by reading the expected high watermark
+   * {@inheritDoc}
+   * @see gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker#setActualHighWatermark(gobblin.configuration.WorkUnitState)
+   */
+  @Override
+  public void setActualHighWatermark(WorkUnitState wus) {
+    if (Boolean.valueOf(wus.getPropAsBoolean(IS_WATERMARK_WORKUNIT_KEY))) {
+      wus.setActualHighWatermark(wus.getWorkunit().getExpectedHighWatermark(MultiKeyValueLongWatermark.class));
+    } else {
+      wus.setActualHighWatermark(wus.getWorkunit().getExpectedHighWatermark(LongWatermark.class));
+    }
+  }
+
+  @VisibleForTesting
+  public static String tableKey(Table table) {
+    return table.getCompleteName();
+  }
+
+  @VisibleForTesting
+  public static String partitionKey(Partition partition) {
+    return PARTITION_VALUES_JOINER.join(partition.getValues());
+  }
+
+  /**
+   * An extension to standard java map with some accessors
+   */
+  @VisibleForTesting
+  static class TableWatermarks extends ConcurrentHashMap<String, Map<String, Long>> {
+
+    private static final long serialVersionUID = 1L;
+
+    public TableWatermarks() {
+      super();
+    }
+
+    void setPartitionWatermarks(String tableKey, Map<String, Long> partitionWatermarks) {
+      this.put(tableKey, partitionWatermarks);
+    }
+
+    boolean hasPartitionWatermarks(String tableKey) {
+      return this.containsKey(tableKey);
+    }
+
+    void removePartitionWatermarks(String tableKey, Collection<String> partitionKeys) {
+      this.get(tableKey).keySet().removeAll(partitionKeys);
+    }
+
+    void addPartitionWatermark(String tableKey, String partitionKey, Long watermark) {
+      this.get(tableKey).put(partitionKey, watermark);
+    }
+
+    Long getPartitionWatermark(String tableKey, String partitionKey) {
+      return this.get(tableKey).get(partitionKey);
+    }
+
+    Map<String, Long> getPartitionWatermarks(String tableKey) {
+      return this.get(tableKey);
+    }
+  }
+
+  /**
+   * Factory to create a {@link PartitionLevelWatermarker}
+   */
+  public static class Factory implements HiveSourceWatermarkerFactory {
+
+    @Override
+    public PartitionLevelWatermarker createFromState(State state) {
+      return new PartitionLevelWatermarker(state);
+    }
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarkerTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarkerTest.java
@@ -1,0 +1,388 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.watermarker;
+
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+
+import org.apache.hadoop.hive.metastore.api.FieldSchema;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.joda.time.DateTime;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.converter.AbstractAvroToOrcConverter;
+import gobblin.data.management.conversion.hive.source.HiveSource;
+import gobblin.source.extractor.extract.LongWatermark;
+import gobblin.source.workunit.WorkUnit;
+
+
+/*
+ * Tests covered
+ *
+ * // Previous state tests
+ * 1. Test previousWatermarks reading.
+ * 1.5 Null previous watermarks in a watermark workunit
+ * 2. Test more than one watermark workunits
+ * 3 Get previous high watermark for partition
+ *
+ *  // Callback tests
+ *  4. Test calling onPartitionProcessBegin before OnTableProcessBegin
+ *  5. Test remove dropped partitions
+ *  6. Test addPartitionWatermarks
+ *
+ *  // OnGetWorkunitsEnd tests
+ *  7.  No previous state. 5 most recently modified partitions
+ *  8. Previous state 3. New partitions 3. 2 from new state retained
+ *  9. Previous state 4. New partitions 5. All 5 new retained
+ *  10. Previous state 5. New partitions 3; 2 existing and 1 new
+ *  11. Previous state 3, 2 dropped. New partitions 2
+ */
+@Test(groups = { "gobblin.data.management.conversion" })
+public class PartitionLevelWatermarkerTest {
+
+  @Test
+  public void testExpectedHighWatermarkNoPreviousState() throws Exception {
+
+    long now = new DateTime().getMillis();
+
+    SourceState state = new SourceState();
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Table table = mockTable("testTable1");
+    Partition part1 = mockPartition(table, ImmutableList.of("2015"));
+    watermarker.onTableProcessBegin(table, 0l);
+    watermarker.onPartitionProcessBegin(part1, 0l, now + 2015l);
+
+    Table table2 = mockTable("testTable2");
+    Partition part2 = mockPartition(table2, ImmutableList.of("16"));
+    watermarker.onTableProcessBegin(table2, 0l);
+    watermarker.onPartitionProcessBegin(part2, 0l, now + 16l);
+
+    List<WorkUnit> workunits = Lists.newArrayList();
+    watermarker.onGetWorkunitsEnd(workunits);
+
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(part1).getValue(), 0l);
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(table).getValue(), 0l);
+
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(part2).getValue(), 0l);
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(table2).getValue(), 0l);
+
+    Assert.assertEquals(workunits.size(), 2);
+
+    Assert.assertEquals(workunits.get(0).getPropAsBoolean(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY), true);
+    Assert.assertEquals(workunits.get(1).getPropAsBoolean(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY), true);
+
+    Collections.sort(workunits, new Comparator<WorkUnit>() {
+      @Override
+      public int compare(WorkUnit o1, WorkUnit o2) {
+        return o1.getProp(ConfigurationKeys.DATASET_URN_KEY).compareTo(o2.getProp(ConfigurationKeys.DATASET_URN_KEY));
+      }
+    });
+
+    Assert.assertEquals(workunits.get(0).getProp(ConfigurationKeys.DATASET_URN_KEY), table.getCompleteName());
+    Assert.assertEquals(workunits.get(1).getProp(ConfigurationKeys.DATASET_URN_KEY), table2.getCompleteName());
+
+    Assert.assertEquals(
+        workunits.get(0).getExpectedHighWatermark(MultiKeyValueLongWatermark.class)
+            .getWatermarks(), ImmutableMap.of(PartitionLevelWatermarker.partitionKey(part1), now + 2015l));
+    Assert.assertEquals(
+        workunits.get(1).getExpectedHighWatermark(MultiKeyValueLongWatermark.class)
+            .getWatermarks(),
+        ImmutableMap.of(PartitionLevelWatermarker.partitionKey(part2), now + 16l));
+
+  }
+
+  @Test
+  public void testReadPreviousWatermarks() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2015", 100l, "2016", 101l)));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousWatermarks().size(), 1);
+    Assert.assertEquals(watermarker.getPreviousWatermarks().get("test_dataset_urn"),
+        ImmutableMap.of("2015", 100l, "2016", 101l));
+
+    // Make sure all the previousWatermarks are added into current expectedHighWatermarks
+    Assert.assertEquals(watermarker.getPreviousWatermarks(), watermarker.getExpectedHighWatermarks());
+
+  }
+
+  @Test
+  public void testStateStoreReadWrite() throws Exception {
+
+    PartitionLevelWatermarker watermarker0 = new PartitionLevelWatermarker(new SourceState());
+    Table mockTable = mockTable("table1");
+    watermarker0.onTableProcessBegin(mockTable, 0l);
+    long now = new DateTime().getMillis();
+    watermarker0.onPartitionProcessBegin(mockPartition(mockTable, ImmutableList.of("2016")), 0, now);
+    List<WorkUnit> workunits = Lists.newArrayList();
+    watermarker0.onGetWorkunitsEnd(workunits);
+
+    @SuppressWarnings("deprecation")
+    WorkUnitState previousWus = new WorkUnitState(workunits.get(0));
+    watermarker0.setActualHighWatermark(previousWus);
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousWatermarks().size(), 1);
+    Assert.assertEquals(watermarker.getPreviousWatermarks().get("table1"), ImmutableMap.of("2016", now));
+
+  }
+
+  @Test
+  public void testReadPreviousWatermarksMultipleTables() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2015", 100l, "2016", 101l)));
+
+    WorkUnitState previousWus2 = new WorkUnitState();
+    previousWus2.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn2");
+    previousWus2.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus2.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("01", 1l, "02", 2l)));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus, previousWus2));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousWatermarks().size(), 2);
+    Assert.assertEquals(watermarker.getPreviousWatermarks().get("test_dataset_urn"),
+        ImmutableMap.of("2015", 100l, "2016", 101l));
+    Assert.assertEquals(watermarker.getPreviousWatermarks().get("test_dataset_urn2"),
+        ImmutableMap.of("01", 1l, "02", 2l));
+
+    // Make sure all the previousWatermarks are added into current expectedHighWatermarks
+    Assert.assertEquals(watermarker.getPreviousWatermarks(), watermarker.getExpectedHighWatermarks());
+
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testMoreThanOneWatermarkWorkunits() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2015", 100l)));
+
+    WorkUnitState previousWus2 = new WorkUnitState();
+    previousWus2.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus2.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus2.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2016", 101l)));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus, previousWus2));
+
+    // Expecting IllegalStateException
+    new PartitionLevelWatermarker(state);
+
+  }
+
+  @Test
+  public void testReadPreviousNullWatermarks() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousWatermarks().size(), 0);
+
+  }
+
+  @Test
+  public void testNoPreviousWatermarkWorkunits() throws Exception {
+
+    // Create one previous workunit with IS_WATERMARK_WORKUNIT_KEY set to true
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2015", 100l)));
+
+    // Create one previous workunit with IS_WATERMARK_WORKUNIT_KEY not set (false)
+    WorkUnitState previousWus2 = new WorkUnitState();
+    previousWus2.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn2");
+    previousWus2.setActualHighWatermark(new LongWatermark(101l));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus, previousWus2));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousWatermarks().size(), 1);
+    Assert.assertEquals(watermarker.getPreviousWatermarks().get("test_dataset_urn"), ImmutableMap.of("2015", 100l));
+
+  }
+
+  @Test
+  public void testGetPreviousHighWatermarkForPartition() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2015", 100l, "2016", 101l)));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Table table = mockTable("test_dataset_urn");
+    Partition partition2015 = mockPartition(table, ImmutableList.of("2015"));
+    Partition partition2016 = mockPartition(table, ImmutableList.of("2016"));
+
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(partition2015), new LongWatermark(100l));
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(partition2016), new LongWatermark(101l));
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testPartitionBeginBegoreTableBegin() throws Exception {
+    SourceState state = new SourceState();
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Table table = mockTable("test_dataset_urn");
+    Partition partition = mockPartition(table, ImmutableList.of(""));
+
+    watermarker.onPartitionProcessBegin(partition, 0l, 0l);
+  }
+
+  @Test
+  public void testDroppedPartitions() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_dataset_urn");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus
+        .setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2015-01", 100l, "2015-02", 101l)));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Table table = mockTable("test_dataset_urn");
+    Mockito.when(table.getPartitionKeys()).thenReturn(ImmutableList.of(new FieldSchema("year", "string", "")));
+
+    Partition partition2015 = mockPartition(table, ImmutableList.of("2015"));
+
+    // partition 2015 replaces 2015-01 and 2015-02
+    Mockito.when(partition2015.getParameters()).thenReturn(
+        ImmutableMap.of(AbstractAvroToOrcConverter.REPLACED_PARTITIONS_HIVE_METASTORE_KEY, "2015-01|2015-02"));
+    watermarker.onPartitionProcessBegin(partition2015, 0l, 0l);
+
+    Assert.assertEquals(watermarker.getExpectedHighWatermarks().get("test_dataset_urn"), ImmutableMap.of("2015", 0l));
+  }
+
+  // No previous state. 5 new modified partitions. Only 3 most recently modified retained in getExpectedHighWatermark
+  @Test
+  public void testRecentlyModifiedPartitionWatermarks() throws Exception {
+
+    SourceState state = new SourceState();
+    state.setProp(HiveSource.HIVE_SOURCE_MAXIMUM_LOOKBACK_DAYS_KEY, 3);
+    long time5DaysAgo = new DateTime().minusDays(5).getMillis();
+
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Table table = mockTable("testTable2");
+    Partition part2010 = mockPartition(table, ImmutableList.of("2010"));
+    Partition part2011 = mockPartition(table, ImmutableList.of("2011"));
+    Partition part2012 = mockPartition(table, ImmutableList.of("2012"));
+    Partition part2013 = mockPartition(table, ImmutableList.of("2013"));
+    Partition part2014 = mockPartition(table, ImmutableList.of("2014"));
+
+    watermarker.onTableProcessBegin(table, 0l);
+
+    watermarker.onPartitionProcessBegin(part2010, 0l, time5DaysAgo - 100l);
+    watermarker.onPartitionProcessBegin(part2011, 0l, time5DaysAgo - 101l);
+
+    watermarker.onPartitionProcessBegin(part2012, 0l, time5DaysAgo + 102l);
+    watermarker.onPartitionProcessBegin(part2013, 0l, time5DaysAgo + 103l);
+    watermarker.onPartitionProcessBegin(part2014, 0l, time5DaysAgo + 104l);
+
+    List<WorkUnit> workunits = Lists.newArrayList();
+    watermarker.onGetWorkunitsEnd(workunits);
+
+    Assert.assertEquals(workunits.size(), 1);
+    WorkUnit watermarkWu = workunits.get(0);
+
+    Assert.assertEquals(watermarkWu.getExpectedHighWatermark(MultiKeyValueLongWatermark.class).getWatermarks(),
+        ImmutableMap.of("2014", time5DaysAgo + 104l, "2013", time5DaysAgo + 103l, "2012", time5DaysAgo + 102l));
+
+  }
+
+  //Previous state 3. New partitions 3. 2 from new state retained
+  @Test
+  public void testRecentlyModifiedPartitionWatermarksWithPreviousState() throws Exception {
+
+    long time5DaysAgo = new DateTime().minusDays(5).getMillis();
+
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "testTable2");
+    previousWus.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("2010", time5DaysAgo - 100l, // Do not retain
+        "2011", time5DaysAgo - 101l, // Do not retain
+        "2012", time5DaysAgo + 102l // Do not retain
+        )));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    state.setProp(HiveSource.HIVE_SOURCE_MAXIMUM_LOOKBACK_DAYS_KEY, 3);
+
+    PartitionLevelWatermarker watermarker = new PartitionLevelWatermarker(state);
+
+    Table table = mockTable("testTable2");
+
+    // Watermark not retained
+    Partition part2009 = mockPartition(table, ImmutableList.of("2009"));
+
+    // Watermark retained
+    Partition part2013 = mockPartition(table, ImmutableList.of("2013"));
+    Partition part2014 = mockPartition(table, ImmutableList.of("2014"));
+
+    watermarker.onTableProcessBegin(table, 0l);
+
+    // Watermark not retained
+    watermarker.onPartitionProcessBegin(part2009, 0l, time5DaysAgo - 99l);
+
+    // Watermark retained
+    watermarker.onPartitionProcessBegin(part2013, 0l, time5DaysAgo + 103l);
+    watermarker.onPartitionProcessBegin(part2014, 0l, time5DaysAgo + 104l);
+
+    List<WorkUnit> workunits = Lists.newArrayList();
+    watermarker.onGetWorkunitsEnd(workunits);
+
+    Assert.assertEquals(workunits.size(), 1);
+    WorkUnit watermarkWu = workunits.get(0);
+
+    Assert.assertEquals(watermarkWu.getExpectedHighWatermark(MultiKeyValueLongWatermark.class).getWatermarks(),
+        ImmutableMap.of("2014", time5DaysAgo + 104l, "2013", time5DaysAgo + 103l, "2012", time5DaysAgo + 102l));
+
+  }
+
+  private static Table mockTable(String name) {
+    Table table = Mockito.mock(Table.class, Mockito.RETURNS_SMART_NULLS);
+    Mockito.when(table.getCompleteName()).thenReturn(name);
+    return table;
+  }
+
+  private static Partition mockPartition(Table table, List<String> values) {
+    Partition partition = Mockito.mock(Partition.class, Mockito.RETURNS_SMART_NULLS);
+    Mockito.when(partition.getTable()).thenReturn(table);
+    Mockito.when(partition.getValues()).thenReturn(values);
+    return partition;
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/watermarker/TableLevelWatermarkerTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/watermarker/TableLevelWatermarkerTest.java
@@ -1,0 +1,105 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.conversion.hive.watermarker;
+
+import java.util.List;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.hive.ql.metadata.Table;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.Lists;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.extract.LongWatermark;
+
+
+@Test(groups = { "gobblin.data.management.conversion" })
+public class TableLevelWatermarkerTest {
+
+  @Test
+  public void testPreviousState() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_table");
+    previousWus.setActualHighWatermark(new LongWatermark(100l));
+
+    // Watermark will be lowest of 100l and 101l
+    WorkUnitState previousWus1 = new WorkUnitState();
+    previousWus1.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_table");
+    previousWus1.setActualHighWatermark(new LongWatermark(101l));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    TableLevelWatermarker watermarker = new TableLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(mockTable("test_table")), new LongWatermark(100l));
+
+  }
+
+  @Test
+  public void testPreviousStateWithPartitionWatermark() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_table");
+    previousWus.setActualHighWatermark(new LongWatermark(100l));
+
+    // Watermark workunits created by PartitionLevelWatermarker need to be ignored.
+    WorkUnitState previousWus1 = new WorkUnitState();
+    previousWus1.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_table");
+    previousWus1.setProp(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY, true);
+    previousWus1.setActualHighWatermark(new MultiKeyValueLongWatermark(ImmutableMap.of("part1", 200l)));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    TableLevelWatermarker watermarker = new TableLevelWatermarker(state);
+
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(mockTable("test_table")), new LongWatermark(100l));
+
+  }
+
+  /**
+   * Make sure that all partitions get the same previous high watermark (table's watermark)
+   */
+  @Test
+  public void testPartitionWatermarks() throws Exception {
+    WorkUnitState previousWus = new WorkUnitState();
+    previousWus.setProp(ConfigurationKeys.DATASET_URN_KEY, "test_table");
+    previousWus.setActualHighWatermark(new LongWatermark(100l));
+
+    SourceState state = new SourceState(new State(), Lists.newArrayList(previousWus));
+    TableLevelWatermarker watermarker = new TableLevelWatermarker(state);
+
+    Table mockTable = mockTable("test_table");
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(mockTable), new LongWatermark(100l));
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(mockPartition(mockTable, ImmutableList.of("2015"))),
+        new LongWatermark(100l));
+    Assert.assertEquals(watermarker.getPreviousHighWatermark(mockPartition(mockTable, ImmutableList.of("2016"))),
+        new LongWatermark(100l));
+  }
+
+  private static Table mockTable(String name) {
+    Table table = Mockito.mock(Table.class, Mockito.RETURNS_SMART_NULLS);
+    Mockito.when(table.getCompleteName()).thenReturn(name);
+    return table;
+  }
+
+  private static Partition mockPartition(Table table, List<String> values) {
+    Partition partition = Mockito.mock(Partition.class, Mockito.RETURNS_SMART_NULLS);
+    Mockito.when(partition.getTable()).thenReturn(table);
+    Mockito.when(partition.getValues()).thenReturn(values);
+    return partition;
+  }
+}


### PR DESCRIPTION
### Changes ###
For every Table we create a NoOp watermark WorkUnit that stores watermarks for all its Partitions as a ```Map```. This workunit is identified by the property ```IS_WATERMARK_WORKUNIT_KEY``` being set to ```true```.
This workunit is intended to only carry watermark state and does not contain any business logic to execute hive conversion queries.

The watermark is stored as a ```MultiKeyValueLongWatermark``` which is an extension to ```Map``` that implements gobblin's ```Watermark``` interface. The key is a Partition identifier and value is the watermark for this Partition

The maximum number of Partition watermarks for each Table can be adjusted by the property MAX_PARTITIONS_IN_WATERMARK_PER_DATASET_KEY, The default is 50. This means we only track watermarks for 50 most recently modified partitions of each table. If a previous watermark is not found for as partition, it returns 0 as the watermark

A ```TableLevelWatermarer``` is still supported. It can be used instead of a ```PartitionLevelWatermarker```

Note that the publish logic is still at a per ```Table``` level. We still fail all partitions if any partition fails. Per partition commit is doable but is an optimization we can work on later.

@chavdar and @abti  can you review?

Internal jira ticket - ETL-4785