### PR TITLE
Object store writer interfaces

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/objectstore/ObjectStoreConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/objectstore/ObjectStoreConverter.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.converter.objectstore;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.converter.SchemaConversionException;
+import gobblin.writer.objectstore.ObjectStoreOperation;
+
+/**
+ * A converter of {@link ObjectStoreOperation}s. The output record of any subclasses is of type {@link ObjectStoreOperation}
+ *
+ * @param <SI> Type of input record schema
+ * @param <DI> Input record type
+ * @param <DO> Type of {@link ObjectStoreOperation}
+ */
+public abstract class ObjectStoreConverter<SI, DI, DO extends ObjectStoreOperation<?>> extends Converter<SI, Class<?>, DI, DO> {
+
+  public ObjectStoreConverter<SI, DI, DO> init(WorkUnitState workUnit) {
+    return this;
+  }
+
+  /**
+   * Convert schema is not used this converter hence return the {@link Class} of input schema as a place holder
+   * {@inheritDoc}
+   * @see gobblin.converter.Converter#convertSchema(java.lang.Object, gobblin.configuration.WorkUnitState)
+   */
+  @Override
+  public Class<?> convertSchema(SI inputSchema, WorkUnitState workUnit) throws SchemaConversionException {
+    return inputSchema.getClass();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/converter/objectstore/ObjectStoreDeleteConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/objectstore/ObjectStoreDeleteConverter.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.converter.objectstore;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SingleRecordIterable;
+import gobblin.util.AvroUtils;
+import gobblin.writer.objectstore.ObjectStoreDeleteOperation;
+import gobblin.writer.objectstore.ObjectStoreOperationBuilder;
+
+
+/**
+ * A converter to build {@link ObjectStoreDeleteOperation}s using an Avro {@link GenericRecord}. The object id field in
+ * input avro record can be set using {@link #OBJECT_ID_FIELD}. The field name is a required property.
+ *
+ */
+public class ObjectStoreDeleteConverter extends ObjectStoreConverter<Schema, GenericRecord, ObjectStoreDeleteOperation> {
+
+  @VisibleForTesting
+  public static final String OBJECT_ID_FIELD = "gobblin.converter.objectstore.delete.objectIdField";
+
+  private String objectIdField;
+
+  public ObjectStoreDeleteConverter init(WorkUnitState workUnit) {
+    Preconditions.checkArgument(workUnit.contains(OBJECT_ID_FIELD),
+        String.format("%s is a required property. ", OBJECT_ID_FIELD));
+    this.objectIdField = workUnit.getProp(OBJECT_ID_FIELD);
+    return this;
+  }
+
+  @Override
+  public Iterable<ObjectStoreDeleteOperation> convertRecord(Class<?> outputSchema, GenericRecord inputRecord,
+      WorkUnitState workUnit) throws DataConversionException {
+    return new SingleRecordIterable<ObjectStoreDeleteOperation>(ObjectStoreOperationBuilder.deleteBuilder()
+        .withObjectId(((byte[]) AvroUtils.getFieldValue(inputRecord, this.objectIdField).orNull())).build());
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreClient.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreClient.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import javax.annotation.Nonnull;
+
+import com.typesafe.config.Config;
+
+import gobblin.writer.objectstore.response.GetObjectResponse;
+
+/**
+ * A client interface to interact with an object store. Supports basic operations like put,delete and get.
+ */
+public interface ObjectStoreClient {
+
+  /**
+   * Puts an object in <code>objectStream</code> to the store. Returns the id of the object created.
+   *
+   * @param objectStream to put in the store
+   * @param putConfig additional config if any (User metadata, put options etc.)
+   * @return the id of newly created object
+   * @throws IOException if put failed
+   */
+  public byte[] put(InputStream objectStream, Config putConfig) throws IOException;
+
+  /**
+   * Puts an object in <code>objectStream</code> to the store at <code>objectId</code>.
+   * Returns the id of the object created.
+   *
+   * @param objectStream to put in the store
+   * @param objectId to put in the store
+   * @param putConfig additional config if any (User metadata, put options etc.)
+   * @return the id of newly created object
+   * @throws IOException if put failed
+   */
+  public byte[] put(InputStream objectStream, @Nonnull byte[] objectId, Config putConfig) throws IOException;
+
+  /**
+   * Delete an object with <code>objectId</code> in the store. Operation is a noop if object does not exist
+   *
+   * @param objectId to delete
+   * @param deleteConfig additional config if any
+   * @throws IOException if delete failed
+   */
+  public void delete(@Nonnull byte[] objectId, Config deleteConfig) throws IOException;
+
+  /**
+   * Get metadata associated with an object
+   * @param objectId for which metadata is retrieved
+   * @return object metadata
+   * @throws IOException if get object metadata fails
+   */
+  public Config getObjectProps(@Nonnull byte[] objectId) throws IOException;
+
+  /**
+   * Set metadata associated with an object
+   * @param objectId for which metadata is set
+   * @return object metadata
+   * @throws IOException if setting metadata fails
+   */
+  public Config setObjectProps(@Nonnull byte[] objectId) throws IOException;
+
+  /**
+   * Get an object with id <code>objectId</code> stored in the store.
+   * @param objectId to retrieve
+   * @return a {@link GetObjectResponse} with an {@link InputStream} to the object and object metadata
+   * @throws IOException if object does not exist or there was a failure reading the object
+   */
+  public GetObjectResponse getObject(@Nonnull byte[] objectId) throws IOException;
+
+  /**
+   * Close the client
+   * @throws IOException
+   */
+  public void close() throws IOException;
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreDeleteOperation.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreDeleteOperation.java
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore;
+
+import java.io.IOException;
+
+import org.apache.commons.httpclient.HttpStatus;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.writer.objectstore.response.DeleteResponse;
+
+/**
+ * An {@link ObjectStoreOperation} that deletes an object with <code>objectId</code> in the object store.
+ */
+@AllArgsConstructor(access=AccessLevel.PRIVATE)
+@Getter
+public class ObjectStoreDeleteOperation extends ObjectStoreOperation<DeleteResponse> {
+
+  /**
+   * Id of the object to be deleted
+   */
+  private final byte[] objectId;
+  /**
+   * Additional delete configurations if any
+   */
+  private final Config deleteConfig;
+
+  /**
+   * Calls {@link ObjectStoreClient#delete(String, Config)} for the object ot be deleted
+   *
+   * {@inheritDoc}
+   * @see gobblin.writer.objectstore.ObjectStoreOperation#execute(gobblin.writer.objectstore.ObjectStoreClient)
+   */
+  @Override
+  public DeleteResponse execute(ObjectStoreClient objectStoreClient) throws IOException {
+    objectStoreClient.delete(this.objectId, this.deleteConfig);
+    return new DeleteResponse(HttpStatus.SC_ACCEPTED);
+  }
+
+  /**
+   * A builder to build new {@link ObjectStoreDeleteOperation}
+   */
+  public static class Builder {
+    private byte[] objectId;
+    private Config deleteConfig;
+
+    public Builder withObjectId(byte[] objectId) {
+      this.objectId = objectId;
+      return this;
+    }
+
+    public Builder withDeleteConfig(Config deleteConfig) {
+      this.deleteConfig = deleteConfig;
+      return this;
+    }
+
+    public ObjectStoreDeleteOperation build() {
+      Preconditions.checkArgument(this.objectId != null, "Object Id needs to be set");
+      if (this.deleteConfig == null) {
+        this.deleteConfig = ConfigFactory.empty();
+      }
+      return new ObjectStoreDeleteOperation(this.objectId, this.deleteConfig);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreOperation.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreOperation.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore;
+
+import java.io.IOException;
+
+import gobblin.converter.objectstore.ObjectStoreConverter;
+
+
+/**
+ * An {@link ObjectStoreOperation} is the record type used by {@link ObjectStoreWriter}s and {@link ObjectStoreConverter}.
+ * This class represents an operation performed for an object in an object store. The store can be accessed using {@link ObjectStoreClient}.
+ * Some of the operations are DELETE, PUT, GET etc.
+ * Subclasses are specific operations, they need to implement the {@link #execute(ObjectStoreClient)} method to perform their
+ * operation on an object in the store.
+ *
+ * @param <T> Response type of the operation
+ */
+public abstract class ObjectStoreOperation<T> {
+
+  /**
+   * {@link ObjectStoreWriter} calls this method for every {@link ObjectStoreOperation}. This method should be used by
+   * the operation to make necessary calls to object store. The operation can use <code>objectStoreClient</code> to talk
+   * to the store
+   *
+   * @param objectStoreClient a client to the object store
+   * @return the response of this operation
+   * @throws IOException when the operation fails
+   */
+  public abstract T execute(ObjectStoreClient objectStoreClient) throws IOException;
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreOperationBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreOperationBuilder.java
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore;
+
+/**
+ * Builder to build all types of {@link ObjectStoreOperation}s
+ */
+public class ObjectStoreOperationBuilder {
+
+  /**
+   * Get a builder to build a delete operation
+   * @return
+   */
+  public static ObjectStoreDeleteOperation.Builder deleteBuilder() {
+    return new ObjectStoreDeleteOperation.Builder();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/ObjectStoreWriter.java
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore;
+
+import java.io.IOException;
+
+import lombok.Getter;
+
+import com.codahale.metrics.Counter;
+
+import gobblin.configuration.State;
+import gobblin.instrumented.writer.InstrumentedDataWriter;
+
+/**
+ * A writer to execute operations on a object in any object store. The record type of this writer is an {@link ObjectStoreOperation}.
+ * The {@link ObjectStoreOperation} encapsulates operation specific metadata and actions.
+ */
+@SuppressWarnings("rawtypes")
+public class ObjectStoreWriter extends InstrumentedDataWriter<ObjectStoreOperation> {
+
+  private static final String OPERATIONS_EXECUTED_COUNTER = "gobblin.objectStoreWriter.operationsExecuted";
+  private final Counter operationsExecuted;
+  @Getter
+  private final ObjectStoreClient objectStoreClient;
+
+  public ObjectStoreWriter(ObjectStoreClient client, State state) {
+    super(state);
+    this.objectStoreClient = client;
+    this.operationsExecuted = this.getMetricContext().counter(OPERATIONS_EXECUTED_COUNTER);
+  }
+
+  @Override
+  public void close() throws IOException {
+    this.objectStoreClient.close();
+  }
+
+  /**
+   * Calls {@link ObjectStoreOperation#execute(ObjectStoreClient)} on the <code>operation</code> passed
+   *
+   * {@inheritDoc}
+   * @see gobblin.writer.DataWriter#write(java.lang.Object)
+   */
+  @Override
+  public void writeImpl(ObjectStoreOperation operation) throws IOException {
+    operation.execute(this.getObjectStoreClient());
+    this.operationsExecuted.inc();
+  }
+
+  @Override
+  public void commit() throws IOException {
+  }
+
+  @Override
+  public void cleanup() throws IOException {
+    this.getObjectStoreClient().close();
+  }
+
+  @Override
+  public long recordsWritten() {
+    return this.operationsExecuted.getCount();
+  }
+
+  @Override
+  public long bytesWritten() throws IOException {
+    // TODO Will be added when ObjectStorePutOperation is implemented. Currently we only support ObjectStoreDeleteOperation
+    return 0;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/response/DeleteResponse.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/response/DeleteResponse.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * Response of a delete operation
+ */
+@AllArgsConstructor
+@Getter
+public class DeleteResponse {
+  private final int statusCode;
+}

--- a/gobblin-core/src/main/java/gobblin/writer/objectstore/response/GetObjectResponse.java
+++ b/gobblin-core/src/main/java/gobblin/writer/objectstore/response/GetObjectResponse.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore.response;
+
+import java.io.InputStream;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import com.typesafe.config.Config;
+
+import gobblin.writer.objectstore.ObjectStoreClient;
+
+/**
+ * The response of {@link ObjectStoreClient#getObject(String)} that holds an {@link InputStream} to the object and object
+ * metadata
+ */
+@AllArgsConstructor
+@Getter
+public class GetObjectResponse {
+  private final InputStream objectData;
+  private final Config objectConfig;
+}

--- a/gobblin-core/src/test/java/gobblin/writer/objectstore/ObjectStoreWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/objectstore/ObjectStoreWriterTest.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.writer.objectstore;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Iterables;
+import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.objectstore.ObjectStoreDeleteConverter;
+import gobblin.writer.objectstore.response.GetObjectResponse;
+
+
+public class ObjectStoreWriterTest {
+
+  private static final String SCHEMA_STR =
+      "{ \"type\" : \"record\", \"name\" : \"test_schema\", \"namespace\" : \"com.gobblin.test\", "
+          + "\"fields\" : [ { \"name\" : \"objectId\", \"type\" : \"string\"} ], \"doc:\" : \"\" }";
+
+  @Test
+  public void testDelete() throws Exception {
+
+    WorkUnitState wu = new WorkUnitState();
+    wu.setProp(ObjectStoreDeleteConverter.OBJECT_ID_FIELD, "objectId");
+
+    ObjectStoreClient client = new MockObjectStoreClient();
+    byte[] objId = client.put(IOUtils.toInputStream("test", "UTF-8"), ConfigFactory.empty());
+    Assert.assertEquals(IOUtils.toString(client.getObject(objId).getObjectData(), "UTF-8"), "test");
+
+    try (ObjectStoreWriter writer = new ObjectStoreWriter(client, new State());) {
+      ObjectStoreDeleteConverter converter = new ObjectStoreDeleteConverter();
+      converter.init(wu);
+
+      Schema schema = new Schema.Parser().parse(SCHEMA_STR);
+      GenericRecord datum = new GenericData.Record(schema);
+      datum.put("objectId", objId);
+
+      Iterables.getFirst(converter.convertRecord(converter.convertSchema(schema, wu), datum, wu), null);
+      writer.write(Iterables.getFirst(
+          converter.convertRecord(converter.convertSchema(schema, wu), datum, new WorkUnitState()), null));
+    }
+
+    try {
+      client.getObject(objId);
+      Assert.fail("should have thrown an IOException as object is already deleted");
+    } catch (IOException e) {
+      // All good exception thrown because object does not exist
+    }
+  }
+
+  private static class MockObjectStoreClient implements ObjectStoreClient {
+
+    private Map<byte[], String> store;
+
+    public MockObjectStoreClient() {
+      this.store = Maps.newHashMap();
+    }
+
+    @Override
+    public byte[] put(InputStream objectStream, Config putConfig) throws IOException {
+      byte[] objectId = UUID.randomUUID().toString().getBytes(StandardCharsets.UTF_8);
+      this.store.put(objectId, IOUtils.toString(objectStream, "UTF-8"));
+      return objectId;
+    }
+
+    @Override
+    public void delete(byte[] objectId, Config deletetConfig) throws IOException {
+      this.store.remove(objectId);
+    }
+
+    @Override
+    public Config getObjectProps(byte[] objectId) {
+      return ConfigFactory.empty();
+    }
+
+    @Override
+    public void close() throws IOException {
+      this.store.clear();
+    }
+
+    @Override
+    public GetObjectResponse getObject(byte[] objectId) throws IOException {
+      if (!this.store.containsKey(objectId)) {
+        throw new IOException("Object not found " + objectId);
+      }
+      return new GetObjectResponse(IOUtils.toInputStream(this.store.get(objectId), "UTF-8"), ConfigFactory.empty());
+    }
+
+    @Override
+    public Config setObjectProps(byte[] objectId) throws IOException {
+      return ConfigFactory.empty();
+    }
+
+    @Override
+    public byte[] put(InputStream objectStream, byte[] objectId, Config putConfig) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+  }
+}


### PR DESCRIPTION
Added interfaces for object store writer. 
The main abstractions here are 
- `ObjectStoreClient` which wraps any specific client to an object store.
- `ObjectStoreOperation` and its subclasses encapsulates the data and actions for an object in the store. This is also the gobblin record type of the writer
- `ObjectStoreWriter` executes any operation
- `ObjectStoreConverter` and its subclasses build `ObjectStoreOperation`s

@chavdar and @ibuenros can you review?
