### PR TITLE
Make Quartz initialization backward compatible in SchedulerService

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerService.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerService.java
@@ -24,6 +24,7 @@ import com.typesafe.config.Config;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.util.ConfigUtils;
+import gobblin.util.PropertiesUtils;
 
 import lombok.Getter;
 
@@ -48,7 +49,7 @@ public class SchedulerService extends AbstractIdleService {
     this(Boolean.parseBoolean(
             props.getProperty(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY,
                               ConfigurationKeys.DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION)),
-        Optional.of(props));
+        Optional.of(PropertiesUtils.extractPropertiesWithPrefix(props, Optional.of("org.quartz."))));
   }
 
   public SchedulerService(Config cfg) {

--- a/gobblin-utility/src/main/java/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PropertiesUtils.java
@@ -17,6 +17,7 @@ import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
@@ -61,6 +62,9 @@ public class PropertiesUtils {
    * @return a {@link Properties} instance
    */
   public static Properties extractPropertiesWithPrefix(Properties properties, Optional<String> prefix) {
+    Preconditions.checkNotNull(properties);
+    Preconditions.checkNotNull(prefix);
+
     Properties extractedProperties = new Properties();
     for (Map.Entry<Object, Object> entry : properties.entrySet()) {
       if (StringUtils.startsWith(entry.getKey().toString(), prefix.or(StringUtils.EMPTY))) {

--- a/gobblin-utility/src/main/java/gobblin/util/PropertiesUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/PropertiesUtils.java
@@ -15,6 +15,9 @@ package gobblin.util;
 import java.util.Map;
 import java.util.Properties;
 
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableMap;
 
 
@@ -47,5 +50,24 @@ public class PropertiesUtils {
   
   public static boolean getPropAsBoolean(Properties properties, String key, String defaultValue) {
     return Boolean.valueOf(properties.getProperty(key, defaultValue));
+  }
+
+  /**
+   * Extract all the keys that start with a <code>prefix</code> in {@link Properties} to a new {@link Properties}
+   * instance.
+   *
+   * @param properties the given {@link Properties} instance
+   * @param prefix of keys to be extracted
+   * @return a {@link Properties} instance
+   */
+  public static Properties extractPropertiesWithPrefix(Properties properties, Optional<String> prefix) {
+    Properties extractedProperties = new Properties();
+    for (Map.Entry<Object, Object> entry : properties.entrySet()) {
+      if (StringUtils.startsWith(entry.getKey().toString(), prefix.or(StringUtils.EMPTY))) {
+        extractedProperties.put(entry.getKey().toString(), entry.getValue());
+      }
+    }
+
+    return extractedProperties;
   }
 }

--- a/gobblin-utility/src/test/java/gobblin/util/PropertiesUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/PropertiesUtilsTest.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.util;
+
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+
+public class PropertiesUtilsTest {
+
+  @Test
+  public void testExtractPropertiesWithPrefix() {
+
+    Properties properties = new Properties();
+    properties.setProperty("k1.kk1", "v1");
+    properties.setProperty("k1.kk2", "v2");
+    properties.setProperty("k2.kk", "v3");
+
+    // First prefix
+    Properties extractedPropertiesK1 = PropertiesUtils.extractPropertiesWithPrefix(properties, Optional.of("k1"));
+    Assert.assertEquals(extractedPropertiesK1.getProperty("k1.kk1"), "v1");
+    Assert.assertEquals(extractedPropertiesK1.getProperty("k1.kk2"), "v2");
+    Assert.assertTrue(!extractedPropertiesK1.containsKey("k2.kk"));
+
+    // Second prefix
+    Properties extractedPropertiesK2 = PropertiesUtils.extractPropertiesWithPrefix(properties, Optional.of("k2"));
+    Assert.assertTrue(!extractedPropertiesK2.containsKey("k1.kk1"));
+    Assert.assertTrue(!extractedPropertiesK2.containsKey("k1.kk2"));
+    Assert.assertEquals(extractedPropertiesK2.getProperty("k2.kk"), "v3");
+
+    // Missing prefix
+    Properties extractedPropertiesK3 = PropertiesUtils.extractPropertiesWithPrefix(properties, Optional.of("k3"));
+    Assert.assertTrue(!extractedPropertiesK3.containsKey("k1.kk1"));
+    Assert.assertTrue(!extractedPropertiesK3.containsKey("k1.kk1"));
+    Assert.assertTrue(!extractedPropertiesK3.containsKey("k2.kk"));
+  }
+}


### PR DESCRIPTION
Changes to SchedulerService were breaking backward compatibility, because irrespective of whether or not properties at initialization time in SchedulerDaemon had quartz related properties, it was being used to initialize SchedulerFactory; which in turn was making the SchedulerFactory to ignore quartz.properties file in classpath and failing to acquire requisite configs to boot up. 