### PR TITLE
Fix unit test that may not reset system time

### DIFF
--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/filter/LookbackPartitionFilterGeneratorTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/filter/LookbackPartitionFilterGeneratorTest.java
@@ -21,7 +21,7 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-
+@Test(groups = { "SystemTimeTests"})
 public class LookbackPartitionFilterGeneratorTest {
 
   @BeforeMethod

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/HiveRetentionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/integration/HiveRetentionTest.java
@@ -42,7 +42,7 @@ import gobblin.util.PathUtils;
 import gobblin.util.test.RetentionTestDataGenerator.FixedThreadLocalMillisProvider;
 import gobblin.util.test.RetentionTestHelper;
 
-
+@Test(groups = { "SystemTimeTests"})
 public class HiveRetentionTest {
 
   private FileSystem fs;
@@ -62,55 +62,59 @@ public class HiveRetentionTest {
 
   private void testTimeBasedHiveRetention(String dbName, String tableName, String configFileName) throws Exception {
 
-    DateTimeUtils.setCurrentMillisProvider(new FixedThreadLocalMillisProvider(FORMATTER.parseDateTime("2016-01-10-00").getMillis()));
+    try {
+      DateTimeUtils.setCurrentMillisProvider(new FixedThreadLocalMillisProvider(FORMATTER.parseDateTime("2016-01-10-00").getMillis()));
 
-    // Setup 4 partitions. 2 will be deleted and 2 will be retained
-    String tableSdLoc = new Path(testTempPath, dbName + tableName).toString();
-    this.hiveMetastoreTestUtils.dropDatabaseIfExists(dbName);
-    final Table tbl = this.hiveMetastoreTestUtils.createTestTable(dbName, tableName, tableSdLoc, ImmutableList.of("datepartition"), false);
+      // Setup 4 partitions. 2 will be deleted and 2 will be retained
+      String tableSdLoc = new Path(testTempPath, dbName + tableName).toString();
+      this.hiveMetastoreTestUtils.dropDatabaseIfExists(dbName);
+      final Table tbl = this.hiveMetastoreTestUtils.createTestTable(dbName, tableName, tableSdLoc, ImmutableList.of("datepartition"), false);
 
-    String deleted1 = "2016-01-01-00";
-    String deleted2 = "2016-01-02-02";
+      String deleted1 = "2016-01-01-00";
+      String deleted2 = "2016-01-02-02";
 
-    String retained1 = "2016-01-03-04";
-    String retained2 = "2016-01-07-06";
+      String retained1 = "2016-01-03-04";
+      String retained2 = "2016-01-07-06";
 
-    Partition pDeleted1 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(deleted1), (int) System.currentTimeMillis());
-    Partition pDeleted2 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(deleted2), (int) System.currentTimeMillis());
-    Partition pRetained1 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(retained1), (int) System.currentTimeMillis());
-    Partition pRetained2 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(retained2), (int) System.currentTimeMillis());
+      Partition pDeleted1 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(deleted1), (int) System.currentTimeMillis());
+      Partition pDeleted2 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(deleted2), (int) System.currentTimeMillis());
+      Partition pRetained1 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(retained1), (int) System.currentTimeMillis());
+      Partition pRetained2 = this.hiveMetastoreTestUtils.addTestPartition(tbl, ImmutableList.of(retained2), (int) System.currentTimeMillis());
 
-    this.fs.mkdirs(new Path(pDeleted1.getSd().getLocation()));
-    this.fs.mkdirs(new Path(pDeleted2.getSd().getLocation()));
-    this.fs.mkdirs(new Path(pRetained1.getSd().getLocation()));
-    this.fs.mkdirs(new Path(pRetained2.getSd().getLocation()));
+      this.fs.mkdirs(new Path(pDeleted1.getSd().getLocation()));
+      this.fs.mkdirs(new Path(pDeleted2.getSd().getLocation()));
+      this.fs.mkdirs(new Path(pRetained1.getSd().getLocation()));
+      this.fs.mkdirs(new Path(pRetained2.getSd().getLocation()));
 
-    List<Partition> partitions = this.hiveMetastoreTestUtils.getLocalMetastoreClient().listPartitions(dbName, tableName, (short) 10);
-    Assert.assertEquals(partitions.size(), 4);
+      List<Partition> partitions = this.hiveMetastoreTestUtils.getLocalMetastoreClient().listPartitions(dbName, tableName, (short) 10);
+      Assert.assertEquals(partitions.size(), 4);
 
-    RetentionTestHelper.clean(fs, PathUtils.combinePaths(RetentionIntegrationTest.TEST_PACKAGE_RESOURCE_NAME, "testHiveTimeBasedRetention", configFileName),
-        Optional.of(PathUtils.combinePaths(RetentionIntegrationTest.TEST_PACKAGE_RESOURCE_NAME, "testHiveTimeBasedRetention", "jobProps.properties")),
-        testTempPath);
+      RetentionTestHelper.clean(fs, PathUtils.combinePaths(RetentionIntegrationTest.TEST_PACKAGE_RESOURCE_NAME, "testHiveTimeBasedRetention", configFileName),
+          Optional.of(PathUtils.combinePaths(RetentionIntegrationTest.TEST_PACKAGE_RESOURCE_NAME, "testHiveTimeBasedRetention", "jobProps.properties")),
+          testTempPath);
 
-    partitions = this.hiveMetastoreTestUtils.getLocalMetastoreClient().listPartitions(dbName, tableName, (short) 10);
+      partitions = this.hiveMetastoreTestUtils.getLocalMetastoreClient().listPartitions(dbName, tableName, (short) 10);
 
-    Assert.assertEquals(partitions.size(), 2);
+      Assert.assertEquals(partitions.size(), 2);
 
-    assertThat(FluentIterable.from(partitions).transform(new Function<Partition, String>() {
+      assertThat(FluentIterable.from(partitions).transform(new Function<Partition, String>() {
 
-      @Override
-      public String apply(Partition input) {
-        return getQlPartition(tbl, input).getName();
-      }
-    }).toList(), containsInAnyOrder(getQlPartition(tbl, pRetained1).getName(), getQlPartition(tbl, pRetained2).getName()));
+        @Override
+        public String apply(Partition input) {
+          return getQlPartition(tbl, input).getName();
+        }
+      }).toList(), containsInAnyOrder(getQlPartition(tbl, pRetained1).getName(), getQlPartition(tbl, pRetained2).getName()));
 
 
-    Assert.assertTrue(this.fs.exists(new Path(pRetained1.getSd().getLocation())));
-    Assert.assertTrue(this.fs.exists(new Path(pRetained2.getSd().getLocation())));
-    Assert.assertFalse(this.fs.exists(new Path(pDeleted1.getSd().getLocation())));
-    Assert.assertFalse(this.fs.exists(new Path(pDeleted2.getSd().getLocation())));
+      Assert.assertTrue(this.fs.exists(new Path(pRetained1.getSd().getLocation())));
+      Assert.assertTrue(this.fs.exists(new Path(pRetained2.getSd().getLocation())));
+      Assert.assertFalse(this.fs.exists(new Path(pDeleted1.getSd().getLocation())));
+      Assert.assertFalse(this.fs.exists(new Path(pDeleted2.getSd().getLocation())));
 
-    DateTimeUtils.setCurrentMillisSystem();
+    } finally {
+      DateTimeUtils.setCurrentMillisSystem();
+    }
+
   }
 
 


### PR DESCRIPTION
Some of the tests that alter the current time may not set it back if the test fails.
All test that modify system time belong to the group `SystemTimeTests`. We already have an after group method that resets time if the tests themselves has not done it.

@ibuenros can you review? 