### PR TITLE
Configurable http clients

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -401,23 +401,24 @@ public class ConfigurationKeys {
   /**
    * Configuration properties for source connection.
    */
-  public static final String SOURCE_CONN_USE_AUTHENTICATION = "source.conn.use.authentication";
-  public static final String SOURCE_CONN_PRIVATE_KEY = "source.conn.private.key";
-  public static final String SOURCE_CONN_KNOWN_HOSTS = "source.conn.known.hosts";
-  public static final String SOURCE_CONN_CLIENT_SECRET = "source.conn.client.secret";
-  public static final String SOURCE_CONN_CLIENT_ID = "source.conn.client.id";
-  public static final String SOURCE_CONN_DOMAIN = "source.conn.domain";
-  public static final String SOURCE_CONN_USERNAME = "source.conn.username";
-  public static final String SOURCE_CONN_PASSWORD = "source.conn.password";
-  public static final String SOURCE_CONN_SECURITY_TOKEN = "source.conn.security.token";
-  public static final String SOURCE_CONN_HOST_NAME = "source.conn.host";
-  public static final String SOURCE_CONN_VERSION = "source.conn.version";
-  public static final String SOURCE_CONN_TIMEOUT = "source.conn.timeout";
-  public static final String SOURCE_CONN_REST_URL = "source.conn.rest.url";
-  public static final String SOURCE_CONN_USE_PROXY_URL = "source.conn.use.proxy.url";
-  public static final String SOURCE_CONN_USE_PROXY_PORT = "source.conn.use.proxy.port";
-  public static final String SOURCE_CONN_DRIVER = "source.conn.driver";
-  public static final String SOURCE_CONN_PORT = "source.conn.port";
+  public static final String SOURCE_CONN_PREFIX = "source.conn.";
+  public static final String SOURCE_CONN_USE_AUTHENTICATION = SOURCE_CONN_PREFIX + "use.authentication";
+  public static final String SOURCE_CONN_PRIVATE_KEY = SOURCE_CONN_PREFIX + "private.key";
+  public static final String SOURCE_CONN_KNOWN_HOSTS = SOURCE_CONN_PREFIX + "known.hosts";
+  public static final String SOURCE_CONN_CLIENT_SECRET = SOURCE_CONN_PREFIX + "client.secret";
+  public static final String SOURCE_CONN_CLIENT_ID = SOURCE_CONN_PREFIX + "client.id";
+  public static final String SOURCE_CONN_DOMAIN = SOURCE_CONN_PREFIX + "domain";
+  public static final String SOURCE_CONN_USERNAME = SOURCE_CONN_PREFIX + "username";
+  public static final String SOURCE_CONN_PASSWORD = SOURCE_CONN_PREFIX + "password";
+  public static final String SOURCE_CONN_SECURITY_TOKEN = SOURCE_CONN_PREFIX + "security.token";
+  public static final String SOURCE_CONN_HOST_NAME = SOURCE_CONN_PREFIX + "host";
+  public static final String SOURCE_CONN_VERSION = SOURCE_CONN_PREFIX + "version";
+  public static final String SOURCE_CONN_TIMEOUT = SOURCE_CONN_PREFIX + "timeout";
+  public static final String SOURCE_CONN_REST_URL = SOURCE_CONN_PREFIX + "rest.url";
+  public static final String SOURCE_CONN_USE_PROXY_URL = SOURCE_CONN_PREFIX + "use.proxy.url";
+  public static final String SOURCE_CONN_USE_PROXY_PORT = SOURCE_CONN_PREFIX + "use.proxy.port";
+  public static final String SOURCE_CONN_DRIVER = SOURCE_CONN_PREFIX + "driver";
+  public static final String SOURCE_CONN_PORT = SOURCE_CONN_PREFIX + "port";
   public static final int SOURCE_CONN_DEFAULT_PORT = 22;
 
   /**

--- a/gobblin-core/src/main/java/gobblin/http/DefaultHttpClientConfigurator.java
+++ b/gobblin-core/src/main/java/gobblin/http/DefaultHttpClientConfigurator.java
@@ -1,0 +1,142 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.http;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import org.apache.http.HttpHost;
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Strings;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import gobblin.annotation.Alias;
+import gobblin.configuration.State;
+
+/**
+ * Default implementation that uses the following properties to configure an {@link HttpClient}.
+ *
+ * <ul>
+ *  <li>{@link #PROXY_HOSTPORT_KEY}
+ *  <li>{@link #PROXY_URL_KEY}
+ *  <li>{@link #PROXY_PORT_KEY}
+ * </ul>
+ */
+@Alias(value="default")
+public class DefaultHttpClientConfigurator implements HttpClientConfigurator {
+  // IMPORTANT: don't change the values for PROXY_URL_KEY and PROXY_PORT_KEY as they are meant to
+  // be backwards compatible with SOURCE_CONN_USE_PROXY_URL and SOURCE_CONN_USE_PROXY_PORT when
+  // the statePropertiesPrefix is "source.conn."
+  /** The hostname of the HTTP proxy to use */
+  public static final String PROXY_URL_KEY = "use.proxy.url";
+  /** The port of the HTTP proxy to use */
+  public static final String PROXY_PORT_KEY = "use.proxy.port";
+  /** Similar to {@link #PROXY_URL_KEY} and {@link #PROXY_PORT_KEY} but allows you to set it on
+   * one property as <host>:<port> */
+  public static final String PROXY_HOSTPORT_KEY = "proxyHostport";
+  /** Port to use if the HTTP Proxy is enabled but no port is specified */
+  public static final int DEFAULT_HTTP_PROXY_PORT = 8080;
+
+  private static final Pattern HOSTPORT_PATTERN = Pattern.compile("([^:]+)(:([0-9]+))?");
+
+  protected final HttpClientBuilder _builder = HttpClientBuilder.create();
+  protected String _statePropertiesPrefix = null;
+
+  /** {@inheritDoc} */
+  @Override
+  public DefaultHttpClientConfigurator configure(Config httpClientConfig) {
+    Optional<HttpHost> proxy = getProxyAddr(httpClientConfig);
+    if (proxy.isPresent()) {
+      getBuilder().setProxy(proxy.get());
+    }
+    return this;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public DefaultHttpClientConfigurator configure(State state) {
+    Config cfg = stateToConfig(state);
+    return configure(cfg);
+  }
+
+  protected Config stateToConfig(State state) {
+    String proxyUrlKey = getPrefixedPropertyName(PROXY_URL_KEY);
+    String proxyPortKey = getPrefixedPropertyName(PROXY_PORT_KEY);
+    String proxyHostportKey = getPrefixedPropertyName(PROXY_HOSTPORT_KEY);
+
+    Config cfg = ConfigFactory.empty();
+    if (state.contains(proxyUrlKey)) {
+      cfg = cfg.withValue(PROXY_URL_KEY, ConfigValueFactory.fromAnyRef(state.getProp(proxyUrlKey)));
+    }
+    if (state.contains(proxyPortKey)) {
+      cfg = cfg.withValue(PROXY_PORT_KEY, ConfigValueFactory.fromAnyRef(state.getPropAsInt(proxyPortKey)));
+    }
+    if (state.contains(proxyHostportKey)) {
+      cfg = cfg.withValue(PROXY_HOSTPORT_KEY, ConfigValueFactory.fromAnyRef(state.getProp(proxyHostportKey)));
+    }
+    return cfg;
+  }
+
+  /** {@inheritDoc} */
+  @Override
+  public HttpClient createClient() {
+    return _builder.build();
+  }
+
+  @VisibleForTesting
+  public static Optional<HttpHost> getProxyAddr(Config httpClientConfig) {
+    String proxyHost = null;
+    int proxyPort = DEFAULT_HTTP_PROXY_PORT;
+    if (httpClientConfig.hasPath(PROXY_URL_KEY) &&
+        !httpClientConfig.getString(PROXY_URL_KEY).isEmpty()) {
+      proxyHost = httpClientConfig.getString(PROXY_URL_KEY);
+    }
+    if (httpClientConfig.hasPath(PROXY_PORT_KEY)) {
+      proxyPort = httpClientConfig.getInt(PROXY_PORT_KEY);
+    }
+    if (httpClientConfig.hasPath(PROXY_HOSTPORT_KEY)) {
+      String hostport = httpClientConfig.getString(PROXY_HOSTPORT_KEY);
+      Matcher hostportMatcher = HOSTPORT_PATTERN.matcher(hostport);
+      if (!hostportMatcher.matches()) {
+        throw new IllegalArgumentException("Invalid HTTP proxy hostport: " + hostport);
+      }
+      proxyHost = hostportMatcher.group(1);
+      if (!Strings.isNullOrEmpty(hostportMatcher.group(3))) {
+        proxyPort = Integer.parseInt(hostportMatcher.group(3));
+      }
+    }
+    return null != proxyHost ? Optional.of(new HttpHost(proxyHost, proxyPort))
+        : Optional.<HttpHost>absent();
+  }
+
+  @Override
+  public DefaultHttpClientConfigurator setStatePropertiesPrefix(String propertiesPrefix) {
+    _statePropertiesPrefix = propertiesPrefix;
+    return this;
+  }
+
+  String getPrefixedPropertyName(String propertyName) {
+    return null != _statePropertiesPrefix ? _statePropertiesPrefix + propertyName : propertyName;
+  }
+
+  @Override
+  public HttpClientBuilder getBuilder() {
+    return _builder;
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/http/DefaultHttpClientConfigurator.java
+++ b/gobblin-core/src/main/java/gobblin/http/DefaultHttpClientConfigurator.java
@@ -47,7 +47,7 @@ public class DefaultHttpClientConfigurator implements HttpClientConfigurator {
   /** The port of the HTTP proxy to use */
   public static final String PROXY_PORT_KEY = "use.proxy.port";
   /** Similar to {@link #PROXY_URL_KEY} and {@link #PROXY_PORT_KEY} but allows you to set it on
-   * one property as <host>:<port> */
+   * one property as <host>:<port> . This property takes precedence over those properties.  */
   public static final String PROXY_HOSTPORT_KEY = "proxyHostport";
   /** Port to use if the HTTP Proxy is enabled but no port is specified */
   public static final int DEFAULT_HTTP_PROXY_PORT = 8080;

--- a/gobblin-core/src/main/java/gobblin/http/HttpClientConfigurator.java
+++ b/gobblin-core/src/main/java/gobblin/http/HttpClientConfigurator.java
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.http;
+
+import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.typesafe.config.Config;
+
+import gobblin.configuration.State;
+
+/**
+ * An adapter from Gobblin configuration to {@link HttpClientBuilder}. It can also be used to
+ * create {@link HttpClient} instances.
+ */
+public interface HttpClientConfigurator {
+
+  /** Sets a prefix to use when extracting the configuration from {@link State}. The default is
+   * empty. */
+  HttpClientConfigurator setStatePropertiesPrefix(String propertiesPrefix);
+
+  /**
+   * Extracts the HttpClient configuration from a typesafe config. Supported configuration options
+   * may vary from implementation to implementation.
+   * */
+  HttpClientConfigurator configure(Config httpClientConfig);
+
+  /** Same as {@link #configure(Config)} but for legacy cases using State. */
+  HttpClientConfigurator configure(State httpClientConfig);
+
+  /** The underlying client builder */
+  HttpClientBuilder getBuilder();
+
+  /**
+   * Typically this will use {@link HttpClientBuilder#build()} based on the configuration but
+   * implementations may also return decorated instances. */
+  HttpClient createClient();
+
+}

--- a/gobblin-core/src/main/java/gobblin/http/HttpClientConfiguratorLoader.java
+++ b/gobblin-core/src/main/java/gobblin/http/HttpClientConfiguratorLoader.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.http;
+
+import org.apache.http.client.HttpClient;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
+import gobblin.configuration.State;
+import gobblin.util.ClassAliasResolver;
+
+/**
+ * Creates an instance of HttpClientConfigurator using dependency injection from configuration.
+ * Th
+ */
+public class HttpClientConfiguratorLoader {
+
+  /** Classname or alias for an {@link HttpClientConfigurator} instance to use for configuring and
+   * instantiating of {@link HttpClient} instances. */
+  public static final String HTTP_CLIENT_CONFIGURATOR_TYPE_KEY = "httpClientConfigurator.type";
+  public static final String HTTP_CLIENT_CONFIGURATOR_TYPE_FULL_KEY =
+      "gobblin." + HTTP_CLIENT_CONFIGURATOR_TYPE_KEY;
+  public static final Class<? extends HttpClientConfigurator> DEFAULT_CONFIGURATOR_CLASS =
+      DefaultHttpClientConfigurator.class;
+
+  private static final ClassAliasResolver<HttpClientConfigurator> TYPE_RESOLVER =
+      new ClassAliasResolver<>(HttpClientConfigurator.class);
+  private final HttpClientConfigurator _configurator;
+
+  /**
+   * Loads a HttpClientConfigurator using the value of the {@link #HTTP_CLIENT_CONFIGURATOR_TYPE_FULL_KEY}
+   * property in the state.
+   */
+  public HttpClientConfiguratorLoader(State state) {
+    this(Optional.<String>fromNullable(state.getProp(HTTP_CLIENT_CONFIGURATOR_TYPE_FULL_KEY)));
+  }
+
+  /** Loads a HttpClientConfigurator using the value of {@link #HTTP_CLIENT_CONFIGURATOR_TYPE_KEY}
+   * in the local typesafe config. */
+  public HttpClientConfiguratorLoader(Config config) {
+    this(Optional.<String>fromNullable(config.hasPath(HTTP_CLIENT_CONFIGURATOR_TYPE_KEY) ?
+              config.getString(HTTP_CLIENT_CONFIGURATOR_TYPE_KEY) : null));
+  }
+
+  /** Loads a HttpClientConfigurator with the specified class or alias. If not specified,
+   * {@link #DEFAULT_CONFIGURATOR_CLASS} is used. */
+  public HttpClientConfiguratorLoader(Optional<String> configuratorType) {
+    try {
+      _configurator = getConfiguratorClass(configuratorType).newInstance();
+    } catch (InstantiationException | IllegalAccessException | ClassNotFoundException e) {
+      throw new RuntimeException("Unable to find HttpClientConfigurator:" + e, e);
+    }
+  }
+
+  private static Class<? extends HttpClientConfigurator>
+          getConfiguratorClass(Optional<String> configuratorType) throws ClassNotFoundException {
+    return configuratorType.isPresent() ? TYPE_RESOLVER.resolveClass(configuratorType.get()) :
+        DEFAULT_CONFIGURATOR_CLASS;
+  }
+
+  public HttpClientConfigurator getConfigurator() {
+    return _configurator;
+  }
+
+}

--- a/gobblin-core/src/main/java/gobblin/http/HttpClientConfiguratorLoader.java
+++ b/gobblin-core/src/main/java/gobblin/http/HttpClientConfiguratorLoader.java
@@ -21,7 +21,6 @@ import gobblin.util.ClassAliasResolver;
 
 /**
  * Creates an instance of HttpClientConfigurator using dependency injection from configuration.
- * Th
  */
 public class HttpClientConfiguratorLoader {
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -18,16 +18,14 @@ import java.util.List;
 
 import org.apache.commons.io.IOUtils;
 import org.apache.http.HttpEntity;
-import org.apache.http.HttpHost;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpRequestBase;
-import org.apache.http.conn.params.ConnRoutePNames;
-import org.apache.http.impl.client.DefaultHttpClient;
 import org.apache.http.util.EntityUtils;
 
+import com.google.common.base.Charsets;
 import com.google.gson.Gson;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
@@ -35,11 +33,13 @@ import com.google.gson.JsonObject;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
+import gobblin.http.HttpClientConfiguratorLoader;
 import gobblin.source.extractor.exception.RestApiConnectionException;
 import gobblin.source.extractor.exception.RestApiProcessingException;
 import gobblin.source.extractor.extract.Command;
 import gobblin.source.extractor.extract.CommandOutput;
 import gobblin.source.extractor.extract.restapi.RestApiCommand.RestApiCommandType;
+
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -96,7 +96,7 @@ public abstract class RestApiConnector {
           log.error("entity class: " + httpEntity.getClass().getName());
           log.error("entity string size: " + EntityUtils.toString(httpEntity).length());
           log.error("content length: " + httpEntity.getContentLength());
-          log.error("content: " + IOUtils.toString(httpEntity.getContent()));
+          log.error("content: " + IOUtils.toString(httpEntity.getContent(), Charsets.UTF_8));
           throw new RestApiConnectionException(
               "JSON is NULL ! Failed on authentication with the following HTTP response received:\n"
                   + EntityUtils.toString(httpEntity));
@@ -130,16 +130,9 @@ public abstract class RestApiConnector {
 
   protected HttpClient getHttpClient() {
     if (this.httpClient == null) {
-      this.httpClient = new DefaultHttpClient();
-
-      if (this.state.contains(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL)
-          && !this.state.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL).isEmpty()) {
-        log.info("Connecting via proxy: " + this.state.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL));
-
-        HttpHost proxy = new HttpHost(this.state.getProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL),
-            this.state.getPropAsInt(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT));
-        this.httpClient.getParams().setParameter(ConnRoutePNames.DEFAULT_PROXY, proxy);
-      }
+      HttpClientConfiguratorLoader configuratorLoader = new HttpClientConfiguratorLoader(this.state);
+      this.httpClient = configuratorLoader.getConfigurator().
+          setStatePropertiesPrefix(ConfigurationKeys.SOURCE_CONN_PREFIX).createClient();
     }
     return this.httpClient;
   }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -131,8 +131,10 @@ public abstract class RestApiConnector {
   protected HttpClient getHttpClient() {
     if (this.httpClient == null) {
       HttpClientConfiguratorLoader configuratorLoader = new HttpClientConfiguratorLoader(this.state);
-      this.httpClient = configuratorLoader.getConfigurator().
-          setStatePropertiesPrefix(ConfigurationKeys.SOURCE_CONN_PREFIX).createClient();
+      this.httpClient = configuratorLoader.getConfigurator()
+          .setStatePropertiesPrefix(ConfigurationKeys.SOURCE_CONN_PREFIX)
+          .configure(this.state)
+          .createClient();
     }
     return this.httpClient;
   }

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
@@ -17,6 +17,7 @@ import java.net.URISyntaxException;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -72,6 +73,7 @@ public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> im
 
   }
 
+  @SuppressWarnings("rawtypes")
   public AbstractHttpWriter(AbstractHttpWriterBuilder builder) {
     super(builder.getState());
     this.log = builder.getLogger().isPresent() ? (Logger)builder.getLogger() : LoggerFactory.getLogger(this.getClass());

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
@@ -13,10 +13,7 @@ package gobblin.writer.http;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
-
-import lombok.Getter;
 
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.conn.HttpClientConnectionManager;
@@ -34,8 +31,11 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.config.ConfigBuilder;
 import gobblin.configuration.State;
+import gobblin.http.HttpClientConfiguratorLoader;
 import gobblin.writer.Destination;
 import gobblin.writer.FluentDataWriterBuilder;
+
+import lombok.Getter;
 
 @Getter
 public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWriterBuilder<S, D, B>>
@@ -55,21 +55,17 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
     BASIC;
   }
 
-  private static final Config FALLBACK;
-  static {
-    Map<String, Object> configMap = ImmutableMap.<String, Object>builder()
-                                                .put(REQUEST_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
-                                                .put(CONNECTION_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
-                                                .put(HTTP_CONN_MANAGER, ConnManager.BASIC.name())
-                                                .put(POOLING_CONN_MANAGER_MAX_TOTAL_CONN, 20)
-                                                .put(POOLING_CONN_MANAGER_MAX_PER_CONN, 2)
-                                                .build();
-    FALLBACK = ConfigFactory.parseMap(configMap);
-  }
+  private static final Config FALLBACK =
+      ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+          .put(REQUEST_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
+          .put(CONNECTION_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
+          .put(HTTP_CONN_MANAGER, ConnManager.BASIC.name())
+          .put(POOLING_CONN_MANAGER_MAX_TOTAL_CONN, 20)
+          .put(POOLING_CONN_MANAGER_MAX_PER_CONN, 2)
+          .build());
 
   private State state;
-  private HttpClientBuilder httpClientBuilder =
-      HttpClientBuilder.create().disableCookieManagement().useSystemProperties();
+  private Optional<HttpClientBuilder> httpClientBuilder = Optional.absent();
 
   private HttpClientConnectionManager httpConnManager;
   private long reqTimeOut;
@@ -103,7 +99,7 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
                                                .setConnectionRequestTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
                                                .build();
 
-    httpClientBuilder.setDefaultRequestConfig(requestConfig);
+    getHttpClientBuilder().setDefaultRequestConfig(requestConfig);
 
     if (config.hasPath(STATIC_SVC_ENDPOINT)) {
       try {
@@ -131,8 +127,24 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
     return typedSelf();
   }
 
+  public HttpClientBuilder getDefaultBuilder() {
+    HttpClientConfiguratorLoader clientConfiguratorLoader =
+        new HttpClientConfiguratorLoader(getState());
+    clientConfiguratorLoader.getConfigurator().setStatePropertiesPrefix(AbstractHttpWriterBuilder.CONF_PREFIX);
+    return clientConfiguratorLoader.getConfigurator().configure(getState())
+        .getBuilder().disableCookieManagement().useSystemProperties();
+  }
+
+  public HttpClientBuilder getHttpClientBuilder() {
+    if (!this.httpClientBuilder.isPresent()) {
+      this.httpClientBuilder = Optional.of(getDefaultBuilder());
+    }
+
+    return this.httpClientBuilder.get();
+  }
+
   public B withHttpClientBuilder(HttpClientBuilder builder) {
-    this.httpClientBuilder = builder;
+    this.httpClientBuilder = Optional.of(builder);
     return typedSelf();
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
@@ -64,7 +64,7 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
           .put(POOLING_CONN_MANAGER_MAX_PER_CONN, 2)
           .build());
 
-  private State state;
+  private State state = new State();
   private Optional<HttpClientBuilder> httpClientBuilder = Optional.absent();
 
   private HttpClientConnectionManager httpConnManager;

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
@@ -127,7 +127,7 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
     return typedSelf();
   }
 
-  public HttpClientBuilder getDefaultBuilder() {
+  public HttpClientBuilder getDefaultHttpClientBuilder() {
     HttpClientConfiguratorLoader clientConfiguratorLoader =
         new HttpClientConfiguratorLoader(getState());
     clientConfiguratorLoader.getConfigurator().setStatePropertiesPrefix(AbstractHttpWriterBuilder.CONF_PREFIX);
@@ -137,7 +137,7 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
 
   public HttpClientBuilder getHttpClientBuilder() {
     if (!this.httpClientBuilder.isPresent()) {
-      this.httpClientBuilder = Optional.of(getDefaultBuilder());
+      this.httpClientBuilder = Optional.of(getDefaultHttpClientBuilder());
     }
 
     return this.httpClientBuilder.get();

--- a/gobblin-core/src/main/java/gobblin/writer/http/HttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/HttpWriter.java
@@ -29,6 +29,7 @@ import com.google.common.base.Optional;
  * Writes via RESTful API that accepts plain text as a body
  */
 public class HttpWriter<D> extends AbstractHttpWriter<D> {
+  @SuppressWarnings("rawtypes")
   public HttpWriter(AbstractHttpWriterBuilder builder) {
     super(builder);
   }

--- a/gobblin-core/src/test/java/gobblin/http/TestDefaultHttpClientConfiguration.java
+++ b/gobblin-core/src/test/java/gobblin/http/TestDefaultHttpClientConfiguration.java
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.http;
+
+import org.apache.http.HttpHost;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+
+/**
+ * Unit tests for {@link DefaultHttpClientConfigurator}
+ */
+public class TestDefaultHttpClientConfiguration {
+
+  @Test
+  public void testConfigureFromTypesafe() {
+    {
+      Config cfg =
+        ConfigFactory.empty().withValue(DefaultHttpClientConfigurator.PROXY_HOSTPORT_KEY,
+                                        ConfigValueFactory.fromAnyRef("localhost:12345"));
+      Optional<HttpHost> proxyHost = DefaultHttpClientConfigurator.getProxyAddr(cfg);
+      Assert.assertTrue(proxyHost.isPresent());
+      Assert.assertEquals(proxyHost.get(), new HttpHost("localhost", 12345));
+    }
+    {
+      Config cfg =
+        ConfigFactory.empty().withValue(DefaultHttpClientConfigurator.PROXY_HOSTPORT_KEY,
+                                        ConfigValueFactory.fromAnyRef("localhost"));
+      Optional<HttpHost> proxyHost = DefaultHttpClientConfigurator.getProxyAddr(cfg);
+      Assert.assertTrue(proxyHost.isPresent());
+      Assert.assertEquals(proxyHost.get(), new HttpHost("localhost",
+          DefaultHttpClientConfigurator.DEFAULT_HTTP_PROXY_PORT));
+    }
+    {
+      Config cfg =
+        ConfigFactory.empty().withValue(DefaultHttpClientConfigurator.PROXY_URL_KEY,
+                                        ConfigValueFactory.fromAnyRef("host123"));
+      Optional<HttpHost> proxyHost = DefaultHttpClientConfigurator.getProxyAddr(cfg);
+      Assert.assertTrue(proxyHost.isPresent());
+      Assert.assertEquals(proxyHost.get(), new HttpHost("host123",
+          DefaultHttpClientConfigurator.DEFAULT_HTTP_PROXY_PORT));
+    }
+    {
+      Config cfg =
+        ConfigFactory.empty().withValue(DefaultHttpClientConfigurator.PROXY_URL_KEY,
+                                        ConfigValueFactory.fromAnyRef("host123"))
+                              .withValue(DefaultHttpClientConfigurator.PROXY_PORT_KEY,
+                                        ConfigValueFactory.fromAnyRef(54321));
+      Optional<HttpHost> proxyHost = DefaultHttpClientConfigurator.getProxyAddr(cfg);
+      Assert.assertTrue(proxyHost.isPresent());
+      Assert.assertEquals(proxyHost.get(), new HttpHost("host123",54321));
+    }
+    {
+      Config cfg =
+        ConfigFactory.empty();
+      Optional<HttpHost> proxyHost = DefaultHttpClientConfigurator.getProxyAddr(cfg);
+      Assert.assertFalse(proxyHost.isPresent());
+    }
+  }
+
+  @Test
+  public void testConfigureFromState() {
+    {
+      State state = new State();
+      state.setProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL, "localhost");
+      state.setProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT, "11111");
+      DefaultHttpClientConfigurator configurator = new DefaultHttpClientConfigurator();
+      Config cfg = configurator.setStatePropertiesPrefix("source.conn.").stateToConfig(state);
+      Assert.assertEquals(cfg.getString(DefaultHttpClientConfigurator.PROXY_URL_KEY), "localhost");
+      Assert.assertEquals(cfg.getInt(DefaultHttpClientConfigurator.PROXY_PORT_KEY), 11111);
+    }
+    {
+      State state = new State();
+      state.setProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL, "localhost");
+      DefaultHttpClientConfigurator configurator = new DefaultHttpClientConfigurator();
+      Config cfg = configurator.setStatePropertiesPrefix("source.conn.").stateToConfig(state);
+      Assert.assertEquals(cfg.getString(DefaultHttpClientConfigurator.PROXY_URL_KEY), "localhost");
+      Assert.assertFalse(cfg.hasPath(DefaultHttpClientConfigurator.PROXY_PORT_KEY));
+    }
+    {
+      State state = new State();
+      state.setProp(DefaultHttpClientConfigurator.PROXY_HOSTPORT_KEY, "localhost:22222");
+      DefaultHttpClientConfigurator configurator = new DefaultHttpClientConfigurator();
+      Config cfg = configurator.stateToConfig(state);
+      Assert.assertEquals(cfg.getString(DefaultHttpClientConfigurator.PROXY_HOSTPORT_KEY),
+                          "localhost:22222");
+    }
+  }
+
+}

--- a/gobblin-core/src/test/java/gobblin/http/TestHttpClientConfiguratorLoader.java
+++ b/gobblin-core/src/test/java/gobblin/http/TestHttpClientConfiguratorLoader.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.http;
+
+import org.testng.Assert;
+import org.testng.Assert.ThrowingRunnable;
+import org.testng.annotations.Test;
+
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import gobblin.configuration.State;
+
+/**
+ * Unit tests for {@link HttpClientConfiguratorLoader}
+ */
+public class TestHttpClientConfiguratorLoader {
+
+  @Test
+  public void testConfigureFromState() {
+    HttpClientConfiguratorLoader loader = new HttpClientConfiguratorLoader(new State());
+    Assert.assertEquals(loader.getConfigurator().getClass(), DefaultHttpClientConfigurator.class);
+
+    State state = new State();
+    state.setProp(HttpClientConfiguratorLoader.HTTP_CLIENT_CONFIGURATOR_TYPE_FULL_KEY, "default");
+    loader = new HttpClientConfiguratorLoader(state);
+    Assert.assertEquals(loader.getConfigurator().getClass(), DefaultHttpClientConfigurator.class);
+  }
+
+  @Test
+  public void testConfigureFromConfig() {
+    final Config config = ConfigFactory.empty()
+        .withValue(HttpClientConfiguratorLoader.HTTP_CLIENT_CONFIGURATOR_TYPE_KEY,
+                   ConfigValueFactory.fromAnyRef("blah"));
+    Assert.assertThrows(new ThrowingRunnable() {
+      @Override public void run() throws Throwable {
+        new HttpClientConfiguratorLoader(config);
+      }
+    });
+  }
+
+}


### PR DESCRIPTION
Added instrumentation to allow customization of the instantiation of HttpClient objects:
- Enabled configurability through the job State/Config
- Enabled the adding of decorations to the HttpClient

At the core is the HttpClientConfigurator interface which allows to:
- Extract relevant configuration for the HttpConfig from the job Config/State (configure() methods)
- Create decorations of the HttpClients (getHttpClient())

DefaultHttpClientConfigurator is the standard implementation of HttpClientConfigurator. HttpClientConfiguratorLoader can be used to inject different implementations through job State/Config.

I've refactored RestApiConnector and AbstractHttpWriterBuilder to use the above instrumentation. Next is the Wikipedia extractor.

I've also done some minor code hygiene changes to clean up code/remove compiler warnings.

@ydai1124 @jinhyukchang can you review?
