### PR TITLE
Capability to register and update Hive view over converted Hive datasets

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/converter/AbstractAvroToOrcConverter.java
@@ -192,6 +192,10 @@ public abstract class AbstractAvroToOrcConverter extends Converter<Schema, Schem
     Optional<Table> destinationTableMeta = destinationMeta.getLeft();
 
     // Optional
+    // wrapperViewName          : If specified view with 'wrapperViewName' is created if not already exists
+    //                            over destination table
+    // isUpdateViewAlwaysEnabled: If false 'wrapperViewName' is only updated when schema evolves; if true
+    //                            'wrapperViewName' is always updated (everytime publish happens)
     Optional<String> wrapperViewName = getConversionConfig().getDestinationViewName();
     boolean shouldUpdateView = getConversionConfig().isUpdateViewAlwaysEnabled();
     Optional<List<String>> clusterBy =

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -191,6 +191,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
 
     private final String destinationFormat;
     private final String destinationTableName;
+    // destinationViewName : If specified view with 'destinationViewName' is created if not already exists over destinationTableName
     private final Optional<String> destinationViewName;
     private final String destinationStagingTableName;
     private final String destinationDbName;
@@ -200,6 +201,8 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private final Optional<Integer> numBuckets;
     private final Properties hiveRuntimeProperties;
     private final boolean evolutionEnabled;
+    // updateViewAlwaysEnabled: If false 'destinationViewName' is only updated when schema evolves; if true 'destinationViewName'
+    // ... is always updated (everytime publish happens)
     private final boolean updateViewAlwaysEnabled;
     private final Optional<Integer> rowLimit;
     private final List<String> sourceDataPathIdentifier;
@@ -219,11 +222,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.destinationDataPath = resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), table);
 
       // Optional
-      if (config.hasPath(DESTINATION_VIEW_KEY)) {
-        this.destinationViewName = Optional.of(resolveTemplate(config.getString(DESTINATION_VIEW_KEY), table));
-      } else {
-        this.destinationViewName = Optional.absent();
-      }
+      this.destinationViewName = Optional.fromNullable(resolveTemplate(ConfigUtils.getString(config, DESTINATION_VIEW_KEY, null), table));
       this.destinationTableProperties =
           convertKeyValueListToProperties(ConfigUtils.getStringList(config, DESTINATION_TABLE_PROPERTIES_LIST_KEY));
       this.clusterBy = ConfigUtils.getStringList(config, CLUSTER_BY_KEY);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -138,12 +138,14 @@ public class ConvertibleHiveDataset extends HiveDataset {
   @ToString
   public static class ConversionConfig {
     public static final String DESTINATION_TABLE_KEY = "destination.tableName";
+    public static final String DESTINATION_VIEW_KEY = "destination.viewName";
     public static final String DESTINATION_DB_KEY = "destination.dbName";
     public static final String DESTINATION_DATA_PATH_KEY = "destination.dataPath";
     public static final String DESTINATION_TABLE_PROPERTIES_LIST_KEY = "destination.tableProperties";
     public static final String CLUSTER_BY_KEY = "clusterByList";
     public static final String NUM_BUCKETS_KEY = "numBuckets";
     public static final String EVOLUTION_ENABLED = "evolution.enabled";
+    public static final String UPDATE_VIEW_ALWAYS_ENABLED = "updateViewAlways.enabled";
     public static final String ROW_LIMIT_KEY = "rowLimit";
     public static final String HIVE_VERSION_KEY = "hiveVersion";
     private static final String HIVE_RUNTIME_PROPERTIES_LIST_KEY = "hiveRuntimeProperties";
@@ -189,6 +191,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
 
     private final String destinationFormat;
     private final String destinationTableName;
+    private final Optional<String> destinationViewName;
     private final String destinationStagingTableName;
     private final String destinationDbName;
     private final String destinationDataPath;
@@ -197,6 +200,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
     private final Optional<Integer> numBuckets;
     private final Properties hiveRuntimeProperties;
     private final boolean evolutionEnabled;
+    private final boolean updateViewAlwaysEnabled;
     private final Optional<Integer> rowLimit;
     private final List<String> sourceDataPathIdentifier;
 
@@ -215,6 +219,11 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.destinationDataPath = resolveTemplate(config.getString(DESTINATION_DATA_PATH_KEY), table);
 
       // Optional
+      if (config.hasPath(DESTINATION_VIEW_KEY)) {
+        this.destinationViewName = Optional.of(resolveTemplate(config.getString(DESTINATION_VIEW_KEY), table));
+      } else {
+        this.destinationViewName = Optional.absent();
+      }
       this.destinationTableProperties =
           convertKeyValueListToProperties(ConfigUtils.getStringList(config, DESTINATION_TABLE_PROPERTIES_LIST_KEY));
       this.clusterBy = ConfigUtils.getStringList(config, CLUSTER_BY_KEY);
@@ -223,6 +232,7 @@ public class ConvertibleHiveDataset extends HiveDataset {
       this.hiveRuntimeProperties =
           convertKeyValueListToProperties(ConfigUtils.getStringList(config, HIVE_RUNTIME_PROPERTIES_LIST_KEY));
       this.evolutionEnabled = ConfigUtils.getBoolean(config, EVOLUTION_ENABLED, false);
+      this.updateViewAlwaysEnabled = ConfigUtils.getBoolean(config, UPDATE_VIEW_ALWAYS_ENABLED, true);
       this.rowLimit = Optional.fromNullable(ConfigUtils.getInt(config, ROW_LIMIT_KEY, null));
       this.sourceDataPathIdentifier = ConfigUtils.getStringList(config, SOURCE_DATA_PATH_IDENTIFIER_KEY);
     }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -146,6 +146,9 @@ public class HiveDataset implements PrioritizedCopyableDataset {
    * and {@link Table#getTableName()}
    */
   public static String resolveTemplate(String rawString, Table table) {
+    if (StringUtils.isBlank(rawString)) {
+      return rawString;
+    }
     return StringUtils.replaceEach(rawString, new String[] { DATABASE_TOKEN, TABLE_TOKEN }, new String[] { table.getDbName(), table.getTableName() });
   }
 }

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -136,8 +136,10 @@ public class ConvertibleHiveDatasetTest {
 
     Assert.assertEquals(conversionConfig.getDestinationDbName(), "db1_nestedOrcDb");
     Assert.assertEquals(conversionConfig.getDestinationTableName(), "tb1_nestedOrc");
+    Assert.assertEquals(conversionConfig.getDestinationViewName().get(), "tb1_view");
     Assert.assertEquals(conversionConfig.getDestinationDataPath(), "/tmp/data_nestedOrc/db1/tb1");
 
+    Assert.assertEquals(conversionConfig.isUpdateViewAlwaysEnabled(), false);
     Assert.assertEquals(conversionConfig.getClusterBy(), ImmutableList.of("c3", "c4"));
     Assert.assertEquals(conversionConfig.getNumBuckets().get(), Integer.valueOf(5));
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/util/HiveAvroORCQueryGeneratorTest.java
@@ -356,4 +356,20 @@ public class HiveAvroORCQueryGeneratorTest {
     // Check for in-compatible types
     HiveAvroORCQueryGenerator.isTypeEvolved("boolean", "int");
   }
+
+  @Test
+  public void testCreateOrUpdateViewDDL() throws Exception {
+    // Check if two queries for Create and Update View have been generated
+    List<String> ddls = HiveAvroORCQueryGenerator.generateCreateOrUpdateViewDDL("db1", "tbl1", "db2" ,"view1", true);
+
+    Assert.assertEquals(ddls.size(), 2, "Two queries for Create and Update should have been generated");
+    Assert.assertEquals(ddls.get(0), "CREATE VIEW IF NOT EXISTS `db2`.`view1` AS SELECT * FROM `db1`.`tbl1`");
+    Assert.assertEquals(ddls.get(1), "ALTER VIEW `db2`.`view1` AS SELECT * FROM `db1`.`tbl1`");
+
+    // Check if two queries for Create and Update View have been generated
+    ddls = HiveAvroORCQueryGenerator.generateCreateOrUpdateViewDDL("db1", "tbl1", "db2" ,"view1", false);
+
+    Assert.assertEquals(ddls.size(), 1, "One query for Create only should have been generated");
+    Assert.assertEquals(ddls.get(0), "CREATE VIEW IF NOT EXISTS `db2`.`view1` AS SELECT * FROM `db1`.`tbl1`");
+  }
 }

--- a/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.conf
+++ b/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.conf
@@ -19,8 +19,10 @@ hive.conversion.avro : {
   nestedOrc : {
 
     destination.tableName="$TABLE_nestedOrc"
+    destination.viewName="$TABLE_view"
     destination.dbName="$DB_nestedOrcDb"
     destination.dataPath="/tmp/data_nestedOrc/$DB/$TABLE"
+    updateViewAlways.enabled=false
     clusterByList="c3,c4"
     numBuckets=5
 

--- a/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.properties
+++ b/gobblin-data-management/src/test/resources/convertibleHiveDatasetTest/flattenedAndNestedOrc.properties
@@ -8,8 +8,10 @@ hive.conversion.avro.flattenedOrc.numBuckets=4
 hive.conversion.avro.flattenedOrc.hiveRuntimeProperties="hive.merge.mapfiles","false","mapred.map.tasks","10,12"
 
 hive.conversion.avro.nestedOrc.destination.tableName=$TABLE_nestedOrc
+hive.conversion.avro.nestedOrc.destination.viewName=$TABLE_view
 hive.conversion.avro.nestedOrc.destination.dbName=$DB_nestedOrcDb
 hive.conversion.avro.nestedOrc.destination.dataPath=/tmp/data_nestedOrc/$DB/$TABLE
+hive.conversion.avro.nestedOrc.updateViewAlways.enabled=false
 hive.conversion.avro.nestedOrc.clusterByList=c3,c4
 hive.conversion.avro.nestedOrc.numBuckets=5
 hive.conversion.avro.nestedOrc.hiveRuntimeProperties="mapred.map.tasks","12"


### PR DESCRIPTION
This PR adds the following capabilities: 

- Create if not exists Hive view over the converted Hive table / dataset if configured 
- Based on configuration: update view every time Avro to ORC conversion happens OR only when schema evolution happens 