### PR TITLE
Standardize the access to the ImmutableFSJobCatalog config

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/FSJobCatalogHelper.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/FSJobCatalogHelper.java
@@ -6,8 +6,6 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.net.URI;
 import java.util.Map;
-import java.util.Properties;
-import java.util.Set;
 import java.util.UUID;
 
 import javax.annotation.Nullable;
@@ -18,10 +16,7 @@ import org.apache.hadoop.fs.Path;
 import com.google.common.base.Charsets;
 import com.google.common.base.Function;
 import com.google.common.base.Optional;
-import com.google.common.base.Splitter;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.Iterables;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 import com.typesafe.config.ConfigRenderOptions;
@@ -134,20 +129,6 @@ public class FSJobCatalogHelper {
           .withVersion(version)
           .build();
     }
-  }
-
-  public static Set<String> getJobConfigurationFileExtensions(Properties properties) {
-    Iterable<String> jobConfigFileExtensionsIterable = Splitter.on(",")
-        .omitEmptyStrings()
-        .trimResults()
-        .split(properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_EXTENSIONS_KEY,
-            ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_EXTENSIONS));
-    return ImmutableSet.copyOf(Iterables.transform(jobConfigFileExtensionsIterable, new Function<String, String>() {
-      @Override
-      public String apply(String input) {
-        return null != input ? input.toLowerCase() : "";
-      }
-    }));
   }
 
   /**

--- a/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
@@ -94,7 +94,7 @@ public class TestStandardGobblinInstanceLauncher {
     Assert.assertTrue(jobResult.isSuccessful());
 
     instanceLauncher.stopAsync();
-    instanceLauncher.awaitTerminated(100, TimeUnit.MILLISECONDS);
+    instanceLauncher.awaitTerminated(500, TimeUnit.MILLISECONDS);
     Assert.assertEquals(instance.getMetrics().getUpFlag().getValue().intValue(), 0);
     Assert.assertEquals(instance.getMetrics().getUptimeMs().getValue().longValue(), 0);
   }
@@ -126,7 +126,7 @@ public class TestStandardGobblinInstanceLauncher {
             @Override public void onJobLaunch(JobExecutionDriver jobDriver) {
               super.onJobLaunch(jobDriver);
               try {
-                jobDrivers.offer(jobDriver, 100, TimeUnit.MILLISECONDS);
+                jobDrivers.offer(jobDriver, 500, TimeUnit.MILLISECONDS);
               } catch (InterruptedException e) {
                 instance.getLog().error("Offer interrupted.");
               }
@@ -144,7 +144,7 @@ public class TestStandardGobblinInstanceLauncher {
     Assert.assertTrue(jobResult.isSuccessful());
 
     instanceLauncher.stopAsync();
-    instanceLauncher.awaitTerminated(50, TimeUnit.MILLISECONDS);
+    instanceLauncher.awaitTerminated(500, TimeUnit.MILLISECONDS);
   }
 
 
@@ -174,7 +174,7 @@ public class TestStandardGobblinInstanceLauncher {
             @Override public void onJobLaunch(JobExecutionDriver jobDriver) {
               super.onJobLaunch(jobDriver);
               try {
-                jobDrivers.offer(jobDriver, 100, TimeUnit.MILLISECONDS);
+                jobDrivers.offer(jobDriver, 500, TimeUnit.MILLISECONDS);
               } catch (InterruptedException e) {
                 instance.getLog().error("Offer interrupted.");
               }
@@ -191,7 +191,7 @@ public class TestStandardGobblinInstanceLauncher {
     Assert.assertTrue(jobResult.isSuccessful());
 
     instanceLauncher.stopAsync();
-    instanceLauncher.awaitTerminated(50, TimeUnit.MILLISECONDS);
+    instanceLauncher.awaitTerminated(500, TimeUnit.MILLISECONDS);
   }
 
 

--- a/gobblin-runtime/src/test/java/gobblin/runtime/util/FSJobCatalogHelperTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/util/FSJobCatalogHelperTest.java
@@ -32,10 +32,12 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.runtime.api.JobSpec;
@@ -77,7 +79,6 @@ public class FSJobCatalogHelperTest {
   private File subDir11;
   private File subDir2;
 
-  private Properties sysProps;
   private Config sysConfig;
   private PullFileLoader loader;
   private FSJobCatalogHelper.JobSpecConverter converter;
@@ -96,8 +97,10 @@ public class FSJobCatalogHelperTest {
     this.subDir11.mkdirs();
     this.subDir2.mkdirs();
 
-    this.sysProps = new Properties();
-    this.sysConfig = ConfigUtils.propertiesToConfig(sysProps);
+
+    this.sysConfig = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+        .put(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, this.jobConfigDir.getAbsolutePath())
+        .build());
     ImmutableFSJobCatalog.ConfigAccessor cfgAccess =
         new ImmutableFSJobCatalog.ConfigAccessor(this.sysConfig);
     this.loader = new PullFileLoader(new Path(jobConfigDir.toURI()), FileSystem.get(new Configuration()),
@@ -163,30 +166,38 @@ public class FSJobCatalogHelperTest {
     // which is on purpose to keep
     // plus ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY, which is not necessary to convert into JobSpec
     // but keep it here to avoid NullPointer exception and validation purpose for testing.
-    Assert.assertEquals(jobProps1.stringPropertyNames().size(), 4);
+    Assert.assertEquals(jobProps1.stringPropertyNames().size(), 5);
     Assert.assertTrue(jobProps1.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
+    Assert.assertEquals(jobProps1.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY),
+        this.jobConfigDir.getAbsolutePath());
     Assert.assertEquals(jobProps1.getProperty("k1"), "d1");
     Assert.assertEquals(jobProps1.getProperty("k8"), "a8");
     Assert.assertEquals(jobProps1.getProperty("k9"), "a8");
 
     // test-job-conf-dir/test1/test11.pull
     Properties jobProps2 = getJobConfigForFile(jobConfigs, "test11.pull");
-    Assert.assertEquals(jobProps2.stringPropertyNames().size(), 4);
+    Assert.assertEquals(jobProps2.stringPropertyNames().size(), 5);
     Assert.assertTrue(jobProps2.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
+    Assert.assertEquals(jobProps2.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY),
+                        this.jobConfigDir.getAbsolutePath());
     Assert.assertEquals(jobProps2.getProperty("k1"), "c1");
     Assert.assertEquals(jobProps2.getProperty("k3"), "b3");
     Assert.assertEquals(jobProps2.getProperty("k6"), "a6");
 
     // test-job-conf-dir/test1/test12.PULL
     Properties jobProps3 = getJobConfigForFile(jobConfigs, "test12.PULL");
-    Assert.assertEquals(jobProps3.stringPropertyNames().size(), 2);
+    Assert.assertEquals(jobProps3.stringPropertyNames().size(), 3);
     Assert.assertTrue(jobProps3.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
+    Assert.assertEquals(jobProps3.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY),
+        this.jobConfigDir.getAbsolutePath());
     Assert.assertEquals(jobProps3.getProperty("k7"), "a7");
 
     // test-job-conf-dir/test2/test21.PULL
     Properties jobProps4 = getJobConfigForFile(jobConfigs, "test21.PULL");
-    Assert.assertEquals(jobProps4.stringPropertyNames().size(), 2);
+    Assert.assertEquals(jobProps4.stringPropertyNames().size(), 3);
     Assert.assertTrue(jobProps4.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY));
+    Assert.assertEquals(jobProps4.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY),
+        this.jobConfigDir.getAbsolutePath());
     Assert.assertEquals(jobProps4.getProperty("k5"), "b5");
   }
 
@@ -195,12 +206,12 @@ public class FSJobCatalogHelperTest {
       throws ConfigurationException, IOException {
     Path jobConfigPath = new Path(this.subDir11.getAbsolutePath(), "test111.pull");
 
-    Properties properties = new Properties();
-    properties.setProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY, this.jobConfigDir.getAbsolutePath());
+    Properties jobProps =
+        ConfigUtils.configToProperties(loader.loadPullFile(jobConfigPath, this.sysConfig, false));
 
-    Properties jobProps = ConfigUtils.configToProperties(loader.loadPullFile(jobConfigPath, this.sysConfig, false));
-
-    Assert.assertEquals(jobProps.stringPropertyNames().size(), 4);
+    Assert.assertEquals(jobProps.stringPropertyNames().size(), 5);
+    Assert.assertEquals(jobProps.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY),
+        this.jobConfigDir.getAbsolutePath());
     Assert.assertEquals(jobProps.getProperty("k1"), "d1");
     Assert.assertEquals(jobProps.getProperty("k8"), "a8");
     Assert.assertEquals(jobProps.getProperty("k9"), "a8");

--- a/gobblin-runtime/src/test/java/gobblin/runtime/util/FSJobCatalogHelperTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/util/FSJobCatalogHelperTest.java
@@ -40,6 +40,7 @@ import com.typesafe.config.Config;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.job_catalog.FSJobCatalog;
+import gobblin.runtime.job_catalog.ImmutableFSJobCatalog;
 import gobblin.util.ConfigUtils;
 import gobblin.util.PullFileLoader;
 import gobblin.util.filesystem.PathAlterationDetector;
@@ -81,9 +82,6 @@ public class FSJobCatalogHelperTest {
   private PullFileLoader loader;
   private FSJobCatalogHelper.JobSpecConverter converter;
 
-  // Testing the materialized and de-materialized process here.
-  private Config testConfig;
-
   @BeforeClass
   public void setUp()
       throws IOException {
@@ -100,8 +98,10 @@ public class FSJobCatalogHelperTest {
 
     this.sysProps = new Properties();
     this.sysConfig = ConfigUtils.propertiesToConfig(sysProps);
+    ImmutableFSJobCatalog.ConfigAccessor cfgAccess =
+        new ImmutableFSJobCatalog.ConfigAccessor(this.sysConfig);
     this.loader = new PullFileLoader(new Path(jobConfigDir.toURI()), FileSystem.get(new Configuration()),
-        FSJobCatalogHelper.getJobConfigurationFileExtensions(sysProps),
+        cfgAccess.getJobConfigurationFileExtensions(),
         PullFileLoader.DEFAULT_HOCON_PULL_FILE_EXTENSIONS);
     this.converter = new FSJobCatalogHelper.JobSpecConverter(new Path(this.jobConfigDir.toURI()), Optional.of(
         FSJobCatalog.CONF_EXTENSION));


### PR DESCRIPTION
Mostly simple refactoring of ImmutableFSJobCatalog.

Concentrate the config processing of ImmutableFSJobCatalog in ImmutableFSJobCatalog.ConfigAccessor. Remove some unnecessary conversions between typesafe config and properties.

@ibuenros @autumnust  can you review?