### PR TITLE
Add backward compatible constructor

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/limiter/DefaultLimiterFactory.java
+++ b/gobblin-utility/src/main/java/gobblin/util/limiter/DefaultLimiterFactory.java
@@ -27,12 +27,27 @@ import gobblin.configuration.State;
 public class DefaultLimiterFactory {
 
   public static final String EXTRACT_LIMIT_TYPE_KEY = "extract.limit.type";
-  public static final String EXTRACT_LIMIT_RATE_LIMIT_KEY = "extract.limit.rate.limit";
-  public static final String EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY = "extract.limit.rate.limit.timeunit";
-  public static final String EXTRACT_LIMIT_TIME_LIMIT_KEY = "extract.limit.time.limit";
-  public static final String EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY = "extract.limit.time.limit.timeunit";
+
+  public static final String EXTRACT_LIMIT_RATE_LIMIT_KEY = "extract.limit.rateLimit";
+
+  public static final String EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY = "extract.limit.rateLimitTimeunit";
+
+  public static final String EXTRACT_LIMIT_TIME_LIMIT_KEY = "extract.limit.timeLimit";
+
+  public static final String EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY = "extract.limit.timeLimitTimeunit";
+
   public static final String EXTRACT_LIMIT_COUNT_LIMIT_KEY = "extract.limit.count.limit";
+
   public static final String EXTRACT_LIMIT_POOL_SIZE_KEY = "extract.limit.pool.size";
+
+  @Deprecated
+  public static final String EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP = "extract.limit.rate.limit";
+  @Deprecated
+  public static final String EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP = "extract.limit.rate.limit.timeunit";
+  @Deprecated
+  public static final String EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP = "extract.limit.time.limit";
+  @Deprecated
+  public static final String EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP = "extract.limit.time.limit.timeunit";
 
   /**
    * Create a new {@link Limiter} instance of one of the types in {@link BaseLimiterType}.
@@ -57,6 +72,7 @@ public class DefaultLimiterFactory {
    * @throws IllegalArgumentException if the input configuration does not specify a valid supported
    */
   public static Limiter newLimiter(State state) {
+    state = convertDeprecatedConfigs(state);
     Preconditions.checkArgument(state.contains(EXTRACT_LIMIT_TYPE_KEY),
         String.format("Missing configuration property %s for the Limiter type", EXTRACT_LIMIT_TYPE_KEY));
     BaseLimiterType type = BaseLimiterType.forName(state.getProp(EXTRACT_LIMIT_TYPE_KEY));
@@ -89,5 +105,32 @@ public class DefaultLimiterFactory {
       default:
         throw new IllegalArgumentException("Unrecognized Limiter type: " + type.toString());
     }
+  }
+
+  /**
+   * Convert deprecated keys {@value #EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP}, {@value #EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP},
+   * {@value #EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP}, and {@value #EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP}, since they are not
+   * TypeSafe compatible. The deprecated keys will be removed from @param state, and replaced with
+   * {@value #EXTRACT_LIMIT_RATE_LIMIT_KEY}, {@value #EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY}, {@value #EXTRACT_LIMIT_TIME_LIMIT_KEY},
+   * and {@value #EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY}, respectively.
+   */
+  private static State convertDeprecatedConfigs(State state) {
+    if (state.contains(EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP)) {
+      state.setProp(EXTRACT_LIMIT_RATE_LIMIT_KEY, state.getProp(EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP));
+      state.removeProp(EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP);
+    }
+    if (state.contains(EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP)) {
+      state.setProp(EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY, state.getProp(EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP));
+      state.removeProp(EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP);
+    }
+    if (state.contains(EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP)) {
+      state.setProp(EXTRACT_LIMIT_TIME_LIMIT_KEY, state.getProp(EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP));
+      state.removeProp(EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP);
+    }
+    if (state.contains(EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP)) {
+      state.setProp(EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY, state.getProp(EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP));
+      state.removeProp(EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP);
+    }
+    return state;
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/limiter/DefaultLimiterFactoryTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/limiter/DefaultLimiterFactoryTest.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.limiter;
+
+import java.util.concurrent.TimeUnit;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.State;
+
+
+/**
+ * Unit tests for {@link DefaultLimiterFactory}.
+ */
+@Test(groups = {"gobblin.util.limiter"})
+public class DefaultLimiterFactoryTest {
+
+  @Test
+  public void testNewLimiter() {
+    State stateWithRateLimitDeprecatedKeys = new State();
+    stateWithRateLimitDeprecatedKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.RATE_BASED);
+    stateWithRateLimitDeprecatedKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP, "10");
+    stateWithRateLimitDeprecatedKeys
+        .setProp(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP, TimeUnit.MINUTES);
+    Limiter rateLimiterFromDeprecatedKeys = DefaultLimiterFactory.newLimiter(stateWithRateLimitDeprecatedKeys);
+    Assert.assertTrue(rateLimiterFromDeprecatedKeys instanceof RateBasedLimiter);
+    Assert.assertTrue(stateWithRateLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_KEY));
+    Assert
+        .assertFalse(stateWithRateLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP));
+    Assert.assertTrue(
+        stateWithRateLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY));
+    Assert.assertFalse(
+        stateWithRateLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP));
+
+    State stateWithTimeLimitDeprecatedKeys = new State();
+    stateWithTimeLimitDeprecatedKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.TIME_BASED);
+    stateWithTimeLimitDeprecatedKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP, "10");
+    stateWithTimeLimitDeprecatedKeys
+        .setProp(DefaultLimiterFactory.EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP, TimeUnit.MINUTES);
+    Limiter timeLimiterFromDeprecatedKeys = DefaultLimiterFactory.newLimiter(stateWithTimeLimitDeprecatedKeys);
+    Assert.assertTrue(timeLimiterFromDeprecatedKeys instanceof TimeBasedLimiter);
+    Assert.assertTrue(stateWithTimeLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_TIME_LIMIT_KEY));
+    Assert
+        .assertFalse(stateWithTimeLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_TIME_LIMIT_KEY_DEP));
+    Assert.assertTrue(
+        stateWithTimeLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY));
+    Assert.assertFalse(
+        stateWithTimeLimitDeprecatedKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_TIME_LIMIT_TIMEUNIT_KEY_DEP));
+
+    State stateWithNewKeys = new State();
+    stateWithNewKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_TYPE_KEY, BaseLimiterType.RATE_BASED);
+    stateWithNewKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP, "10");
+    stateWithNewKeys.setProp(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP, TimeUnit.MINUTES);
+    Limiter rateLimiterFromNewKeys = DefaultLimiterFactory.newLimiter(stateWithNewKeys);
+    Assert.assertTrue(rateLimiterFromNewKeys instanceof RateBasedLimiter);
+
+    Assert.assertTrue(stateWithNewKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_KEY));
+    Assert.assertFalse(stateWithNewKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_KEY_DEP));
+    Assert.assertTrue(stateWithNewKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY));
+    Assert.assertFalse(stateWithNewKeys.contains(DefaultLimiterFactory.EXTRACT_LIMIT_RATE_LIMIT_TIMEUNIT_KEY_DEP));
+  }
+}


### PR DESCRIPTION
#1199 removed the constructor `(KafkaAvroSchemaRegistry, String)` and introduced backwards incompatible change. Restored this constructor.
@pcadabam Can you review?