### PR TITLE
Add sanitization of job property keys which are prefixes of others

### DIFF
--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinYarnAppLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinYarnAppLauncher.java
@@ -19,11 +19,12 @@ import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.log4j.Logger;
 
-import azkaban.jobExecutor.AbstractJob;
+import com.typesafe.config.Config;
 
-import com.typesafe.config.ConfigFactory;
-
+import gobblin.util.ConfigUtils;
 import gobblin.yarn.GobblinYarnAppLauncher;
+
+import azkaban.jobExecutor.AbstractJob;
 
 
 /**
@@ -49,8 +50,8 @@ public class AzkabanGobblinYarnAppLauncher extends AbstractJob {
 
   public AzkabanGobblinYarnAppLauncher(String jobId, Properties props) throws IOException {
     super(jobId, LOGGER);
-    this.gobblinYarnAppLauncher =
-        new GobblinYarnAppLauncher(ConfigFactory.parseProperties(props), new YarnConfiguration());
+    Config gobblinConfig = ConfigUtils.propertiesToConfig(props);
+    this.gobblinYarnAppLauncher = new GobblinYarnAppLauncher(gobblinConfig, new YarnConfiguration());
   }
 
   @Override

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -198,6 +198,8 @@ public class ConfigUtils {
           !blacklistedKeys.contains(entryKey)) {
         if (fullPrefixKeys.contains(entryKey)) {
           entryKey = sanitizeFullPrefixKey(entryKey);
+        } else if (entryKey.endsWith(STRIP_SUFFIX)) {
+          throw new RuntimeException("Properties are not allowed to end in " + STRIP_SUFFIX);
         }
         immutableMapBuilder.put(entryKey, entry.getValue());
       }

--- a/gobblin-utility/src/test/java/gobblin/util/PullFileLoaderTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/PullFileLoaderTest.java
@@ -76,7 +76,7 @@ public class PullFileLoaderTest {
     sysProps.put("key1", "sysProps1");
 
     path = new Path(this.basePath, "ajob.pull");
-    pullFile = loader.loadPullFile(path, ConfigFactory.parseProperties(sysProps), false);
+    pullFile = loader.loadPullFile(path, ConfigUtils.propertiesToConfig(sysProps), false);
     Assert.assertEquals(pullFile.getString("key1"), "sysProps1");
     Assert.assertEquals(pullFile.getString("key2"), "aValue");
     Assert.assertEquals(pullFile.getString("key10"), "aValue");
@@ -84,7 +84,7 @@ public class PullFileLoaderTest {
     Assert.assertEquals(pullFile.entrySet().size(), 4);
 
     path = new Path(this.basePath, "dir1/job.pull");
-    pullFile = loader.loadPullFile(path, ConfigFactory.parseProperties(sysProps), false);
+    pullFile = loader.loadPullFile(path, ConfigUtils.propertiesToConfig(sysProps), false);
     Assert.assertEquals(pullFile.getString("key1"), "jobValue1,jobValue2,jobValue3");
     Assert.assertEquals(pullFile.getString("key2"), "jobValue2");
     Assert.assertEquals(pullFile.getString(ConfigurationKeys.JOB_CONFIG_FILE_PATH_KEY), path.toString());
@@ -107,7 +107,7 @@ public class PullFileLoaderTest {
     Properties sysProps = new Properties();
     sysProps.put("key1", "sysProps1");
     Collection<Config> configs =
-        loader.loadPullFilesRecursively(this.basePath, ConfigFactory.parseProperties(sysProps), false);
+        loader.loadPullFilesRecursively(this.basePath, ConfigUtils.propertiesToConfig(sysProps), false);
 
     path = new Path(this.basePath, "ajob.pull");
     pullFile = pullFileFromPath(configs, path);
@@ -142,7 +142,7 @@ public class PullFileLoaderTest {
     sysProps.put("key1", "sysProps1");
 
     path = new Path(this.basePath, "ajob.pull");
-    pullFile = loader.loadPullFile(path, ConfigFactory.parseProperties(sysProps), true);
+    pullFile = loader.loadPullFile(path, ConfigUtils.propertiesToConfig(sysProps), true);
     Assert.assertEquals(pullFile.getString("key1"), "rootValue1");
     Assert.assertEquals(pullFile.getString("key2"), "aValue");
     Assert.assertEquals(pullFile.getString("key10"), "aValue");
@@ -151,7 +151,7 @@ public class PullFileLoaderTest {
     Assert.assertEquals(pullFile.entrySet().size(), 5);
 
     path = new Path(this.basePath, "dir1/job.pull");
-    pullFile = loader.loadPullFile(path, ConfigFactory.parseProperties(sysProps), true);
+    pullFile = loader.loadPullFile(path, ConfigUtils.propertiesToConfig(sysProps), true);
     Assert.assertEquals(pullFile.getString("key1"), "jobValue1,jobValue2,jobValue3");
     Assert.assertEquals(pullFile.getString("key2"), "jobValue2");
     Assert.assertEquals(pullFile.getString("key3"), "rootValue3");
@@ -178,7 +178,7 @@ public class PullFileLoaderTest {
     Properties sysProps = new Properties();
     sysProps.put("key1", "sysProps1");
     Collection<Config> configs =
-        loader.loadPullFilesRecursively(this.basePath, ConfigFactory.parseProperties(sysProps), true);
+        loader.loadPullFilesRecursively(this.basePath, ConfigUtils.propertiesToConfig(sysProps), true);
 
     path = new Path(this.basePath, "ajob.pull");
     pullFile = pullFileFromPath(configs, path);


### PR DESCRIPTION
We have repeated issues with converting Properties to Config because of keys which are prefixes of other keys.

The approach I've taken is to detect Properties collections which have such keys and sanitize the names for such properties.

- ConfigUtils.propertiesToConfig() will detect such keys and append .ROOT_VALUE at the end of the offending property
- ConfigUtils.configToProperties() will detect properties which end in .ROOT_VALUE and remove it transparently.

For legacy jobs, constructs we typically have the flow: Job pull file (Properties) -> Job config (Config) -> State properties. PullFileLoader/SchedulerUtils use the ConfigUtils.propertiesToConfig() to do the first transition and JobLauncherExecutionDriver uses ConfigUtils.configToProperties() to do the second transition, the offending properties are handled transparently.

Further, when we move to fully Config-based job files, we can still explicitly add the .ROOT_VALUE suffix and work with legacy components.

I've refactored a bunch of classes to use ConfigUtils.propertiesToConfig() instead of ConfigFactory.parseProperties() to make use of the santiization.

@ydai @pcadabam  Can you review?