### PR TITLE
Wikipedia httpclient

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/objectstore/ObjectStoreDeleteConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/objectstore/ObjectStoreDeleteConverter.java
@@ -16,6 +16,7 @@ import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.primitives.Ints;
@@ -45,6 +46,7 @@ public class ObjectStoreDeleteConverter extends ObjectStoreConverter<Schema, Gen
 
   private String objectIdField;
 
+  @Override
   public ObjectStoreDeleteConverter init(WorkUnitState workUnit) {
     Preconditions.checkArgument(workUnit.contains(OBJECT_ID_FIELD),
         String.format("%s is a required property. ", OBJECT_ID_FIELD));
@@ -61,7 +63,7 @@ public class ObjectStoreDeleteConverter extends ObjectStoreConverter<Schema, Gen
       if (fieldValue.get() instanceof Utf8) {
         objectId = ((Utf8) fieldValue.get()).getBytes();
       } else if (fieldValue.get() instanceof String) {
-        objectId = ((String) fieldValue.get()).getBytes();
+        objectId = ((String) fieldValue.get()).getBytes(Charsets.UTF_8);
       } else if (fieldValue.get() instanceof Long) {
         objectId = Longs.toByteArray((Long) fieldValue.get());
       } else if (fieldValue.get() instanceof Integer) {

--- a/gobblin-core/src/main/java/gobblin/http/DefaultHttpClientConfigurator.java
+++ b/gobblin-core/src/main/java/gobblin/http/DefaultHttpClientConfigurator.java
@@ -16,6 +16,7 @@ import java.util.regex.Pattern;
 
 import org.apache.http.HttpHost;
 import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -94,7 +95,7 @@ public class DefaultHttpClientConfigurator implements HttpClientConfigurator {
 
   /** {@inheritDoc} */
   @Override
-  public HttpClient createClient() {
+  public CloseableHttpClient createClient() {
     return _builder.build();
   }
 

--- a/gobblin-core/src/main/java/gobblin/http/HttpClientConfigurator.java
+++ b/gobblin-core/src/main/java/gobblin/http/HttpClientConfigurator.java
@@ -12,6 +12,7 @@
 package gobblin.http;
 
 import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.typesafe.config.Config;
@@ -43,6 +44,6 @@ public interface HttpClientConfigurator {
   /**
    * Typically this will use {@link HttpClientBuilder#build()} based on the configuration but
    * implementations may also return decorated instances. */
-  HttpClient createClient();
+  CloseableHttpClient createClient();
 
 }

--- a/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
+++ b/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
@@ -298,6 +298,11 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
 
   }
 
+  //TODO
+  // HttpRequest constructHttpRequest(String rootUrl, Map<String, String> query) {
+  //
+  // }
+
   private Queue<JsonElement> retrievePageRevisions(Map<String, String> query)
       throws IOException, URISyntaxException {
 
@@ -349,6 +354,12 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
     LOG.info(retrievedRevisions.size() + " record(s) retrieved for title " + this.requestedTitle);
     return retrievedRevisions;
   }
+
+  // TODO
+  // protected HttpClient createHttpClient() {
+  //
+  //   return httpClient;
+  //}
 
   private HttpURLConnection getHttpConnection(URL url) throws IOException {
     Proxy proxy = Proxy.NO_PROXY;

--- a/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
+++ b/gobblin-example/src/main/java/gobblin/example/wikipedia/WikipediaExtractor.java
@@ -15,11 +15,9 @@ package gobblin.example.wikipedia;
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
-import java.net.HttpURLConnection;
-import java.net.InetSocketAddress;
-import java.net.Proxy;
+import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URL;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
@@ -27,9 +25,15 @@ import java.util.Map;
 import java.util.Queue;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpStatus;
 import org.apache.http.NameValuePair;
+import org.apache.http.client.ClientProtocolException;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.client.utils.URLEncodedUtils;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.message.BasicNameValuePair;
 import org.joda.time.DateTime;
 import org.joda.time.Period;
@@ -50,6 +54,8 @@ import com.google.gson.JsonObject;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
+import gobblin.http.HttpClientConfigurator;
+import gobblin.http.HttpClientConfiguratorLoader;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.extract.LongWatermark;
@@ -70,8 +76,10 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
   private static final Logger LOG = LoggerFactory.getLogger(WikipediaExtractor.class);
   private static final DateTimeFormatter WIKIPEDIA_TIMESTAMP_FORMAT = DateTimeFormat.forPattern("YYYYMMddHHmmss");
 
-  public static final String MAX_REVISION_PER_PAGE = "gobblin.wikipediaSource.maxRevisionsPerPage";
+  public static final String CONFIG_PREFIX = "gobblin.wikipediaSource.";
+  public static final String MAX_REVISION_PER_PAGE = CONFIG_PREFIX+ "maxRevisionsPerPage";
   public static final int DEFAULT_MAX_REVISIONS_PER_PAGE = -1;
+  public static final String HTTP_CLIENT_CONFIG_PREFIX = CONFIG_PREFIX + "httpClient.";
 
   public static final String SOURCE_PAGE_TITLES = "source.page.titles";
   public static final String BOOTSTRAP_PERIOD = "wikipedia.source.bootstrap.lookback";
@@ -98,6 +106,8 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
   private final ImmutableMap<String, String> baseQuery;
   private final WorkUnitState workUnitState;
   private final int maxRevisionsPulled;
+  private final HttpClientConfigurator httpClientConfigurator;
+  private CloseableHttpClient httpClient;
 
   private class WikiResponseReader implements Iterator<JsonElement> {
 
@@ -181,6 +191,12 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
     this.baseQuery =
         ImmutableMap.<String, String>builder().put("format", "json").put("action","query").put("prop","revisions").build();
 
+    HttpClientConfiguratorLoader httpClientConfiguratorLoader
+        = new HttpClientConfiguratorLoader(workUnitState);
+    this.httpClientConfigurator = httpClientConfiguratorLoader.getConfigurator();
+    this.httpClientConfigurator.setStatePropertiesPrefix(HTTP_CLIENT_CONFIG_PREFIX)
+                               .configure(workUnitState);
+
     try {
       Queue<JsonElement> lastRevision = retrievePageRevisions(ImmutableMap.<String, String>builder().putAll(this.baseQuery)
           .put("rvprop","ids").put("titles",this.requestedTitle).put("rvlimit","1").build());
@@ -247,30 +263,20 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
     return value;
   }
 
-  private boolean isPropPresent(String key, WorkUnitState workUnitState) {
-    return workUnitState.contains(key)
-        || workUnitState.getWorkunit().contains(key)
-        || workUnitState.getJobState().contains(key);
-  }
-
   private JsonElement performHttpQuery(String rootUrl, Map<String, String> query) throws URISyntaxException, IOException {
-
-    List<NameValuePair> queryTokens = Lists.newArrayList();
-    for (Map.Entry<String, String> entry : query.entrySet()) {
-      queryTokens.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+    if (null == this.httpClient) {
+      this.httpClient = createHttpClient();
     }
-    String encodedQuery = URLEncodedUtils.format(queryTokens, Charsets.UTF_8);
-
-    URL actualURL = new URIBuilder(rootUrl).setQuery(encodedQuery).build().toURL();
+    HttpUriRequest req = createHttpRequest(rootUrl, query);
 
     Closer closer = Closer.create();
-    HttpURLConnection conn = null;
+
     StringBuilder sb = new StringBuilder();
     try {
-      conn = getHttpConnection(actualURL);
-      conn.connect();
+      CloseableHttpResponse response = closer.register(sendHttpRequest(req, this.httpClient));
       BufferedReader br = closer.register(
-          new BufferedReader(new InputStreamReader(conn.getInputStream(), ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
+          new BufferedReader(new InputStreamReader(response.getEntity().getContent(),
+                                                   ConfigurationKeys.DEFAULT_CHARSET_ENCODING)));
       String line;
       while ((line = br.readLine()) != null) {
         sb.append(line + "\n");
@@ -281,15 +287,12 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
       try {
         closer.close();
       } catch (IOException e) {
-        LOG.error("IOException in Closer.close() while performing query " + actualURL);
-      }
-      if (conn != null) {
-        conn.disconnect();
+        LOG.error("IOException in Closer.close() while performing query " + req + ": " + e, e);
       }
     }
 
     if (Strings.isNullOrEmpty(sb.toString())) {
-      LOG.warn("Received empty response for query: " + actualURL);
+      LOG.warn("Received empty response for query: " + req);
       return new JsonObject();
     }
 
@@ -298,10 +301,37 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
 
   }
 
-  //TODO
-  // HttpRequest constructHttpRequest(String rootUrl, Map<String, String> query) {
-  //
-  // }
+  public static URI createRequestURI(String rootUrl, Map<String, String> query)
+      throws MalformedURLException, URISyntaxException {
+    List<NameValuePair> queryTokens = Lists.newArrayList();
+    for (Map.Entry<String, String> entry : query.entrySet()) {
+      queryTokens.add(new BasicNameValuePair(entry.getKey(), entry.getValue()));
+    }
+    String encodedQuery = URLEncodedUtils.format(queryTokens, Charsets.UTF_8);
+
+    URI actualURL = new URIBuilder(rootUrl).setQuery(encodedQuery).build();
+    return actualURL;
+  }
+
+  HttpUriRequest createHttpRequest(String rootUrl, Map<String, String> query)
+              throws MalformedURLException, URISyntaxException {
+    URI requestUri = createRequestURI(rootUrl, query);
+    HttpGet req = new HttpGet(requestUri);
+
+    return req;
+  }
+
+  CloseableHttpResponse sendHttpRequest(HttpUriRequest req, CloseableHttpClient httpClient)
+      throws ClientProtocolException, IOException {
+    LOG.debug("Sending request {}", req);
+    CloseableHttpResponse response = httpClient.execute(req);
+    if (response.getStatusLine().getStatusCode() != HttpStatus.SC_OK ||
+        null == response.getEntity()) {
+      response.close();
+      throw new IOException("HTTP Request " + req + " returned unexpected response " + response);
+    }
+    return response;
+  }
 
   private Queue<JsonElement> retrievePageRevisions(Map<String, String> query)
       throws IOException, URISyntaxException {
@@ -355,29 +385,15 @@ public class WikipediaExtractor implements Extractor<String, JsonElement> {
     return retrievedRevisions;
   }
 
-  // TODO
-  // protected HttpClient createHttpClient() {
-  //
-  //   return httpClient;
-  //}
-
-  private HttpURLConnection getHttpConnection(URL url) throws IOException {
-    Proxy proxy = Proxy.NO_PROXY;
-    if (isPropPresent(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL, this.workUnitState)
-        && isPropPresent(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT, this.workUnitState)) {
-      LOG.info("Use proxy host: " + readProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL, this.workUnitState));
-      LOG.info("Use proxy port: " + readProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT, this.workUnitState));
-      InetSocketAddress proxyAddress =
-          new InetSocketAddress(readProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_URL, this.workUnitState),
-              Integer.parseInt(readProp(ConfigurationKeys.SOURCE_CONN_USE_PROXY_PORT, this.workUnitState)));
-      proxy = new Proxy(Proxy.Type.HTTP, proxyAddress);
-    }
-    return (HttpURLConnection) url.openConnection(proxy);
+  protected CloseableHttpClient createHttpClient() {
+     return this.httpClientConfigurator.createClient();
   }
 
   @Override
   public void close() throws IOException {
-    // There's nothing to close
+    if (null != this.httpClient) {
+      this.httpClient.close();
+    }
   }
 
   @Override


### PR DESCRIPTION
Originally, the Wikipedia extract used a plain Java HttpURLConnection. For example, it does not support going through a HTTP proxy.

This is a rather rudimentary solution. I've switched the client to the new configurable HttpClients facility.

@pcadabam  can you review?