### PR TITLE
Move lock attempt into AbstractJobLauncher's constructor

### DIFF
--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_exec/TestJobLauncherExecutionDriver.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_exec/TestJobLauncherExecutionDriver.java
@@ -57,7 +57,8 @@ public class TestJobLauncherExecutionDriver {
           .withValue(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY,
                      ConfigValueFactory.fromAnyRef(localJobRootDir.getPath()))
           .withValue(ConfigurationKeys.SOURCE_CLASS_KEY,
-                     ConfigValueFactory.fromAnyRef(TestingSource.class.getName()));
+                     ConfigValueFactory.fromAnyRef(TestingSource.class.getName()))
+          .withValue(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, ConfigValueFactory.fromAnyRef(false));
 
       JobSpec jobSpec1 = JobSpec.builder().withConfig(jobConf1).build();
 
@@ -88,7 +89,8 @@ public class TestJobLauncherExecutionDriver {
           .withValue(ConfigurationKeys.MR_JOB_ROOT_DIR_KEY,
                      ConfigValueFactory.fromAnyRef(mrJobRootDir.getPath()))
           .withValue(ConfigurationKeys.SOURCE_CLASS_KEY,
-                     ConfigValueFactory.fromAnyRef(TestingSource.class.getName()));
+                     ConfigValueFactory.fromAnyRef(TestingSource.class.getName()))
+          .withValue(ConfigurationKeys.JOB_LOCK_ENABLED_KEY, ConfigValueFactory.fromAnyRef(false));
 
       JobSpec jobSpec2 = JobSpec.builder().withConfig(jobConf2).build();
 


### PR DESCRIPTION
`MRJobLauncher` deletes the working directory before the lock is checked. See (https://github.com/linkedin/gobblin/blob/3f5939c2521061c633ee082bb954a98ab9027f54/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java#L149). 

This causes the running job that has the lock to fail when it tries to read files in the working directory. Moving the lock check into `AbstractJobLauncher`'s constructor prevents subclasses from doing destructive operations like this without having the lock.

The diff here is ugly due to whitespace but the change is relatively simple.
See https://github.com/linkedin/gobblin/commit/a0ac0a39af26fe6fd15f05ae632ad4a0055c7812?w=1 to view the diff without whitespace