### PR TITLE
Hive registration config governing database and tables made more generic. 

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -182,35 +182,35 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
   }
 
   /***
-   * Obtain Hive table names filtered by <code>dbPropertyFilter</code> (if present).
+   * Obtain Hive table names filtered by <code>dbPrefix</code> (if present).
    *
    * The returned {@link List} contains:
-   *  A. If <code>dbPropertyFilter</code> is absent:
+   *  A. If <code>dbPrefix</code> is absent:
    *    1. Table name returned by {@link #getTableName(Path)}
    *    2. Table names specified by <code>additional.hive.table.names</code>
-   *  B. If dbPropertyFilter is present:
-   *    1. Table names specified by <code>dbPropertyFilter.additional.hive.table.names</code>
+   *  B. If dbPrefix is present:
+   *    1. Table names specified by <code>dbPrefix.hive.table.names</code>
    *
    * In table names above, the {@value PRIMARY_TABLE_TOKEN} if present is also replaced by the
    * table name obtained via {@link #getTableName(Path)}.
    *
-   * @param dbPropertyFilter Prefix to the property <code>additional.table.names</code>, to obtain table names only
-   *                         for the specified db. Eg. If <code>dbPropertyFilter</code> is db, then
-   *                         <code>db.additional.table.names</code> is the resolved property name.
+   * @param dbPrefix Prefix to the property <code>additional.table.names</code>, to obtain table names only
+   *                         for the specified db. Eg. If <code>dbPrefix</code> is db, then
+   *                         <code>db.hive.table.names</code> is the resolved property name.
    * @param path Path for the table on filesystem.
    * @return Table names to register.
    */
-  protected List<String> getTableNames(Optional<String> dbPropertyFilter, Path path) {
+  protected List<String> getTableNames(Optional<String> dbPrefix, Path path) {
     List<String> tableNames = Lists.newArrayList();
 
     Optional<String> primaryTableName;
-    if ((primaryTableName = getTableName(path)).isPresent() && !dbPropertyFilter.isPresent()) {
+    if ((primaryTableName = getTableName(path)).isPresent() && !dbPrefix.isPresent()) {
       tableNames.add(primaryTableName.get());
     }
 
     String additionalNamesProp;
-    if (dbPropertyFilter.isPresent()) {
-      additionalNamesProp = String.format("%s.%s", dbPropertyFilter.get(), ADDITIONAL_HIVE_TABLE_NAMES);
+    if (dbPrefix.isPresent()) {
+      additionalNamesProp = String.format("%s.%s", dbPrefix.get(), HIVE_TABLE_NAME);
     } else {
       additionalNamesProp = ADDITIONAL_HIVE_TABLE_NAMES;
     }
@@ -277,11 +277,10 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
       }
 
       // If no tables found via db filter, get tables to register in all Hive databases and add them for this database
-      if (foundTablesViaDbFilter) {
-        continue;
-      }
-      for (String tableName : getTableNames(path)) {
-        tables.add(getTable(path, databaseName, tableName));
+      if (!foundTablesViaDbFilter) {
+        for (String tableName : getTableNames(path)) {
+          tables.add(getTable(path, databaseName, tableName));
+        }
       }
     }
     return tables;

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/policy/HiveRegistrationPolicyBase.java
@@ -64,6 +64,8 @@ public class HiveRegistrationPolicyBase implements HiveRegistrationPolicy {
   public static final String HIVE_TABLE_NAME_SUFFIX = "hive.table.name.suffix";
   public static final String HIVE_SANITIZE_INVALID_NAMES = "hive.sanitize.invalid.names";
   public static final String HIVE_FS_URI = "hive.registration.fs.uri";
+  // {@value PRIMARY_TABLE_TOKEN} if present in {@value ADDITIONAL_HIVE_TABLE_NAMES} or dbPrefix.{@value HIVE_TABLE_NAME}
+  // .. will be replaced by the table name determined via {@link #getTableName(Path)} 
   public static final String PRIMARY_TABLE_TOKEN = "$PRIMARY_TABLE";
 
   /**

--- a/gobblin-hive-registration/src/test/java/gobblin/hive/policy/HiveRegistrationPolicyBaseTest.java
+++ b/gobblin-hive-registration/src/test/java/gobblin/hive/policy/HiveRegistrationPolicyBaseTest.java
@@ -63,6 +63,40 @@ public class HiveRegistrationPolicyBaseTest {
     examine(spec, "db2", "tbl3");
   }
 
+  @Test
+  public void testGetHiveSpecsWithDBFilter() throws IOException{
+    State state = new State();
+    state.appendToListProp(HiveRegistrationPolicyBase.HIVE_DATABASE_NAME, "db1");
+    state.appendToListProp(HiveRegistrationPolicyBase.ADDITIONAL_HIVE_DATABASE_NAMES, "db2");
+
+    state.appendToListProp(HiveRegistrationPolicyBase.HIVE_TABLE_NAME, "tbl1");
+    state.appendToListProp(HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES, "tbl2,tbl3,$PRIMARY_TABLE_col");
+
+    state.appendToListProp("db2." + HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES, "$PRIMARY_TABLE_col,tbl4,tbl5");
+
+    this.path = new Path(getClass().getResource("/test-hive-table").toString());
+
+    Collection<HiveSpec> specs = new HiveRegistrationPolicyBase(state).getHiveSpecs(this.path);
+
+    Assert.assertEquals(specs.size(), 7);
+    Iterator<HiveSpec> iterator = specs.iterator();
+    HiveSpec spec = iterator.next();
+    examine(spec, "db1", "tbl1");
+    spec = iterator.next();
+    examine(spec, "db1", "tbl2");
+    spec = iterator.next();
+    examine(spec, "db1", "tbl3");
+    spec = iterator.next();
+    examine(spec, "db1", "tbl1_col");
+    spec = iterator.next();
+    examine(spec, "db2", "tbl1_col");
+    spec = iterator.next();
+    examine(spec, "db2", "tbl4");
+    spec = iterator.next();
+    examine(spec, "db2", "tbl5");
+  }
+
+
   private static void examine(HiveSpec spec, String dbName, String tableName) {
     Assert.assertEquals(spec.getClass(), SimpleHiveSpec.class);
     Assert.assertEquals(spec.getTable().getDbName(), dbName);

--- a/gobblin-hive-registration/src/test/java/gobblin/hive/policy/HiveRegistrationPolicyBaseTest.java
+++ b/gobblin-hive-registration/src/test/java/gobblin/hive/policy/HiveRegistrationPolicyBaseTest.java
@@ -72,7 +72,7 @@ public class HiveRegistrationPolicyBaseTest {
     state.appendToListProp(HiveRegistrationPolicyBase.HIVE_TABLE_NAME, "tbl1");
     state.appendToListProp(HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES, "tbl2,tbl3,$PRIMARY_TABLE_col");
 
-    state.appendToListProp("db2." + HiveRegistrationPolicyBase.ADDITIONAL_HIVE_TABLE_NAMES, "$PRIMARY_TABLE_col,tbl4,tbl5");
+    state.appendToListProp("db2." + HiveRegistrationPolicyBase.HIVE_TABLE_NAME, "$PRIMARY_TABLE_col,tbl4,tbl5");
 
     this.path = new Path(getClass().getResource("/test-hive-table").toString());
 


### PR DESCRIPTION
This PR contains two enhancements: 
- Hive registration config governing database and tables to register has been made more generic.
- Basic template support added for Hive tables to register. 

At the moment, if we have the following config: 
```
# Databases to register to
hive.database.name=db1 
additional.hive.database.name=db2 

# Tables to register in each database 
hive.table.name=tbl1 
additional.hive.table.name=tbl2,tbl3
```

Then the following Hive db.table registration will take place: 
```
db1.tbl1 
db1.tbl2
db1.tbl3
db2.tbl1 
db2.tbl2
db2.tbl3
```

Hence, there was no way to control selectively tables that should only be registered to a database, with this PR the following config is possible: 
```
# Databases to register to
hive.database.name=db1 
additional.hive.database.name=db2 

# Tables to register in each database 
hive.table.name=tbl1 
additional.hive.table.name=tbl2,tbl3
db2.additional.hive.table.name=tbl3,tbl4,$PRIMARY_TABLE_col
```

And this will result in the following Hive db.table registration: 
```
db1.tbl1 
db1.tbl2
db1.tbl3
db2.tbl3 
db2.tbl4
db2.tbl1_col
```
