### PR TITLE
Edited JdbcWriter to use setProp rather than appendToListProp method …

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/JdbcWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/JdbcWriter.java
@@ -73,7 +73,7 @@ public class JdbcWriter implements DataWriter<JdbcEntryData> {
 
   public JdbcWriter(JdbcWriterBuilder builder) {
     this.state = builder.destination.getProperties();
-    this.state.appendToListProp(ConfigurationKeys.FORK_BRANCH_ID_KEY, Integer.toString(builder.branch));
+    this.state.setProp(ConfigurationKeys.FORK_BRANCH_ID_KEY, Integer.toString(builder.branch));
 
     String databaseTableKey = ForkOperatorUtils.getPropertyNameForBranch(JdbcPublisher.JDBC_PUBLISHER_DATABASE_NAME,
         builder.branches, builder.branch);


### PR DESCRIPTION
Changed JdbcWriter to use setProp rather than appendToListProp when setting the property FORK_BRANCH_ID_KEY.
Please refer to the issue #1322 .