### PR TITLE
Adding plugins support to StandardGobblinInstanceDriver

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstancePlugin.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstancePlugin.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.api;
+
+import com.google.common.util.concurrent.Service;
+
+/**
+ * The interfaces for Gobblin instance plugins. Plugins are objects the share configuration and
+ * lifespan with a specific Gobblin instance and can be used to extend its functionality. Examples
+ * of plugins maybe providing a REST interface, authentication and so on.
+ */
+public interface GobblinInstancePlugin extends Service {
+
+  /** Override this method to provide a human-readable description of the plugin */
+  @Override String toString();
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstancePluginFactory.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/GobblinInstancePluginFactory.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.api;
+
+/**
+ * Creates a {@link GobblinInstancePlugin} for a specific {@link GobblinInstanceDriver} .
+ *
+ * <p><b>IMPORTANT:</b> Implementations of {@link GobblinInstancePluginFactory} must have a
+ * default public constructor.
+ */
+public interface GobblinInstancePluginFactory {
+
+  /** Creates an instance of the plugin for a specific Gobblin instance */
+  GobblinInstancePlugin createPlugin(GobblinInstanceDriver instance);
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/instance/StandardGobblinInstanceDriver.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/instance/StandardGobblinInstanceDriver.java
@@ -21,8 +21,11 @@ import java.util.concurrent.atomic.AtomicInteger;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Function;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.Service;
 import com.google.common.util.concurrent.ServiceManager;
 import com.typesafe.config.ConfigFactory;
@@ -34,6 +37,8 @@ import gobblin.metrics.Tag;
 import gobblin.runtime.api.Configurable;
 import gobblin.runtime.api.GobblinInstanceEnvironment;
 import gobblin.runtime.api.GobblinInstanceLauncher;
+import gobblin.runtime.api.GobblinInstancePlugin;
+import gobblin.runtime.api.GobblinInstancePluginFactory;
 import gobblin.runtime.api.JobCatalog;
 import gobblin.runtime.api.JobExecutionLauncher;
 import gobblin.runtime.api.JobSpecScheduler;
@@ -44,26 +49,68 @@ import gobblin.runtime.job_exec.JobLauncherExecutionDriver;
 import gobblin.runtime.scheduler.ImmediateJobSpecScheduler;
 import gobblin.runtime.scheduler.QuartzJobSpecScheduler;
 import gobblin.runtime.std.DefaultConfigurableImpl;
+import gobblin.util.ClassAliasResolver;
 
 /** A simple wrapper {@link DefaultGobblinInstanceDriverImpl} that will instantiate necessary
  * sub-components (e.g. {@link JobCatalog}, {@link JobSpecScheduler}, {@link JobExecutionLauncher}
  * and it will manage their lifecycle. */
 public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverImpl {
+
+  public static final String INSTANCE_CFG_PREFIX = "gobblin.instance";
+  /** A comma-separated list of class names or aliases of {@link GobblinInstancePluginFactory} for
+   * plugins to be instantiated with this instance. */
+  public static final String PLUGINS_KEY = "plugins";
+  public static final String PLUGINS_FULL_KEY = INSTANCE_CFG_PREFIX + "." + PLUGINS_KEY;
+
   private ServiceManager _subservices;
+  private final List<GobblinInstancePlugin> _plugins;
 
   protected StandardGobblinInstanceDriver(String instanceName, Configurable sysConfig,
       JobCatalog jobCatalog,
       JobSpecScheduler jobScheduler, JobExecutionLauncher jobLauncher,
       Optional<MetricContext> instanceMetricContext,
-      Optional<Logger> log) {
+      Optional<Logger> log,
+      List<GobblinInstancePluginFactory> plugins) {
     super(instanceName, sysConfig, jobCatalog, jobScheduler, jobLauncher, instanceMetricContext, log);
     List<Service> componentServices = new ArrayList<>();
+
     checkComponentService(getJobCatalog(), componentServices);
     checkComponentService(getJobScheduler(), componentServices);
     checkComponentService(getJobLauncher(), componentServices);
+
+    _plugins = createPlugins(plugins, componentServices);
+
     if (componentServices.size() > 0) {
       _subservices = new ServiceManager(componentServices);
     }
+  }
+
+  private List<GobblinInstancePlugin> createPlugins(List<GobblinInstancePluginFactory> plugins,
+      List<Service> componentServices) {
+    List<GobblinInstancePlugin> res = new ArrayList<>();
+
+    for (GobblinInstancePluginFactory pluginFactory: plugins) {
+      GobblinInstancePlugin plugin = createPlugin(this, pluginFactory, componentServices);
+      if (null != plugin) {
+        res.add(plugin);
+      }
+    }
+    return res;
+  }
+
+  static GobblinInstancePlugin createPlugin(StandardGobblinInstanceDriver instance,
+      GobblinInstancePluginFactory pluginFactory, List<Service> componentServices) {
+    instance.getLog().info("Instantiating a plugin of type: " + pluginFactory);
+    try {
+      GobblinInstancePlugin plugin = pluginFactory.createPlugin(instance);
+      componentServices.add(plugin);
+      instance.getLog().info("Instantiated plugin: " + plugin);
+      return plugin;
+    }
+    catch (RuntimeException e) {
+      instance.getLog().warn("Failed to create plugin: " + e, e);
+    }
+    return null;
   }
 
   @Override
@@ -99,6 +146,10 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
     }
   }
 
+  public static Builder builder() {
+    return new Builder();
+  }
+
   /**
    * A builder for StandardGobblinInstanceDriver instances. The goal is to be convention driven
    * rather than configuration.
@@ -123,6 +174,7 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
     private Optional<JobExecutionLauncher> _jobLauncher = Optional.absent();
     private Optional<MetricContext> _metricContext = Optional.absent();
     private Optional<Boolean> _instrumentationEnabled = Optional.absent();
+    private List<GobblinInstancePluginFactory> _plugins = new ArrayList<>();
 
     public Builder(Optional<GobblinInstanceEnvironment> instanceLauncher) {
       _instanceEnv = instanceLauncher;
@@ -297,7 +349,9 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
              getJobLauncher(),
              isInstrumentationEnabled() ? Optional.of(getMetricContext()) :
                    Optional.<MetricContext>absent(),
-             Optional.of(getLog()));
+             Optional.of(getLog()),
+             getPlugins()
+             );
     }
 
     @Override public Configurable getSysConfig() {
@@ -333,6 +387,45 @@ public class StandardGobblinInstanceDriver extends DefaultGobblinInstanceDriverI
     @Override public void switchMetricContext(MetricContext context) {
       throw new UnsupportedOperationException();
     }
+
+    public List<GobblinInstancePluginFactory> getDefaultPlugins() {
+      if (!getSysConfig().getConfig().hasPath(PLUGINS_FULL_KEY)) {
+        return Collections.emptyList();
+      }
+
+      String pluginsListStr = getSysConfig().getConfig().getString(PLUGINS_FULL_KEY);
+      List<String> pluginNames = Splitter.on(',').omitEmptyStrings().trimResults().splitToList(pluginsListStr);
+
+      final ClassAliasResolver<GobblinInstancePluginFactory> aliasResolver =
+          new ClassAliasResolver<>(GobblinInstancePluginFactory.class);
+      return Lists.transform(pluginNames, new Function<String, GobblinInstancePluginFactory>() {
+
+        @Override public GobblinInstancePluginFactory apply(String input) {
+          Class<? extends GobblinInstancePluginFactory> factoryClass;
+          try {
+            factoryClass = aliasResolver.resolveClass(input);
+            return factoryClass.newInstance();
+          } catch (ClassNotFoundException|InstantiationException|IllegalAccessException e) {
+            throw new RuntimeException("Unable to instantiate plugin factory " + input + ": " + e, e);
+          }
+        }
+      });
+    }
+
+    public List<GobblinInstancePluginFactory> getPlugins() {
+      List<GobblinInstancePluginFactory> res = new ArrayList<>(getDefaultPlugins());
+      res.addAll(_plugins);
+      return res;
+    }
+
+    public Builder addPlugin(GobblinInstancePluginFactory pluginFactory) {
+      _plugins.add(pluginFactory);
+      return this;
+    }
+  }
+
+  public List<GobblinInstancePlugin> getPlugins() {
+    return _plugins;
   }
 
 }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestDefaultGobblinInstanceDriverImpl.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestDefaultGobblinInstanceDriverImpl.java
@@ -11,6 +11,7 @@
  */
 package gobblin.runtime.instance;
 
+import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
 import org.mockito.Mockito;
@@ -26,6 +27,7 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.metrics.MetricContext;
 import gobblin.runtime.api.Configurable;
+import gobblin.runtime.api.GobblinInstancePluginFactory;
 import gobblin.runtime.api.JobExecutionLauncher;
 import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.api.JobSpecScheduler;
@@ -53,7 +55,8 @@ public class TestDefaultGobblinInstanceDriverImpl {
         new StandardGobblinInstanceDriver("testScheduling", sysConfig, jobCatalog, scheduler,
             jobLauncher,
             Optional.<MetricContext>absent(),
-            loggerOpt);
+            loggerOpt,
+            Collections.<GobblinInstancePluginFactory>emptyList());
 
     JobSpec js1_1 = JobSpec.builder("test.job1").withVersion("1").build();
     JobSpec js1_2 = JobSpec.builder("test.job1").withVersion("2").build();

--- a/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestStandardGobblinInstanceDriver.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/instance/TestStandardGobblinInstanceDriver.java
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.runtime.instance;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.util.concurrent.AbstractIdleService;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.annotation.Alias;
+import gobblin.runtime.api.GobblinInstanceDriver;
+import gobblin.runtime.api.GobblinInstanceEnvironment;
+import gobblin.runtime.api.GobblinInstancePlugin;
+import gobblin.runtime.api.GobblinInstancePluginFactory;
+import gobblin.runtime.std.DefaultConfigurableImpl;
+
+import avro.shaded.com.google.common.collect.ImmutableMap;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Unit tests for {@link StandardGobblinInstanceDriver}
+ */
+public class TestStandardGobblinInstanceDriver {
+
+  @Test
+  public void testBuilder() {
+    Config instanceCfg = ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+        .put(StandardGobblinInstanceDriver.PLUGINS_FULL_KEY, "fake1")
+        .build());
+    GobblinInstanceEnvironment mockEnv = Mockito.mock(GobblinInstanceEnvironment.class);
+    Mockito.when(mockEnv.getSysConfig())
+           .thenReturn(DefaultConfigurableImpl.createFromConfig(instanceCfg));
+    StandardGobblinInstanceDriver.Builder builder =
+        StandardGobblinInstanceDriver.builder()
+        .withInstanceEnvironment(mockEnv)
+        .addPlugin(new FakePluginFactory2());
+
+    List<GobblinInstancePluginFactory> plugins = builder.getPlugins();
+    Assert.assertEquals(plugins.size(), 2);
+
+    Set<Class<?>> pluginClasses = new HashSet<>();
+    pluginClasses.add(plugins.get(0).getClass());
+    pluginClasses.add(plugins.get(1).getClass());
+
+    Assert.assertTrue(pluginClasses.contains(FakePluginFactory1.class));
+    Assert.assertTrue(pluginClasses.contains(FakePluginFactory2.class));
+  }
+
+  @AllArgsConstructor
+  static class FakePlugin extends AbstractIdleService implements GobblinInstancePlugin {
+    @Getter final GobblinInstanceDriver instance;
+
+    @Override protected void startUp() throws Exception {
+      // Do nothing
+    }
+    @Override protected void shutDown() throws Exception {
+      // Do nothing
+    }
+  }
+
+  @Alias("fake1")
+  static class FakePluginFactory1 implements GobblinInstancePluginFactory {
+    @Override public GobblinInstancePlugin createPlugin(GobblinInstanceDriver instance) {
+      return new FakePlugin(instance);
+    }
+  }
+
+  @Alias("fake2")
+  static class FakePluginFactory2 implements GobblinInstancePluginFactory {
+    @Override public GobblinInstancePlugin createPlugin(GobblinInstanceDriver instance) {
+      return new FakePlugin(instance);
+    }
+  }
+
+}


### PR DESCRIPTION
Adding the concept of a plugin which a service that gets started/stopped along with the instance driver and can be used to extend it. For example, a plugin can load a keytab and authenticate with Kerberos.

@pcadabam, @ibuenros can you review?