### PR TITLE
Changed LiKafkaSchemaRegistry to use correct id from MD5Digest

### DIFF
--- a/gobblin-kafka/src/main/java/gobblin/kafka/schemareg/LiKafkaSchemaRegistry.java
+++ b/gobblin-kafka/src/main/java/gobblin/kafka/schemareg/LiKafkaSchemaRegistry.java
@@ -211,7 +211,7 @@ public class LiKafkaSchemaRegistry implements KafkaSchemaRegistry<MD5Digest, Sch
    * Fetch schema by key.
    */
   protected Schema fetchSchemaByKey(MD5Digest key) throws SchemaRegistryException {
-    String schemaUrl = this.url + GET_RESOURCE_BY_ID + key;
+    String schemaUrl = this.url + GET_RESOURCE_BY_ID + key.asString();
 
     GetMethod get = new GetMethod(schemaUrl);
 


### PR DESCRIPTION
Fixed LiKafkaSchemaRegistry to use MD5Digest asString method that provides correct hex digest of data for schema id instead of toString which is not overridden over default impl