### PR TITLE
Make AccessControlAction to update permissions only when required

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/CombineSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/CombineSelectionPolicy.java
@@ -22,6 +22,8 @@ import java.util.Set;
 
 import javax.annotation.Nullable;
 
+import lombok.ToString;
+
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.base.Preconditions;
@@ -57,6 +59,7 @@ import gobblin.util.reflection.GobblinConstructorUtils;
  *   Additionally, any configuration necessary for combined policies must be specified.
  * </p>
  */
+@ToString
 public class CombineSelectionPolicy implements VersionSelectionPolicy<DatasetVersion> {
 
   public static final String VERSION_SELECTION_POLICIES_PREFIX = "selection.combine.policy.classes";

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/EmbeddedRetentionSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/EmbeddedRetentionSelectionPolicy.java
@@ -15,6 +15,7 @@ import java.util.Collection;
 import java.util.List;
 
 import lombok.AllArgsConstructor;
+import lombok.ToString;
 
 import gobblin.data.management.retention.policy.RetentionPolicy;
 import gobblin.data.management.version.FileSystemDatasetVersion;
@@ -23,6 +24,7 @@ import gobblin.data.management.version.FileSystemDatasetVersion;
  * A wrapper {@link VersionSelectionPolicy} that delegates calls to deprecated {@link RetentionPolicy}
  */
 @AllArgsConstructor
+@ToString
 public class EmbeddedRetentionSelectionPolicy<T extends FileSystemDatasetVersion> implements VersionSelectionPolicy<T> {
 
   private final RetentionPolicy<T> embeddedRetentionPolicy;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/NewestKSelectionPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/NewestKSelectionPolicy.java
@@ -16,6 +16,9 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import lombok.Data;
+import lombok.ToString;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -26,12 +29,11 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.data.management.version.DatasetVersion;
 
-import lombok.Data;
-
 
 /**
  * Select the newest k versions of the dataset.
  */
+@ToString
 public class NewestKSelectionPolicy implements VersionSelectionPolicy<DatasetVersion> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(NewestKSelectionPolicy.class);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectAfterTimeBasedPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectAfterTimeBasedPolicy.java
@@ -13,6 +13,8 @@ package gobblin.data.management.policy;
 
 import java.util.Properties;
 
+import lombok.ToString;
+
 import org.joda.time.Period;
 
 import com.google.common.base.Optional;
@@ -28,6 +30,7 @@ import gobblin.util.ConfigUtils;
  * Selects {@link TimestampedDatasetVersion}s newer than lookbackTime.
  */
 @Alias("SelectAfterTimeBasedPolicy")
+@ToString(callSuper=true)
 public class SelectAfterTimeBasedPolicy extends SelectBetweenTimeBasedPolicy {
 
   public static final String TIME_BASED_SELECTION_LOOK_BACK_TIME_KEY = "selection.timeBased.lookbackTime";

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectAllPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectAllPolicy.java
@@ -16,12 +16,15 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import lombok.ToString;
+
 import gobblin.data.management.version.FileSystemDatasetVersion;
 
 
 /**
  * Implementation of {@link VersionSelectionPolicy} that selects all {@link FileSystemDatasetVersion}s.
  */
+@ToString
 public class SelectAllPolicy implements VersionSelectionPolicy<FileSystemDatasetVersion> {
 
   public SelectAllPolicy(Properties properties) {}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectBeforeTimeBasedPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectBeforeTimeBasedPolicy.java
@@ -13,6 +13,8 @@ package gobblin.data.management.policy;
 
 import java.util.Properties;
 
+import lombok.ToString;
+
 import org.joda.time.Period;
 
 import com.google.common.base.Optional;
@@ -28,6 +30,7 @@ import gobblin.util.ConfigUtils;
  * Selects {@link TimestampedDatasetVersion}s older than lookbackTime.
  */
 @Alias("SelectBeforeTimeBasedPolicy")
+@ToString(callSuper=true)
 public class SelectBeforeTimeBasedPolicy extends SelectBetweenTimeBasedPolicy {
 
   private static final String TIME_BASED_SELECTION_LOOK_BACK_TIME_KEY = "selection.timeBased.lookbackTime";

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectBetweenTimeBasedPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectBetweenTimeBasedPolicy.java
@@ -14,6 +14,8 @@ package gobblin.data.management.policy;
 import java.util.Collection;
 import java.util.List;
 
+import lombok.ToString;
+
 import org.joda.time.DateTime;
 import org.joda.time.Period;
 import org.joda.time.format.PeriodFormatter;
@@ -40,6 +42,7 @@ import gobblin.data.management.version.TimestampedDatasetVersion;
  *
  */
 @Alias("SelectBetweenTimeBasedPolicy")
+@ToString
 public class SelectBetweenTimeBasedPolicy implements VersionSelectionPolicy<TimestampedDatasetVersion> {
 
   protected final Optional<Period> minLookBackPeriod;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectNothingPolicy.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/policy/SelectNothingPolicy.java
@@ -16,6 +16,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Properties;
 
+import lombok.ToString;
+
 import com.google.common.collect.Lists;
 
 import gobblin.data.management.version.FileSystemDatasetVersion;
@@ -24,6 +26,7 @@ import gobblin.data.management.version.FileSystemDatasetVersion;
 /**
  * Implementation of {@link VersionSelectionPolicy} that selects nothing.
  */
+@ToString
 public class SelectNothingPolicy implements VersionSelectionPolicy<FileSystemDatasetVersion> {
 
   public SelectNothingPolicy(Properties properties) {}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/DatasetCleaner.java
@@ -65,7 +65,7 @@ public class DatasetCleaner implements Instrumentable, Closeable {
   public static final String DATASET_CLEAN_HDFS_CALLS_PER_SECOND_LIMIT =
       CONFIGURATION_KEY_PREFIX + "hdfs.calls.per.second.limit";
 
-  public static final String DEFAULT_MAX_CONCURRENT_DATASETS_CLEANED = "1000";
+  public static final String DEFAULT_MAX_CONCURRENT_DATASETS_CLEANED = "100";
 
   private static Logger LOG = LoggerFactory.getLogger(DatasetCleaner.class);
 
@@ -90,6 +90,7 @@ public class DatasetCleaner implements Instrumentable, Closeable {
             Long.parseLong(props.getProperty(DATASET_CLEAN_HDFS_CALLS_PER_SECOND_LIMIT))));
         ((RateControlledFileSystem) optionalRateControlledFs).startRateControl();
       }
+
       this.datasetFinder = new MultiCleanableDatasetFinder(optionalRateControlledFs, props);
     } catch (NumberFormatException exception) {
       throw new IOException(exception);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/action/MultiAccessControlAction.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/action/MultiAccessControlAction.java
@@ -63,8 +63,8 @@ public class MultiAccessControlAction extends RetentionAction {
    * @param actionConfig to use while creating a new {@link MultiAccessControlAction}
    * @param fs
    */
-  private MultiAccessControlAction(Config actionConfig, FileSystem fs) {
-    super(actionConfig, fs);
+  private MultiAccessControlAction(Config actionConfig, FileSystem fs, Config jobConfig) {
+    super(actionConfig, fs, jobConfig);
     this.embeddedAccessControlActions = Lists.newArrayList();
     for (String policy : ConfigUtils.getStringList(actionConfig, POLICIES_KEY)) {
       Preconditions.checkArgument(
@@ -72,7 +72,7 @@ public class MultiAccessControlAction extends RetentionAction {
           String.format("Policy %s is specified at key %s but actionConfig does not have config for this policy."
               + "Complete actionConfig %s", policy, POLICIES_KEY,
               actionConfig.root().render(ConfigRenderOptions.concise())));
-      embeddedAccessControlActions.add(new AccessControlAction(actionConfig.getConfig(policy), fs));
+      embeddedAccessControlActions.add(new AccessControlAction(actionConfig.getConfig(policy), fs, jobConfig));
     }
   }
 
@@ -99,13 +99,13 @@ public class MultiAccessControlAction extends RetentionAction {
         + ACCESS_CONTROL_KEY;
 
     @Override
-    public MultiAccessControlAction createRetentionAction(Config config, FileSystem fs) {
+    public MultiAccessControlAction createRetentionAction(Config config, FileSystem fs, Config jobConfig) {
       Preconditions.checkArgument(this.canCreateWithConfig(config),
           "Can not create MultiAccessControlAction with config " + config.root().render(ConfigRenderOptions.concise()));
       if (config.hasPath(LEGACY_ACCESS_CONTROL_KEY)) {
-        return new MultiAccessControlAction(config.getConfig(LEGACY_ACCESS_CONTROL_KEY), fs);
+        return new MultiAccessControlAction(config.getConfig(LEGACY_ACCESS_CONTROL_KEY), fs, jobConfig);
       } else if (config.hasPath(ACCESS_CONTROL_KEY)) {
-        return new MultiAccessControlAction(config.getConfig(ACCESS_CONTROL_KEY), fs);
+        return new MultiAccessControlAction(config.getConfig(ACCESS_CONTROL_KEY), fs, jobConfig);
       }
       throw new IllegalStateException(
           "RetentionActionFactory.canCreateWithConfig returned true but could not create MultiAccessControlAction");

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableHiveDataset.java
@@ -53,7 +53,7 @@ import gobblin.util.reflection.GobblinConstructorUtils;
  *
  * <ul>
  * <li>A version finder at {@value #VERSION_FINDER_CLASS_KEY} is used to find all the partitions the dataset
- * <li>A selection policy at {@value #SELECTION_POLICY_CLASS_KEY} is appliced on all these partitions to get the partitions to be deleted.
+ * <li>A selection policy at {@value #SELECTION_POLICY_CLASS_KEY} is applied on all these partitions to get the partitions to be deleted.
  * <li>These selected partitions are dropped in the hive metastore and all the data on FileSystem is also deleted
  * </ul>
  *
@@ -63,7 +63,7 @@ import gobblin.util.reflection.GobblinConstructorUtils;
 public class CleanableHiveDataset extends HiveDataset implements CleanableDataset {
 
   private static final String SHOULD_DELETE_DATA_KEY = "gobblin.retention.hive.shouldDeleteData";
-  private static final String SHOULD_DELETE_DATA_DEFAULT = Boolean.toString(true);
+  private static final String SHOULD_DELETE_DATA_DEFAULT = Boolean.toString(false);
 
   private static final String VERSION_FINDER_CLASS_KEY = "version.finder.class";
   private static final String DEFAULT_VERSION_FINDER_CLASS = DatePartitionHiveVersionFinder.class.getName();

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/ConfigurableCleanableDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/ConfigurableCleanableDataset.java
@@ -187,7 +187,8 @@ public class ConfigurableCleanableDataset<T extends FileSystemDatasetVersion>
       try {
         RetentionActionFactory factory = factoryClass.newInstance();
         if (factory.canCreateWithConfig(config)) {
-          builder.retentionAction((RetentionAction) factory.createRetentionAction(config, this.fs));
+          builder.retentionAction((RetentionAction) factory.createRetentionAction(config, this.fs,
+              ConfigUtils.propertiesToConfig(jobProps)));
         }
       } catch (InstantiationException | IllegalAccessException e) {
         Throwables.propagate(e);
@@ -224,7 +225,7 @@ public class ConfigurableCleanableDataset<T extends FileSystemDatasetVersion>
   @SuppressWarnings("unchecked")
   private VersionSelectionPolicy<T> createSelectionPolicy(String className, Config config, Properties jobProps) {
     try {
-      this.log.info(String.format("Configuring selection policy %s for %s with %s", className, this.datasetRoot,
+      this.log.debug(String.format("Configuring selection policy %s for %s with %s", className, this.datasetRoot,
           config.root().render(ConfigRenderOptions.concise())));
       return (VersionSelectionPolicy<T>) GobblinConstructorUtils.invokeFirstConstructor(Class.forName(className),
           ImmutableList.<Object> of(config), ImmutableList.<Object> of(config, jobProps),

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/MultiVersionCleanableDatasetBase.java
@@ -269,7 +269,7 @@ public abstract class MultiVersionCleanableDatasetBase<T extends FileSystemDatas
       }
 
       this.log.info(String.format("Cleaning dataset %s. Using version finder %s and policy %s", this,
-          versionFinder.getClass().getName(), selectionPolicy.getClass().getName()));
+          versionFinder.getClass().getName(), selectionPolicy));
 
       List<T> versions = Lists.newArrayList(versionFinder.findDatasetVersions(this));
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiCleanableDatasetFinder.java
@@ -25,14 +25,20 @@ import com.typesafe.config.Config;
  * A Clenable DatasetFinder that instantiates multiple DatasetFinders.
  * <p>
  * If {@link #DATASET_FINDER_CLASS_KEY} is set, a single datasetFinder is created.
- * Otherwise {@link #TAGS_TO_IMPORT_KEY} is used to find all the importedBy {@link URI}s from gobblin config management.
+ * Otherwise {@link #TAGS_TO_IMPORT_KEY} is used to find all the importedBy {@link URI}s from gobblin config store.
  * The {@link Config} for each {@link URI} should have a {@link #DATASET_FINDER_CLASS_KEY} set.
  * </p>
  *
  */
 public class MultiCleanableDatasetFinder extends MultiDatasetFinder {
 
+  /**
+   * Comma separated list of tags in the config store. Any dataset that imports this tag will be processed
+   */
   public static final String TAGS_TO_IMPORT_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX + "tag";
+  /**
+   * Exact dataset finder class to use
+   */
   public static final String DATASET_FINDER_CLASS_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX + "dataset.finder.class";
   public static final String DEPRECATED_DATASET_PROFILE_CLASS_KEY = DatasetCleaner.CONFIGURATION_KEY_PREFIX + "dataset.profile.class";
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/profile/MultiDatasetFinder.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
+import com.google.common.base.Splitter;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -54,6 +55,8 @@ import gobblin.util.reflection.GobblinConstructorUtils;
  */
 @Slf4j
 public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
+  private static final Splitter TAGS_SPLITTER = Splitter.on(",").omitEmptyStrings().trimResults();
+
   protected abstract String datasetFinderClassKey();
 
   protected abstract String datasetFinderImportedByKey();
@@ -61,6 +64,7 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
   List<DatasetsFinder<Dataset>> datasetFinders;
 
   protected final Properties jobProps;
+
   @SuppressWarnings({ "rawtypes", "unchecked" })
   public MultiDatasetFinder(FileSystem fs, Properties jobProps) {
     this.jobProps = jobProps;
@@ -69,9 +73,9 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
 
       if (jobProps.containsKey(datasetFinderClassKey())) {
         try {
+          log.info(String.format("Instantiating datasetfinder %s ", jobProps.getProperty(datasetFinderClassKey())));
           this.datasetFinders.add((DatasetsFinder) ConstructorUtils.invokeConstructor(
               Class.forName(jobProps.getProperty(datasetFinderClassKey())), fs, jobProps));
-          log.info(String.format("Instantiated datasetfinder %s ", jobProps.getProperty(datasetFinderClassKey())));
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException | InstantiationException
             | ClassNotFoundException e) {
           log.error(
@@ -79,10 +83,17 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
                   jobProps.getProperty(datasetFinderClassKey())), e);
           Throwables.propagate(e);
         }
-      } else {
+      } else if (jobProps.containsKey(datasetFinderImportedByKey())) {
+
+        log.info("Instatiating dataset finders using tag " + jobProps.getProperty(datasetFinderImportedByKey()));
+
         ConfigClient client = ConfigClientCache.getClient(VersionStabilityPolicy.STRONG_LOCAL_STABILITY);
-        Collection<URI> importedBys =
-            client.getImportedBy(new URI(jobProps.getProperty(datasetFinderImportedByKey())), false);
+        Collection<URI> importedBys = Lists.newArrayList();
+
+        for (String tag : TAGS_SPLITTER.split(jobProps.getProperty(datasetFinderImportedByKey()))) {
+          log.info("Looking for datasets that import tag " + tag);
+          importedBys.addAll(client.getImportedBy(new URI(tag), false));
+        }
 
         for (URI importedBy : importedBys) {
           Config datasetClassConfig = client.getConfig(importedBy);
@@ -100,6 +111,10 @@ public abstract class MultiDatasetFinder implements DatasetsFinder<Dataset> {
             Throwables.propagate(e);
           }
         }
+      } else {
+        log.warn(String.format(
+            "NO DATASET_FINDERS FOUND. Either specify dataset finder class at %s or specify the imported tags at %s",
+            datasetFinderClassKey(), datasetFinderImportedByKey()));
       }
 
     } catch (IllegalArgumentException | VersionDoesNotExistException | ConfigStoreFactoryDoesNotExistsException

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/finder/DateTimeDatasetVersionFinder.java
@@ -12,8 +12,10 @@
 
 package gobblin.data.management.retention.version.finder;
 
+import java.io.IOException;
 import java.util.Properties;
 
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
@@ -59,14 +61,23 @@ public class DateTimeDatasetVersionFinder extends DatasetVersionFinder<Timestamp
   }
 
   @Override
-  public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, Path fullPath) {
-    gobblin.data.management.version.TimestampedDatasetVersion timestampedDatasetVersion = this.realVersionFinder.getDatasetVersion(pathRelativeToDatasetRoot, fullPath);
+  public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, FileStatus versionFileStatus) {
+    gobblin.data.management.version.TimestampedDatasetVersion timestampedDatasetVersion =
+        this.realVersionFinder.getDatasetVersion(pathRelativeToDatasetRoot, versionFileStatus);
     if (timestampedDatasetVersion != null) {
       return new TimestampedDatasetVersion(timestampedDatasetVersion);
     }
     return null;
   }
 
+  // This Method will never be called. It exists because the deprecated super class gobblin.data.management.retention.version.finder.DatasetVersionFinder
+  // requires it. getDatasetVersion(Path pathRelativeToDatasetRoot, FileStatus versionFileStatus) will be called instead
+  @Override
+  public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, Path fullPath) {
+    throw new UnsupportedOperationException(
+        "This method should not be called. getDatasetVersion(Path pathRelativeToDatasetRoot, FileStatus versionFileStatus) "
+        + "should have been called instead");
+  }
 
   /**
    * This conversion is required because the deprecated keys {@value #RETENTION_DATE_TIME_PATTERN_KEY} and
@@ -85,4 +96,6 @@ public class DateTimeDatasetVersionFinder extends DatasetVersionFinder<Timestamp
     }
     return props;
   }
+
+
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/FileStatusAware.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/FileStatusAware.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version;
+
+import java.util.Set;
+
+import org.apache.hadoop.fs.FileStatus;
+
+/**
+ * A {@link FileSystemDatasetVersion} that is aware {@link FileStatus}s or its paths
+ */
+public interface FileStatusAware {
+  /**
+   * Get the set of {@link FileStatus}s that are included in this dataset version or the {@link FileStatus} of the dataset
+   * version itself (In which case the set has one file status).
+   *
+   */
+  public Set<FileStatus> getFileStatuses();
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/FileStatusTimestampedDatasetVersion.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/FileStatusTimestampedDatasetVersion.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.version;
+
+import java.util.Set;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.joda.time.DateTime;
+
+import com.google.common.collect.Sets;
+
+/**
+ * A {@link TimestampedDatasetVersion} that is also aware of the {@link FileStatus}s of all its paths.
+ */
+public class FileStatusTimestampedDatasetVersion extends TimestampedDatasetVersion implements FileStatusAware {
+
+  private final FileStatus fileStatus;
+  public FileStatusTimestampedDatasetVersion(DateTime version, FileStatus fileStatus) {
+    super(version, fileStatus.getPath());
+    this.fileStatus = fileStatus;
+  }
+
+  @Override
+  public Set<FileStatus> getFileStatuses() {
+    return Sets.newHashSet(this.fileStatus);
+  }
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/AbstractDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/AbstractDatasetVersionFinder.java
@@ -1,0 +1,106 @@
+/*
+* Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+*
+* Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+* this file except in compliance with the License. You may obtain a copy of the
+* License at  http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed
+* under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+* CONDITIONS OF ANY KIND, either express or implied.
+*/
+
+package gobblin.data.management.version.finder;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.collect.Lists;
+
+import gobblin.dataset.Dataset;
+import gobblin.dataset.FileSystemDataset;
+import gobblin.data.management.version.FileSystemDatasetVersion;
+import gobblin.util.PathUtils;
+
+
+/**
+ * Class to find {@link FileSystemDataset} versions in the file system.
+ *
+ * Concrete subclasses should implement a ({@link org.apache.hadoop.fs.FileSystem}, {@link java.util.Properties})
+ * constructor to be instantiated.
+ *
+ * Provides a callback {@link AbstractDatasetVersionFinder#getDatasetVersion(Path, FileStatus)} which subclasses need to
+ * implement.
+ *
+ * @param <T> Type of {@link gobblin.data.management.version.FileSystemDatasetVersion} expected from this class.
+ */
+public abstract class AbstractDatasetVersionFinder<T extends FileSystemDatasetVersion> implements VersionFinder<T> {
+
+  protected FileSystem fs;
+
+  public AbstractDatasetVersionFinder(FileSystem fs, Properties props) {
+    this.fs = fs;
+  }
+
+  public AbstractDatasetVersionFinder(FileSystem fs) {
+    this(fs, new Properties());
+  }
+
+  /**
+   * Find dataset versions in the input {@link org.apache.hadoop.fs.Path}. Dataset versions are subdirectories of the
+   * input {@link org.apache.hadoop.fs.Path} representing a single manageable unit in the dataset.
+   * See {@link gobblin.data.management.retention.DatasetCleaner} for more information.
+   *
+   * @param dataset {@link org.apache.hadoop.fs.Path} to directory containing all versions of a dataset.
+   * @return Map of {@link gobblin.data.management.version.DatasetVersion} and {@link org.apache.hadoop.fs.FileStatus}
+   *        for each dataset version found.
+   * @throws IOException
+   */
+  @Override
+  public Collection<T> findDatasetVersions(Dataset dataset) throws IOException {
+    FileSystemDataset fsDataset = (FileSystemDataset) dataset;
+    Path versionGlobStatus = new Path(fsDataset.datasetRoot(), globVersionPattern());
+    FileStatus[] dataSetVersionPaths = this.fs.globStatus(versionGlobStatus);
+
+    List<T> dataSetVersions = Lists.newArrayList();
+    for (FileStatus dataSetVersionPath : dataSetVersionPaths) {
+      T datasetVersion =
+          getDatasetVersion(PathUtils.relativizePath(dataSetVersionPath.getPath(), fsDataset.datasetRoot()),
+              dataSetVersionPath);
+      if (datasetVersion != null) {
+        dataSetVersions.add(datasetVersion);
+      }
+    }
+
+    return dataSetVersions;
+  }
+
+  /**
+   * Should return class of T.
+   */
+  @Override
+  public abstract Class<? extends FileSystemDatasetVersion> versionClass();
+
+  /**
+   * Glob pattern relative to the root of the dataset used to find {@link org.apache.hadoop.fs.FileStatus} for each
+   * dataset version.
+   * @return glob pattern relative to dataset root.
+   */
+  public abstract Path globVersionPattern();
+
+  /**
+   * Create a {@link gobblin.data.management.version.DatasetVersion} with <code>versionFileStatus</code> and a path
+   * relative to the dataset.
+   * @param pathRelativeToDatasetRoot {@link org.apache.hadoop.fs.Path} of dataset version relative to dataset root.
+   * @param versionFileStatus {@link FileStatus} of the dataset version.
+   * @return {@link gobblin.data.management.version.DatasetVersion} for that {@link FileStatus}.
+   */
+  public abstract T getDatasetVersion(Path pathRelativeToDatasetRoot, FileStatus versionFileStatus);
+
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/DatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/DatasetVersionFinder.java
@@ -12,21 +12,14 @@
 
 package gobblin.data.management.version.finder;
 
-import java.io.IOException;
-import java.util.Collection;
-import java.util.List;
 import java.util.Properties;
 
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 
-import com.google.common.collect.Lists;
-
-import gobblin.dataset.Dataset;
-import gobblin.dataset.FileSystemDataset;
 import gobblin.data.management.version.FileSystemDatasetVersion;
-import gobblin.util.PathUtils;
+import gobblin.dataset.FileSystemDataset;
 
 
 /**
@@ -35,61 +28,27 @@ import gobblin.util.PathUtils;
  * Concrete subclasses should implement a ({@link org.apache.hadoop.fs.FileSystem}, {@link java.util.Properties})
  * constructor to be instantiated.
  *
+ * Provides a callback with just the path of the version {@link DatasetVersionFinder#getDatasetVersion(Path, Path)}.
+ * Use {@link AbstractDatasetVersionFinder#getDatasetVersion(Path, FileStatus)} if you need a callback with {@link FileStatus}
+ * of the version.
+ *
  * @param <T> Type of {@link gobblin.data.management.version.FileSystemDatasetVersion} expected from this class.
  */
-public abstract class DatasetVersionFinder<T extends FileSystemDatasetVersion> implements VersionFinder<T> {
-
-  protected FileSystem fs;
+public abstract class DatasetVersionFinder<T extends FileSystemDatasetVersion> extends AbstractDatasetVersionFinder<T>
+    implements VersionFinder<T> {
 
   public DatasetVersionFinder(FileSystem fs, Properties props) {
-    this.fs = fs;
+    super(fs, props);
   }
 
   public DatasetVersionFinder(FileSystem fs) {
     this(fs, new Properties());
   }
 
-  /**
-   * Find dataset versions in the input {@link org.apache.hadoop.fs.Path}. Dataset versions are subdirectories of the
-   * input {@link org.apache.hadoop.fs.Path} representing a single manageable unit in the dataset.
-   * See {@link gobblin.data.management.retention.DatasetCleaner} for more information.
-   *
-   * @param dataset {@link org.apache.hadoop.fs.Path} to directory containing all versions of a dataset.
-   * @return Map of {@link gobblin.data.management.version.DatasetVersion} and {@link org.apache.hadoop.fs.FileStatus}
-   *        for each dataset version found.
-   * @throws IOException
-   */
   @Override
-  public Collection<T> findDatasetVersions(Dataset dataset) throws IOException {
-    FileSystemDataset fsDataset = (FileSystemDataset) dataset;
-    Path versionGlobStatus = new Path(fsDataset.datasetRoot(), globVersionPattern());
-    FileStatus[] dataSetVersionPaths = this.fs.globStatus(versionGlobStatus);
-
-    List<T> dataSetVersions = Lists.newArrayList();
-    for (FileStatus dataSetVersionPath : dataSetVersionPaths) {
-      T datasetVersion =
-          getDatasetVersion(PathUtils.relativizePath(dataSetVersionPath.getPath(), fsDataset.datasetRoot()),
-              dataSetVersionPath.getPath());
-      if (datasetVersion != null) {
-        dataSetVersions.add(datasetVersion);
-      }
-    }
-
-    return dataSetVersions;
+  public T getDatasetVersion(Path pathRelativeToDatasetRoot, FileStatus versionFileStatus) {
+    return getDatasetVersion(pathRelativeToDatasetRoot, versionFileStatus.getPath());
   }
-
-  /**
-   * Should return class of T.
-   */
-  @Override
-  public abstract Class<? extends FileSystemDatasetVersion> versionClass();
-
-  /**
-   * Glob pattern relative to the root of the dataset used to find {@link org.apache.hadoop.fs.FileStatus} for each
-   * dataset version.
-   * @return glob pattern relative to dataset root.
-   */
-  public abstract Path globVersionPattern();
 
   /**
    * Parse {@link gobblin.data.management.version.DatasetVersion} from the path of a dataset version.

--- a/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/DateTimeDatasetVersionFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/version/finder/DateTimeDatasetVersionFinder.java
@@ -15,6 +15,7 @@ package gobblin.data.management.version.finder;
 import java.util.Properties;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTimeZone;
@@ -28,6 +29,7 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.data.management.version.FileStatusTimestampedDatasetVersion;
 import gobblin.data.management.version.FileSystemDatasetVersion;
 import gobblin.data.management.version.TimestampedDatasetVersion;
 
@@ -37,7 +39,7 @@ import gobblin.data.management.version.TimestampedDatasetVersion;
  * Uses a datetime pattern to find dataset versions from the dataset path
  * and parse the {@link org.joda.time.DateTime} representing the version.
  */
-public class DateTimeDatasetVersionFinder extends DatasetVersionFinder<TimestampedDatasetVersion> {
+public class DateTimeDatasetVersionFinder extends AbstractDatasetVersionFinder<TimestampedDatasetVersion> {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(DateTimeDatasetVersionFinder.class);
 
@@ -111,18 +113,22 @@ public class DateTimeDatasetVersionFinder extends DatasetVersionFinder<Timestamp
    * Parse {@link org.joda.time.DateTime} from {@link org.apache.hadoop.fs.Path} using datetime pattern.
    */
   @Override
-  public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, Path fullPath) {
+  public TimestampedDatasetVersion getDatasetVersion(Path pathRelativeToDatasetRoot, FileStatus versionFileStatus) {
+
+    String dateTimeString = null;
     try {
       // pathRelativeToDatasetRoot can be daily/2016/03/02 or 2016/03/02. In either case we need to pick 2016/03/02 as version
-      String dateTimeString =
+      dateTimeString =
           StringUtils.substring(pathRelativeToDatasetRoot.toString(), pathRelativeToDatasetRoot.toString().length()
               - this.datePartitionPattern.length());
 
-      return new TimestampedDatasetVersion(this.formatter.parseDateTime(dateTimeString), fullPath);
+      return new FileStatusTimestampedDatasetVersion(this.formatter.parseDateTime(dateTimeString), versionFileStatus);
 
     } catch (IllegalArgumentException exception) {
-      LOGGER.warn("Candidate dataset version at " + pathRelativeToDatasetRoot
-          + " does not match expected pattern. Ignoring.");
+      LOGGER.warn(String.format(
+          "Candidate dataset version with pathRelativeToDatasetRoot: %s has inferred dataTimeString:%s. "
+              + "It does not match expected datetime pattern %s. Ignoring.", pathRelativeToDatasetRoot, dateTimeString,
+          this.datePartitionPattern));
       return null;
     }
   }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/TimestampedDatasetVersionFinderTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/TimestampedDatasetVersionFinderTest.java
@@ -14,54 +14,80 @@ package gobblin.data.management.retention;
 
 import java.util.Properties;
 
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.data.management.retention.version.TimestampedDatasetVersion;
 import gobblin.data.management.retention.version.finder.DateTimeDatasetVersionFinder;
+import gobblin.util.PathUtils;
 
 
 public class TimestampedDatasetVersionFinderTest {
 
+  private FileSystem fs;
+  private Path testDataPathDummyPath;
+
+  @BeforeClass
+  public void setup() throws Exception {
+    this.fs = FileSystem.get(new Configuration());
+    this.testDataPathDummyPath = new Path(TimestampedDatasetVersionFinderTest.class.getClassLoader().getResource("").getFile());
+    this.fs.mkdirs(this.testDataPathDummyPath);
+  }
+
   @Test
-  public void testVersionParser() {
+  public void testVersionParser() throws Exception {
+
     Properties props = new Properties();
     props.put(DateTimeDatasetVersionFinder.RETENTION_DATE_TIME_PATTERN_KEY, "yyyy/MM/dd/hh/mm");
 
-    DateTimeDatasetVersionFinder parser = new DateTimeDatasetVersionFinder(null, props);
+    DateTimeDatasetVersionFinder parser = new DateTimeDatasetVersionFinder(this.fs, props);
 
     Assert.assertEquals(parser.versionClass(), TimestampedDatasetVersion.class);
     Assert.assertEquals(parser.globVersionPattern(), new Path("*/*/*/*/*"));
-    DateTime version = parser.getDatasetVersion(new Path("2015/06/01/10/12"), new Path("fullPath")).getDateTime();
+    DateTime version = parser.getDatasetVersion(new Path("2015/06/01/10/12"), this.fs.getFileStatus(testDataPathDummyPath)).getDateTime();
     Assert.assertEquals(version.getZone(), DateTimeZone.forID(ConfigurationKeys.PST_TIMEZONE_NAME));
     Assert.assertEquals(version, new DateTime(2015, 6, 1, 10, 12, 0, 0, DateTimeZone.forID(ConfigurationKeys.PST_TIMEZONE_NAME)));
 
-    Assert.assertEquals(parser.getDatasetVersion(new Path("2015/06/01/10/12"), new Path("fullPath")).getPathsToDelete()
-        .iterator().next(), new Path("fullPath"));
+    Assert.assertEquals(
+        PathUtils.getPathWithoutSchemeAndAuthority(parser
+            .getDatasetVersion(new Path("2015/06/01/10/12"), this.fs.getFileStatus(testDataPathDummyPath))
+            .getPathsToDelete().iterator().next()),
+        PathUtils.getPathWithoutSchemeAndAuthority(this.testDataPathDummyPath));
 
   }
 
   @Test
-  public void testVersionParserWithTimeZone() {
+  public void testVersionParserWithTimeZone()  throws Exception {
 
     Properties props = new Properties();
     props.put(DateTimeDatasetVersionFinder.RETENTION_DATE_TIME_PATTERN_KEY, "yyyy/MM/dd/hh/mm");
     props.put(DateTimeDatasetVersionFinder.RETENTION_DATE_TIME_PATTERN_TIMEZONE_KEY, "UTC");
 
-    DateTimeDatasetVersionFinder parser = new DateTimeDatasetVersionFinder(null, props);
+    DateTimeDatasetVersionFinder parser = new DateTimeDatasetVersionFinder(this.fs, props);
 
     Assert.assertEquals(parser.versionClass(), TimestampedDatasetVersion.class);
     Assert.assertEquals(parser.globVersionPattern(), new Path("*/*/*/*/*"));
-    DateTime version = parser.getDatasetVersion(new Path("2015/06/01/10/12"), new Path("fullPath")).getDateTime();
+    DateTime version = parser.getDatasetVersion(new Path("2015/06/01/10/12"), this.fs.getFileStatus(testDataPathDummyPath)).getDateTime();
     Assert.assertEquals(version.getZone(), DateTimeZone.forID("UTC"));
     Assert.assertEquals(version,
         new DateTime(2015, 6, 1, 10, 12, 0, 0, DateTimeZone.forID("UTC")));
-    Assert.assertEquals(parser.getDatasetVersion(new Path("2015/06/01/10/12"), new Path("fullPath")).getPathsToDelete()
-        .iterator().next(), new Path("fullPath"));
+    Assert.assertEquals(
+        PathUtils.getPathWithoutSchemeAndAuthority(parser
+            .getDatasetVersion(new Path("2015/06/01/10/12"), this.fs.getFileStatus(testDataPathDummyPath))
+            .getPathsToDelete().iterator().next()),
+        PathUtils.getPathWithoutSchemeAndAuthority(this.testDataPathDummyPath));
   }
 
+  @AfterClass
+  public void after() throws Exception {
+    this.fs.delete(this.testDataPathDummyPath, true);
+  }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/action/RetentionActionTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/action/RetentionActionTest.java
@@ -29,14 +29,15 @@ public class RetentionActionTest {
     // Using alias
     AccessControlAction testRetentionAction =
         new AccessControlAction(ConfigFactory.parseMap(ImmutableMap.<String, String> of("selection.policy.class",
-            "SelectAfterTimeBasedPolicy", "selection.timeBased.lookbackTime", "7d")), null);
+            "SelectAfterTimeBasedPolicy", "selection.timeBased.lookbackTime", "7d")), null, ConfigFactory.empty());
 
     Assert.assertEquals(testRetentionAction.getSelectionPolicy().getClass(), SelectAfterTimeBasedPolicy.class);
 
     // Using complete class name
     testRetentionAction =
         new AccessControlAction(ConfigFactory.parseMap(ImmutableMap.<String, String> of("selection.policy.class",
-            SelectAfterTimeBasedPolicy.class.getName(), "selection.timeBased.lookbackTime", "7d")), null);
+            SelectAfterTimeBasedPolicy.class.getName(), "selection.timeBased.lookbackTime", "7d")), null,
+            ConfigFactory.empty());
 
     Assert.assertEquals(testRetentionAction.getSelectionPolicy().getClass(), SelectAfterTimeBasedPolicy.class);
   }

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/hive-retention.job
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/hive-retention.job
@@ -9,3 +9,4 @@ gobblin.retention.version.finder.class=gobblin.data.management.version.finder.Da
 gobblin.retention.hive.partition.key.name=datepartition
 gobblin.retention.hive.partition.value.datetime.pattern=yyyy-MM-dd-HH
 gobblin.retention.hive.partition.value.datetime.timezone=America/Los_Angeles
+gobblin.retention.hive.shouldDeleteData=true

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/jobProps.properties
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/jobProps.properties
@@ -1,1 +1,2 @@
 hive.dataset.whitelist=hiveTestDbConfigStore.testTable
+gobblin.retention.hive.shouldDeleteData=true

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testMultiVersionRetention/daily-hourly-retention.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testMultiVersionRetention/daily-hourly-retention.conf
@@ -30,7 +30,7 @@ gobblin.retention : {
       version : {
         finder.class=${gobblin.retention.DateTimeDatasetVersionFinder}
         globPattern = "hourly/*/*/*/*"
-        datetime.pattern = "yyyy/MM/dd/hh"
+        datetime.pattern = "yyyy/MM/dd/HH"
       }
   }
 }

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testMultiVersionRetention/setup_validate.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testMultiVersionRetention/setup_validate.conf
@@ -4,23 +4,23 @@ gobblin.test : {
       {path:"user/gobblin/data/TrackingEvent2/daily/2016/02/12", modTime:"02/12/2016 21:00:00"},
       {path:"user/gobblin/data/TrackingEvent2/daily/2016/02/17", modTime:"02/13/2016 10:00:00"},
       {path:"user/gobblin/data/TrackingEvent2/daily/2016/02/19", modTime:"02/19/2016 20:00:00"},
-      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/16/11", modTime:"02/17/2016 19:00:00"},
-      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/11", modTime:"02/17/2016 20:00:00"},
-      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/20", modTime:"02/17/2016 21:00:00"},
-      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/19/09", modTime:"02/19/2016 10:00:00"}
+      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/16/11", modTime:"02/16/2016 11:00:00"},
+      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/11", modTime:"02/17/2016 11:00:00"},
+      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/20", modTime:"02/17/2016 20:00:00"},
+      {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/19/09", modTime:"02/19/2016 09:00:00"}
     ]
 
     validate : {
       retained : [
         {path:"user/gobblin/data/TrackingEvent2/daily/2016/02/17", modTime:"02/13/2016 10:00:00"},
         {path:"user/gobblin/data/TrackingEvent2/daily/2016/02/19", modTime:"02/19/2016 20:00:00"},
-        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/20", modTime:"02/17/2016 21:00:00"},
-        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/19/09", modTime:"02/19/2016 10:00:00"}
+        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/19/09", modTime:"02/19/2016 09:00:00"}
       ]
       deleted : [
         {path:"user/gobblin/data/TrackingEvent2/daily/2016/02/12", modTime:"02/12/2016 21:00:00"},
-        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/16/11", modTime:"02/17/2016 19:00:00"},
-        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/11", modTime:"02/17/2016 20:00:00"}
+        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/16/11", modTime:"02/16/2016 11:00:00"},
+        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/11", modTime:"02/17/2016 11:00:00"},
+        {path:"user/gobblin/data/TrackingEvent2/hourly/2016/02/17/20", modTime:"02/17/2016 20:00:00"}
       ]
     }
 }


### PR DESCRIPTION
### Changes
This PR looks like a lot of changes but it is not. It has several unrelated changes in a single PR

#### Major changes

1. Major change is in `AccessControlAction` to not make unecessary `FileSystem` calls. With this change, `AccessControlAction` calls `fs.setPermission` and `fs.setOwner` if the permissions and owner of a path are different from what the user wants. To make this change I had to move around some code because the current `FileSystemDatasetVersion` does not know the `FileStatus` of a `DatasetVersion`. It only knows the `Path`.
2. Currently `DatasetCleanerJob` only supports running retention on datasets that import a tag. The only way to run retention on multiple kinds of datasets  that import different tags is to have different jobs. I have added multi tag support in this pr. The same key `gobblin.retention.tag` is now a comma separated list of tags in the config store. (Internal ask from ops ETL-4855)


#### Minor trivial changes

1. Logging in retention was too verbose and useless. Moved some of them to debug. Added `@ToString` to all the version selection policies for more meaningful logs
2. By default the hive based retention used to delete data as well. Looking at the use cases, it seems like the default should to not delete data. Changed it in `CleanableHiveDataset` and a few unit tests.
3. Chagned the `DEFAULT_MAX_CONCURRENT_DATASETS_CLEANED` to 100 from 1000. Since we have more actions like `AccessControl`, I expect more namenode calls. There is no need to stress the namenode because retention is not a time critical job.
4. Added simulate mode for `AccessControlAction`

@ydai1124 and @ibuenros  can you review?