### PR TITLE
Updates to Gobblin daemon + other minor features

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -56,7 +56,7 @@ public class ConfigurationKeys {
   public static final int DEFAULT_JOB_EXECUTOR_THREAD_POOL_SIZE = 5;
   // Job configuration file monitor polling interval in milliseconds
   public static final String JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY = "jobconf.monitor.interval";
-  public static final long DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL = 300000;
+  public static final long DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL = 30000;
   // Directory where all job configuration files are stored WHEN ALL confs reside in local FS.
   public static final String JOB_CONFIG_FILE_DIR_KEY = "jobconf.dir";
 

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinDaemon.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanGobblinDaemon.java
@@ -1,7 +1,13 @@
 package gobblin.azkaban;
 
+import java.util.List;
 import java.util.Properties;
 import org.apache.log4j.Logger;
+
+import com.google.common.collect.Lists;
+
+import gobblin.metrics.RootMetricContext;
+import gobblin.metrics.Tag;
 import gobblin.scheduler.SchedulerDaemon;
 import azkaban.jobExecutor.AbstractJob;
 
@@ -18,6 +24,11 @@ public class AzkabanGobblinDaemon extends AbstractJob {
 
   public AzkabanGobblinDaemon(String jobId, Properties props) throws Exception {
     super(jobId, LOG);
+
+    List<Tag<?>> tags = Lists.newArrayList();
+    tags.addAll(Tag.fromMap(AzkabanTags.getAzkabanTags()));
+    RootMetricContext.get(tags);
+
     this.daemon = new SchedulerDaemon(props);
   }
 

--- a/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
+++ b/gobblin-azkaban/src/main/java/gobblin/azkaban/AzkabanJobLauncher.java
@@ -40,6 +40,7 @@ import com.google.common.io.Closer;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.metrics.GobblinMetrics;
+import gobblin.metrics.RootMetricContext;
 import gobblin.metrics.Tag;
 import gobblin.runtime.JobException;
 import gobblin.runtime.JobLauncher;
@@ -141,6 +142,7 @@ public class AzkabanJobLauncher extends AbstractJob implements ApplicationLaunch
 
     List<Tag<?>> tags = Lists.newArrayList();
     tags.addAll(Tag.fromMap(AzkabanTags.getAzkabanTags()));
+    RootMetricContext.get(tags);
     GobblinMetrics.addCustomTagsToProperties(this.props, tags);
 
     // If the job launcher type is not specified in the job configuration,

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -57,6 +57,7 @@ dependencies {
   compile externalDependency.googleOauthClient
   compile externalDependency.googleApiClient
   compile externalDependency.opencsv
+  compile externalDependency.hadoopHdfs
 
   runtime externalDependency.protobuf
 

--- a/gobblin-core/src/main/java/gobblin/filesystem/InstrumentedHDFSFileSystem.java
+++ b/gobblin-core/src/main/java/gobblin/filesystem/InstrumentedHDFSFileSystem.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A {@link org.apache.hadoop.fs.FileSystem} that extends HDFS and allows instrumentation of certain calls (for example,
+ * counting the number of calls to a certain method or measuring latency). For now it is just a skeleton.
+ *
+ * Using the scheme "instrumented-hdfs" will automatically use this {@link org.apache.hadoop.fs.FileSystem} and work
+ * transparently as any other HDFS file system.
+ *
+ * When modifying this class, tests must be run manually (see InstrumentedHDFSFileSystemTest).
+ */
+@Slf4j
+public class InstrumentedHDFSFileSystem extends DistributedFileSystem {
+
+  public static final String INSTRUMENTED_HDFS_SCHEME = "instrumented-hdfs";
+
+  private static final String HDFS_SCHEME = "hdfs";
+
+  @Override
+  public String getScheme() {
+    return INSTRUMENTED_HDFS_SCHEME;
+  }
+
+  @Override
+  public void initialize(URI uri, Configuration conf)
+      throws IOException {
+    super.initialize(replaceScheme(uri, INSTRUMENTED_HDFS_SCHEME, HDFS_SCHEME), conf);
+  }
+
+  @Override
+  protected URI getCanonicalUri() {
+    return replaceScheme(super.getCanonicalUri(), HDFS_SCHEME, INSTRUMENTED_HDFS_SCHEME);
+  }
+
+  @Override
+  public URI getUri() {
+    return replaceScheme(super.getUri(), HDFS_SCHEME, INSTRUMENTED_HDFS_SCHEME);
+  }
+
+  @Override
+  protected URI canonicalizeUri(URI uri) {
+    return replaceScheme(super.canonicalizeUri(uri), HDFS_SCHEME, INSTRUMENTED_HDFS_SCHEME);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    super.close();
+    // Should print out statistics here
+  }
+
+  private URI replaceScheme(URI uri, String replace, String replacement) {
+    try {
+      if (replace != null && replace.equals(uri.getScheme())) {
+        return new URI(replacement, uri.getUserInfo(), uri.getHost(), uri.getPort(), uri.getPath(), uri.getQuery(), uri.getFragment());
+      } else {
+        return uri;
+      }
+    } catch (URISyntaxException use) {
+      throw new RuntimeException("Failed to replace scheme.");
+    }
+  }
+}

--- a/gobblin-core/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
+++ b/gobblin-core/src/main/resources/META-INF/services/org.apache.hadoop.fs.FileSystem
@@ -1,0 +1,13 @@
+#
+# Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+# this file except in compliance with the License. You may obtain a copy of the
+# License at  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software distributed
+# under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+# CONDITIONS OF ANY KIND, either express or implied.
+#
+
+gobblin.filesystem.InstrumentedHDFSFileSystem

--- a/gobblin-core/src/test/java/gobblin/filesystem/InstrumentedHDFSFileSystemTest.java
+++ b/gobblin-core/src/test/java/gobblin/filesystem/InstrumentedHDFSFileSystemTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.filesystem;
+
+import java.net.URI;
+import java.util.UUID;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class InstrumentedHDFSFileSystemTest {
+
+  /**
+   * This test is disabled because it requires a local hdfs cluster at localhost:8020, which requires installation and setup.
+   * Changes to {@link InstrumentedHDFSFileSystem} should be followed by a manual run of this tests.
+   *
+   * TODO: figure out how to fully automate this test.
+   * @throws Exception
+   */
+  @Test(enabled = false)
+  public void test() throws Exception {
+
+    FileSystem fs = FileSystem.get(new URI("instrumented-hdfs://localhost:8020"), new Configuration());
+
+    String name = UUID.randomUUID().toString();
+    fs.mkdirs(new Path("/tmp"));
+
+    // Test absolute paths
+    Path absolutePath = new Path("/tmp", name);
+    Assert.assertFalse(fs.exists(absolutePath));
+    fs.createNewFile(absolutePath);
+    Assert.assertTrue(fs.exists(absolutePath));
+    Assert.assertEquals(fs.getFileStatus(absolutePath).getLen(), 0);
+    fs.delete(absolutePath, false);
+    Assert.assertFalse(fs.exists(absolutePath));
+
+
+    // Test fully qualified paths
+    Path fqPath = new Path("instrumented-hdfs://localhost:8020/tmp", name);
+    Assert.assertFalse(fs.exists(fqPath));
+    fs.createNewFile(fqPath);
+    Assert.assertTrue(fs.exists(fqPath));
+    Assert.assertEquals(fs.getFileStatus(fqPath).getLen(), 0);
+    fs.delete(fqPath, false);
+    Assert.assertFalse(fs.exists(fqPath));
+  }
+
+}

--- a/gobblin-metrics/src/main/java/gobblin/metrics/RootMetricContext.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/RootMetricContext.java
@@ -69,9 +69,9 @@ public class RootMetricContext extends MetricContext {
     addShutdownHook();
   }
 
-  private static void initialize() {
+  private static void initialize(List<Tag<?>> tags) {
     try {
-      INSTANCE = new RootMetricContext(Lists.<Tag<?>>newArrayList());
+      INSTANCE = new RootMetricContext(tags);
     } catch (NameConflictException nce) {
       // Should never happen, as there is no parent, so no conflict.
       throw new IllegalStateException("Failed to generate root metric context. This is an error in the code.", nce);
@@ -83,8 +83,16 @@ public class RootMetricContext extends MetricContext {
    * @return singleton instance of {@link RootMetricContext}.
    */
   public synchronized static RootMetricContext get() {
+    return get(Lists.<Tag<?>>newArrayList());
+  }
+
+  /**
+   * Get the singleton {@link RootMetricContext}, adding the specified tags if and only if this is the first call.
+   * @return singleton instance of {@link RootMetricContext}.
+   */
+  public synchronized static RootMetricContext get(List<Tag<?>> tags) {
     if (INSTANCE == null) {
-      initialize();
+      initialize(tags);
     }
     return INSTANCE;
   }

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -173,12 +173,8 @@ public class JobScheduler extends AbstractIdleService {
     }
 
     // Note: This should not be mandatory, gobblin-cluster modes have their own job configuration managers
-    if (this.properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY)) {
-
-      Preconditions.checkArgument(
-          this.properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY) || this.properties.containsKey(
-              ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY),
-          "Error in configuration file: Please check your .pull file");
+    if (this.properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY)
+        || this.properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY)) {
 
       if (this.properties.containsKey(ConfigurationKeys.JOB_CONFIG_FILE_DIR_KEY) && !this.properties.containsKey(
           ConfigurationKeys.JOB_CONFIG_FILE_GENERAL_PATH_KEY)) {

--- a/gobblin-utility/src/main/java/gobblin/util/filesystem/ExceptionCatchingPathAlterationListenerDecorator.java
+++ b/gobblin-utility/src/main/java/gobblin/util/filesystem/ExceptionCatchingPathAlterationListenerDecorator.java
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.util.filesystem;
+
+import org.apache.hadoop.fs.Path;
+
+import gobblin.util.Decorator;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A decorator for {@link PathAlterationListener} that catches and logs any exception thrown by the underlying listener,
+ * preventing it from failing the application.
+ */
+@AllArgsConstructor
+@Slf4j
+public class ExceptionCatchingPathAlterationListenerDecorator implements PathAlterationListener, Decorator {
+
+  private final PathAlterationListener underlying;
+
+  @Override
+  public Object getDecoratedObject() {
+    return this.underlying;
+  }
+
+  @Override
+  public void onStart(PathAlterationObserver observer) {
+    try {
+      this.underlying.onStart(observer);
+    } catch (Throwable exc) {
+      log.error("onStart failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onFileCreate(Path path) {
+    try {
+      this.underlying.onFileCreate(path);
+    } catch (Throwable exc) {
+      log.error("onFileCreate failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onFileChange(Path path) {
+    try {
+      this.underlying.onFileChange(path);
+    } catch (Throwable exc) {
+      log.error("onFileChange failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onStop(PathAlterationObserver observer) {
+    try {
+      this.underlying.onStop(observer);
+    } catch (Throwable exc) {
+      log.error("onStop failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onDirectoryCreate(Path directory) {
+    try {
+      this.underlying.onDirectoryCreate(directory);
+    } catch (Throwable exc) {
+      log.error("onDirectoryCreate failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onDirectoryChange(Path directory) {
+    try {
+      this.underlying.onDirectoryChange(directory);
+    } catch (Throwable exc) {
+      log.error("onDirectoryChange failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onDirectoryDelete(Path directory) {
+    try {
+      this.underlying.onDirectoryDelete(directory);
+    } catch (Throwable exc) {
+      log.error("onDirectoryDelete failure: ", exc);
+    }
+  }
+
+  @Override
+  public void onFileDelete(Path path) {
+    try {
+      this.underlying.onFileDelete(path);
+    } catch (Throwable exc) {
+      log.error("onFileDelete failure: ", exc);
+    }
+  }
+}


### PR DESCRIPTION
Three main changes:

* Fixed a closed `FileSystem` in Gobblin daemon, as well as silent failures of the `JobScheduler`.
* Added injection of tags to `RootMetricContext` when running in Azkaban mode.
* Created an instrumented HDFS file system (used for debugging, in the future we can add metrics to it)