### PR TITLE
Added new construct of VersionCleaner with pre and post activity hook in Retention. Also added capability in Hive retention to swap-in partitions as post cleanup activity

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -190,7 +190,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
    * @return  Parsed logical DB and Table.
    */
   @VisibleForTesting
-  public static DbAndTable parseLogicalDbAndTable(String datasetNamePattern, DbAndTable dbAndTable,
+  protected static DbAndTable parseLogicalDbAndTable(String datasetNamePattern, DbAndTable dbAndTable,
       String logicalDbToken, String logicalTableToken) {
     Preconditions.checkArgument(StringUtils.isNotBlank(datasetNamePattern), "Dataset name pattern must not be empty.");
 
@@ -222,7 +222,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
    * @return Extracted token value from the source entity.
    */
   @VisibleForTesting
-  public static String extractTokenValueFromEntity(String sourceEntity, String sourceTemplate, String token) {
+  protected static String extractTokenValueFromEntity(String sourceEntity, String sourceTemplate, String token) {
     Preconditions.checkArgument(StringUtils.isNotBlank(sourceEntity), "Source entity should not be blank");
     Preconditions.checkArgument(StringUtils.isNotBlank(sourceTemplate), "Source template should not be blank");
     Preconditions.checkArgument(sourceTemplate.contains(token), String.format("Source template: %s should contain token: %s", sourceTemplate, token));
@@ -245,7 +245,7 @@ public class HiveDataset implements PrioritizedCopyableDataset {
    * @return Resolved config object.
    */
   @VisibleForTesting
-  public static Config resolveConfig(Config datasetConfig, DbAndTable realDbAndTable, DbAndTable logicalDbAndTable) {
+  protected static Config resolveConfig(Config datasetConfig, DbAndTable realDbAndTable, DbAndTable logicalDbAndTable) {
     Preconditions.checkNotNull(datasetConfig, "Dataset config should not be null");
     Preconditions.checkNotNull(realDbAndTable, "Real DB and table should not be null");
     Preconditions.checkNotNull(logicalDbAndTable, "Logical DB and table should not be null");

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -17,6 +17,7 @@ import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 
 import lombok.Getter;
@@ -28,11 +29,16 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.metadata.Table;
 
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
 import com.google.common.base.Optional;
 import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValue;
+import com.typesafe.config.ConfigValueType;
 
 import gobblin.annotation.Alpha;
 import gobblin.configuration.State;
@@ -46,6 +52,7 @@ import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.Tag;
+import gobblin.util.ConfigUtils;
 import gobblin.util.PathUtils;
 
 
@@ -58,13 +65,19 @@ import gobblin.util.PathUtils;
 @ToString
 public class HiveDataset implements PrioritizedCopyableDataset {
 
+  private static Splitter SPLIT_ON_DOT = Splitter.on(".").omitEmptyStrings().trimResults();
+
   public static final String REGISTERER = "registerer";
   public static final String REGISTRATION_GENERATION_TIME_MILLIS = "registrationGenerationTimeMillis";
+  public static final String DATASET_NAME_PATTERN_KEY = "hive.datasetNamePattern";
   public static final String DATABASE = "Database";
   public static final String TABLE = "Table";
 
   public static final String DATABASE_TOKEN = "$DB";
   public static final String TABLE_TOKEN = "$TABLE";
+
+  public static final String LOGICAL_DB_TOKEN = "$LOGICAL_DB";
+  public static final String LOGICAL_TABLE_TOKEN = "$LOGICAL_TABLE";
 
   // Will not be serialized/de-serialized
   protected transient final Properties properties;
@@ -78,7 +91,9 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   // Only set if table has exactly one location
   protected final Optional<Path> tableRootPath;
   protected final String tableIdentifier;
+  protected final Optional<String> datasetNamePattern;
   protected final DbAndTable dbAndTable;
+  protected final DbAndTable logicalDbAndTable;
 
   public HiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Properties properties) {
     this(fs, clientPool, table, properties, ConfigFactory.empty());
@@ -93,14 +108,20 @@ public class HiveDataset implements PrioritizedCopyableDataset {
     this.clientPool = clientPool;
     this.table = table;
     this.properties = properties;
-    this.datasetConfig = datasetConfig;
 
     this.tableRootPath = PathUtils.isGlob(this.table.getDataLocation()) ? Optional.<Path> absent() : Optional.of(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
     log.info("Created Hive dataset for table " + this.tableIdentifier);
 
+    this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
     this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());
+    if (this.datasetNamePattern.isPresent()) {
+      this.logicalDbAndTable = parseLogicalDbAndTable(this.datasetNamePattern.get(), this.dbAndTable, LOGICAL_DB_TOKEN, LOGICAL_TABLE_TOKEN);
+    } else {
+      this.logicalDbAndTable = this.dbAndTable;
+    }
+    this.datasetConfig = resolveConfig(datasetConfig, dbAndTable, logicalDbAndTable);
 
     this.metricContext = Instrumented.getMetricContext(new State(properties), HiveDataset.class,
         Lists.<Tag<?>> newArrayList(new Tag<>(DATABASE, table.getDbName()), new Tag<>(TABLE, table.getTableName())));
@@ -150,5 +171,106 @@ public class HiveDataset implements PrioritizedCopyableDataset {
       return rawString;
     }
     return StringUtils.replaceEach(rawString, new String[] { DATABASE_TOKEN, TABLE_TOKEN }, new String[] { table.getDbName(), table.getTableName() });
+  }
+
+  /***
+   * Parse logical Database and Table name from a given DbAndTable object.
+   *
+   * Eg.
+   * Dataset Name Pattern         : prod_$LOGICAL_DB_linkedin.prod_$LOGICAL_TABLE_linkedin
+   * Source DB and Table          : prod_dbName_linkedin.prod_tableName_linkedin
+   * Logical DB Token             : $LOGICAL_DB
+   * Logical Table Token          : $LOGICAL_TABLE
+   * Parsed Logical DB and Table  : dbName.tableName
+   *
+   * @param datasetNamePattern    Dataset name pattern.
+   * @param dbAndTable            Source DB and Table.
+   * @param logicalDbToken        Logical DB token.
+   * @param logicalTableToken     Logical Table token.
+   * @return  Parsed logical DB and Table.
+   */
+  @VisibleForTesting
+  public static DbAndTable parseLogicalDbAndTable(String datasetNamePattern, DbAndTable dbAndTable,
+      String logicalDbToken, String logicalTableToken) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(datasetNamePattern), "Dataset name pattern must not be empty.");
+
+    List<String> datasetNameSplit = Lists.newArrayList(SPLIT_ON_DOT.split(datasetNamePattern));
+    Preconditions.checkArgument(datasetNameSplit.size() == 2, "Dataset name pattern must of the format: "
+        + "dbPrefix_$LOGICAL_DB_dbPostfix.tablePrefix_$LOGICAL_TABLE_tablePostfix (prefix / postfix are optional)");
+
+    String dbNamePattern = datasetNameSplit.get(0);
+    String tableNamePattern = datasetNameSplit.get(1);
+
+    String logicalDb = extractTokenValueFromEntity(dbAndTable.getDb(), dbNamePattern, logicalDbToken);
+    String logicalTable = extractTokenValueFromEntity(dbAndTable.getTable(), tableNamePattern, logicalTableToken);
+
+    return new DbAndTable(logicalDb, logicalTable);
+  }
+
+  /***
+   * Extract token value from source entity, where token value is represented by a token in the source entity.
+   *
+   * Eg.
+   * Source Entity  : prod_tableName_avro
+   * Source Template: prod_$LOGICAL_TABLE_avro
+   * Token          : $LOGICAL_TABLE
+   * Extracted Value: tableName
+   *
+   * @param sourceEntity      Source entity (typically a table or database name).
+   * @param sourceTemplate    Source template representing the source entity.
+   * @param token             Token representing the value to extract from the source entity using the template.
+   * @return Extracted token value from the source entity.
+   */
+  @VisibleForTesting
+  public static String extractTokenValueFromEntity(String sourceEntity, String sourceTemplate, String token) {
+    Preconditions.checkArgument(StringUtils.isNotBlank(sourceEntity), "Source entity should not be blank");
+    Preconditions.checkArgument(StringUtils.isNotBlank(sourceTemplate), "Source template should not be blank");
+    Preconditions.checkArgument(sourceTemplate.contains(token), String.format("Source template: %s should contain token: %s", sourceTemplate, token));
+
+    String extractedValue = sourceEntity;
+    List<String> preAndPostFix = Lists.newArrayList(Splitter.on(token).trimResults().split(sourceTemplate));
+
+    extractedValue = StringUtils.removeStart(extractedValue, preAndPostFix.get(0));
+    extractedValue = StringUtils.removeEnd(extractedValue, preAndPostFix.get(1));
+
+    return extractedValue;
+  }
+
+  /***
+   * Replace various tokens (DB, TABLE, LOGICAL_DB, LOGICAL_TABLE) with their values.
+   *
+   * @param datasetConfig       The config object that needs to be resolved with final values.
+   * @param realDbAndTable      Real DB and Table .
+   * @param logicalDbAndTable   Logical DB and Table.
+   * @return Resolved config object.
+   */
+  @VisibleForTesting
+  public static Config resolveConfig(Config datasetConfig, DbAndTable realDbAndTable, DbAndTable logicalDbAndTable) {
+    Preconditions.checkNotNull(datasetConfig, "Dataset config should not be null");
+    Preconditions.checkNotNull(realDbAndTable, "Real DB and table should not be null");
+    Preconditions.checkNotNull(logicalDbAndTable, "Logical DB and table should not be null");
+
+    Properties resolvedProperties = new Properties();
+    Config resolvedConfig = datasetConfig.resolve();
+    for (Map.Entry<String, ConfigValue> entry : resolvedConfig.entrySet()) {
+      if (ConfigValueType.LIST.equals(entry.getValue().valueType())) {
+        List<String> rawValueList = resolvedConfig.getStringList(entry.getKey());
+        List<String> resolvedValueList = Lists.newArrayList();
+        for (String rawValue : rawValueList) {
+          String resolvedValue = StringUtils.replaceEach(rawValue,
+              new String[] { DATABASE_TOKEN, TABLE_TOKEN, LOGICAL_DB_TOKEN, LOGICAL_TABLE_TOKEN },
+              new String[] { realDbAndTable.getDb(), realDbAndTable.getTable(), logicalDbAndTable.getDb(), logicalDbAndTable.getTable() });
+          resolvedValueList.add(resolvedValue);
+        }
+        resolvedProperties.setProperty(entry.getKey(), resolvedValueList.toString());
+      } else {
+        String resolvedValue = StringUtils.replaceEach(resolvedConfig.getString(entry.getKey()),
+          new String[] { DATABASE_TOKEN, TABLE_TOKEN, LOGICAL_DB_TOKEN, LOGICAL_TABLE_TOKEN },
+          new String[] { realDbAndTable.getDb(), realDbAndTable.getTable(), logicalDbAndTable.getDb(), logicalDbAndTable.getTable() });
+        resolvedProperties.setProperty(entry.getKey(), resolvedValue);
+      }
+    }
+
+    return ConfigUtils.propertiesToConfig(resolvedProperties);
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/dataset/CleanableHiveDataset.java
@@ -20,14 +20,13 @@ import java.util.List;
 import java.util.Properties;
 import java.util.Set;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hive.metastore.IMetaStoreClient;
 import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
-import org.apache.thrift.TException;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -37,6 +36,7 @@ import com.typesafe.config.ConfigRenderOptions;
 import gobblin.data.management.copy.hive.HiveDataset;
 import gobblin.data.management.policy.SelectBeforeTimeBasedPolicy;
 import gobblin.data.management.policy.VersionSelectionPolicy;
+import gobblin.data.management.retention.version.HiveDatasetVersionCleaner;
 import gobblin.data.management.version.HiveDatasetVersion;
 import gobblin.data.management.version.finder.AbstractHiveDatasetVersionFinder;
 import gobblin.data.management.version.finder.DatePartitionHiveVersionFinder;
@@ -60,6 +60,7 @@ import gobblin.util.reflection.GobblinConstructorUtils;
  */
 @Slf4j
 @SuppressWarnings({ "rawtypes", "unchecked" })
+@Getter
 public class CleanableHiveDataset extends HiveDataset implements CleanableDataset {
 
   private static final String SHOULD_DELETE_DATA_KEY = "gobblin.retention.hive.shouldDeleteData";
@@ -133,29 +134,23 @@ public class CleanableHiveDataset extends HiveDataset implements CleanableDatase
         versions.size()));
 
     List<Exception> exceptions = Lists.newArrayList();
-    Set<Path> possiblyEmptyDirectories = new HashSet<>();
 
-    try (AutoReturnableObject<IMetaStoreClient> client = this.clientPool.getClient()) {
+    for (HiveDatasetVersion hiveDatasetVersion : deletableVersions) {
+      try {
+        // Initialize the version cleaner
+        HiveDatasetVersionCleaner hiveDatasetVersionCleaner = new HiveDatasetVersionCleaner(hiveDatasetVersion, this);
 
-      for (HiveDatasetVersion hiveDatasetVersion : deletableVersions) {
-        Partition partition = hiveDatasetVersion.getPartition();
-        try {
-          if (!this.simulate) {
-            client.get().dropPartition(partition.getTable().getDbName(), partition.getTable().getTableName(), partition.getValues(), false);
-            log.info("Successfully dropped partition " + partition.getCompleteName());
-          } else {
-            log.info("Simulating drop partition " + partition.getCompleteName());
-          }
-          if (this.shouldDeleteData) {
-            this.fsCleanableHelper.clean(hiveDatasetVersion, possiblyEmptyDirectories);
-          }
-        } catch (TException | IOException e) {
-          log.warn(String.format("Failed to completely delete partition %s.", partition.getCompleteName()), e);
-          exceptions.add(e);
-        }
+        // Perform pre-clean actions
+        hiveDatasetVersionCleaner.preCleanAction();
+
+        // Perform actual cleaning
+        hiveDatasetVersionCleaner.clean();
+
+        // Perform post-clean actions eg. swap partitions
+        hiveDatasetVersionCleaner.postCleanAction();
+      } catch (IOException e) {
+        exceptions.add(e);
       }
-
-      this.fsCleanableHelper.cleanEmptyDirectories(possiblyEmptyDirectories, this);
     }
 
     if (!exceptions.isEmpty()) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/HiveDatasetVersionCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/HiveDatasetVersionCleaner.java
@@ -149,7 +149,7 @@ public class HiveDatasetVersionCleaner extends VersionCleaner {
    * @return  True if partition should be replaced-in from another table.
    */
   @VisibleForTesting
-  public static boolean shouldReplacePartition(Config config,
+  protected static boolean shouldReplacePartition(Config config,
       String replacedPartitionDbName, String replacedPartitionTableName,
       Optional<String> replacementPartitionDbName, Optional<String> replacementPartitionTableName) {
     // If disabled explicitly, rest does not matters

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/HiveDatasetVersionCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/HiveDatasetVersionCleaner.java
@@ -1,0 +1,170 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.version;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.thrift.TException;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.retention.dataset.CleanableHiveDataset;
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.data.management.version.HiveDatasetVersion;
+import gobblin.util.AutoReturnableObject;
+import gobblin.util.ConfigUtils;
+
+
+/**
+ * An abstraction for cleaning a {@link HiveDatasetVersionCleaner} of a {@link CleanableHiveDataset}.
+ */
+@Slf4j
+public class HiveDatasetVersionCleaner extends VersionCleaner {
+
+  public static final String REPLACEMENT_HIVE_DB_NAME_KEY = "hive.replacementHiveDbName";
+  public static final String REPLACEMENT_HIVE_TABLE_NAME_KEY = "hive.replacementHiveTableName";
+  public static final String SHOULD_REPLACE_PARTITION_KEY = "hive.shouldReplacePartition";
+
+  private final CleanableHiveDataset cleanableHiveDataset;
+  private final HiveDatasetVersion hiveDatasetVersion;
+
+  private final Optional<String> replacementDbName;
+  private final Optional<String> replacementTableName;
+
+  public HiveDatasetVersionCleaner(DatasetVersion datasetVersion, CleanableDataset cleanableDataset) {
+    super(datasetVersion, cleanableDataset);
+
+    Preconditions.checkArgument(cleanableDataset instanceof CleanableHiveDataset, String.format("%s only supports %s, "
+        + "found: %s", this.getClass(), CleanableHiveDataset.class, cleanableDataset.getClass()));
+    Preconditions.checkArgument(datasetVersion instanceof HiveDatasetVersion, String.format("%s only supports %s, "
+        + "found: %s", this.getClass(), HiveDatasetVersionCleaner.class, datasetVersion.getClass()));
+
+    this.cleanableHiveDataset = (CleanableHiveDataset) cleanableDataset;
+    this.hiveDatasetVersion = (HiveDatasetVersion) datasetVersion;
+
+    // For post cleanup activity:
+    // Get db / table name from which partition has to be replaced-in for the target partition being deleted.
+    this.replacementDbName = Optional.fromNullable(ConfigUtils.getString(cleanableHiveDataset.getDatasetConfig(), REPLACEMENT_HIVE_DB_NAME_KEY, null));
+    this.replacementTableName = Optional.fromNullable(ConfigUtils.getString(cleanableHiveDataset.getDatasetConfig(), REPLACEMENT_HIVE_TABLE_NAME_KEY, null));
+  }
+
+  @Override
+  public void preCleanAction() throws IOException {
+    // no-op
+  }
+
+  @Override
+  public void clean() throws IOException {
+
+    // Possible empty directories to clean for this partition (version)
+    Set<Path> possiblyEmptyDirectories = new HashSet<>();
+
+    try (AutoReturnableObject<IMetaStoreClient> client = cleanableHiveDataset.getClientPool().getClient()) {
+      Partition partition = hiveDatasetVersion.getPartition();
+      try {
+        if (!cleanableHiveDataset.isSimulate()) {
+          client.get().dropPartition(partition.getTable().getDbName(), partition.getTable().getTableName(), partition.getValues(), false);
+          log.info("Successfully dropped partition " + partition.getCompleteName());
+        } else {
+          log.info("Simulating drop partition " + partition.getCompleteName());
+        }
+        if (cleanableHiveDataset.isShouldDeleteData()) {
+          cleanableHiveDataset.getFsCleanableHelper().clean(hiveDatasetVersion, possiblyEmptyDirectories);
+        }
+      } catch (TException | IOException e) {
+        log.warn(String.format("Failed to completely delete partition %s.", partition.getCompleteName()), e);
+        throw new IOException(e);
+      }
+    }
+    cleanableHiveDataset.getFsCleanableHelper().cleanEmptyDirectories(possiblyEmptyDirectories, cleanableHiveDataset);
+  }
+
+  @Override
+  public void postCleanAction() throws IOException {
+    // As a post-cleanup activity, Hive dataset version cleaner supports swapping-in a different partition.
+    // So, if configured, swap-in the other partition.
+    boolean shouldReplacePartition = shouldReplacePartition(cleanableHiveDataset.getDatasetConfig(),
+        hiveDatasetVersion.getPartition().getTable().getDbName(), hiveDatasetVersion.getPartition().getTable().getTableName(),
+        this.replacementDbName, this.replacementTableName);
+    // Replace the partition being dropped with a replacement partition from another table (if configured)
+    // This is required for cases such as when we want to replace-in a different storage format partition in
+    // .. a hybrid table. Eg. Replace ORC partition with Avro or vice-versa
+    if (shouldReplacePartition) {
+      try (AutoReturnableObject<IMetaStoreClient> client = cleanableHiveDataset.getClientPool().getClient()) {
+        org.apache.hadoop.hive.metastore.api.Partition sourcePartition = client.get().getPartition(
+            this.replacementDbName.get(),
+            this.replacementTableName.get(),
+            hiveDatasetVersion.getPartition().getValues());
+        org.apache.hadoop.hive.metastore.api.Partition replacementPartition = new org.apache.hadoop.hive.metastore.api.Partition(
+            hiveDatasetVersion.getPartition().getValues(),
+            hiveDatasetVersion.getPartition().getTable().getDbName(),
+            hiveDatasetVersion.getPartition().getTable().getTableName(),
+            sourcePartition.getCreateTime(),
+            sourcePartition.getLastAccessTime(),
+            sourcePartition.getSd(),
+            sourcePartition.getParameters());
+        if (!cleanableHiveDataset.isSimulate()) {
+          client.get().add_partition(replacementPartition);
+          log.info("Successfully swapped partition " + replacementPartition);
+        } else {
+          log.info("Simulating swap partition " + replacementPartition);
+        }
+      } catch (TException e) {
+        log.warn(String.format("Failed to swap-in replacement partition for partition being deleted: %s",
+            hiveDatasetVersion.getPartition().getCompleteName()), e);
+        throw new IOException(e);
+      }
+    }
+  }
+
+  /***
+   * Determine if a partition should be replaced-in from another table for a partition being deleted from
+   * the current table.
+   *
+   * @param config                          Config to get check if partition replacement is enabled.
+   * @param replacedPartitionDbName         Database name for the table from where partition is being deleted.
+   * @param replacedPartitionTableName      Table name from where partition is being deleted.
+   * @param replacementPartitionDbName      Database name from where the partition should be registered.
+   * @param replacementPartitionTableName   Table name from where the partition should be registered.
+   * @return  True if partition should be replaced-in from another table.
+   */
+  @VisibleForTesting
+  public static boolean shouldReplacePartition(Config config,
+      String replacedPartitionDbName, String replacedPartitionTableName,
+      Optional<String> replacementPartitionDbName, Optional<String> replacementPartitionTableName) {
+    // If disabled explicitly, rest does not matters
+    boolean shouldReplacePartition = ConfigUtils.getBoolean(config, SHOULD_REPLACE_PARTITION_KEY, false);
+
+    // If any of the replacement DB name or replacement Table name is missing, then do not replace partition
+    if (!replacementPartitionDbName.isPresent() || !replacementPartitionTableName.isPresent()) {
+      return false;
+    }
+    // If not disabled explicitly, check if source db / table are same as the replacement partition's db / table
+    // .. if so, do not try replacement.
+    else {
+      return shouldReplacePartition
+          && !(replacedPartitionDbName.equalsIgnoreCase(replacementPartitionDbName.get()) &&
+          replacedPartitionTableName.equalsIgnoreCase(replacementPartitionTableName.get()));
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/VersionCleaner.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/retention/version/VersionCleaner.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention.version;
+
+import java.io.IOException;
+
+import com.google.common.base.Preconditions;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.version.DatasetVersion;
+
+
+/**
+ * An abstraction for cleaning a {@link DatasetVersion} of a {@link CleanableDataset}.
+ */
+@Slf4j
+public abstract class VersionCleaner {
+
+  protected final CleanableDataset cleanableDataset;
+  protected final DatasetVersion datasetVersion;
+
+  public VersionCleaner(DatasetVersion datasetVersion, CleanableDataset cleanableDataset) {
+    Preconditions.checkNotNull(cleanableDataset);
+    Preconditions.checkNotNull(datasetVersion);
+
+    this.cleanableDataset = cleanableDataset;
+    this.datasetVersion = datasetVersion;
+  }
+
+  /**
+   * Action to perform before cleaning a {@link DatasetVersion} of a {@link CleanableDataset}.
+   * @throws IOException
+   */
+  public abstract void preCleanAction() throws IOException;
+
+  /**
+   * Cleans the {@link DatasetVersion} of a {@link CleanableDataset}.
+   * @throws IOException
+   */
+  public abstract void clean() throws IOException;
+
+  /**
+   * Action to perform after cleaning a {@link DatasetVersion} of a {@link CleanableDataset}.
+   * @throws IOException
+   */
+  public abstract void postCleanAction() throws IOException;
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/copy/hive/HiveDatasetTest.java
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2014-2015 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.copy.hive;
+
+import java.io.IOException;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.data.management.retention.version.HiveDatasetVersionCleaner;
+
+
+public class HiveDatasetTest {
+
+  private static String DUMMY_CONFIG_KEY_WITH_DB_TOKEN = "dummyConfig.withDB";
+  private static String DUMMY_CONFIG_KEY_WITH_TABLE_TOKEN = "dummyConfig.withTable";
+  private static Config config = ConfigFactory.parseMap(ImmutableMap.<String, String> of(
+      HiveDatasetVersionCleaner.REPLACEMENT_HIVE_DB_NAME_KEY, "resPrefix_$LOGICAL_DB_resPostfix",
+      HiveDatasetVersionCleaner.REPLACEMENT_HIVE_TABLE_NAME_KEY, "resPrefix_$LOGICAL_TABLE_resPostfix",
+      DUMMY_CONFIG_KEY_WITH_DB_TOKEN, "resPrefix_$DB_resPostfix",
+      DUMMY_CONFIG_KEY_WITH_TABLE_TOKEN, "resPrefix_$TABLE_resPostfix"));
+
+  @Test
+  public void testParseLogicalDbAndTable() throws IOException {
+
+    String datasetNamePattern;
+    HiveDatasetFinder.DbAndTable logicalDbAndTable;
+
+    // Happy Path
+    datasetNamePattern = "dbPrefix_$LOGICAL_DB_dbPostfix.tablePrefix_$LOGICAL_TABLE_tablePostfix";
+    logicalDbAndTable = HiveDataset.parseLogicalDbAndTable(datasetNamePattern,
+        new HiveDatasetFinder.DbAndTable("dbPrefix_myDB_dbPostfix", "tablePrefix_myTable_tablePostfix"),
+        HiveDataset.LOGICAL_DB_TOKEN, HiveDataset.LOGICAL_TABLE_TOKEN);
+    Assert.assertEquals(logicalDbAndTable.getDb(), "myDB", "DB name not parsed correctly");
+    Assert.assertEquals(logicalDbAndTable.getTable(), "myTable", "Table name not parsed correctly");
+
+    // Happy Path - without prefix in DB and Table names
+    datasetNamePattern = "$LOGICAL_DB_dbPostfix.$LOGICAL_TABLE_tablePostfix";
+    logicalDbAndTable = HiveDataset.parseLogicalDbAndTable(datasetNamePattern,
+        new HiveDatasetFinder.DbAndTable("myDB_dbPostfix", "myTable_tablePostfix"),
+        HiveDataset.LOGICAL_DB_TOKEN, HiveDataset.LOGICAL_TABLE_TOKEN);
+    Assert.assertEquals(logicalDbAndTable.getDb(), "myDB", "DB name not parsed correctly");
+    Assert.assertEquals(logicalDbAndTable.getTable(), "myTable", "Table name not parsed correctly");
+
+    // Happy Path - without postfix in DB and Table names
+    datasetNamePattern = "dbPrefix_$LOGICAL_DB.tablePrefix_$LOGICAL_TABLE";
+    logicalDbAndTable = HiveDataset.parseLogicalDbAndTable(datasetNamePattern,
+        new HiveDatasetFinder.DbAndTable("dbPrefix_myDB", "tablePrefix_myTable"),
+        HiveDataset.LOGICAL_DB_TOKEN, HiveDataset.LOGICAL_TABLE_TOKEN);
+    Assert.assertEquals(logicalDbAndTable.getDb(), "myDB", "DB name not parsed correctly");
+    Assert.assertEquals(logicalDbAndTable.getTable(), "myTable", "Table name not parsed correctly");
+
+    // Happy Path - without any prefix and postfix in DB and Table names
+    datasetNamePattern = "$LOGICAL_DB.$LOGICAL_TABLE";
+    logicalDbAndTable = HiveDataset.parseLogicalDbAndTable(datasetNamePattern,
+        new HiveDatasetFinder.DbAndTable("myDB", "myTable"),
+        HiveDataset.LOGICAL_DB_TOKEN, HiveDataset.LOGICAL_TABLE_TOKEN);
+    Assert.assertEquals(logicalDbAndTable.getDb(), "myDB", "DB name not parsed correctly");
+    Assert.assertEquals(logicalDbAndTable.getTable(), "myTable", "Table name not parsed correctly");
+
+    // Dataset name pattern missing
+    datasetNamePattern = "";
+    try {
+      logicalDbAndTable = HiveDataset.parseLogicalDbAndTable(datasetNamePattern,
+          new HiveDatasetFinder.DbAndTable("dbPrefix_myDB_dbPostfix", "tablePrefix_myTable_tablePostfix"),
+          HiveDataset.LOGICAL_DB_TOKEN, HiveDataset.LOGICAL_TABLE_TOKEN);
+      Assert.fail("Dataset name pattern is missing, code should have thrown exception");
+    } catch (IllegalArgumentException e) {
+      // Ignore exception, it was expected
+    }
+
+    // Malformed Dataset name pattern
+    datasetNamePattern = "dbPrefix_$LOGICAL_DB_dbPostfixtablePrefix_$LOGICAL_TABLE_tablePostfix";
+    try {
+      logicalDbAndTable = HiveDataset.parseLogicalDbAndTable(datasetNamePattern,
+          new HiveDatasetFinder.DbAndTable("dbPrefix_myDB_dbPostfix", "tablePrefix_myTable_tablePostfix"),
+          HiveDataset.LOGICAL_DB_TOKEN, HiveDataset.LOGICAL_TABLE_TOKEN);
+      Assert.fail("Dataset name pattern is missing, code should have thrown exception");
+    } catch (IllegalArgumentException e) {
+      // Ignore exception, it was expected
+    }
+  }
+
+  @Test
+  public void testExtractTokenValueFromEntity() throws IOException {
+
+    String tokenValue;
+
+    // Happy Path
+    tokenValue = HiveDataset.extractTokenValueFromEntity("dbPrefix_myDB_dbPostfix", "dbPrefix_$LOGICAL_DB_dbPostfix",
+        HiveDataset.LOGICAL_DB_TOKEN);
+    Assert.assertEquals(tokenValue, "myDB", "DB name not extracted correctly");
+
+    // Happy Path - without prefix
+    tokenValue = HiveDataset.extractTokenValueFromEntity("myDB_dbPostfix", "$LOGICAL_DB_dbPostfix",
+        HiveDataset.LOGICAL_DB_TOKEN);
+    Assert.assertEquals(tokenValue, "myDB", "DB name not extracted correctly");
+
+    // Happy Path - without postfix
+    tokenValue = HiveDataset.extractTokenValueFromEntity("dbPrefix_myDB", "dbPrefix_$LOGICAL_DB",
+        HiveDataset.LOGICAL_DB_TOKEN);
+    Assert.assertEquals(tokenValue, "myDB", "DB name not extracted correctly");
+
+    // Missing token in template
+    try {
+      tokenValue = HiveDataset.extractTokenValueFromEntity("dbPrefix_myDB_dbPostfix", "dbPrefix_$LOGICAL_TABLE_dbPostfix",
+          HiveDataset.LOGICAL_DB_TOKEN);
+      Assert.fail("Token is missing in template, code should have thrown exception");
+    } catch (IllegalArgumentException e) {
+      // Ignore exception, it was expected
+    }
+
+    // Missing source entity
+    try {
+      tokenValue = HiveDataset.extractTokenValueFromEntity("", "dbPrefix_$LOGICAL_DB_dbPostfix",
+          HiveDataset.LOGICAL_DB_TOKEN);
+      Assert.fail("Source entity is missing, code should have thrown exception");
+    } catch (IllegalArgumentException e) {
+      // Ignore exception, it was expected
+    }
+
+    // Missing template
+    try {
+      tokenValue = HiveDataset.extractTokenValueFromEntity("dbPrefix_myDB_dbPostfix", "",
+          HiveDataset.LOGICAL_DB_TOKEN);
+      Assert.fail("Template is missing, code should have thrown exception");
+    } catch (IllegalArgumentException e) {
+      // Ignore exception, it was expected
+    }
+  }
+
+  @Test
+  public void testResolveConfig() throws IOException {
+    HiveDatasetFinder.DbAndTable realDbAndTable = new HiveDatasetFinder.DbAndTable("realDb", "realTable");
+    HiveDatasetFinder.DbAndTable logicalDbAndTable = new HiveDatasetFinder.DbAndTable("logicalDb", "logicalTable");
+    Config resolvedConfig = HiveDataset.resolveConfig(config, realDbAndTable, logicalDbAndTable);
+
+    Assert.assertEquals(resolvedConfig.getString(DUMMY_CONFIG_KEY_WITH_DB_TOKEN),
+        "resPrefix_realDb_resPostfix", "Real DB not resolved correctly");
+    Assert.assertEquals(resolvedConfig.getString(DUMMY_CONFIG_KEY_WITH_TABLE_TOKEN),
+        "resPrefix_realTable_resPostfix", "Real Table not resolved correctly");
+
+    Assert.assertEquals(resolvedConfig.getString(HiveDatasetVersionCleaner.REPLACEMENT_HIVE_DB_NAME_KEY),
+        "resPrefix_logicalDb_resPostfix", "Logical DB not resolved correctly");
+    Assert.assertEquals(resolvedConfig.getString(HiveDatasetVersionCleaner.REPLACEMENT_HIVE_TABLE_NAME_KEY),
+        "resPrefix_logicalTable_resPostfix", "Logical Table not resolved correctly");
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/HiveDatasetVersionCleanerTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/HiveDatasetVersionCleanerTest.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.data.management.retention;
+
+import java.io.IOException;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.data.management.retention.version.HiveDatasetVersionCleaner;
+
+
+public class HiveDatasetVersionCleanerTest {
+
+  private static Config config = ConfigFactory.parseMap(ImmutableMap.<String, String> of(
+      HiveDatasetVersionCleaner.SHOULD_REPLACE_PARTITION_KEY, "true"));
+
+  private static String replacedDb = "db_orc";
+  private static String replacedTable = "table_orc";
+  private static String replacementDb = "db_avro";
+  private static String replacementTable = "table_avro";
+
+  @Test
+  public void testShouldReplacePartitionHappyPath() throws IOException {
+    // Happy path 1:
+    // - Replacement is enabled
+    // - Replacement DB, Table names are specified and are different than Replaced DB and Table names
+    Assert.assertTrue(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.of(replacementDb), Optional.of(replacementTable)), "Replaced and replacement db / table are different. "
+        + "This should have been true. ");
+
+    // Happy path 2:
+    // - Replacement is enabled
+    // - Replacement DB, Table names are specified and Replaced DB name is different
+    Assert.assertTrue(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.of(replacementDb), Optional.of(replacedTable)), "Replaced and replacement db / table are different. "
+        + "This should have been true. ");
+
+    // Happy path 3:
+    // - Replacement is enabled
+    // - Replacement DB, Table names are specified and Replaced Table name is different
+    Assert.assertTrue(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.of(replacedDb), Optional.of(replacementTable)), "Replaced and replacement db / table are different. "
+        + "This should have been true. ");
+  }
+
+  @Test
+  public void testShouldReplacePartitionDisabledByConfig() throws IOException {
+    Config config = ConfigFactory.parseMap(ImmutableMap.<String, String> of(
+        HiveDatasetVersionCleaner.SHOULD_REPLACE_PARTITION_KEY, "false"));
+
+    Assert.assertFalse(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.of(replacementDb), Optional.of(replacementTable)), "Property governing partition replacement is set to false. "
+        + "This should have been false. ");
+  }
+
+  @Test
+  public void testShouldReplacePartitionDisabledByCodePath() throws IOException {
+    // Replacement DB and Table names are same as Replaced DB and Table names
+    Assert.assertFalse(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.of(replacedDb), Optional.of(replacedTable)), "Replaced and replacement db / table are same. "
+        + "This should have been false. ");
+
+    // Replaced DB name is missing
+    Assert.assertFalse(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.<String>absent(), Optional.of(replacementTable)), "Replacement DB name is missing. "
+        + "This should have been false. ");
+
+    // Replaced Table name is missing
+    Assert.assertFalse(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.of(replacementDb), Optional.<String>absent()), "Replacement table name is missing. "
+        + "This should have been false. ");
+
+    // Both DB and Table names are missing
+    Assert.assertFalse(HiveDatasetVersionCleaner.shouldReplacePartition(config, replacedDb, replacedTable,
+        Optional.<String>absent(), Optional.<String>absent()), "Replacement DB and table names are missing. "
+        + "This should have been false. ");
+  }
+}

--- a/gobblin-data-management/src/test/java/gobblin/data/management/retention/version/HiveDatasetVersionCleanerTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/retention/version/HiveDatasetVersionCleanerTest.java
@@ -9,7 +9,7 @@
  * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
  * CONDITIONS OF ANY KIND, either express or implied.
  */
-package gobblin.data.management.retention;
+package gobblin.data.management.retention.version;
 
 import java.io.IOException;
 

--- a/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/replacement.conf
+++ b/gobblin-data-management/src/test/resources/retentionIntegrationTest/testHiveTimeBasedRetention/replacement.conf
@@ -1,0 +1,27 @@
+gobblin.retention : {
+
+  is.blacklisted=false
+
+  dataset : {
+    finder.class=gobblin.data.management.retention.dataset.finder.CleanableHiveDatasetFinder
+  }
+
+  selection : {
+    policy.class=gobblin.data.management.policy.SelectBeforeTimeBasedPolicy
+    timeBased.lookbackTime=7d
+  }
+
+  version.finder.class=gobblin.data.management.version.finder.DatePartitionHiveVersionFinder
+
+  hive {
+    partition {
+      key.name=datepartition
+      value.datetime.pattern=yyyy-MM-dd-HH
+      value.datetime.timezone=America/Los_Angeles
+    }
+    datasetNamePattern="$LOGICAL_DB.$LOGICAL_TABLE"
+    replacementHiveDbName="$LOGICAL_DB_source"
+    replacementHiveTableName="$LOGICAL_TABLE_source"
+    shouldReplacePartition=true
+  }
+}


### PR DESCRIPTION
This PR adds: 

A. New construct of VersionCleaner in Retention with pre and post activity hook. 

B. Capability in Hive retention to swap-in a partition from another table in lieu of the partition being deleted from the current table as post cleanup activity. 

This is important for use-cases such as hybrid tables (with Avro and ORC based partitions), where we want to replace ORC partitions with Avro partitions when certain retention predicate become true (such as retain ORC partitions for 30 days, and then replace them with Avro partitions from another table which has the same data in Avro format) 

To illustrate its functioning lets assume that: 
1. We want to delete ORC partition (date="2016-01-01-00") from table db_orc.prod1_table_orc
2. We want to register Avro partition (date="2016-01-01-00") from table db_avro.prod2_table_avro to table db_orc.prod1_table_orc at the same time (since it contains same data but in different physical format ie. avro)

So, this is achieved as follows:
1. Following configuration is set in config store for this dataset (or parent level dataset, refer to config store setup details to learn more in Gobblin wiki): 
- hive.datasetNamePattern = $LOGICAL_DB_orc.prod1_$LOGICAL_TABLE_orc
- hive.replacementHiveDbName = $LOGICAL_DB_avro
- hive.replacementHiveTableName = prod2_$LOGICAL_TABLE_avro
- hive.shouldReplacePartition = true (to enable partition replacement) 
Note: $LOGICAL_DB and $LOGICAL_TABLE are recognized tokens by the code 
In HiveDataset, by applying hive.datasetNamePattern on current Hive dataset (db.table): 
$LOGICAL_DB is auto-resolved to: db 
$LOGICAL_TABLE is auto-resolved to: table 
hive.replacementHiveDbName is auto-resolved to: db_avro 
hive.replacementHiveTableName is auto-resolved to: prod2_table_avro 
2. The HiveVersionCleaner in its clean() method, drops the partition (date="2016-01-01-00") from db_orc.prod1_table_orc
3. The HiveVersionCleaner in its postCleanAction() method then registers the corresponding partition (date="2016-01-01-00") from db_avro.prod2_table_avro to db_orc.prod1_table_orc table 

Please note: This cross-registration of the partition does not duplicates the data, rather the partition registration is only a reference to the data from source table 