### PR TITLE
Close sftp connection after getting mtime

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpFsHelper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpFsHelper.java
@@ -451,14 +451,20 @@ public class SftpFsHelper implements TimestampAwareFileBasedHelper {
 
   @Override
   public long getFileMTime(String filePath) throws FileBasedHelperException {
-    try {
-      ChannelSftp channelSftp = getSftpChannel();
-      int modificationTime = channelSftp.lstat(filePath).getMTime();
-      channelSftp.disconnect();
-      return modificationTime;
-    } catch (SftpException e) {
-      throw new FileBasedHelperException(String
-          .format("Failed to get modified timestamp for file at path %s due to error %s", filePath, e.getMessage()), e);
-    }
+      ChannelSftp channelSftp = null;
+      try {
+	  channelSftp = getSftpChannel();
+	  int modificationTime = channelSftp.lstat(filePath).getMTime();
+	  return modificationTime;
+      } catch (SftpException e) {
+	  throw new FileBasedHelperException(
+					     String.format("Failed to get modified timestamp for file at path %s due to error %s", filePath,
+							   e.getMessage()),
+					     e);
+      } finally {
+	  if (channelSftp != null) {
+	      channelSftp.disconnect();
+	  }
+      }
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpFsHelper.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/sftp/SftpFsHelper.java
@@ -453,7 +453,9 @@ public class SftpFsHelper implements TimestampAwareFileBasedHelper {
   public long getFileMTime(String filePath) throws FileBasedHelperException {
     try {
       ChannelSftp channelSftp = getSftpChannel();
-      return channelSftp.lstat(filePath).getMTime();
+      int modificationTime = channelSftp.lstat(filePath).getMTime();
+      channelSftp.disconnect();
+      return modificationTime;
     } catch (SftpException e) {
       throw new FileBasedHelperException(String
           .format("Failed to get modified timestamp for file at path %s due to error %s", filePath, e.getMessage()), e);


### PR DESCRIPTION
Fix for #1267. 
Sftp connection is not being closed while getting modification time. So, only 10 files can be pulled from sftp source as sshd supports 10 concurrent channels by default. Fix is added to close the connection once we get modification time.