### PR TITLE
Initial commit for speculative execution in MR mode

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -143,6 +143,7 @@ public class ConfigurationKeys {
    */
   public static final String JOB_ID_KEY = "job.id";
   public static final String TASK_ID_KEY = "task.id";
+  public static final String TASK_ATTEMPT_ID_KEY = "task.AttemptId";
   public static final String JOB_CONFIG_FILE_PATH_KEY = "job.config.path";
   public static final String TASK_FAILURE_EXCEPTION_KEY = "task.failure.exception";
   public static final String TASK_RETRIES_KEY = "task.retries";

--- a/gobblin-api/src/main/java/gobblin/writer/DataWriterBuilder.java
+++ b/gobblin-api/src/main/java/gobblin/writer/DataWriterBuilder.java
@@ -34,6 +34,7 @@ public abstract class DataWriterBuilder<S, D> {
   protected S schema;
   protected int branches;
   protected int branch;
+  protected String writerAttemptId;
 
   /**
    * Tell the writer the destination to write to.
@@ -98,6 +99,15 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> forBranch(int branch) {
     this.branch = branch;
+    return this;
+  }
+
+  /**
+   * Attempt Id for this writer. There could be two duplicate writers with the same {@link #writerId},
+   * their writerAttemptId should be different.
+   */
+  public DataWriterBuilder<S, D> withAttemptId(String attemptId) {
+    this.writerAttemptId = attemptId;
     return this;
   }
 

--- a/gobblin-core/src/main/java/gobblin/commit/SpeculativeAttemptAwareConstruct.java
+++ b/gobblin-core/src/main/java/gobblin/commit/SpeculativeAttemptAwareConstruct.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.commit;
+
+import gobblin.annotation.Alpha;
+
+
+/**
+ * A declaration by any Gobblin construct to claim whether it is safe to have multiple speculative attempts.
+ * For example, if any {@link gobblin.writer.DataWriter} implements {@link SpeculativeAttemptAwareConstruct}
+ * and returns true in {@link #isSpeculativeAttemptSafe()}, then multiple attempts of one {@link gobblin.writer.DataWriter}
+ * should not cause conflict among them.
+ */
+@Alpha
+public interface SpeculativeAttemptAwareConstruct {
+
+  /**
+   * @return true if it is safe to have multiple speculative attempts; false, otherwise.
+   * To avoid inheritance issue, the suggested pattern would be "return this.class == MyClass.class".
+   */
+  public boolean isSpeculativeAttemptSafe();
+}

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -111,4 +111,9 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
     // Open the file and return the DataFileWriter
     return writer.create(this.schema, this.stagingFileOutputStream);
   }
+
+  @Override
+  public boolean isSpeculativeAttemptSafe() {
+    return this.writerAttemptIdOptional.isPresent() && this.getClass() == AvroHdfsDataWriter.class;
+  }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -26,6 +26,7 @@ import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 
+import gobblin.commit.SpeculativeAttemptAwareConstruct;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.util.FinalState;
@@ -42,7 +43,7 @@ import gobblin.util.recordcount.IngestionRecordCountProvider;
  *
  * @author akshay@nerdwallet.com
  */
-public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
+public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, SpeculativeAttemptAwareConstruct {
 
   private static final Logger LOG = LoggerFactory.getLogger(FsDataWriter.class);
 
@@ -66,6 +67,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
   protected final FsPermission dirPermission;
   protected final Optional<String> group;
   protected final Closer closer = Closer.create();
+  protected final Optional<String> writerAttemptIdOptional;
 
   public FsDataWriter(FsDataWriterBuilder<?, D> builder, State properties) throws IOException {
     this.properties = properties;
@@ -73,16 +75,19 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
     this.numBranches = builder.getBranches();
     this.branchId = builder.getBranch();
     this.fileName = builder.getFileName(properties);
+    this.writerAttemptIdOptional = Optional.fromNullable(builder.getWriterAttemptId());
 
     Configuration conf = new Configuration();
     // Add all job configuration properties so they are picked up by Hadoop
     JobConfigurationUtils.putStateIntoConfiguration(properties, conf);
-
     this.fs = WriterUtils.getWriterFS(properties, this.numBranches, this.branchId);
 
     // Initialize staging/output directory
-    this.stagingFile =
-        new Path(WriterUtils.getWriterStagingDir(properties, this.numBranches, this.branchId), this.fileName);
+    Path writerStagingDir = this.writerAttemptIdOptional.isPresent() ?  WriterUtils
+        .getWriterStagingDir(properties, this.numBranches, this.branchId, this.writerAttemptIdOptional.get())
+        : WriterUtils.getWriterStagingDir(properties, this.numBranches, this.branchId);
+    this.stagingFile = new Path(writerStagingDir, this.fileName);
+
     this.outputFile =
         new Path(WriterUtils.getWriterOutputDir(properties, this.numBranches, this.branchId), this.fileName);
     this.allOutputFilesPropName = ForkOperatorUtils
@@ -249,5 +254,10 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState {
    */
   public String getFullyQualifiedOutputFilePath() {
     return this.fs.makeQualified(this.outputFile).toString();
+  }
+
+  @Override
+  public boolean isSpeculativeAttemptSafe() {
+    return this.writerAttemptIdOptional.isPresent() && this.getClass() == FsDataWriter.class;
   }
 }

--- a/gobblin-core/src/test/java/gobblin/writer/PartitionedWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/PartitionedWriterTest.java
@@ -36,7 +36,7 @@ public class PartitionedWriterTest {
 
     TestPartitionAwareWriterBuilder builder = new TestPartitionAwareWriterBuilder();
 
-    DataWriter<String> writer = new PartitionedDataWriter<String, String>(builder, state);
+    PartitionedDataWriter writer = new PartitionedDataWriter<String, String>(builder, state);
 
     Assert.assertEquals(builder.actions.size(), 0);
 
@@ -52,17 +52,19 @@ public class PartitionedWriterTest {
     Assert.assertEquals(action.getPartition(), "a");
     Assert.assertEquals(action.getType(), TestPartitionAwareWriterBuilder.Actions.WRITE);
     Assert.assertEquals(action.getTarget(), record1);
+    Assert.assertTrue(writer.isSpeculativeAttemptSafe());
 
-    String record2 = "bcd";
+    String record2 = "123";
     writer.write(record2);
 
     Assert.assertEquals(builder.actions.size(), 2);
     action = builder.actions.poll();
-    Assert.assertEquals(action.getPartition(), "b");
+    Assert.assertEquals(action.getPartition(), "1");
     Assert.assertEquals(action.getType(), TestPartitionAwareWriterBuilder.Actions.BUILD);
+    Assert.assertFalse(writer.isSpeculativeAttemptSafe());
 
     action = builder.actions.poll();
-    Assert.assertEquals(action.getPartition(), "b");
+    Assert.assertEquals(action.getPartition(), "1");
     Assert.assertEquals(action.getType(), TestPartitionAwareWriterBuilder.Actions.WRITE);
     Assert.assertEquals(action.getTarget(), record2);
 
@@ -77,6 +79,7 @@ public class PartitionedWriterTest {
 
     Assert.assertEquals(writer.recordsWritten(), 3);
     Assert.assertEquals(writer.bytesWritten(), 3);
+    Assert.assertFalse(writer.isSpeculativeAttemptSafe());
 
     writer.cleanup();
     Assert.assertEquals(builder.actions.size(), 2);
@@ -98,7 +101,5 @@ public class PartitionedWriterTest {
     Assert.assertEquals(action.getType(), TestPartitionAwareWriterBuilder.Actions.COMMIT);
     action = builder.actions.poll();
     Assert.assertEquals(action.getType(), TestPartitionAwareWriterBuilder.Actions.COMMIT);
-
   }
-
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterBuilder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriterBuilder.java
@@ -36,7 +36,7 @@ public class FileAwareInputStreamDataWriterBuilder extends DataWriterBuilder<Str
   }
 
   protected DataWriter<FileAwareInputStream> buildWriter() throws IOException {
-    return new FileAwareInputStreamDataWriter(this.destination.getProperties(), this.branches, this.branch);
+    return new FileAwareInputStreamDataWriter(this.destination.getProperties(), this.branches, this.branch, this.writerAttemptId);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Fork.java
@@ -27,6 +27,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.io.Closer;
 
 import gobblin.Constructs;
+import gobblin.commit.SpeculativeAttemptAwareConstruct;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.converter.Converter;
@@ -85,6 +86,7 @@ public class Fork implements Closeable, Runnable, FinalState {
   // A TaskState instance specific to this Fork
   private final TaskState forkTaskState;
   private final String taskId;
+  private final Optional<String> taskAttemptId;
 
   private final int branches;
   private final int index;
@@ -114,7 +116,8 @@ public class Fork implements Closeable, Runnable, FinalState {
 
   private static final String FORK_METRICS_BRANCH_NAME_KEY = "forkBranchName";
 
-  public Fork(TaskContext taskContext, Object schema, int branches, int index) throws Exception {
+  public Fork(TaskContext taskContext, Object schema, int branches, int index)
+      throws Exception {
     this.logger = LoggerFactory.getLogger(Fork.class.getName() + "-" + index);
 
     this.taskContext = taskContext;
@@ -122,6 +125,7 @@ public class Fork implements Closeable, Runnable, FinalState {
     // Make a copy if there are more than one branches
     this.forkTaskState = branches > 1 ? new TaskState(this.taskState) : this.taskState;
     this.taskId = this.taskState.getTaskId();
+    this.taskAttemptId = this.taskState.getTaskAttemptId();
 
     this.branches = branches;
     this.index = index;
@@ -132,21 +136,20 @@ public class Fork implements Closeable, Runnable, FinalState {
     this.rowLevelPolicyChecker = this.closer.register(this.taskContext.getRowLevelPolicyChecker(this.index));
     this.rowLevelPolicyCheckingResult = new RowLevelPolicyCheckResults();
 
-    boolean useEagerWriterInitialization = this.taskState.getPropAsBoolean(
-        ConfigurationKeys.WRITER_EAGER_INITIALIZATION_KEY, ConfigurationKeys.DEFAULT_WRITER_EAGER_INITIALIZATION);
+    boolean useEagerWriterInitialization = this.taskState
+        .getPropAsBoolean(ConfigurationKeys.WRITER_EAGER_INITIALIZATION_KEY,
+            ConfigurationKeys.DEFAULT_WRITER_EAGER_INITIALIZATION);
     if (useEagerWriterInitialization) {
       buildWriterIfNotPresent();
     }
 
-    this.recordQueue = BoundedBlockingRecordQueue.newBuilder()
-        .hasCapacity(this.taskState.getPropAsInt(ConfigurationKeys.FORK_RECORD_QUEUE_CAPACITY_KEY,
-            ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_CAPACITY))
-        .useTimeout(this.taskState.getPropAsLong(ConfigurationKeys.FORK_RECORD_QUEUE_TIMEOUT_KEY,
-            ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_TIMEOUT))
-        .useTimeoutTimeUnit(
-            TimeUnit.valueOf(this.taskState.getProp(ConfigurationKeys.FORK_RECORD_QUEUE_TIMEOUT_UNIT_KEY,
-                ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_TIMEOUT_UNIT)))
-        .collectStats().build();
+    this.recordQueue = BoundedBlockingRecordQueue.newBuilder().hasCapacity(this.taskState
+        .getPropAsInt(ConfigurationKeys.FORK_RECORD_QUEUE_CAPACITY_KEY,
+            ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_CAPACITY)).useTimeout(this.taskState
+        .getPropAsLong(ConfigurationKeys.FORK_RECORD_QUEUE_TIMEOUT_KEY,
+            ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_TIMEOUT)).useTimeoutTimeUnit(TimeUnit.valueOf(this.taskState
+            .getProp(ConfigurationKeys.FORK_RECORD_QUEUE_TIMEOUT_UNIT_KEY,
+                ConfigurationKeys.DEFAULT_FORK_RECORD_QUEUE_TIMEOUT_UNIT))).collectStats().build();
 
     this.forkState = new AtomicReference<>(ForkState.PENDING);
 
@@ -155,8 +158,8 @@ public class Fork implements Closeable, Runnable, FinalState {
      * {@link Instrumented#setMetricContextName(State, String)} will be children of the forkMetrics.
      */
     if (GobblinMetrics.isEnabled(this.taskState)) {
-      GobblinMetrics forkMetrics =
-          GobblinMetrics.get(getForkMetricsName(taskContext.getTaskMetrics(), this.taskState, index),
+      GobblinMetrics forkMetrics = GobblinMetrics
+          .get(getForkMetricsName(taskContext.getTaskMetrics(), this.taskState, index),
               taskContext.getTaskMetrics().getMetricContext(), getForkMetricsTags(this.taskState, index));
       this.closer.register(forkMetrics.getMetricContext());
       Instrumented.setMetricContextName(this.taskState, forkMetrics.getMetricContext().getName());
@@ -211,7 +214,8 @@ public class Fork implements Closeable, Runnable, FinalState {
    * @return whether the record has been successfully put into the queue
    * @throws InterruptedException
    */
-  public boolean putRecord(Object record) throws InterruptedException {
+  public boolean putRecord(Object record)
+      throws InterruptedException {
     if (this.forkState.compareAndSet(ForkState.FAILED, ForkState.FAILED)) {
       throw new IllegalStateException(
           String.format("Fork %d of task %s has failed and is no longer running", this.index, this.taskId));
@@ -243,7 +247,8 @@ public class Fork implements Closeable, Runnable, FinalState {
   /**
    * Update byte-level metrics.
    */
-  public void updateByteMetrics() throws IOException {
+  public void updateByteMetrics()
+      throws IOException {
     if (this.writer.isPresent()) {
       this.taskState.updateByteMetrics(this.writer.get().bytesWritten(), this.index);
     }
@@ -254,7 +259,8 @@ public class Fork implements Closeable, Runnable, FinalState {
    *
    * @throws Exception if there is anything wrong committing the data
    */
-  public boolean commit() throws Exception {
+  public boolean commit()
+      throws Exception {
     try {
       if (checkDataQuality(this.convertedSchema)) {
         // Commit data if all quality checkers pass. Again, not to catch the exception
@@ -320,7 +326,8 @@ public class Fork implements Closeable, Runnable, FinalState {
   }
 
   @Override
-  public void close() throws IOException {
+  public void close()
+      throws IOException {
     // Tell this fork that the parent task is done. This is a second chance call if the parent
     // task failed and didn't do so through the normal way of calling markParentTaskDone().
     this.parentTaskDone = true;
@@ -366,18 +373,23 @@ public class Fork implements Closeable, Runnable, FinalState {
   /**
    * Build a {@link gobblin.writer.DataWriter} for writing fetched data records.
    */
-  private DataWriter<Object> buildWriter() throws IOException {
+  private DataWriter<Object> buildWriter()
+      throws IOException {
     DataWriterBuilder<Object, Object> builder = this.taskContext.getDataWriterBuilder(this.branches, this.index)
         .writeTo(Destination.of(this.taskContext.getDestinationType(this.branches, this.index), this.taskState))
         .writeInFormat(this.taskContext.getWriterOutputFormat(this.branches, this.index)).withWriterId(this.taskId)
         .withSchema(this.convertedSchema.orNull()).withBranches(this.branches).forBranch(this.index);
+    if (this.taskAttemptId.isPresent()) {
+      builder.withAttemptId(this.taskAttemptId.get());
+    }
 
     DataWriter<Object> writer = new PartitionedDataWriter<>(builder, this.taskContext.getTaskState());
     logger.info("Wrapping writer " + writer);
     return new DataWriterWrapperBuilder<>(writer, this.taskState).build();
   }
 
-  private void buildWriterIfNotPresent() throws IOException {
+  private void buildWriterIfNotPresent()
+      throws IOException {
     if (!this.writer.isPresent()) {
       this.writer = Optional.of(this.closer.register(buildWriter()));
     }
@@ -386,7 +398,8 @@ public class Fork implements Closeable, Runnable, FinalState {
   /**
    * Get new records off the record queue and process them.
    */
-  private void processRecords() throws IOException, DataConversionException {
+  private void processRecords()
+      throws IOException, DataConversionException {
     while (true) {
       try {
         Object record = this.recordQueue.get();
@@ -417,7 +430,8 @@ public class Fork implements Closeable, Runnable, FinalState {
    *
    * @return whether data publishing is successful and data should be committed
    */
-  private boolean checkDataQuality(Optional<Object> schema) throws Exception {
+  private boolean checkDataQuality(Optional<Object> schema)
+      throws Exception {
     if (this.branches > 1) {
       this.forkTaskState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED,
           this.taskState.getProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED));
@@ -441,8 +455,9 @@ public class Fork implements Closeable, Runnable, FinalState {
 
     try {
       // Do task-level quality checking
-      TaskLevelPolicyCheckResults taskResults = this.taskContext
-          .getTaskLevelPolicyChecker(this.forkTaskState, this.branches > 1 ? this.index : -1).executePolicies();
+      TaskLevelPolicyCheckResults taskResults =
+          this.taskContext.getTaskLevelPolicyChecker(this.forkTaskState, this.branches > 1 ? this.index : -1)
+              .executePolicies();
       TaskPublisher publisher = this.taskContext.getTaskPublisher(this.forkTaskState, taskResults);
       switch (publisher.canPublish()) {
         case SUCCESS:
@@ -470,7 +485,8 @@ public class Fork implements Closeable, Runnable, FinalState {
   /**
    * Commit task data.
    */
-  private void commitData() throws IOException {
+  private void commitData()
+      throws IOException {
     if (this.writer.isPresent()) {
       // Not to catch the exception this may throw so it gets propagated
       this.writer.get().commit();
@@ -494,8 +510,8 @@ public class Fork implements Closeable, Runnable, FinalState {
    */
   private void compareAndSetForkState(ForkState expectedState, ForkState newState) {
     if (!this.forkState.compareAndSet(expectedState, newState)) {
-      throw new IllegalStateException(String.format("Expected fork state %s; actual fork state %s",
-          expectedState.name(), this.forkState.get().name()));
+      throw new IllegalStateException(String
+          .format("Expected fork state %s; actual fork state %s", expectedState.name(), this.forkState.get().name()));
     }
   }
 
@@ -504,7 +520,7 @@ public class Fork implements Closeable, Runnable, FinalState {
    * index and the branch name.
    */
   private static List<Tag<?>> getForkMetricsTags(State state, int index) {
-    return ImmutableList.<Tag<?>> of(new Tag<>(FORK_METRICS_BRANCH_NAME_KEY, getForkMetricsId(state, index)));
+    return ImmutableList.<Tag<?>>of(new Tag<>(FORK_METRICS_BRANCH_NAME_KEY, getForkMetricsId(state, index)));
   }
 
   /**
@@ -521,5 +537,16 @@ public class Fork implements Closeable, Runnable, FinalState {
   private static String getForkMetricsId(State state, int index) {
     return state.getProp(ConfigurationKeys.FORK_BRANCH_NAME_KEY + "." + index,
         ConfigurationKeys.DEFAULT_FORK_BRANCH_NAME + index);
+  }
+
+  public boolean isSpeculativeExecutionSafe() {
+    if (!this.writer.isPresent()) {
+      return true;
+    }
+    if (!(this.writer.get() instanceof SpeculativeAttemptAwareConstruct)) {
+      this.logger.info("Writer is not speculative safe: " + this.writer.get().getClass().toString());
+      return false;
+    }
+    return ((SpeculativeAttemptAwareConstruct) this.writer.get()).isSpeculativeAttemptSafe();
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.runtime;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Future;
+
+import com.google.common.base.Function;
+import com.google.common.base.Optional;
+import com.google.common.collect.Iterators;
+import com.google.common.collect.Lists;
+
+import gobblin.annotation.Alpha;
+import gobblin.commit.CommitStep;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.metastore.StateStore;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.Either;
+import gobblin.util.ExecutorsUtils;
+import gobblin.util.executors.IteratorExecutor;
+
+import javax.annotation.Nullable;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Attempt of running multiple {@link Task}s generated from a list of{@link WorkUnit}s.
+ * A {@link GobblinMultiTaskAttempt} is usually a unit of workunits that are assigned to one container.
+ */
+@Slf4j
+@RequiredArgsConstructor
+@Alpha
+public class GobblinMultiTaskAttempt {
+  private final List<WorkUnit> workUnits;
+  private final String jobId;
+  private final JobState jobState;
+  private final TaskStateTracker taskStateTracker;
+  private final TaskExecutor taskExecutor;
+  private final Optional<String> containerIdOptional;
+  private final Optional<StateStore<TaskState>> taskStateStoreOptional;
+  private List<Task> tasks;
+
+  /**
+   * Additional commit steps that may be added by different launcher, and can be environment specific.
+   * Usually it should be clean-up steps, which are always executed at the end of {@link #commit()}.
+   */
+  private List<CommitStep> cleanupCommitSteps;
+
+  /**
+   * Run {@link #workUnits} assigned in this attempt.
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  public void run()
+      throws IOException, InterruptedException {
+    // TODO -  add workunits execution.
+  }
+
+  /**
+   * Commit {@link #tasks} by 1. calling {@link Task#commit()} in parallel; 2. executing any additional {@link CommitStep};
+   * 3. persist task statestore.
+   * @throws IOException
+   */
+  public void commit()
+      throws IOException {
+    Iterator<Callable<Void>> callableIterator =
+        Iterators.transform(this.tasks.iterator(), new Function<Task, Callable<Void>>() {
+          @Override
+          public Callable<Void> apply(final Task task) {
+            return new Callable<Void>() {
+              @Nullable
+              @Override
+              public Void call()
+                  throws Exception {
+                task.commit();
+                return null;
+              }
+            };
+          }
+        });
+
+    try {
+
+      List<Either<Void, ExecutionException>> executionResults =
+          new IteratorExecutor<>(callableIterator, this.getTaskCommitThreadPoolSize(),
+              ExecutorsUtils.newDaemonThreadFactory(Optional.of(log), Optional.of("Task-committing-pool-%d")))
+              .executeAndGetResults();
+      IteratorExecutor.logFailures(executionResults, log, 10);
+    } catch (InterruptedException ie) {
+      log.error("Committing of tasks interrupted. Aborting.");
+      throw new RuntimeException(ie);
+    } finally {
+      // persistTaskStateStore();
+      for (CommitStep cleanupCommitStep : this.cleanupCommitSteps) {
+        log.info("Executing additional commit step.");
+        cleanupCommitStep.execute();
+      }
+    }
+  }
+
+  public boolean isSpeculativeExecutionSafe() {
+    for (Task task : tasks) {
+      if (!task.isSpeculativeExecutionSafe()) {
+        log.info("one task is not safe");
+        return false;
+      }
+    }
+    log.info("all tasks are safe");
+    return true;
+  }
+
+  private final int getTaskCommitThreadPoolSize() {
+    return Integer.parseInt(this.jobState.getProp(ConfigurationKeys.TASK_EXECUTOR_THREADPOOL_SIZE_KEY,
+        Integer.toString(ConfigurationKeys.DEFAULT_TASK_EXECUTOR_THREADPOOL_SIZE)));
+  }
+
+  public void addCleanupCommitStep(CommitStep commitStep) {
+    if (this.cleanupCommitSteps == null) {
+      this.cleanupCommitSteps = Lists.newArrayList(commitStep);
+    } else {
+      this.cleanupCommitSteps.add(commitStep);
+    }
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -46,6 +46,8 @@ import gobblin.source.workunit.Extract;
 import gobblin.util.ForkOperatorUtils;
 import gobblin.metrics.GobblinMetrics;
 
+import lombok.Getter;
+
 
 /**
  * An extension to {@link WorkUnitState} with run-time task state information.
@@ -78,6 +80,8 @@ public class TaskState extends WorkUnitState {
 
   private String jobId;
   private String taskId;
+  @Getter
+  private Optional<String> taskAttemptId;
   private long startTime = 0;
   private long endTime = 0;
   private long duration;
@@ -92,6 +96,7 @@ public class TaskState extends WorkUnitState {
     addAll(workUnitState);
     this.jobId = workUnitState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = workUnitState.getProp(ConfigurationKeys.TASK_ID_KEY);
+    this.taskAttemptId = Optional.fromNullable(workUnitState.getProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY));
     this.setId(this.taskId);
   }
 

--- a/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/WriterUtils.java
@@ -70,6 +70,14 @@ public class WriterUtils {
   }
 
   /**
+   * Get the staging {@link Path} for {@link gobblin.writer.DataWriter} that has attemptId in the path.
+   */
+  public static Path getWriterStagingDir(State state, int numBranches, int branchId, String attemptId) {
+    Preconditions.checkArgument(attemptId != null && !attemptId.isEmpty(), "AttemptId cannot be null or empty: " + attemptId);
+    return new Path(getWriterStagingDir(state, numBranches, branchId), attemptId);
+  }
+
+  /**
    * Get the {@link Path} corresponding the to the directory a given {@link gobblin.writer.DataWriter} should be writing
    * its output data. The output data directory is determined by combining the
    * {@link ConfigurationKeys#WRITER_OUTPUT_DIR} and the {@link ConfigurationKeys#WRITER_FILE_PATH}.


### PR DESCRIPTION
This is the first PR of https://docs.google.com/document/d/1Vf5A7pHbFKwr7-Bbw2X3zBBVZSvT7HXEPE6bsi9qGco/
Main changes:
1. It has the new `GobblinMultiTaskAttempt`, which does not contain any real execution but provides the layout.
Gobblin `Task` has new `commit` method, which is empty in this PR.
1. It has the new interface `SpeculativeAttemptAwareConstruct`. Some most commonly used gobblin writers, and writer wrappers, have implemented this interface.

@chavdar @ibuenros Can you review?
