### PR TITLE
AvroFieldsPickConverter to maintain the order of fields as user defined.

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/filter/AvroFieldsPickConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/filter/AvroFieldsPickConverter.java
@@ -165,7 +165,7 @@ public class AvroFieldsPickConverter extends AvroToAvroConverterBase {
 
     TrieNode(String val) {
       this.val = val;
-      this.children = Maps.newHashMap();
+      this.children = Maps.newLinkedHashMap();
     }
 
     void add(String fqn) {


### PR DESCRIPTION
Updated AvroFieldsPickConverter to maintain the order of fields as user defined.
(AvroFieldsPickConverter was introduced with JDBCWriter where order didn't matter. This fix is for the use case, that needs to keep the order of Avro schema and record as user defined).

Example:
converter.avro.fields=userId,memberId,businessUnit

{
  "type" : "record",
  "name" : "TUPLE_0",
  "fields" : [ {
    "name" : "userId",
    "type" : [ "null", "string" ],
  }, {
    "name" : "memberId",
    "type" : [ "null", "long" ],
  }, {
    "name" : "businessUnit",
    "type" : [ "null", "string" ],
  } ]
}
