### PR TITLE
Fixed silent failures and hung application when a standalone service …

### DIFF
--- a/gobblin-cluster/src/main/java/gobblin/cluster/GobblinHelixJobScheduler.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/GobblinHelixJobScheduler.java
@@ -34,6 +34,7 @@ import gobblin.runtime.JobLauncher;
 import gobblin.runtime.listeners.JobListener;
 import gobblin.scheduler.JobScheduler;
 import gobblin.cluster.event.NewJobConfigArrivalEvent;
+import gobblin.scheduler.SchedulerService;
 
 
 /**
@@ -58,8 +59,8 @@ public class GobblinHelixJobScheduler extends JobScheduler {
   private final List<? extends Tag<?>> metadataTags;
 
   public GobblinHelixJobScheduler(Properties properties, HelixManager helixManager, EventBus eventBus,
-      Path appWorkDir, List<? extends Tag<?>> metadataTags) throws Exception {
-    super(properties);
+      Path appWorkDir, List<? extends Tag<?>> metadataTags, SchedulerService schedulerService) throws Exception {
+    super(properties, schedulerService);
     this.properties = properties;
     this.helixManager = helixManager;
     this.eventBus = eventBus;

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
@@ -35,7 +35,9 @@ public class SchedulerDaemon extends ServiceBasedAppLauncher {
 
   public SchedulerDaemon(Properties properties) throws Exception {
     super(properties, getAppName(properties));
-    addService(new JobScheduler(properties));
+    SchedulerService schedulerService = new SchedulerService(properties);
+    addService(schedulerService);
+    addService(new JobScheduler(properties, schedulerService));
   }
 
   private static String getAppName(Properties properties) {

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerService.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerService.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.scheduler;
+
+import java.util.Properties;
+
+import org.quartz.Scheduler;
+import org.quartz.impl.StdSchedulerFactory;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+
+import gobblin.configuration.ConfigurationKeys;
+
+import lombok.Getter;
+
+
+/**
+ * A {@link com.google.common.util.concurrent.Service} wrapping a Quartz {@link Scheduler} allowing correct shutdown
+ * of the scheduler when {@link JobScheduler} fails to initialize.
+ */
+public class SchedulerService extends AbstractIdleService {
+
+  @Getter
+  private Scheduler scheduler;
+  private final boolean waitForJobCompletion;
+
+  public SchedulerService(Properties props) {
+    this.waitForJobCompletion = Boolean.parseBoolean(
+        props.getProperty(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY,
+            ConfigurationKeys.DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION));
+  }
+
+  @Override
+  protected void startUp()
+      throws Exception {
+    this.scheduler = new StdSchedulerFactory().getScheduler();
+  }
+
+  @Override
+  protected void shutDown()
+      throws Exception {
+    this.scheduler.shutdown(this.waitForJobCompletion);
+  }
+}

--- a/gobblin-runtime/src/test/java/gobblin/scheduler/JobConfigFileMonitorTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/scheduler/JobConfigFileMonitorTest.java
@@ -80,7 +80,7 @@ public class JobConfigFileMonitorTest {
     properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY, "1000");
     properties.setProperty(ConfigurationKeys.METRICS_ENABLED_KEY, "false");
 
-    this.jobScheduler = new JobScheduler(properties);
+    this.jobScheduler = new JobScheduler(properties, new SchedulerService(new Properties()));
     this.serviceManager = new ServiceManager(Lists.newArrayList(this.jobScheduler));
     this.serviceManager.startAsync();
   }

--- a/gobblin-utility/src/main/java/gobblin/util/ResourceBasedTemplate.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ResourceBasedTemplate.java
@@ -27,7 +27,10 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
 
+import lombok.extern.slf4j.Slf4j;
 
+
+@Slf4j
 public class ResourceBasedTemplate implements JobTemplate {
   private String templatePath;
   private Set<String> _userSpecifiedAttributesList;


### PR DESCRIPTION
…fails to initialize.

Issue:
Previously, if `JobScheduler` failed to start, the application would hang and no error would be reported.

Solution:
Added a listener to the `ServiceManager` in `ServiceBasedAppLauncher` that logs failures of the services and shutdowns Gobblin on failure of a service.
Also separated the quartz scheduler as an independent service managed in the `ServiceManager`. This is necessary because otherwise, when `JobScheduler` fails, its `shutDown` method cannot be called, so the scheduler cannot be closed, causing the application to hang. As a separate service, the `ServiceManager` will shutdown the scheduler correctly.