### PR TITLE
Replace DatePartitionedDailyAvroSource with configurable partitioning

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/DatePartitionedAvroFileSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/DatePartitionedAvroFileSource.java
@@ -22,6 +22,7 @@ import java.util.List;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -29,12 +30,16 @@ import org.apache.hadoop.fs.PathFilter;
 
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
+import org.joda.time.DurationFieldType;
 import org.joda.time.format.DateTimeFormat;
 import org.joda.time.format.DateTimeFormatter;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Enums;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 import com.google.common.base.Throwables;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -48,78 +53,98 @@ import gobblin.source.extractor.filebased.FileBasedSource;
 import gobblin.source.extractor.hadoop.AvroFsHelper;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.Extract.TableType;
+import gobblin.writer.partitioner.DatePartitionType;
+import gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner;
 import gobblin.source.workunit.MultiWorkUnitWeightedQueue;
 import gobblin.source.workunit.WorkUnit;
 
 
 /**
  * Implementation of {@link gobblin.source.Source} that reads over date-partitioned Avro data.
- *
+ * This source can be regarded as the reader equivalent of {@link TimeBasedAvroWriterPartitioner}.
+ * 
  * <p>
- *
- * For example, if {@link ConfigurationKeys#SOURCE_FILEBASED_DATA_DIRECTORY} is set to /my/data/, then the class assumes
- * folders following the pattern /my/data/daily/[year]/[month]/[day] are present. It will iterate through all the data
- * under these folders starting from the date specified by {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until
- * either {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data
+ * The class will iterate through all the data folders given by the base directory
+ * {@link ConfigurationKeys#SOURCE_FILEBASED_DATA_DIRECTORY} and the partitioning type 
+ * {@link #DATE_PARTITIONED_SOURCE_PARTITION_PATTERN} or {@link #DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY}
+ * 
+ * <p>
+ * For example, if the base directory is set to /my/data/ and daily partitioning is used, then it is assumed that
+ * /my/data/daily/[year]/[month]/[day] is present. It will iterate through all the data under these folders starting 
+ * from the date specified by {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until either 
+ * {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data 
  * to process. For example, if {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} is set to 2015/01/01, then the job
- * will read from the folder /my/data/daily/2015/01/01/, /my/data/daily/2015/01/02/, /my/data/2015/01/03/ etc.
- *
- * <p>
- *
+ * will read from the folder /my/data/daily/2015/01/02/, /my/data/daily/2015/01/03/, /my/data/2015/01/04/ etc.
+ * </p>
+ * 
+ * </p>
+ * 
  * The class will only process data in Avro format.
  */
-public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, GenericRecord> {
-
+public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, GenericRecord> {
+  
   // Configuration parameters
-  private static final String DATE_PARTITIONED_SOURCE_PREFIX = "date.partitioned.source.";
+  private static final String DATE_PARTITIONED_SOURCE_PREFIX = "date.partitioned.source";
+  
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_PREFIX =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.prefix";
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.suffix";
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_PATTERN =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.pattern";
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_TIMEZONE =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.timezone";
+  public static final String DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_TIMEZONE = ConfigurationKeys.PST_TIMEZONE_NAME;
+  public static final String DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".partition.granularity";
+  public static final DatePartitionType DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY =
+      DatePartitionType.HOUR;
+  
+  /**
+  * A String of the format defined by {@link #DATE_PARTITIONED_SOURCE_PARTITION_PATTERN} or 
+  * {@link #DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY}. For example for yyyy/MM/dd the 
+  * 2015/01/01 corresponds to January 1st, 2015. The job will start reading data from this point in time. 
+  * If this parameter is not specified the job will start reading data from
+  * the beginning of Unix time.
+  */
+  public static final String DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".min.watermark.value";
 
   /**
-   * A String of the format [year]/[month]/[day], for example 2015/01/01 corresponds to January 1st, 2015. The job will
-   * start reading data from this point in time. If this parameter is not specified the job will start reading data from
-   * the beginning of Unix time.
-   */
-  private static final String DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE =
-      DATE_PARTITIONED_SOURCE_PREFIX + "min.watermark.value";
+  * The maximum number of files that this job should process.
+  */
+  public static final String DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".max.files.per.job";
 
   /**
-   * The maximum number of files that this job should process.
-   */
-  private static final String DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB =
-      DATE_PARTITIONED_SOURCE_PREFIX + "max.files.per.job";
-
-  /**
-   * The maximum number of {@link MultiWorkUnits} to create for this job. This number also corresponds to the number of
-   * tasks (or if running on Hadoop, the number of map tasks) that will be launched in this job.
-   */
-  private static final String DATE_PARTITIONED_SOURCE_MAX_WORKUNITS_PER_JOB =
-      DATE_PARTITIONED_SOURCE_PREFIX + "max.workunits.per.job";
+  * The maximum number of {@link MultiWorkUnits} to create for this job. This number also corresponds to the number of
+  * tasks (or if running on Hadoop, the number of map tasks) that will be launched in this job.
+  */
+  public static final String DATE_PARTITIONED_SOURCE_MAX_WORKUNITS_PER_JOB =
+      DATE_PARTITIONED_SOURCE_PREFIX + ".max.workunits.per.job";
 
   // Default configuration parameter values
 
   /**
-   * Default value for {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB}
-   */
+  * Default value for {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB}
+  */
   private static final int DEFAULT_DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB = 2000;
 
   /**
-   * Default value for {@link #DATE_PARTITIONED_SOURCE_MAX_WORKUNITS_PER_JOB}
-   */
+  * Default value for {@link #DATE_PARTITIONED_SOURCE_MAX_WORKUNITS_PER_JOB}
+  */
   private static final int DEFAULT_DATE_PARTITIONED_SOURCE_MAX_WORKUNITS_PER_JOB = 500;
 
   /**
-   * Controls the default value for {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE}. The default value will be set
-   * to the 1970/01/01.
-   */
+  * Controls the default value for {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE}. The default value will be set
+  * to the epoch.
+  */
   private static final int DEFAULT_DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE = 0;
 
   // String constants
-  private static final String DAILY_FOLDER_NAME = "daily";
   private static final String AVRO_SUFFIX = ".avro";
 
-  // Joda formatters
-  private static final DateTimeFormatter DAILY_FOLDER_FORMATTER = DateTimeFormat.forPattern("yyyy/MM/dd");
-
-  private static final Logger LOG = LoggerFactory.getLogger(DatePartitionedDailyAvroSource.class);
+  private static final Logger LOG = LoggerFactory.getLogger(DatePartitionedAvroFileSource.class);
 
   // Instance variables
   private SourceState sourceState;
@@ -130,7 +155,11 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
   private int fileCount;
   private TableType tableType;
   private Path sourceDir;
-
+  private String sourcePartitionPrefix;
+  private String sourcePartitionSuffix;
+  private DateTimeFormatter partitionPatternFormatter;
+  private DurationFieldType incrementalUnit;
+  
   /**
    * Gobblin calls the {@link Source#getWorkunits(SourceState)} method after creating a {@link Source} object with a
    * blank constructor, so any custom initialization of the object needs to be done here.
@@ -138,7 +167,13 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
   private void init(SourceState state) {
     DateTimeZone.setDefault(DateTimeZone
         .forID(state.getProp(ConfigurationKeys.SOURCE_TIMEZONE, ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE)));
-
+    
+    initDatePartitionFromPattern(state);
+    
+    if (this.partitionPatternFormatter == null) {
+      initDatePartitionFromGranularity(state);
+    }
+    
     try {
       initFileSystemHelper(state);
     } catch (FileBasedHelperException e) {
@@ -152,7 +187,7 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
 
     this.lowWaterMark =
         getLowWaterMark(state.getPreviousWorkUnitStates(), state.getProp(DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE,
-            DAILY_FOLDER_FORMATTER.print(DEFAULT_DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE)));
+            this.partitionPatternFormatter.print(DEFAULT_DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE)));
 
     this.maxFilesPerJob = state.getPropAsInt(DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB,
         DEFAULT_DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB);
@@ -165,8 +200,44 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
     this.fileCount = 0;
 
     this.sourceDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
+    
+    this.sourcePartitionPrefix = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_PREFIX, StringUtils.EMPTY);
+    
+    this.sourcePartitionSuffix = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX, StringUtils.EMPTY);
+    
   }
-
+  
+  private void initDatePartitionFromPattern(State state) {
+    String partitionPattern = null;
+    try {
+      partitionPattern = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_PATTERN);
+      if (partitionPattern != null) {
+        this.partitionPatternFormatter =
+            DateTimeFormat.forPattern(partitionPattern).withZone(DateTimeZone.getDefault());
+        this.incrementalUnit = DatePartitionType.getLowestIntervalUnit(partitionPattern).getDurationType();
+      }
+    }
+    catch(Exception e) {
+      throw new IllegalArgumentException("Invalid source partition pattern: " + partitionPattern, e);
+    }
+  }
+  
+  private void initDatePartitionFromGranularity(State state) {
+    String granularityProp = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY);
+    DatePartitionType partitionType = null;
+    if (granularityProp == null) {
+      partitionType = DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY;
+    } else {
+      Optional<DatePartitionType> partitionTypeOpt =
+          Enums.getIfPresent(DatePartitionType.class, granularityProp.toUpperCase());
+      Preconditions.checkState(partitionTypeOpt.isPresent(),
+          "Invalid source partition granularity: " + granularityProp);
+      partitionType = partitionTypeOpt.get();
+    }
+    this.partitionPatternFormatter = DateTimeFormat.forPattern(partitionType.getDateTimePattern());
+    this.incrementalUnit = partitionType.getDateTimeFieldType().getDurationType();
+  }
+  
   @Override
   public void initFileSystemHelper(State state) throws FileBasedHelperException {
     this.fsHelper = new AvroFsHelper(state);
@@ -184,7 +255,7 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
     // Initialize all instance variables for this object
     init(state);
 
-    LOG.info("Will pull data from " + DAILY_FOLDER_FORMATTER.print(this.lowWaterMark) + " until " + this.maxFilesPerJob
+    LOG.info("Will pull data from " + this.partitionPatternFormatter.print(this.lowWaterMark) + " until " + this.maxFilesPerJob
         + " files have been processed, or until there is no more data to consume");
     LOG.info("Creating workunits");
 
@@ -242,13 +313,13 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
 
     // Process all data from the lowWaterMark date until the maxFilesPerJob has been hit
     for (DateTime date = lowWaterMarkDate; !date.isAfter(currentDay) && this.fileCount < this.maxFilesPerJob; date =
-        date.plusDays(1)) {
-
-      // Construct a daily path folder - e.g. /my/data/daily/2015/01/01/
-      Path dayPath = new Path(this.sourceDir, DAILY_FOLDER_NAME + Path.SEPARATOR + DAILY_FOLDER_FORMATTER.print(date));
-
+        date.withFieldAdded(incrementalUnit, 1)) {
+       
+      // Constructs the path folder - e.g. /my/data/prefix/2015/01/01/suffix
+      Path sourcePath = constructSourcePath(date);
+      
       try {
-        if (this.fs.exists(dayPath)) {
+        if (this.fs.exists(sourcePath)) {
 
           // Create an extract object for the dayPath
           SourceState partitionState = new SourceState();
@@ -259,10 +330,10 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
           Extract extract = partitionState.createExtract(this.tableType,
               partitionState.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY), topicName);
 
-          LOG.info("Created extract: " + extract.getExtractId() + " for path " + dayPath);
+          LOG.info("Created extract: " + extract.getExtractId() + " for path " + sourcePath);
 
           // Create a WorkUnit for each file in the folder
-          for (FileStatus fileStatus : this.fs.listStatus(dayPath, getFileFilter())) {
+          for (FileStatus fileStatus : this.fs.listStatus(sourcePath, getFileFilter())) {
 
             LOG.info("Will process file " + fileStatus.getPath());
 
@@ -277,7 +348,7 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
             this.fileCount++;
           }
         } else {
-          LOG.info("Path " + dayPath + " does not exist, skipping");
+          LOG.info("Path " + sourcePath + " does not exist, skipping");
         }
       } catch (IOException e) {
         Throwables.propagate(e);
@@ -287,13 +358,18 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
     LOG.info("Total number of files extracted for the current run: " + this.fileCount);
   }
 
+  private Path constructSourcePath(DateTime date) {
+    return new Path(this.sourceDir, this.sourcePartitionPrefix + Path.SEPARATOR
+        + this.partitionPatternFormatter.print(date) + Path.SEPARATOR + this.sourcePartitionSuffix);
+  }
+  
   /**
-   * Gets the LWM for this job runs. The new LWM is the HWM of the previous run + 1 day. If there was no previous
-   * execution then it is set to the given lowWaterMark + 1 day.
+   * Gets the LWM for this job runs. The new LWM is the HWM of the previous run + 1 unit (day,hour,minute..etc). 
+   * If there was no previous execution then it is set to the given lowWaterMark + 1 unit.
    */
-  private static long getLowWaterMark(Iterable<WorkUnitState> previousStates, String lowWaterMark) {
+  private long getLowWaterMark(Iterable<WorkUnitState> previousStates, String lowWaterMark) {
 
-    long lowWaterMarkValue = DAILY_FOLDER_FORMATTER.parseMillis(lowWaterMark);
+    long lowWaterMarkValue = this.partitionPatternFormatter.parseMillis(lowWaterMark);
 
     // Find the max HWM from the previous states, this is the new current LWM
     for (WorkUnitState previousState : previousStates) {
@@ -304,8 +380,7 @@ public class DatePartitionedDailyAvroSource extends FileBasedSource<Schema, Gene
         }
       }
     }
-
-    return new DateTime(lowWaterMarkValue).plusDays(1).getMillis();
+    return new DateTime(lowWaterMarkValue).withFieldAdded(this.incrementalUnit, 1).getMillis();
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/source/DatePartitionedDailyAvroSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/DatePartitionedDailyAvroSource.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.util.DatePartitionType;
+
+
+/**
+ * Implementation of {@link gobblin.source.Source} that reads over date-partitioned Avro data.
+ *
+ * <p>
+ *
+ * For example, if {@link ConfigurationKeys#SOURCE_FILEBASED_DATA_DIRECTORY} is set to /my/data/, then the class assumes
+ * folders following the pattern /my/data/daily/[year]/[month]/[day] are present. It will iterate through all the data
+ * under these folders starting from the date specified by {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until
+ * either {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data
+ * to process. For example, if {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} is set to 2015/01/01, then the job
+ * will read from the folder /my/data/daily/2015/01/01/, /my/data/daily/2015/01/02/, /my/data/2015/01/03/ etc.
+ *
+ * <p>
+ *
+ * The class will only process data in Avro format.
+ */
+public class DatePartitionedDailyAvroSource extends DatePartitionedAvroFileSource {
+
+  @Override
+  protected void init(SourceState state) {
+    state.setProp(DATE_PARTITIONED_SOURCE_PARTITION_PATTERN, DatePartitionType.DAY.getDateTimePattern());
+    super.init(state);
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/writer/partitioner/DatePartitionType.java
+++ b/gobblin-core/src/main/java/gobblin/writer/partitioner/DatePartitionType.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2016 Lorand Bendig All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.writer.partitioner;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeFieldType;
+
+
+/**
+ * Temporal granularity types for writing (see {@link TimeBasedWriterPartitioner}) and reading
+ * (see {@link DatePartitionedAvroFileSource}) date partitioned data.
+ * 
+ * @author Lorand Bendig
+ *
+ */
+public enum DatePartitionType {
+
+  YEAR("yyyy", DateTimeFieldType.year()),
+  MONTH("yyyy/MM", DateTimeFieldType.monthOfYear()),
+  DAY("yyyy/MM/dd", DateTimeFieldType.dayOfMonth()),
+  HOUR("yyyy/MM/dd/HH", DateTimeFieldType.hourOfDay()),
+  MINUTE("yyyy/MM/dd/HH/mm", DateTimeFieldType.minuteOfHour());
+
+  private static final Map<String, DateTimeFieldType> lookupByPattern = new LinkedHashMap<>();
+
+  static {
+    lookupByPattern.put("s", DateTimeFieldType.secondOfMinute());
+    lookupByPattern.put("m", DateTimeFieldType.minuteOfHour());
+    lookupByPattern.put("h", DateTimeFieldType.hourOfDay());
+    lookupByPattern.put("H", DateTimeFieldType.hourOfDay());
+    lookupByPattern.put("K", DateTimeFieldType.hourOfDay());
+    lookupByPattern.put("d", DateTimeFieldType.dayOfMonth());
+    lookupByPattern.put("D", DateTimeFieldType.dayOfMonth());
+    lookupByPattern.put("e", DateTimeFieldType.dayOfMonth());
+
+    lookupByPattern.put("w", DateTimeFieldType.weekOfWeekyear());
+    lookupByPattern.put("M", DateTimeFieldType.monthOfYear());
+    lookupByPattern.put("y", DateTimeFieldType.year());
+    lookupByPattern.put("Y", DateTimeFieldType.year());
+  }
+
+  private DateTimeFieldType dateTimeField;
+  private String dateTimePattern;
+
+  private DatePartitionType(String dateTimePattern, DateTimeFieldType dateTimeField) {
+    this.dateTimeField = dateTimeField;
+    this.dateTimePattern = dateTimePattern;
+  }
+
+  /**
+   * @param pattern full partitioning pattern
+   * @return a DateTimeFieldType corresponding to the smallest temporal unit in the pattern. 
+   * E.g for yyyy/MM/dd {@link DateTimeFieldType#dayOfMonth()}
+   */
+  public static DateTimeFieldType getLowestIntervalUnit(String pattern) {
+    DateTimeFieldType intervalUnit = null;
+    for (Map.Entry<String, DateTimeFieldType> pat : lookupByPattern.entrySet()) {
+      if (pattern.contains(pat.getKey())) {
+        intervalUnit = pat.getValue();
+        break;
+      }
+    }
+    return intervalUnit;
+  }
+  
+  public DateTimeFieldType getDateTimeFieldType() {
+    return dateTimeField;
+  }
+  
+  public int getField(DateTime dateTime) {
+    return dateTime.get(this.dateTimeField);
+  }
+  
+  public String getDateTimePattern() {
+    return dateTimePattern;
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/writer/partitioner/TimeBasedWriterPartitioner.java
+++ b/gobblin-core/src/main/java/gobblin/writer/partitioner/TimeBasedWriterPartitioner.java
@@ -37,6 +37,7 @@ import com.google.common.base.Strings;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
+import gobblin.util.DatePartitionType;
 import gobblin.util.ForkOperatorUtils;
 
 

--- a/gobblin-core/src/main/java/gobblin/writer/partitioner/TimeBasedWriterPartitioner.java
+++ b/gobblin-core/src/main/java/gobblin/writer/partitioner/TimeBasedWriterPartitioner.java
@@ -45,7 +45,7 @@ import gobblin.util.ForkOperatorUtils;
  *
  * There are two ways to partition a timestamp: (1) specify a {@link DateTimeFormat} using
  * {@link #WRITER_PARTITION_PATTERN}, e.g., 'yyyy/MM/dd/HH'; (2) specify a
- * {@link TimeBasedWriterPartitioner.Granularity} using {@link #WRITER_PARTITION_GRANULARITY}.
+ * {@link DatePartitionType} using {@link #WRITER_PARTITION_GRANULARITY}.
  *
  * A prefix and a suffix can be added to the partition, e.g., the partition path can be
  * 'prefix/2015/11/05/suffix'.
@@ -60,23 +60,15 @@ public abstract class TimeBasedWriterPartitioner<D> implements WriterPartitioner
   public static final String WRITER_PARTITION_TIMEZONE = ConfigurationKeys.WRITER_PREFIX + ".partition.timezone";
   public static final String DEFAULT_WRITER_PARTITION_TIMEZONE = ConfigurationKeys.PST_TIMEZONE_NAME;
   public static final String WRITER_PARTITION_GRANULARITY = ConfigurationKeys.WRITER_PREFIX + ".partition.granularity";
-  public static final Granularity DEFAULT_WRITER_PARTITION_GRANULARITY = Granularity.HOUR;
+  public static final DatePartitionType DEFAULT_WRITER_PARTITION_GRANULARITY = DatePartitionType.HOUR;
 
   public static final String PARTITIONED_PATH = "partitionedPath";
   public static final String PREFIX = "prefix";
   public static final String SUFFIX = "suffix";
 
-  public enum Granularity {
-    YEAR,
-    MONTH,
-    DAY,
-    HOUR,
-    MINUTE;
-  }
-
   private final String writerPartitionPrefix;
   private final String writerPartitionSuffix;
-  private final Granularity granularity;
+  private final DatePartitionType granularity;
   private final DateTimeZone timeZone;
   private final Optional<DateTimeFormatter> timestampToPathFormatter;
   private final Schema schema;
@@ -100,10 +92,11 @@ public abstract class TimeBasedWriterPartitioner<D> implements WriterPartitioner
     return state.getProp(propName, StringUtils.EMPTY);
   }
 
-  private static Granularity getGranularity(State state, int numBranches, int branchId) {
+  private static DatePartitionType getGranularity(State state, int numBranches, int branchId) {
     String propName = ForkOperatorUtils.getPropertyNameForBranch(WRITER_PARTITION_GRANULARITY, numBranches, branchId);
     String granularityValue = state.getProp(propName, DEFAULT_WRITER_PARTITION_GRANULARITY.toString());
-    Optional<Granularity> granularity = Enums.getIfPresent(Granularity.class, granularityValue.toUpperCase());
+    Optional<DatePartitionType> granularity =
+        Enums.getIfPresent(DatePartitionType.class, granularityValue.toUpperCase());
     Preconditions.checkState(granularity.isPresent(),
         granularityValue + " is not a valid writer partition granularity");
     return granularity.get();
@@ -152,20 +145,7 @@ public abstract class TimeBasedWriterPartitioner<D> implements WriterPartitioner
       partition.put(PARTITIONED_PATH, partitionedPath);
     } else {
       DateTime dateTime = new DateTime(timestamp, this.timeZone);
-      switch (this.granularity) {
-        case MINUTE:
-          partition.put(Granularity.MINUTE.toString(), dateTime.getMinuteOfHour());
-        case HOUR:
-          partition.put(Granularity.HOUR.toString(), dateTime.getHourOfDay());
-        case DAY:
-          partition.put(Granularity.DAY.toString(), dateTime.getDayOfMonth());
-        case MONTH:
-          partition.put(Granularity.MONTH.toString(), dateTime.getMonthOfYear());
-        case YEAR:
-          partition.put(Granularity.YEAR.toString(), dateTime.getYear());
-        default:
-          break;
-      }
+      partition.put(this.granularity.toString(), this.granularity.getField(dateTime));
     }
 
     return partition;
@@ -195,21 +175,7 @@ public abstract class TimeBasedWriterPartitioner<D> implements WriterPartitioner
     if (!Strings.isNullOrEmpty(this.writerPartitionSuffix)) {
       assembler = assembler.name(SUFFIX).type(Schema.create(Schema.Type.STRING)).noDefault();
     }
-
-    switch (this.granularity) {
-      case MINUTE:
-        assembler = assembler.name(Granularity.MINUTE.toString()).type(Schema.create(Schema.Type.STRING)).noDefault();
-      case HOUR:
-        assembler = assembler.name(Granularity.HOUR.toString()).type(Schema.create(Schema.Type.STRING)).noDefault();
-      case DAY:
-        assembler = assembler.name(Granularity.DAY.toString()).type(Schema.create(Schema.Type.STRING)).noDefault();
-      case MONTH:
-        assembler = assembler.name(Granularity.MONTH.toString()).type(Schema.create(Schema.Type.STRING)).noDefault();
-      case YEAR:
-        assembler = assembler.name(Granularity.YEAR.toString()).type(Schema.create(Schema.Type.STRING)).noDefault();
-      default:
-        break;
-    }
+    assembler = assembler.name(this.granularity.toString()).type(Schema.create(Schema.Type.STRING)).noDefault();
 
     if (!Strings.isNullOrEmpty(this.writerPartitionPrefix)) {
       assembler = assembler.name(PREFIX).type(Schema.create(Schema.Type.STRING)).noDefault();

--- a/gobblin-core/src/test/java/gobblin/source/extractor/DatePartitionedAvroFileExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/DatePartitionedAvroFileExtractorTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2016 Lorand Bendig All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.source.extractor;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.fs.Path;
+import org.joda.time.DateTime;
+import org.joda.time.DateTimeZone;
+import org.joda.time.format.DateTimeFormat;
+import org.junit.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.DatePartitionedAvroFileSource;
+import gobblin.source.workunit.Extract.TableType;
+import gobblin.source.workunit.MultiWorkUnit;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.writer.AvroDataWriterBuilder;
+import gobblin.writer.DataWriter;
+import gobblin.writer.DataWriterBuilder;
+import gobblin.writer.Destination;
+import gobblin.writer.PartitionedDataWriter;
+import gobblin.writer.WriterOutputFormat;
+import gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner;
+import gobblin.writer.partitioner.TimeBasedWriterPartitioner;
+
+
+/**
+ * Unit tests for {@link DatePartitionedAvroFileExtractor}.
+ *
+ * @author Lorand Bendig
+ */
+@Test(groups = { "gobblin.source.extractor." })
+public class DatePartitionedAvroFileExtractorTest {
+
+  private static final String SIMPLE_CLASS_NAME = DatePartitionedAvroFileExtractorTest.class.getSimpleName();
+
+  private static final String TEST_ROOT_DIR = "/tmp/" + SIMPLE_CLASS_NAME + "-test";
+  private static final String STAGING_DIR = TEST_ROOT_DIR + Path.SEPARATOR + "staging";
+  private static final String OUTPUT_DIR = TEST_ROOT_DIR + Path.SEPARATOR + "job-output";
+  private static final String FILE_NAME = SIMPLE_CLASS_NAME + "-name.avro";
+  private static final String PARTITION_COLUMN_NAME = "timestamp";
+
+  private static final String PREFIX = "minutes";
+  private static final String SUFFIX = "test";
+  private static final String SOURCE_ENTITY = "testsource"; 
+  
+  private static final String DATE_PATTERN = "yyyy/MM/dd/HH_mm";
+  private static final int RECORD_SIZE = 4;
+  
+  private static final String AVRO_SCHEMA =
+    "{" +
+      "\"type\" : \"record\"," +
+      "\"name\" : \"User\"," +
+      "\"namespace\" : \"example.avro\"," +
+        "\"fields\" : [" +
+        "{" +
+          "\"name\" : \"" + PARTITION_COLUMN_NAME + "\"," +
+          "\"type\" : \"long\"" +
+        "}" +
+      "]" +
+    "}";
+
+  private Schema schema;
+  private DataWriter<GenericRecord> writer;
+
+  private DateTime startDateTime;
+  private long[] recordTimestamps = new long[RECORD_SIZE];
+
+  private static final DateTimeZone TZ = DateTimeZone.forID(ConfigurationKeys.PST_TIMEZONE_NAME);
+
+  @BeforeClass
+  public void setUp() throws IOException {
+    
+    this.schema = new Schema.Parser().parse(AVRO_SCHEMA);
+    
+    //set up datetime objects
+    DateTime now = new DateTime(TZ).minusHours(2);
+    this.startDateTime =
+        new DateTime(now.getYear(), now.getMonthOfYear(), now.getDayOfMonth(), now.getHourOfDay(), 30, 0, TZ);
+
+    //create records, shift their timestamp by 1 minute
+    DateTime recordDt = startDateTime;
+    for (int i = 0; i < RECORD_SIZE; i++) {
+      recordDt = recordDt.plusMinutes(1);
+      recordTimestamps[i] = recordDt.getMillis();
+    }
+
+    // create dummy data partitioned by minutes
+    State state = new State();
+    state.setProp(TimeBasedAvroWriterPartitioner.WRITER_PARTITION_COLUMNS, PARTITION_COLUMN_NAME);
+    state.setProp(ConfigurationKeys.WRITER_BUFFER_SIZE, ConfigurationKeys.DEFAULT_BUFFER_SIZE);
+    state.setProp(ConfigurationKeys.WRITER_FILE_SYSTEM_URI, ConfigurationKeys.LOCAL_FS_URI);
+    state.setProp(ConfigurationKeys.WRITER_STAGING_DIR, STAGING_DIR);
+    state.setProp(ConfigurationKeys.WRITER_OUTPUT_DIR, OUTPUT_DIR);
+    state.setProp(ConfigurationKeys.WRITER_FILE_PATH, SOURCE_ENTITY);
+    state.setProp(ConfigurationKeys.WRITER_FILE_NAME, FILE_NAME);
+    state.setProp(TimeBasedWriterPartitioner.WRITER_PARTITION_PATTERN, DATE_PATTERN);
+    state.setProp(TimeBasedWriterPartitioner.WRITER_PARTITION_PREFIX, PREFIX);
+    state.setProp(TimeBasedWriterPartitioner.WRITER_PARTITION_SUFFIX, SUFFIX);
+    state.setProp(ConfigurationKeys.WRITER_PARTITIONER_CLASS, TimeBasedAvroWriterPartitioner.class.getName());
+
+    DataWriterBuilder<Schema, GenericRecord> builder = new AvroDataWriterBuilder()
+        .writeTo(Destination.of(Destination.DestinationType.HDFS, state))
+        .writeInFormat(WriterOutputFormat.AVRO)
+        .withWriterId("writer-1")
+        .withSchema(this.schema)
+        .withBranches(1).forBranch(0);
+    
+    this.writer = new PartitionedDataWriter<Schema, GenericRecord>(builder, state);
+
+    GenericRecordBuilder genericRecordBuilder = new GenericRecordBuilder(this.schema);
+    for (int i = 0; i < RECORD_SIZE; i++) {
+      genericRecordBuilder.set(PARTITION_COLUMN_NAME, recordTimestamps[i]);
+      this.writer.write(genericRecordBuilder.build());
+    }
+
+    this.writer.close();
+    this.writer.commit();
+
+  }
+
+  @Test
+  public void testReadPartitionsByMinute() throws IOException, DataRecordException {
+
+    DatePartitionedAvroFileSource source = new DatePartitionedAvroFileSource();
+
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.SOURCE_FILEBASED_FS_URI, ConfigurationKeys.LOCAL_FS_URI);
+    state.setProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, SOURCE_ENTITY);
+    state.setProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY, OUTPUT_DIR + Path.SEPARATOR + SOURCE_ENTITY);
+    state.setProp(ConfigurationKeys.SOURCE_ENTITY, SOURCE_ENTITY);
+    state.setProp(ConfigurationKeys.SOURCE_MAX_NUMBER_OF_PARTITIONS, 2);
+
+    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_PARTITION_PATTERN, DATE_PATTERN);
+    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE,
+        DateTimeFormat.forPattern(DATE_PATTERN).print(this.startDateTime.minusMinutes(1)));
+    state.setProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY, TableType.SNAPSHOT_ONLY);
+    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_PARTITION_PREFIX, PREFIX);
+    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX, SUFFIX);
+
+    //Read data partitioned by minutes, i.e each workunit is assigned records under the same YYYY/MM/dd/HH_mm directory
+    List<WorkUnit> workunits = source.getWorkunits(state);
+
+    Assert.assertEquals(workunits.size(), 4);
+    for (int i = 0; i < RECORD_SIZE; i++) {
+      WorkUnit workUnit = ((MultiWorkUnit) workunits.get(i)).getWorkUnits().get(0);
+      WorkUnitState wuState = new WorkUnitState(workunits.get(i), new State());
+      wuState.setProp(ConfigurationKeys.SOURCE_FILEBASED_FS_URI, ConfigurationKeys.LOCAL_FS_URI);
+      wuState.setProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL,
+          workUnit.getProp(ConfigurationKeys.SOURCE_FILEBASED_FILES_TO_PULL));
+      try (DatePartitionedAvroFileExtractor extractor = new DatePartitionedAvroFileExtractor(wuState);) {
+
+        GenericRecord record = extractor.readRecord(null);
+        Assert.assertEquals(recordTimestamps[i], record.get(PARTITION_COLUMN_NAME));
+      }
+    }
+  }
+
+  @AfterClass
+  public void tearDown() throws IOException {
+    this.writer.close();
+    FileUtils.deleteDirectory(new File(TEST_ROOT_DIR));
+  }
+
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/DatePartitionedAvroFileExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/DatePartitionedAvroFileExtractorTest.java
@@ -154,12 +154,12 @@ public class DatePartitionedAvroFileExtractorTest {
     state.setProp(ConfigurationKeys.SOURCE_ENTITY, SOURCE_ENTITY);
     state.setProp(ConfigurationKeys.SOURCE_MAX_NUMBER_OF_PARTITIONS, 2);
 
-    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_PARTITION_PATTERN, DATE_PATTERN);
-    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE,
-        DateTimeFormat.forPattern(DATE_PATTERN).print(this.startDateTime.minusMinutes(1)));
+    state.setProp("date.partitioned.source.partition.pattern", DATE_PATTERN);
+    state.setProp("date.partitioned.source.min.watermark.value", DateTimeFormat.forPattern(DATE_PATTERN).print(
+        this.startDateTime.minusMinutes(1)));
     state.setProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY, TableType.SNAPSHOT_ONLY);
-    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_PARTITION_PREFIX, PREFIX);
-    state.setProp(DatePartitionedAvroFileSource.DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX, SUFFIX);
+    state.setProp("date.partitioned.source.partition.prefix", PREFIX);
+    state.setProp("date.partitioned.source.partition.suffix", SUFFIX);
 
     //Read data partitioned by minutes, i.e each workunit is assigned records under the same YYYY/MM/dd/HH_mm directory
     List<WorkUnit> workunits = source.getWorkunits(state);

--- a/gobblin-example/src/main/resources/hdfs-monthly-to-hdfs-daily.pull
+++ b/gobblin-example/src/main/resources/hdfs-monthly-to-hdfs-daily.pull
@@ -1,0 +1,61 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+job.name=ReadMonthlyPartitionedHDFSWriteDailyPartitionedHDFS
+job.group=HDFSSourceTarget
+job.description=Pull monthly partitioned data from HDFS, write it back as daily partitioned
+
+source.filebased.data.directory=/data/monthly_partitioned/job_output/dataset
+source.filebased.fs.uri=hdfs://localhost:8020
+
+source.class=gobblin.source.DatePartitionedAvroFileSource
+source.entity=dataset
+
+# Looking for data in /data/monthly_partitioned/job_output/dataset/monthly/2015/02...
+date.partitioned.source.min.watermark.value=2015/01
+date.partitioned.source.partition.prefix=monthly
+date.partitioned.source.partition.pattern=yyyy/MM
+
+extract.namespace=gobblin.example.partitioned
+extract.table.name=dataset
+extract.is.full=true
+extract.table.type=snapshot_only
+
+
+# Wite to HDFS as daily partitioned
+writer.fs.uri=hdfs://localhost:8020
+writer.codec.type=snappy
+writer.builder.class=gobblin.writer.AvroDataWriterBuilder
+writer.buffer.size=4096
+writer.file.path.type=TABLENAME
+
+writer.partitioner.class=gobblin.writer.partitioner.TimeBasedAvroWriterPartitioner
+writer.partition.columns=change_dt
+writer.partition.pattern=yyyy/MM/dd
+writer.partition.prefix=daily
+writer.partition.timezone=Europe/Zurich
+
+data.publisher.type=gobblin.publisher.TimePartitionedDataPublisher
+
+# Misc
+source.timezone=Europe/Zurich
+mapreduce.job.queuename=Myqueue
+
+# Metrics
+mr.report.metrics.as.counters=true
+metrics.reporting.file.enabled=true
+metrics.log.dir=${env:GOBBLIN_WORK_DIR}/metrics

--- a/gobblin-utility/src/main/java/gobblin/util/DatePartitionType.java
+++ b/gobblin-utility/src/main/java/gobblin/util/DatePartitionType.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.writer.partitioner;
+package gobblin.util;
 
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -20,8 +20,8 @@ import org.joda.time.DateTimeFieldType;
 
 
 /**
- * Temporal granularity types for writing (see {@link TimeBasedWriterPartitioner}) and reading
- * (see {@link DatePartitionedAvroFileSource}) date partitioned data.
+ * Temporal granularity types for writing ({@link gobblin.writer.partitioner.TimeBasedWriterPartitioner}) and reading
+ * ({@link gobblin.source.DatePartitionedAvroFileSource}) date partitioned data.
  * 
  * @author Lorand Bendig
  *


### PR DESCRIPTION
This PR is a continuation of PR https://github.com/linkedin/gobblin/pull/1196 .

Currently the `DatePartitionedDailyAvroSource` can only read daily partitioned data.
This PR extends this functionality by introducing `DatePartitionedAvroFileSource` in which the partitioning is configurable by the properties as follows:

> date.partitioned.source.partition.prefix
> date.partitioned.source.partition.suffix
> date.partitioned.source.partition.pattern
> date.partitioned.source.partition.granularity

This is the _reader equivalent_ of the time-based writer and partitioner, found in `TimeBasedWriterPartitioner` and `TimePartitionedDataPublisher`.
With this add-on new data sets can be read using different temporal granularity, not just as daily partitioned data.
