### PR TITLE
[AvroToOrc] Use comma separated list for hiveRuntime properties

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -268,7 +268,8 @@ ext.externalDependency = [
   "embeddedProcess": "de.flapdoodle.embed:de.flapdoodle.embed.process:1.50.2",
   "testMysqlServer": "com.wix:wix-embedded-mysql:2.0.1",
   "flyway": "org.flywaydb:flyway-core:3.2.1",
-  "oltu": "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2"
+  "oltu": "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2",
+  "opencsv": "net.sf.opencsv:opencsv:2.3"
 ];
 
 if (!isDefaultEnvironment)

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -27,7 +27,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.typesafe.config.Config;
-import com.typesafe.config.ConfigFactory;
 
 import gobblin.data.management.copy.hive.HiveDataset;
 import gobblin.data.management.copy.hive.HiveDatasetFinder;
@@ -53,6 +52,7 @@ import gobblin.util.ConfigUtils;
  *  And the destination table name for nested ORC is set at nestedOrc.tableName
  * </ul>
  * </p>
+ * @see ConversionConfig
  */
 @ToString
 public class ConvertibleHiveDataset extends HiveDataset {
@@ -125,8 +125,12 @@ public class ConvertibleHiveDataset extends HiveDataset {
    *  <ul>
    *    <li>{@value #CLUSTER_BY_KEY}
    *    <li>{@value #NUM_BUCKETS_KEY}
-   *    <li>Any properties with a prefix of {@value #HIVE_RUNTIME_PROPERTIES_KEY_PREFIX} will be available at
-   *    {@link #getHiveRuntimeProperties()} without the prefix.
+   *    <li>{@value #HIVE_RUNTIME_PROPERTIES_LIST_KEY} can be used to provide a list of hive properties to be set before
+   *    conversion. The value should can be an array of keys and values or a comma separated string of keys and values.
+   *    E.g. [key1,value1,key2,value2] or key1,value1,key2,value2
+   *    <li>{@value #DESTINATION_TABLE_PROPERTIES_LIST_KEY} can be used to provide a list of table properties to be set
+   *    on the destination table. The value should can be an array of keys and values or a comma separated string of keys and values.
+   *    E.g. [key1,value1,key2,value2] or key1,value1,key2,value2
    *  </ul>
    * <p>
    */
@@ -136,13 +140,13 @@ public class ConvertibleHiveDataset extends HiveDataset {
     public static final String DESTINATION_TABLE_KEY = "destination.tableName";
     public static final String DESTINATION_DB_KEY = "destination.dbName";
     public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
-    public static final String DESTINATION_TABLE_PROPERTIES_KEY = "destination.tableProperties";
+    public static final String DESTINATION_TABLE_PROPERTIES_LIST_KEY = "destination.tableProperties";
     public static final String CLUSTER_BY_KEY = "clusterByList";
     public static final String NUM_BUCKETS_KEY = "numBuckets";
     public static final String EVOLUTION_ENABLED = "evolution.enabled";
     public static final String ROW_LIMIT_KEY = "rowLimit";
     public static final String HIVE_VERSION_KEY = "hiveVersion";
-    private static final String HIVE_RUNTIME_PROPERTIES_KEY_PREFIX = "hiveRuntime";
+    private static final String HIVE_RUNTIME_PROPERTIES_LIST_KEY = "hiveRuntimeProperties";
 
     /***
      * Comma separated list of string that should be used as a prefix for destination partition directory name
@@ -211,15 +215,28 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.destinationDataPath = resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), table);
 
       // Optional
-      this.destinationTableProperties = ConfigUtils
-          .configToProperties(ConfigUtils.getConfig(config, DESTINATION_TABLE_PROPERTIES_KEY, ConfigFactory.empty()));
+      this.destinationTableProperties =
+          convertKeyValueListToProperties(ConfigUtils.getStringList(config, DESTINATION_TABLE_PROPERTIES_LIST_KEY));
       this.clusterBy = ConfigUtils.getStringList(config, CLUSTER_BY_KEY);
       this.numBuckets = Optional.fromNullable(ConfigUtils.getInt(config, NUM_BUCKETS_KEY, null));
-      this.hiveRuntimeProperties = ConfigUtils
-          .configToProperties(ConfigUtils.getConfig(config, HIVE_RUNTIME_PROPERTIES_KEY_PREFIX, ConfigFactory.empty()));
+
+      this.hiveRuntimeProperties =
+          convertKeyValueListToProperties(ConfigUtils.getStringList(config, HIVE_RUNTIME_PROPERTIES_LIST_KEY));
       this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
       this.rowLimit = Optional.fromNullable(ConfigUtils.getInt(config, ROW_LIMIT_KEY, null));
       this.sourceDataPathIdentifier = ConfigUtils.getStringList(config, SOURCE_DATA_PATH_IDENTIFIER_KEY);
+    }
+
+    private Properties convertKeyValueListToProperties(List<String> keyValueList) {
+      Preconditions.checkArgument(keyValueList.size() % 2 == 0, String.format(
+          "The list %s does not have equal number of keys and values. Size %s", keyValueList, keyValueList.size()));
+      Properties props = new Properties();
+      for (int i = 0; i < keyValueList.size(); i += 2) {
+        String key = keyValueList.get(i);
+        String value = keyValueList.get(i + 1);
+        props.put(key, value);
+      }
+      return props;
     }
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -127,7 +127,7 @@ public class ConvertibleHiveDatasetTest {
     Assert.assertEquals(conversionConfig.getNumBuckets().get(), Integer.valueOf(4));
 
     Properties hiveProps = new Properties();
-    hiveProps.setProperty("mapred.map.tasks", "10");
+    hiveProps.setProperty("mapred.map.tasks", "10,12");
     hiveProps.setProperty("hive.merge.mapfiles", "false");
     Assert.assertEquals(conversionConfig.getHiveRuntimeProperties(), hiveProps);
   }

--- a/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.conf
+++ b/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.conf
@@ -10,10 +10,10 @@ hive.conversion.avro : {
     clusterByList="c1,c2"
     numBuckets=4
 
-    hiveRuntime : {
-      hive.merge.mapfiles=false
-      mapred.map.tasks=10
-    }
+    hiveRuntimeProperties : [
+      "hive.merge.mapfiles","false",
+      "mapred.map.tasks","10,12"
+    ]
   }
 
   nestedOrc : {
@@ -24,8 +24,8 @@ hive.conversion.avro : {
     clusterByList="c3,c4"
     numBuckets=5
 
-    hiveRuntime : {
-      mapred.map.tasks=12
-    }
+    hiveRuntimeProperties : [
+      "mapred.map.tasks","12"
+    ]
   }
 }

--- a/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.properties
+++ b/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.properties
@@ -5,12 +5,11 @@ hive.conversion.avro.flattenedOrc.destination.dbName=$DB_flattenedOrcDb
 hive.conversion.avro.flattenedOrc.destination.dataPath=/tmp/data_flattenedOrc/$DB/$TABLE
 hive.conversion.avro.flattenedOrc.clusterByList=c1,c2
 hive.conversion.avro.flattenedOrc.numBuckets=4
-hive.conversion.avro.flattenedOrc.hiveRuntime.hive.merge.mapfiles=false
-hive.conversion.avro.flattenedOrc.hiveRuntime.mapred.map.tasks=10
+hive.conversion.avro.flattenedOrc.hiveRuntimeProperties="hive.merge.mapfiles","false","mapred.map.tasks","10,12"
 
 hive.conversion.avro.nestedOrc.destination.tableName=$TABLE_nestedOrc
 hive.conversion.avro.nestedOrc.destination.dbName=$DB_nestedOrcDb
 hive.conversion.avro.nestedOrc.destination.dataPath=/tmp/data_nestedOrc/$DB/$TABLE
 hive.conversion.avro.nestedOrc.clusterByList=c3,c4
 hive.conversion.avro.nestedOrc.numBuckets=5
-hive.conversion.avro.nestedOrc.hiveRuntime.mapred.map.tasks=12
+hive.conversion.avro.nestedOrc.hiveRuntimeProperties="mapred.map.tasks","12"

--- a/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedOrc.conf
+++ b/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedOrc.conf
@@ -7,9 +7,9 @@ hive.conversion.avro : {
     clusterByList="c1,c2"
     numBuckets=4
 
-    hiveRuntime : {
-      hive.merge.mapfiles=false
-      mapred.map.tasks=10
-    }
+    hiveRuntimeProperties : [
+      "hive.merge.mapfiles","false",
+      "mapred.map.tasks","10,12"
+    ]
   }
 }

--- a/gobblin-utility/build.gradle
+++ b/gobblin-utility/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   compile externalDependency.avroMapredH2
   compile externalDependency.commonsLang3
   compile externalDependency.gson
+  compile externalDependency.opencsv
 
   runtime externalDependency.hadoopCommon
   runtime externalDependency.hadoopClientCore

--- a/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
@@ -69,14 +69,35 @@ public class ConfigUtilsTest {
   @Test
   public void testGetStringList() throws Exception {
 
-    // Comma separated
-    Assert.assertEquals(ConfigUtils.getStringList(ConfigFactory.parseMap(ImmutableMap.of("key1", "value1,value2")), "key1"),
-        ImmutableList.of("value1", "value2"));
+    // values as comma separated strings
+    Assert.assertEquals(ConfigUtils.getStringList(ConfigFactory.parseMap(ImmutableMap.of("a.b", "1,2,3")), "a.b"),
+        ImmutableList.of("1", "2", "3"));
 
-    // Type safe list
-    Assert.assertEquals(
-        ConfigUtils.getStringList(ConfigFactory.empty().withValue("key1", ConfigValueFactory.fromIterable(ImmutableList.of("value1", "value2"))), "key1"),
-        ImmutableList.of("value1", "value2"));
+    // values as quoted comma separated strings
+    Assert.assertEquals(ConfigUtils.getStringList(ConfigFactory.parseMap(ImmutableMap.of("a.b", "\"1\",\"2\",\"3\"")), "a.b"),
+        ImmutableList.of("1", "2", "3"));
+
+    // values as quoted comma separated strings (Multiple values)
+    Assert.assertEquals(ConfigUtils.getStringList(ConfigFactory.parseMap(ImmutableMap.of("a.b", "\"1\",\"2,3\"")), "a.b"),
+        ImmutableList.of("1", "2,3"));
+
+    // values as Type safe list
+    Assert.assertEquals(ConfigUtils.getStringList(
+            ConfigFactory.empty().withValue("a.b",
+                ConfigValueFactory.fromIterable(ImmutableList.of("1", "2","3"))), "a.b"),
+        ImmutableList.of("1", "2", "3"));
+
+    // values as quoted Type safe list
+    Assert.assertEquals(ConfigUtils.getStringList(
+            ConfigFactory.empty().withValue("a.b",
+                ConfigValueFactory.fromIterable(ImmutableList.of("\"1\"", "\"2\"","\"3\""))), "a.b"),
+        ImmutableList.of("1", "2", "3"));
+
+    // values as quoted Type safe list (Multiple values)
+    Assert.assertEquals(ConfigUtils.getStringList(
+            ConfigFactory.empty().withValue("a.b",
+                ConfigValueFactory.fromIterable(ImmutableList.of("\"1\"", "\"2,3\""))), "a.b"),
+        ImmutableList.of("1", "2,3"));
 
     // Empty list if path does not exist
     Assert.assertEquals(ConfigUtils.getStringList(ConfigFactory.parseMap(ImmutableMap.of("key1", "value1,value2")), "key2"), ImmutableList.of());


### PR DESCRIPTION
Currently `hiveRuntime` properties are set in the config store as 

```
hiveRuntime : {
      mapreduce.input.fileinputformat.split.minsize=32000000
      mapreduce.input.fileinputformat.split.minsize.per.node=32000000
}

```
Since we use `TypeSafeConfig` to parse, the config  `mapreduce.input.fileinputformat.split.minsize.per.node=32000000` is overwritten by `mapreduce.input.fileinputformat.split.minsize=32000000`

Hence changing the syntax of `hiveRuntime` to a list of key value pairs.


```
hiveRuntime : [
      mapreduce.input.fileinputformat.split.minsize,32000000
      ,mapreduce.input.fileinputformat.split.minsize.per.node,32000000
]
```

@abti can you review?

