### PR TITLE
Make topic suffix configurable for lookup in Confluent Schema Registry

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistry.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistry.java
@@ -48,7 +48,7 @@ public class ConfluentKafkaSchemaRegistry extends KafkaSchemaRegistry<Integer, S
   public static final String CONFLUENT_MAX_SCHEMAS_PER_SUBJECT =
       "kafka.schema_registry.confluent.max_schemas_per_subject";
 
-  public static final String CONFLUENT_SCHEMA_NAME_SUFFIX = "kafka.schema_registry.confluent.schema.name.suffix";
+  public static final String CONFLUENT_SCHEMA_NAME_SUFFIX = "kafka.schema_registry.confluent.schema_name_suffix";
   
   // Default suffix of the topic name to register / retrieve from the registry
   private static final String DEFAULT_CONFLUENT_SCHEMA_NAME_SUFFIX = "-value";

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistry.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistry.java
@@ -48,6 +48,11 @@ public class ConfluentKafkaSchemaRegistry extends KafkaSchemaRegistry<Integer, S
   public static final String CONFLUENT_MAX_SCHEMAS_PER_SUBJECT =
       "kafka.schema_registry.confluent.max_schemas_per_subject";
 
+  public static final String CONFLUENT_SCHEMA_NAME_SUFFIX = "kafka.schema_registry.confluent.schema.name.suffix";
+  
+  // Default suffix of the topic name to register / retrieve from the registry
+  private static final String CONFLUENT_SCHEMA_DEFAULT_NAME_SUFFIX = "-value";
+  
   @Getter
   private final SchemaRegistryClient schemaRegistryClient;
 
@@ -74,7 +79,8 @@ public class ConfluentKafkaSchemaRegistry extends KafkaSchemaRegistry<Integer, S
   @Override
   public Schema getLatestSchemaByTopic(String topic) throws SchemaRegistryException {
     try {
-      return new Schema.Parser().parse(this.schemaRegistryClient.getLatestSchemaMetadata(topic).getSchema());
+      String schemaName = topic + props.getProperty(CONFLUENT_SCHEMA_NAME_SUFFIX, CONFLUENT_SCHEMA_DEFAULT_NAME_SUFFIX);
+      return new Schema.Parser().parse(this.schemaRegistryClient.getLatestSchemaMetadata(schemaName).getSchema());
     } catch (IOException | RestClientException e) {
       throw new SchemaRegistryException(e);
     }
@@ -88,7 +94,8 @@ public class ConfluentKafkaSchemaRegistry extends KafkaSchemaRegistry<Integer, S
   @Override
   public Integer register(Schema schema, String name) throws SchemaRegistryException {
     try {
-      return this.schemaRegistryClient.register(name, schema);
+      String schemaName = name + props.getProperty(CONFLUENT_SCHEMA_NAME_SUFFIX, CONFLUENT_SCHEMA_DEFAULT_NAME_SUFFIX);
+      return this.schemaRegistryClient.register(schemaName, schema);
     } catch (IOException | RestClientException e) {
       throw new SchemaRegistryException(e);
     }

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistryTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/kafka/ConfluentKafkaSchemaRegistryTest.java
@@ -58,6 +58,20 @@ public class ConfluentKafkaSchemaRegistryTest {
     Properties properties = new Properties();
     properties.setProperty(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL, TEST_URL);
 
+    doTestRegisterAndGetLatest(properties);
+  }
+  
+  @Test
+  public void testRegisterAndGetLatestCustomSuffix() throws SchemaRegistryException {
+    Properties properties = new Properties();
+    properties.setProperty(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_URL, TEST_URL);
+    properties.setProperty(ConfluentKafkaSchemaRegistry.CONFLUENT_SCHEMA_NAME_SUFFIX, "-key");
+
+    doTestRegisterAndGetLatest(properties);
+  }
+  
+  private void doTestRegisterAndGetLatest(Properties properties) throws SchemaRegistryException {
+
     SchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient();
     KafkaSchemaRegistry<Integer, Schema> kafkaSchemaRegistry =
         new ConfluentKafkaSchemaRegistry(properties, schemaRegistryClient);


### PR DESCRIPTION
Currently only the name of the Kafka topic is used to retrieve the schema from the registry, however schemas are usually registered under `topicName-value` or `topicName-key`. 
Thus the schema will never be retrieved from the registry and the following exception is thrown:
```
...
Caused by: gobblin.metrics.kafka.SchemaRegistryException:
io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException:
Subject not found.; error code: 40401
...
```
This PR adds a new config parameter `kafka.schema_registry.confluent.schema.name.suffix `which defaults to `-value`. This suffix will be used along with the topic name to query the registry.
