### PR TITLE
Adding a simple wiki for distcp-ng events

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/publisher/CopyDataPublisher.java
@@ -24,20 +24,16 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Predicate;
 import com.google.common.collect.ArrayListMultimap;
-import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
-
-import javax.annotation.Nullable;
-import lombok.extern.slf4j.Slf4j;
 
 import gobblin.commit.CommitStep;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.configuration.WorkUnitState.WorkingState;
+import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.CopySource;
 import gobblin.data.management.copy.CopyableDataset;
 import gobblin.data.management.copy.CopyableDatasetMetadata;
@@ -47,15 +43,16 @@ import gobblin.data.management.copy.entities.PostPublishStep;
 import gobblin.data.management.copy.entities.PrePublishStep;
 import gobblin.data.management.copy.recovery.RecoveryHelper;
 import gobblin.data.management.copy.writer.FileAwareInputStreamDataWriter;
-import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.writer.FileAwareInputStreamDataWriterBuilder;
-import gobblin.publisher.UnpublishedHandling;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.GobblinMetrics;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.publisher.DataPublisher;
+import gobblin.publisher.UnpublishedHandling;
 import gobblin.util.HadoopUtils;
+
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -207,6 +204,15 @@ public class CopyDataPublisher extends DataPublisher implements UnpublishedHandl
           datasetUpstreamTimestamp = copyableFile.getUpstreamTimestamp();
         }
       }
+    }
+
+    // if there are no valid values for datasetOriginTimestamp and datasetUpstreamTimestamp, use
+    // something more readable
+    if (Long.MAX_VALUE == datasetOriginTimestamp) {
+      datasetOriginTimestamp = 0;
+    }
+    if (Long.MAX_VALUE == datasetUpstreamTimestamp) {
+      datasetUpstreamTimestamp = 0;
     }
 
     CopyEventSubmitterHelper.submitSuccessfulDatasetPublish(this.eventSubmitter, datasetAndPartition,

--- a/gobblin-docs/data-management/DistcpNgEvents.md
+++ b/gobblin-docs/data-management/DistcpNgEvents.md
@@ -1,0 +1,31 @@
+# Table of contents
+[TOC]
+
+# Copy publisher monitoring events
+
+The following metadata attributes are shared across all events:
+
+- Standard execution metadata (TODO add link)
+- `namespace=gobblin.copy.CopyDataPublisher`
+- `metadata["class"]=gobblin.data.management.copy.publisher.CopyDataPublisher`
+
+Events by `name`:
+
+- `DatasetPublished` - a datasets gets successfully copied and published
+    - `datasetUrn` - the URN of the dataset (dataset-specific) that was copied
+    - `partition` - the partition (dataset-specific) that was copied
+    - `originTimestamp` - the timestamp of the dataset partition as generated in the origin (e.g. the database)
+    - `upstreamTimestamp` - the timestamp of the dataset partition as made available in the upstream system; this will be equal to `originTimestamp` if the data is read directly from the origin.
+
+- `DatasetPublishFailed` - a dataset failed to publish 
+    - `datasetUrn` - the URN of the dataset (dataset-specific) whose publish failed
+
+
+- `FilePublished` - sent when an individual file gets published
+    - `datasetUrn` - the URN of the dataset (dataset-specific) of which the part is part
+    - `partition` - the partition (dataset-specific) of which the part is part
+    - `SourcePath` - the full source path for the file 
+    - `TargetPath` - the full destination path for the file 
+    - `originTimestamp` - similar to `originTimestamp` for `DatasetPublished` events
+    - `upstreamTimestamp` - similar to `upstreamTimestamp` for `DatasetPublished` events
+    - `SizeInBytes` - the size in bytes of the file

--- a/gobblin-docs/data-management/DistcpNgEvents.md
+++ b/gobblin-docs/data-management/DistcpNgEvents.md
@@ -23,7 +23,7 @@ Events by `name`:
 
 - `FilePublished` - sent when an individual file gets published
     - `datasetUrn` - the URN of the dataset (dataset-specific) of which the part is part
-    - `partition` - the partition (dataset-specific) of which the part is part
+    - `partition` - the partition (dataset-specific) of which this file is part
     - `SourcePath` - the full source path for the file 
     - `TargetPath` - the full destination path for the file 
     - `originTimestamp` - similar to `originTimestamp` for `DatasetPublished` events


### PR DESCRIPTION
- Added a simple wiki that documents the events sent by the Distcp-ng publisher
- Added code to CopyDataPublisher to use a more readable value if the origin/update timestamps are missing.

@ibuenros @pcadabam @ydai1124 can you review?