### PR TITLE
Various changes to job execution to appropriately close services and …

### DIFF
--- a/gobblin-api/src/main/java/gobblin/util/ClassAliasResolver.java
+++ b/gobblin-api/src/main/java/gobblin/util/ClassAliasResolver.java
@@ -97,4 +97,11 @@ public class ClassAliasResolver<T> {
           String.format("Found class %s but it cannot be cast to %s.", aliasOrClassName, this.subtypeOf.getName()), cce);
     }
   }
+
+  /**
+   * Get the map from found aliases to classes.
+   */
+  public Map<String, Class<? extends T>> getAliasMap() {
+    return ImmutableMap.copyOf(this.aliasToClassCache);
+  }
 }

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -21,6 +21,7 @@ dependencies {
   compile project(path: ':gobblin-rest-service:gobblin-rest-api', configuration: 'restClient')
   compile project(path: ':gobblin-rest-service:gobblin-rest-api', configuration: 'dataTemplate', classifier: 'data-template')
   compile project(":gobblin-rest-service:gobblin-rest-server")
+  compile project(":gobblin-data-management")
 
   compile externalDependency.avro
   compile externalDependency.avroMapredH2

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalog.java
@@ -31,7 +31,7 @@ import lombok.Getter;
  * A catalog of all the {@link JobSpec}s a Gobblin instance is currently aware of.
  */
 @Alpha
-public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable, Service {
+public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable {
   /** Returns an immutable {@link Collection} of {@link JobSpec}s that are known to the catalog. */
   Collection<JobSpec> getJobs();
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobCatalog.java
@@ -16,6 +16,7 @@ import java.util.Collection;
 
 import com.codahale.metrics.Gauge;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.Service;
 
 import gobblin.annotation.Alpha;
 import gobblin.instrumented.GobblinMetricsKeys;
@@ -30,7 +31,7 @@ import lombok.Getter;
  * A catalog of all the {@link JobSpec}s a Gobblin instance is currently aware of.
  */
 @Alpha
-public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable {
+public interface JobCatalog extends JobCatalogListenersContainer, Instrumentable, Service {
   /** Returns an immutable {@link Collection} of {@link JobSpec}s that are known to the catalog. */
   Collection<JobSpec> getJobs();
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionDriver.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionDriver.java
@@ -45,9 +45,9 @@ public interface JobExecutionDriver
   //void stopForcefully();
 
   /** {@inheritDoc} */
-  @Override JobExecutionResult get() throws InterruptedException, ExecutionException;
+  @Override JobExecutionResult get() throws InterruptedException;
 
   /** {@inheritDoc} */
   @Override JobExecutionResult get(long timeout, TimeUnit unit)
-            throws InterruptedException, TimeoutException, ExecutionException;
+            throws InterruptedException, TimeoutException;
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionDriver.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/JobExecutionDriver.java
@@ -11,10 +11,13 @@
  */
 package gobblin.runtime.api;
 
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
+import java.util.concurrent.RunnableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Service;
 
 /**
@@ -30,7 +33,7 @@ import com.google.common.util.concurrent.Service;
  * <ul>
  */
 public interface JobExecutionDriver
-       extends Service, JobExecutionStateListenerContainer, Future<JobExecutionResult> {
+       extends JobExecutionStateListenerContainer, ListenableFuture<JobExecutionResult>, RunnableFuture<JobExecutionResult> {
 
   /** The job execution ID */
   JobExecution getJobExecution();
@@ -42,9 +45,9 @@ public interface JobExecutionDriver
   //void stopForcefully();
 
   /** {@inheritDoc} */
-  @Override JobExecutionResult get() throws InterruptedException;
+  @Override JobExecutionResult get() throws InterruptedException, ExecutionException;
 
   /** {@inheritDoc} */
   @Override JobExecutionResult get(long timeout, TimeUnit unit)
-            throws InterruptedException, TimeoutException;
+            throws InterruptedException, TimeoutException, ExecutionException;
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
@@ -43,6 +43,8 @@ import gobblin.runtime.api.MutableJobCatalog;
 import gobblin.runtime.std.DefaultJobCatalogListenerImpl;
 import gobblin.runtime.std.DefaultJobExecutionStateListenerImpl;
 import gobblin.runtime.std.JobLifecycleListenersList;
+import gobblin.util.ExecutorsUtils;
+
 
 /**
  * A default implementation of {@link GobblinInstanceDriver}. It accepts already instantiated
@@ -189,7 +191,7 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
          JobExecutionDriver driver = _jobLauncher.launchJob(_jobSpec);
          _callbacksDispatcher.onJobLaunch(driver);
          driver.registerStateListener(new JobStateTracker());
-        new Thread(driver).start();
+        ExecutorsUtils.newThreadFactory(Optional.of(_log), Optional.of("gobblin-instance-driver")).newThread(driver).start();
       }
       catch (Throwable t) {
         _log.error("Job launch failed: " + t, t);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance/DefaultGobblinInstanceDriverImpl.java
@@ -140,6 +140,7 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
     if (null != _jobSpecListener) {
       _jobCatalog.removeListener(_jobSpecListener);
     }
+    _callbacksDispatcher.close();
     getLog().info("Default driver: shut down.");
   }
 
@@ -188,7 +189,7 @@ public class DefaultGobblinInstanceDriverImpl extends AbstractIdleService
          JobExecutionDriver driver = _jobLauncher.launchJob(_jobSpec);
          _callbacksDispatcher.onJobLaunch(driver);
          driver.registerStateListener(new JobStateTracker());
-         driver.startAsync();
+        new Thread(driver).start();
       }
       catch (Throwable t) {
         _log.error("Job launch failed: " + t, t);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/CachingJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/CachingJobCatalog.java
@@ -66,10 +66,8 @@ public class CachingJobCatalog extends AbstractIdleService implements JobCatalog
   @Override
   protected void startUp() {
     _cache.startAsync();
-    _fallback.startAsync();
     try {
       _cache.awaitRunning(2, TimeUnit.SECONDS);
-      _fallback.awaitRunning(2, TimeUnit.SECONDS);
     } catch (TimeoutException te) {
       throw new RuntimeException("Failed to start " + CachingJobCatalog.class.getName(), te);
     }
@@ -78,10 +76,8 @@ public class CachingJobCatalog extends AbstractIdleService implements JobCatalog
   @Override
   protected void shutDown() {
     _cache.stopAsync();
-    _fallback.stopAsync();
     try {
       _cache.awaitTerminated(2, TimeUnit.SECONDS);
-      _fallback.awaitTerminated(2, TimeUnit.SECONDS);
     } catch (TimeoutException te) {
       throw new RuntimeException("Failed to stop " + CachingJobCatalog.class.getName(), te);
     }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/FSJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/FSJobCatalog.java
@@ -92,6 +92,7 @@ public class FSJobCatalog extends ImmutableFSJobCatalog implements MutableJobCat
    */
   @Override
   public synchronized void put(JobSpec jobSpec) {
+    Preconditions.checkState(state() == State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
     Preconditions.checkNotNull(jobSpec);
     try {
       Path jobSpecPath = getPathForURI(this.jobConfDirPath, jobSpec.getUri());
@@ -110,6 +111,7 @@ public class FSJobCatalog extends ImmutableFSJobCatalog implements MutableJobCat
    */
   @Override
   public synchronized void remove(URI jobURI) {
+    Preconditions.checkState(state() == State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
     try {
       Path jobSpecPath = getPathForURI(this.jobConfDirPath, jobURI);
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/InMemoryJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/InMemoryJobCatalog.java
@@ -14,9 +14,7 @@ package gobblin.runtime.job_catalog;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import org.slf4j.Logger;
@@ -25,14 +23,10 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 
-import gobblin.configuration.State;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
-import gobblin.metrics.Tag;
 import gobblin.runtime.api.GobblinInstanceEnvironment;
 import gobblin.runtime.api.JobCatalog;
-import gobblin.runtime.api.JobCatalogListener;
-import gobblin.runtime.api.JobCatalogListener.AddJobCallback;
 import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.api.JobSpecNotFoundException;
 import gobblin.runtime.api.MutableJobCatalog;
@@ -42,12 +36,8 @@ import gobblin.runtime.api.MutableJobCatalog;
  * Simple implementation of a Gobblin job catalog that stores all JobSpecs in memory. No persistence
  * is provided.
  */
-public class InMemoryJobCatalog implements MutableJobCatalog {
-  protected final JobCatalogListenersList listeners;
-  protected final Logger log;
+public class InMemoryJobCatalog extends MutableJobCatalogBase {
   protected final Map<URI, JobSpec> jobSpecs = new HashMap<>();
-  protected final MetricContext metricContext;
-  protected final StandardMetrics metrics;
 
   public InMemoryJobCatalog() {
     this(Optional.<Logger>absent());
@@ -64,18 +54,7 @@ public class InMemoryJobCatalog implements MutableJobCatalog {
 
   public InMemoryJobCatalog(Optional<Logger> log, Optional<MetricContext> parentMetricContext,
       boolean instrumentationEnabled) {
-    this.log = log.isPresent() ? log.get() : LoggerFactory.getLogger(getClass());
-    this.listeners = new JobCatalogListenersList(log);
-    if (instrumentationEnabled) {
-      MetricContext realParentCtx =
-          parentMetricContext.or(Instrumented.getMetricContext(new State(), getClass()));
-      this.metricContext = realParentCtx.childBuilder(JobCatalog.class.getSimpleName()).build();
-      this.metrics = new StandardMetrics(this);
-    }
-    else {
-      this.metricContext = null;
-      this.metrics = null;
-    }
+    super(log, parentMetricContext, instrumentationEnabled);
   }
 
   /**{@inheritDoc}*/
@@ -95,70 +74,13 @@ public class InMemoryJobCatalog implements MutableJobCatalog {
     }
   }
 
-  /**{@inheritDoc}*/
   @Override
-  public synchronized void addListener(JobCatalogListener jobListener) {
-    Preconditions.checkNotNull(jobListener);
-
-    this.listeners.addListener(jobListener);
-    for (Map.Entry<URI, JobSpec> jobSpecEntry : this.jobSpecs.entrySet()) {
-      AddJobCallback addJobCallback = new AddJobCallback(jobSpecEntry.getValue());
-      this.listeners.callbackOneListener(addJobCallback, jobListener);
-    }
-  }
-
-  /**{@inheritDoc}*/
-  @Override
-  public synchronized void removeListener(JobCatalogListener jobListener) {
-    this.listeners.removeListener(jobListener);
+  protected JobSpec doPut(JobSpec jobSpec) {
+    return this.jobSpecs.put(jobSpec.getUri(), jobSpec);
   }
 
   @Override
-  public synchronized void put(JobSpec jobSpec) {
-    Preconditions.checkNotNull(jobSpec);
-    JobSpec oldSpec = this.jobSpecs.put(jobSpec.getUri(), jobSpec);
-    if (null == oldSpec) {
-      this.listeners.onAddJob(jobSpec);
-    } else {
-      this.listeners.onUpdateJob(jobSpec);
-    }
-  }
-
-  @Override
-  public synchronized void remove(URI uri) {
-    Preconditions.checkNotNull(uri);
-    JobSpec jobSpec = this.jobSpecs.remove(uri);
-    if (null != jobSpec) {
-      this.listeners.onDeleteJob(jobSpec.getUri(), jobSpec.getVersion());
-    }
-  }
-
-  @Override
-  public void registerWeakJobCatalogListener(JobCatalogListener jobListener) {
-    this.listeners.registerWeakJobCatalogListener(jobListener);
-  }
-
-  @Override public MetricContext getMetricContext() {
-    return this.metricContext;
-  }
-
-  @Override public boolean isInstrumentationEnabled() {
-    return null != this.metricContext;
-  }
-
-  @Override public List<Tag<?>> generateTags(State state) {
-    return Collections.emptyList();
-  }
-
-  @Override public void switchMetricContext(List<Tag<?>> tags) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override public void switchMetricContext(MetricContext context) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override public StandardMetrics getMetrics() {
-    return this.metrics;
+  protected JobSpec doRemove(URI uri) {
+    return this.jobSpecs.remove(uri);
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/JobCatalogListenersList.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/JobCatalogListenersList.java
@@ -1,5 +1,7 @@
 package gobblin.runtime.job_catalog;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.net.URI;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -19,7 +21,7 @@ import gobblin.util.callbacks.CallbacksDispatcher;
 
 /** A helper class to manage a list of {@link JobCatalogListener}s for a
  * {@link JobCatalog}. It will dispatch the callbacks to each listener sequentially.*/
-public class JobCatalogListenersList implements JobCatalogListener, JobCatalogListenersContainer {
+public class JobCatalogListenersList implements JobCatalogListener, JobCatalogListenersContainer, Closeable {
   private final CallbacksDispatcher<JobCatalogListener> _disp;
 
   public JobCatalogListenersList() {
@@ -77,6 +79,12 @@ public class JobCatalogListenersList implements JobCatalogListener, JobCatalogLi
     } catch (InterruptedException e) {
       getLog().warn("onUpdateJob interrupted.");
     }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _disp.close();
   }
 
   public void callbackOneListener(Function<JobCatalogListener, Void> callback,

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/MutableJobCatalogBase.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/MutableJobCatalogBase.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime.job_catalog;
+
+import java.net.URI;
+
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.metrics.MetricContext;
+import gobblin.runtime.api.GobblinInstanceEnvironment;
+import gobblin.runtime.api.JobSpec;
+import gobblin.runtime.api.MutableJobCatalog;
+
+
+/**
+ * A base for {@link MutableJobCatalog}s. Handles notifications to listeners on calls to {@link #put}, {@link #remove},
+ * as well as the state of the {@link com.google.common.util.concurrent.Service}.
+ */
+public abstract class MutableJobCatalogBase extends JobCatalogBase implements MutableJobCatalog {
+
+  public MutableJobCatalogBase() {
+  }
+
+  public MutableJobCatalogBase(Optional<Logger> log) {
+    super(log);
+  }
+
+  public MutableJobCatalogBase(GobblinInstanceEnvironment env) {
+    super(env);
+  }
+
+  public MutableJobCatalogBase(Optional<Logger> log, Optional<MetricContext> parentMetricContext,
+      boolean instrumentationEnabled) {
+    super(log, parentMetricContext, instrumentationEnabled);
+  }
+
+  @Override
+  public void put(JobSpec jobSpec) {
+    Preconditions.checkState(state() == State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
+    Preconditions.checkNotNull(jobSpec);
+    JobSpec oldSpec = doPut(jobSpec);
+    if (null == oldSpec) {
+      this.listeners.onAddJob(jobSpec);
+    } else {
+      this.listeners.onUpdateJob(jobSpec);
+    }
+  }
+
+  /**
+   * Add the {@link JobSpec} to the catalog. If a {@link JobSpec} already existed with that {@link URI}, it should be
+   * replaced and the old one returned.
+   * @return if a {@link JobSpec} already existed with that {@link URI}, return the old {@link JobSpec}. Otherwise return
+   * null.
+   */
+  protected abstract JobSpec doPut(JobSpec jobSpec);
+
+  @Override
+  public void remove(URI uri) {
+    Preconditions.checkState(state() == State.RUNNING, String.format("%s is not running.", this.getClass().getName()));
+    Preconditions.checkNotNull(uri);
+    JobSpec jobSpec = doRemove(uri);
+    if (null != jobSpec) {
+      this.listeners.onDeleteJob(jobSpec.getUri(), jobSpec.getVersion());
+    }
+  }
+
+  /**
+   * Remove the {@link JobSpec} with the given {@link URI} from the catalog.
+   * @return The removed {@link JobSpec}, or null if no {@link JobSpec} with the given {@link URI} existed.
+   */
+  protected abstract JobSpec doRemove(URI uri);
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_exec/JobLauncherExecutionDriver.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_exec/JobLauncherExecutionDriver.java
@@ -1,8 +1,12 @@
 package gobblin.runtime.job_exec;
 
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Executor;
+import java.util.concurrent.FutureTask;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -12,7 +16,9 @@ import org.slf4j.LoggerFactory;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.io.Closer;
 import com.google.common.util.concurrent.AbstractIdleService;
+import com.google.common.util.concurrent.ExecutionList;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -25,6 +31,7 @@ import gobblin.runtime.JobException;
 import gobblin.runtime.JobLauncher;
 import gobblin.runtime.JobLauncherFactory;
 import gobblin.runtime.JobLauncherFactory.JobLauncherType;
+import gobblin.runtime.JobState;
 import gobblin.runtime.JobState.RunningState;
 import gobblin.runtime.api.Configurable;
 import gobblin.runtime.api.GobblinInstanceEnvironment;
@@ -41,20 +48,23 @@ import gobblin.runtime.std.DefaultConfigurableImpl;
 import gobblin.runtime.std.JobExecutionStateListeners;
 import gobblin.runtime.std.JobExecutionUpdatable;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
 /**
  * An implementation of JobExecutionDriver which acts as an adapter to the legacy
  * {@link JobLauncher} API.
  */
-public class JobLauncherExecutionDriver extends AbstractIdleService implements JobExecutionDriver {
+public class JobLauncherExecutionDriver extends FutureTask<JobExecutionResult> implements JobExecutionDriver {
   private final Logger _log;
-  private final Configurable _sysConfig;
-  private final JobLauncher _legacyLauncher;
   private final JobSpec _jobSpec;
   private final JobExecutionUpdatable _jobExec;
   private final JobExecutionState _jobState;
   private final JobExecutionStateListeners _callbackDispatcher;
-  private final boolean _instrumentationEnabled;
-  private final JobExecutionLauncher.StandardMetrics _launcherMetrics;
+  private final ExecutionList _executionList;
+  private final DriverRunnable _runnable;
+  private final Closer _closer;
   private JobContext _jobContext;
 
   /**
@@ -70,26 +80,63 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
    * @param log                   an optional logger to be used; if none is specified, a default one
    *                              will be instantiated.
    */
-  public JobLauncherExecutionDriver(Configurable sysConfig, JobSpec jobSpec,
+  public static JobLauncherExecutionDriver create(Configurable sysConfig, JobSpec jobSpec,
       Optional<JobLauncherFactory.JobLauncherType> jobLauncherType,
       Optional<Logger> log, boolean instrumentationEnabled,
       JobExecutionLauncher.StandardMetrics launcherMetrics) {
-    _log = log.isPresent() ? log.get() : LoggerFactory.getLogger(getClass());
-    _sysConfig = sysConfig;
-    _jobSpec = jobSpec;
-    _jobExec = JobExecutionUpdatable.createFromJobSpec(jobSpec);
-    _callbackDispatcher = new JobExecutionStateListeners(_log);
-    _jobState = new JobExecutionState(_jobSpec, _jobExec,
-                                      Optional.<JobExecutionStateListener>of(_callbackDispatcher));
-    _instrumentationEnabled = instrumentationEnabled;
-    _launcherMetrics = launcherMetrics;
-    _legacyLauncher =
-        createLauncher(jobLauncherType.isPresent() ?
-                      Optional.of(jobLauncherType.get().toString()) :
-                      Optional.<String>absent());
+
+    Logger actualLog = log.isPresent() ? log.get() : LoggerFactory.getLogger(JobLauncherExecutionDriver.class);
+
+    JobExecutionStateListeners _callbackDispatcher = new JobExecutionStateListeners(actualLog);
+    JobExecutionUpdatable _jobExec = JobExecutionUpdatable.createFromJobSpec(jobSpec);
+    JobExecutionState _jobState = new JobExecutionState(jobSpec, _jobExec,
+        Optional.<JobExecutionStateListener>of(_callbackDispatcher));
+
+    JobLauncher jobLauncher = createLauncher(sysConfig, jobSpec, actualLog, jobLauncherType.isPresent() ?
+        Optional.of(jobLauncherType.get().toString()) :
+        Optional.<String>absent());
+    JobListenerToJobStateBridge bridge = new JobListenerToJobStateBridge(actualLog, _jobState, instrumentationEnabled, launcherMetrics);
+
+    DriverRunnable runnable = new DriverRunnable(jobLauncher, bridge, _jobState);
+
+    return new JobLauncherExecutionDriver(jobSpec, actualLog, runnable);
   }
 
-  private JobLauncher createLauncher(Optional<String> jobLauncherType) {
+  protected JobLauncherExecutionDriver(JobSpec jobSpec, Logger log, DriverRunnable runnable) {
+    super(runnable);
+    _closer = Closer.create();
+    _closer.register(runnable.getJobLauncher());
+    _log = log;
+    _jobSpec = jobSpec;
+    _jobExec = JobExecutionUpdatable.createFromJobSpec(jobSpec);
+    _callbackDispatcher = _closer.register(new JobExecutionStateListeners(_log));
+    _jobState = new JobExecutionState(_jobSpec, _jobExec,
+                                      Optional.<JobExecutionStateListener>of(_callbackDispatcher));
+    _executionList = new ExecutionList();
+    _runnable = runnable;
+  }
+
+  /**
+   * A runnable that actually executes the job.
+   */
+  @AllArgsConstructor
+  @Getter
+  private static class DriverRunnable implements Callable<JobExecutionResult> {
+
+    private final JobLauncher jobLauncher;
+    private final JobListenerToJobStateBridge bridge;
+    private final JobExecutionState jobState;
+
+    @Override
+    public JobExecutionResult call() throws JobException, InterruptedException, TimeoutException  {
+        jobLauncher.launchJob(bridge);
+        jobState.awaitForDone(Long.MAX_VALUE);
+        return JobExecutionResult.createFromState(jobState);
+    }
+  }
+
+  private static JobLauncher createLauncher(Configurable _sysConfig, JobSpec _jobSpec, Logger _log,
+      Optional<String> jobLauncherType) {
     if (jobLauncherType.isPresent()) {
       return JobLauncherFactory.newJobLauncher(_sysConfig.getConfigAsProperties(),
              _jobSpec.getConfigAsProperties(), jobLauncherType.get());
@@ -115,14 +162,22 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
     return _jobState;
   }
 
-  @Override
-  protected void startUp() throws Exception {
+  protected void startAsync() throws JobException {
     _log.info("Starting " + getClass().getSimpleName());
-    _legacyLauncher.launchJob(new JobListenerToJobStateBridge());
+    new Thread(this).start();
   }
 
   @Override
-  protected void shutDown() throws Exception {
+  protected void done() {
+    _executionList.execute();
+    try {
+      shutDown();
+    } catch (IOException ioe) {
+      _log.error("Failed to close job launcher.");
+    }
+  }
+
+  private void shutDown() throws IOException {
     _log.info("Shutting down " + getClass().getSimpleName());
     if (null != _jobContext) {
       switch (_jobContext.getJobState().getState()) {
@@ -143,21 +198,39 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
       }
     }
 
-    _legacyLauncher.close();
+    _closer.close();
   }
 
+  @Override
+  public void addListener(Runnable listener, Executor executor) {
+    _executionList.add(listener, executor);
+  }
 
-  class JobListenerToJobStateBridge extends AbstractJobListener {
+  static class JobListenerToJobStateBridge extends AbstractJobListener {
 
-    public JobListenerToJobStateBridge() {
-      super(Optional.of(JobLauncherExecutionDriver.this._log));
+    private final JobExecutionState _jobState;
+    private final boolean _instrumentationEnabled;
+    private final JobExecutionLauncher.StandardMetrics _launcherMetrics;
+
+    private JobContext _jobContext;
+
+    public JobListenerToJobStateBridge(Logger log, JobExecutionState jobState,
+        boolean instrumentationEnabled, JobExecutionLauncher.StandardMetrics launcherMetrics) {
+      super(Optional.of(log));
+      _jobState = jobState;
+      _instrumentationEnabled = instrumentationEnabled;
+      _launcherMetrics = launcherMetrics;
     }
+
 
     @Override
     public void onJobPrepare(JobContext jobContext) throws Exception {
       super.onJobPrepare(jobContext);
       _jobContext = jobContext;
-      _jobState.switchToPending();
+      if (_jobState.getRunningState() == null) {
+        _jobState.switchToPending();
+      }
+      _jobState.switchToRunning();
       if (_instrumentationEnabled && null != _launcherMetrics) {
         _launcherMetrics.getNumJobsLaunched().inc();
       }
@@ -166,7 +239,6 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
     @Override
     public void onJobStart(JobContext jobContext) throws Exception {
       super.onJobStart(jobContext);
-      _jobState.switchToRunning();
     }
 
     @Override
@@ -206,7 +278,7 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
   }
 
   @VisibleForTesting JobLauncher getLegacyLauncher() {
-    return _legacyLauncher;
+    return _runnable.getJobLauncher();
   }
 
   /** {@inheritDoc} */
@@ -344,7 +416,7 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
 
     @Override public JobExecutionDriver launchJob(JobSpec jobSpec) {
       Preconditions.checkNotNull(jobSpec);
-      return new JobLauncherExecutionDriver(getSysConfig(), jobSpec, _jobLauncherType,
+      return JobLauncherExecutionDriver.create(getSysConfig(), jobSpec, _jobLauncherType,
           Optional.of(getLog(jobSpec)), isInstrumentationEnabled(), getMetrics());
     }
 
@@ -408,34 +480,15 @@ public class JobLauncherExecutionDriver extends AbstractIdleService implements J
     }
     try {
       // No special processing of callbacks necessary
-      _legacyLauncher.cancelJob(new AbstractJobListener(){});
+      getLegacyLauncher().cancelJob(new AbstractJobListener(){});
     } catch (JobException e) {
       throw new RuntimeException("Unable to cancel job " + _jobSpec + ": " + e, e);
     }
-    return true;
+    return super.cancel(mayInterruptIfRunning);
   }
 
   @Override public boolean isCancelled() {
     return getJobExecutionStatus().getRunningState().isCancelled();
   }
 
-  @Override public JobExecutionResult get() throws InterruptedException {
-    try {
-      return get(0, TimeUnit.MILLISECONDS);
-    } catch (TimeoutException e) {
-      throw new Error("This should never happen.");
-    }
-  }
-
-  @Override
-  public JobExecutionResult get(long timeout, TimeUnit unit)
-         throws InterruptedException, TimeoutException {
-    Preconditions.checkNotNull(unit);
-    if (0 == timeout) {
-      timeout = Long.MAX_VALUE;
-      unit = TimeUnit.SECONDS;
-    }
-    getJobExecutionState().awaitForDone(unit.toMillis(timeout));
-    return JobExecutionResult.createFromState(getJobExecutionState());
-  }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/scheduler/AbstractJobSpecScheduler.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/scheduler/AbstractJobSpecScheduler.java
@@ -11,6 +11,7 @@
  */
 package gobblin.runtime.scheduler;
 
+import java.io.IOException;
 import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
@@ -178,7 +179,11 @@ public abstract class AbstractJobSpecScheduler extends AbstractIdleService
 
   @Override
   protected void shutDown() throws TimeoutException {
-    // Do nothing by default
+    try {
+      _callbacksDispatcher.close();
+    } catch (IOException ioe) {
+      _log.error("Failed to shut down " + this.getClass().getName(), ioe);
+    }
   }
 
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/scheduler/JobSpecSchedulerListeners.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/scheduler/JobSpecSchedulerListeners.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.scheduler;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -28,7 +30,7 @@ import gobblin.util.callbacks.CallbacksDispatcher;
  * Manages a list of {@link JobSpecSchedulerListener}s and can dispatch callbacks to them.
  */
 public class JobSpecSchedulerListeners
-       implements JobSpecSchedulerListenersContainer, JobSpecSchedulerListener {
+       implements JobSpecSchedulerListenersContainer, JobSpecSchedulerListener, Closeable {
   private CallbacksDispatcher<JobSpecSchedulerListener> _dispatcher;
 
   public JobSpecSchedulerListeners(Optional<ExecutorService> execService,
@@ -88,4 +90,9 @@ public class JobSpecSchedulerListeners
     _dispatcher.addWeakListener(listener);
   }
 
+  @Override
+  public void close()
+      throws IOException {
+    _dispatcher.close();
+  }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/JobExecutionStateListeners.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/JobExecutionStateListeners.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.std;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.concurrent.ExecutorService;
 
 import org.slf4j.Logger;
@@ -29,7 +31,7 @@ import gobblin.util.callbacks.CallbacksDispatcher;
  * listeners.
  */
 public class JobExecutionStateListeners
-    implements JobExecutionStateListener, JobExecutionStateListenerContainer {
+    implements JobExecutionStateListener, JobExecutionStateListenerContainer, Closeable {
   private CallbacksDispatcher<JobExecutionStateListener> _dispatcher;
 
   public JobExecutionStateListeners(Optional<ExecutorService> execService,
@@ -93,4 +95,9 @@ public class JobExecutionStateListeners
     _dispatcher.addWeakListener(listener);
   }
 
+  @Override
+  public void close()
+      throws IOException {
+    _dispatcher.close();
+  }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/std/JobLifecycleListenersList.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/std/JobLifecycleListenersList.java
@@ -11,6 +11,8 @@
  */
 package gobblin.runtime.std;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 
@@ -34,7 +36,7 @@ import gobblin.util.callbacks.CallbacksDispatcher;
  * A default implementation to manage a list of {@link JobLifecycleListener}
  *
  */
-public class JobLifecycleListenersList implements JobLifecycleListenersContainer {
+public class JobLifecycleListenersList implements JobLifecycleListenersContainer, Closeable {
   private final CallbacksDispatcher<JobLifecycleListener> _dispatcher;
   private final JobCatalogListenersContainer _jobCatalogDelegate;
   private final JobSpecSchedulerListenersContainer _jobSchedulerDelegate;
@@ -75,6 +77,12 @@ public class JobLifecycleListenersList implements JobLifecycleListenersContainer
     _jobSchedulerDelegate.unregisterJobSpecSchedulerListener(listener);
     _jobCatalogDelegate.removeListener(listener);
     _dispatcher.removeListener(listener);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _dispatcher.close();
   }
 
   /** {@inheritDoc} */

--- a/gobblin-runtime/src/main/resources/embedded/embedded.conf
+++ b/gobblin-runtime/src/main/resources/embedded/embedded.conf
@@ -20,11 +20,6 @@ writer.output.format=AVRO
 writer.staging.dir=${GOBBLIN_WORK_DIR}/task-staging
 writer.output.dir=${GOBBLIN_WORK_DIR}/task-output
 
-# Data publisher related configuration properties
-data.publisher.type=gobblin.publisher.BaseDataPublisher
-data.publisher.final.dir=${GOBBLIN_WORK_DIR}/job-output
-data.publisher.replace.final.dir=false
-
 # Directory where job/task state files are stored
 state.store.dir=${GOBBLIN_WORK_DIR}/state-store
 
@@ -34,11 +29,10 @@ gobblin.runtime.commit.sequence.store.dir=${GOBBLIN_WORK_DIR}/commit-sequence-st
 # Directory where error files from the quality checkers are stored
 qualitychecker.row.err.file=${GOBBLIN_WORK_DIR}/err
 
-# Directory where job locks are stored
-job.lock.dir=${GOBBLIN_WORK_DIR}/locks
-
 # Directory where metrics log files are stored
 metrics.log.dir=${GOBBLIN_WORK_DIR}/metrics
 
 # Interval of task state reporting in milliseconds
 task.status.reportintervalinms=5000
+
+job.lock.enabled=false

--- a/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestDefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestDefaultGobblinInstanceDriverImpl.java
@@ -50,7 +50,7 @@ public class TestDefaultGobblinInstanceDriverImpl {
     Configurable sysConfig = DefaultConfigurableImpl.createFromConfig(ConfigFactory.empty());
 
     final DefaultGobblinInstanceDriverImpl driver =
-        new DefaultGobblinInstanceDriverImpl("testScheduling", sysConfig, jobCatalog, scheduler,
+        new StandardGobblinInstanceDriver("testScheduling", sysConfig, jobCatalog, scheduler,
             jobLauncher,
             Optional.<MetricContext>absent(),
             loggerOpt);
@@ -59,14 +59,13 @@ public class TestDefaultGobblinInstanceDriverImpl {
     JobSpec js1_2 = JobSpec.builder("test.job1").withVersion("2").build();
     JobSpec js2 = JobSpec.builder("test.job2").withVersion("1").build();
 
-    jobCatalog.put(js1_1);
-
     driver.startAsync().awaitRunning(100, TimeUnit.MILLISECONDS);
     long startTimeMs = System.currentTimeMillis();
     Assert.assertTrue(driver.isRunning());
     Assert.assertTrue(driver.isInstrumentationEnabled());
     Assert.assertNotNull(driver.getMetricContext());
 
+    jobCatalog.put(js1_1);
 
     AssertWithBackoff awb = AssertWithBackoff.create().backoffFactor(1.5).maxSleepMs(100)
         .timeoutMs(1000).logger(log);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestStandardGobblinInstanceLauncher.java
@@ -13,6 +13,7 @@ package gobblin.runtime.instance;
 
 import java.util.ArrayList;
 import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
@@ -90,9 +91,9 @@ public class TestStandardGobblinInstanceLauncher {
 
 
   private void checkLaunchJob(StandardGobblinInstanceLauncher instanceLauncher, JobSpec js1,
-      GobblinInstanceDriver instance) throws TimeoutException, InterruptedException {
+      GobblinInstanceDriver instance) throws TimeoutException, InterruptedException, ExecutionException {
     JobExecutionDriver jobDriver = instance.getJobLauncher().launchJob(js1);
-    jobDriver.startAsync();
+    new Thread(jobDriver).run();
     JobExecutionResult jobResult = jobDriver.get(5, TimeUnit.SECONDS);
 
     Assert.assertTrue(jobResult.isSuccessful());

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestFSJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestFSJobCatalog.java
@@ -17,6 +17,7 @@ import java.net.URI;
 import java.util.Hashtable;
 import java.util.Map;
 import java.util.Properties;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.fs.Path;
 import org.mockito.Mockito;
@@ -55,6 +56,8 @@ public class TestFSJobCatalog {
 
     /* Exposed the observer so that checkAndNotify can be manually invoked. */
     FSJobCatalog cat = new FSJobCatalog(ConfigUtils.propertiesToConfig(properties), observer);
+    cat.startAsync();
+    cat.awaitRunning(10, TimeUnit.SECONDS);
 
     final Map<URI, JobSpec> specs = new Hashtable<>();
 
@@ -128,5 +131,8 @@ public class TestFSJobCatalog {
     // enough time for file deletion.
     observer.checkAndNotify();
     Assert.assertFalse(specs.containsKey(js2.getUri()));
+
+    cat.stopAsync();
+    cat.awaitTerminated(10, TimeUnit.SECONDS);
   }
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestInMemoryJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestInMemoryJobCatalog.java
@@ -27,6 +27,8 @@ public class TestInMemoryJobCatalog {
   public void testCallbacks()
       throws Exception {
     InMemoryJobCatalog cat = new InMemoryJobCatalog();
+    cat.startAsync();
+    cat.awaitRunning(1, TimeUnit.SECONDS);
 
     JobCatalogListener l = Mockito.mock(JobCatalogListener.class);
 
@@ -52,6 +54,9 @@ public class TestInMemoryJobCatalog {
     Mockito.verify(l).onDeleteJob(Mockito.eq(js2.getUri()), Mockito.eq(js2.getVersion()));
 
     Mockito.verifyNoMoreInteractions(l);
+
+    cat.stopAsync();
+    cat.awaitTerminated(1, TimeUnit.SECONDS);
   }
 
   @SuppressWarnings("unchecked")
@@ -60,6 +65,9 @@ public class TestInMemoryJobCatalog {
     final Logger log = LoggerFactory.getLogger(getClass().getSimpleName() +".testMetrics");
     InMemoryJobCatalog cat = new InMemoryJobCatalog(Optional.of(log),
         Optional.<MetricContext>absent(), true);
+    cat.startAsync();
+    cat.awaitRunning(1, TimeUnit.SECONDS);
+
     MetricsAssert ma = new MetricsAssert(cat.getMetricContext());
 
     JobSpec js1_1 = JobSpec.builder("test:job1").withVersion("1").build();
@@ -162,6 +170,9 @@ public class TestInMemoryJobCatalog {
         MetricsAssert.eqEventMetdata(GobblinMetricsKeys.JOB_SPEC_VERSION_META, js1_3.getVersion())
         ),
         100, TimeUnit.MILLISECONDS);
+
+    cat.stopAsync();
+    cat.awaitTerminated(1, TimeUnit.SECONDS);
 
   }
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
@@ -12,6 +12,7 @@
 package gobblin.runtime.job_catalog;
 
 import java.net.URI;
+import java.util.concurrent.TimeUnit;
 
 import org.mockito.Mockito;
 import org.slf4j.Logger;
@@ -37,6 +38,9 @@ public class TestMutableCachingJobCatalog {
 
     JobCatalogListener l = Mockito.mock(JobCatalogListener.class);
     cachedCat.addListener(l);
+
+    cachedCat.startAsync();
+    cachedCat.awaitRunning(10, TimeUnit.SECONDS);
 
     JobSpec js1_1 = JobSpec.builder("test:job1").withVersion("1").build();
     JobSpec js1_2 = JobSpec.builder("test:job1").withVersion("2").build();
@@ -85,6 +89,9 @@ public class TestMutableCachingJobCatalog {
     Mockito.verify(l).onDeleteJob(Mockito.eq(js1_2.getUri()), Mockito.eq(js1_2.getVersion()));
 
     Mockito.verifyNoMoreInteractions(l);
+
+    cachedCat.stopAsync();
+    cachedCat.awaitTerminated(10, TimeUnit.SECONDS);
   }
 
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestMutableCachingJobCatalog.java
@@ -33,6 +33,8 @@ public class TestMutableCachingJobCatalog {
   public void test() throws Exception {
     InMemoryJobCatalog baseCat =
         new InMemoryJobCatalog(Optional.<Logger>of(LoggerFactory.getLogger("baseCat")));
+    baseCat.startAsync();
+    baseCat.awaitRunning(2, TimeUnit.SECONDS);
     MutableCachingJobCatalog cachedCat =
         new MutableCachingJobCatalog(baseCat, Optional.<Logger>of(LoggerFactory.getLogger("cachedCat")));
 
@@ -92,6 +94,8 @@ public class TestMutableCachingJobCatalog {
 
     cachedCat.stopAsync();
     cachedCat.awaitTerminated(10, TimeUnit.SECONDS);
+    baseCat.stopAsync();
+    baseCat.awaitTerminated(2, TimeUnit.SECONDS);
   }
 
 }

--- a/gobblin-utility/src/main/java/gobblin/util/callbacks/CallbacksDispatcher.java
+++ b/gobblin-utility/src/main/java/gobblin/util/callbacks/CallbacksDispatcher.java
@@ -11,6 +11,8 @@
  */
 package gobblin.util.callbacks;
 
+import java.io.Closeable;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.IdentityHashMap;
 import java.util.List;
@@ -20,6 +22,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,7 +44,7 @@ import lombok.Data;
  * @param L     the listener type; it is strongly advised that the class implements toString() to
  *              provide useful logging
  */
-public class CallbacksDispatcher<L> {
+public class CallbacksDispatcher<L> implements Closeable {
   private final Logger _log;
   private final List<L> _listeners = new ArrayList<>();
   private final WeakHashMap<L, Void> _autoListeners = new WeakHashMap<>();
@@ -76,6 +79,12 @@ public class CallbacksDispatcher<L> {
 
   public CallbacksDispatcher(ExecutorService execService, Logger log) {
     this(Optional.of(execService), Optional.of(log));
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    ExecutorsUtils.shutdownExecutorService(_execService, Optional.of(_log), 5, TimeUnit.SECONDS);
   }
 
   public synchronized List<L> getListeners() {


### PR DESCRIPTION
…executors.

There are three main changes here:
* Make JobLauncherExecutionDriver a `FutureTask` (which also makes it a `RunnableFuture`) and a `ListenableFuture`, and it not longer implements `Service`. Futures have a concrete end, which is appropriate for the job driver. `FutureTask` additionally offers a concrete start, which was the other requirement for the job driver. Finally, `ListenableFuture` allows adding callbacks.
* Make `JobCatalog` a `Service` so it can be shut down allowing it to clean up whatever threads it spawned. Also extended `JobCatalogBase` to handle the service part of the catalog, and implemented `MutableJobCatalogBase` that does the same for `MutableJobCatalog`. Most `JobCatalog` implementations were simplified taking advantage of the base job catalogs.
* Make `CallbackDispatcher` closeable to allow it to shut down its `ExecutorService`. All classes that use `CallbackDispatcher` were updated accordingly.

Additionally, some small, unrelated changes to `EmbeddedGobblin` that make it easier to run from a command line.