### PR TITLE
Use FileSystem.newInstance instead of FileSystem.get

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFsHelper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/hadoop/HadoopFsHelper.java
@@ -115,7 +115,7 @@ public class HadoopFsHelper implements TimestampAwareFileBasedHelper {
 
     } else {
       // Initialize file system as the current user.
-      this.fs = FileSystem.get(URI.create(uri), this.configuration);
+      this.fs = FileSystem.newInstance(URI.create(uri), this.configuration);
     }
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -182,6 +182,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
         cleanUpWorkingDirectory();
       } finally {
         super.close();
+        fs.close();
       }
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -497,7 +497,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
   private static FileSystem buildFileSystem(Properties jobProps, Configuration configuration)
       throws IOException {
     URI fsUri = URI.create(jobProps.getProperty(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI));
-    return FileSystem.get(fsUri, configuration);
+    return FileSystem.newInstance(fsUri, configuration);
   }
 
   /**

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
@@ -110,7 +110,7 @@ public class ProxiedFileSystemWrapper {
       @Override
       public Void run() throws IOException {
         LOG.debug("Now performing file system operations as :" + UserGroupInformation.getCurrentUser());
-        proxiedFs = FileSystem.get(fsURI, conf);
+        proxiedFs = FileSystem.newInstance(fsURI, conf);
         return null;
       }
     });

--- a/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ProxiedFileSystemWrapper.java
@@ -110,7 +110,7 @@ public class ProxiedFileSystemWrapper {
       @Override
       public Void run() throws IOException {
         LOG.debug("Now performing file system operations as :" + UserGroupInformation.getCurrentUser());
-        proxiedFs = FileSystem.newInstance(fsURI, conf);
+        proxiedFs = FileSystem.get(fsURI, conf);
         return null;
       }
     });


### PR DESCRIPTION
Use FileSystem.newInstance instead of FileSystem.get as it closes shared resource.
Performed integration test.

https://github.com/linkedin/gobblin/issues/1219
