### PR TITLE
Writer to launch compaction job using hive metadata

### DIFF
--- a/gobblin-compaction/build.gradle
+++ b/gobblin-compaction/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   compile project(":gobblin-utility")
   compile project(":gobblin-metrics")
   compile project(":gobblin-core")
+  compile project(":gobblin-data-management")
 
   compile externalDependency.calciteCore
   compile externalDependency.calciteAvatica
@@ -47,8 +48,8 @@ dependencies {
 }
 
 
-configurations { 
-    compile { transitive = true } 
+configurations {
+    compile { transitive = true }
 }
 
 ext.classification="library"

--- a/gobblin-compaction/src/main/java/gobblin/compaction/dataset/DatasetsFinder.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/dataset/DatasetsFinder.java
@@ -48,6 +48,7 @@ public abstract class DatasetsFinder implements gobblin.dataset.DatasetsFinder<D
   public static final char DATASETS_WITH_DIFFERENT_RECOMPACT_THRESHOLDS_SEPARATOR = ';';
   public static final char DATASETS_WITH_SAME_RECOMPACT_THRESHOLDS_SEPARATOR = ',';
   public static final char DATASETS_AND_RECOMPACT_THRESHOLD_SEPARATOR = ':';
+  public static final String TMP_OUTPUT_SUBDIR = "output";
 
   protected final State state;
   protected final Configuration conf;
@@ -107,7 +108,7 @@ public abstract class DatasetsFinder implements gobblin.dataset.DatasetsFinder<D
 
   private String getTmpOutputDir() {
     return new Path(this.state.getProp(MRCompactor.COMPACTION_TMP_DEST_DIR,
-        MRCompactor.DEFAULT_COMPACTION_TMP_DEST_DIR), "output").toString();
+        MRCompactor.DEFAULT_COMPACTION_TMP_DEST_DIR), TMP_OUTPUT_SUBDIR).toString();
   }
 
   private FileSystem getFileSystem() {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/dataset/DatasetsFinder.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/dataset/DatasetsFinder.java
@@ -106,7 +106,8 @@ public abstract class DatasetsFinder implements gobblin.dataset.DatasetsFinder<D
   }
 
   private String getTmpOutputDir() {
-    return this.state.getProp(MRCompactor.COMPACTION_TMP_DEST_DIR, MRCompactor.DEFAULT_COMPACTION_TMP_DEST_DIR);
+    return new Path(this.state.getProp(MRCompactor.COMPACTION_TMP_DEST_DIR,
+        MRCompactor.DEFAULT_COMPACTION_TMP_DEST_DIR), "output").toString();
   }
 
   private FileSystem getFileSystem() {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/AvroExternalTable.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/AvroExternalTable.java
@@ -28,7 +28,7 @@ import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 
 
 /**

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/HiveManagedTable.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/HiveManagedTable.java
@@ -14,7 +14,7 @@ package gobblin.compaction.hive;
 
 import java.sql.SQLException;
 
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 
 /**
  * A class for managing Hive managed tables.

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/HiveTable.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/HiveTable.java
@@ -22,7 +22,7 @@ import org.apache.commons.lang.StringUtils;
 
 import com.google.common.base.Splitter;
 
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 
 
 /**

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hive/SerialCompactor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hive/SerialCompactor.java
@@ -24,7 +24,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.io.Closer;
 
 import gobblin.compaction.Compactor;
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 
 
 /**

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
@@ -6,6 +6,7 @@ import java.util.List;
 import java.util.Properties;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.base.Joiner;
 import gobblin.compaction.listeners.CompactorListener;
 import gobblin.compaction.mapreduce.MRCompactor;
 import gobblin.metrics.Tag;
@@ -29,7 +30,7 @@ public class CompactionLauncherWriter implements DataWriter<MRCompactionEntity> 
     Properties props = new Properties();
     props.putAll(compactionEntity.getProps());
     props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY,
-        compactionEntity.getDeltaList().toString().replace("[", "").replace("]", ""));
+        Joiner.on(',').join(compactionEntity.getDeltaList()));
     props.setProperty(MRCompactor.COMPACTION_INPUT_DIR, compactionEntity.getDataFilesPath().toString());
 
     MRCompactor compactor = new MRCompactor(props, list, Optional.<CompactorListener>absent());

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
@@ -28,8 +28,9 @@ public class CompactionLauncherWriter implements DataWriter<MRCompactionEntity> 
 
     Properties props = new Properties();
     props.putAll(compactionEntity.getProps());
-    props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY, compactionEntity.getDeltaInfo());
-    props.setProperty(MRCompactor.COMPACTION_INPUT_DIR, compactionEntity.getLocation());
+    props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY,
+        compactionEntity.getDeltaList().toString().replace("[", "").replace("]", ""));
+    props.setProperty(MRCompactor.COMPACTION_INPUT_DIR, compactionEntity.getDataFilesPath().toString());
 
     MRCompactor compactor = new MRCompactor(props, list, Optional.<CompactorListener>absent());
     compactor.compact();

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
@@ -16,6 +16,8 @@ import gobblin.compaction.mapreduce.avro.ConfBasedDeltaFieldProvider;
 /**
  * {@link DataWriter} that launches an {@link MRCompactor} job given an {@link MRCompactionEntity} specifying config
  * for compaction
+ *
+ * Delta field is passed using {@link ConfBasedDeltaFieldProvider}
  */
 public class CompactionLauncherWriter implements DataWriter<MRCompactionEntity> {
   @Override
@@ -24,11 +26,12 @@ public class CompactionLauncherWriter implements DataWriter<MRCompactionEntity> 
 
     List<? extends Tag<?>> list = new ArrayList<>();
 
-    Properties props = compactionEntity.getProps();
-    props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY, compactionEntity.getDelta());
+    Properties props = new Properties();
+    props.putAll(compactionEntity.getProps());
+    props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY, compactionEntity.getDeltaInfo());
     props.setProperty(MRCompactor.COMPACTION_INPUT_DIR, compactionEntity.getLocation());
 
-    MRCompactor compactor = new MRCompactor(compactionEntity.getProps(), list, Optional.<CompactorListener>absent());
+    MRCompactor compactor = new MRCompactor(props, list, Optional.<CompactorListener>absent());
     compactor.compact();
   }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
@@ -1,0 +1,53 @@
+package gobblin.compaction.hivebasedconstructs;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import gobblin.compaction.listeners.CompactorListener;
+import gobblin.compaction.mapreduce.MRCompactor;
+import gobblin.metrics.Tag;
+import gobblin.writer.DataWriter;
+import gobblin.compaction.mapreduce.avro.ConfBasedDeltaFieldProvider;
+
+
+/**
+ * {@link DataWriter} that launches an {@link MRCompactor} job given an {@link MRCompactionEntity} specifying config
+ * for compaction
+ */
+public class CompactionLauncherWriter implements DataWriter<MRCompactionEntity> {
+  @Override
+  public void write(MRCompactionEntity compactionEntity) throws IOException {
+    Preconditions.checkNotNull(compactionEntity);
+
+    List<? extends Tag<?>> list = new ArrayList<>();
+
+    Properties props = compactionEntity.getProps();
+    props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY, compactionEntity.getDelta());
+    props.setProperty(MRCompactor.COMPACTION_INPUT_DIR, compactionEntity.getLocation());
+
+    MRCompactor compactor = new MRCompactor(compactionEntity.getProps(), list, Optional.<CompactorListener>absent());
+    compactor.compact();
+  }
+
+  @Override
+  public void commit() throws IOException {}
+
+  @Override
+  public void cleanup() throws IOException {}
+
+  @Override
+  public long recordsWritten() {
+    return 0;
+  }
+
+  @Override
+  public long bytesWritten() throws IOException {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriterBuilder.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriterBuilder.java
@@ -1,0 +1,17 @@
+package gobblin.compaction.hivebasedconstructs;
+
+import java.io.IOException;
+import org.apache.avro.Schema;
+import gobblin.writer.DataWriter;
+import gobblin.writer.DataWriterBuilder;
+
+
+/**
+ * {@link DataWriterBuilder} for {@link CompactionLauncherWriter}
+ */
+public class CompactionLauncherWriterBuilder extends DataWriterBuilder<Schema, MRCompactionEntity> {
+  @Override
+  public DataWriter<MRCompactionEntity> build() throws IOException {
+    return new CompactionLauncherWriter();
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
@@ -1,7 +1,6 @@
 package gobblin.compaction.hivebasedconstructs;
 
 import java.io.IOException;
-import org.apache.avro.Schema;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
@@ -19,6 +18,7 @@ import gobblin.data.management.copy.hive.HiveDatasetFinder;
 import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.source.extractor.Extractor;
 import gobblin.util.AutoReturnableObject;
+import gobblin.data.management.conversion.hive.extractor.HiveBaseExtractor;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
  * creates an {@link MRCompactionEntity}
  */
 @Slf4j
-public class HiveMetadataForCompactionExtractor implements Extractor<Schema, MRCompactionEntity> {
+public class HiveMetadataForCompactionExtractor extends HiveBaseExtractor<Void, MRCompactionEntity> {
 
   public static final String COMPACTION_PRIMARY_KEY = "hive.metastore.primaryKey";
   public static final String COMPACTION_DELTA = "hive.metastore.delta";
@@ -72,20 +72,7 @@ public class HiveMetadataForCompactionExtractor implements Extractor<Schema, MRC
   }
 
   @Override
-  public Schema getSchema() throws IOException {
+  public Void getSchema() throws IOException {
     return null;
   }
-
-  @Override
-  public long getExpectedRecordCount() {
-    return 1;
-  }
-
-  @Override
-  public long getHighWatermark() {
-    return 0;
-  }
-
-  @Override
-  public void close() throws IOException {}
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
@@ -1,0 +1,91 @@
+package gobblin.compaction.hivebasedconstructs;
+
+import java.io.IOException;
+import org.apache.avro.Schema;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.thrift.TException;
+import com.google.common.base.Optional;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.avro.AvroSchemaManager;
+import gobblin.data.management.conversion.hive.source.HiveWorkUnit;
+import gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarker;
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.hive.HiveMetastoreClientPool;
+import gobblin.source.extractor.Extractor;
+import gobblin.util.AutoReturnableObject;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * {@link Extractor} that extracts primary key field name, delta field name, and location from hive metastore and
+ * creates an {@link MRCompactionEntity}
+ */
+@Slf4j
+public class HiveMetadataForCompactionExtractor implements Extractor<Schema, MRCompactionEntity> {
+
+  public static final String COMPACTION_PRIMARY_KEY = "hive.metastore.primaryKey";
+  public static final String COMPACTION_DELTA = "hive.metastore.delta";
+
+  private MRCompactionEntity compactionEntity;
+  private boolean extracted = false;
+
+  public HiveMetadataForCompactionExtractor(WorkUnitState state, FileSystem fs) throws IOException, TException, HiveException {
+    if (Boolean.valueOf(state.getPropAsBoolean(PartitionLevelWatermarker.IS_WATERMARK_WORKUNIT_KEY))) {
+      log.info("Ignoring Watermark workunit for {}", state.getProp(ConfigurationKeys.DATASET_URN_KEY));
+      return;
+    }
+
+    HiveWorkUnit hiveWorkUnit = new HiveWorkUnit(state.getWorkunit());
+    HiveDataset hiveDataset = hiveWorkUnit.getHiveDataset();
+    String dbName = hiveDataset.getDbAndTable().getDb();
+    String tableName = hiveDataset.getDbAndTable().getTable();
+
+    HiveMetastoreClientPool pool =
+        HiveMetastoreClientPool.get(state.getJobState().getProperties(),
+            Optional.fromNullable(state.getJobState().getProp(HiveDatasetFinder.HIVE_METASTORE_URI_KEY)));
+    try (AutoReturnableObject<IMetaStoreClient> client = pool.getClient()) {
+      Table table = client.get().getTable(dbName, tableName);
+
+      String primaryKey = table.getParameters().get(state.getProp(COMPACTION_PRIMARY_KEY));
+      String delta = table.getParameters().get(state.getProp(COMPACTION_DELTA));
+      String topicName = AvroSchemaManager.getSchemaFromUrl(hiveWorkUnit.getTableSchemaUrl(), fs).getName();
+      String location = new Path(table.getSd().getLocation(), topicName).toString();
+
+      compactionEntity = new MRCompactionEntity(primaryKey, delta, location, state.getProperties());
+    }
+  }
+
+  @Override
+  public MRCompactionEntity readRecord(MRCompactionEntity reuse) {
+    if (!extracted) {
+      extracted = true;
+      return compactionEntity;
+    } else {
+      return null;
+    }
+  }
+
+  @Override
+  public Schema getSchema() throws IOException {
+    return null;
+  }
+
+  @Override
+  public long getExpectedRecordCount() {
+    return 1;
+  }
+
+  @Override
+  public long getHighWatermark() {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractorFactory.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractorFactory.java
@@ -1,0 +1,20 @@
+package gobblin.compaction.hivebasedconstructs;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.extractor.HiveBaseExtractor;
+import gobblin.data.management.conversion.hive.extractor.HiveBaseExtractorFactory;
+import java.io.IOException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.thrift.TException;
+
+
+/**
+ * Factory for {@link HiveMetadataForCompactionExtractor}
+ */
+public class HiveMetadataForCompactionExtractorFactory implements HiveBaseExtractorFactory {
+  public HiveBaseExtractor createExtractor(WorkUnitState state, FileSystem sourceFs)
+      throws IOException, TException, HiveException {
+    return new HiveMetadataForCompactionExtractor(state, sourceFs);
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/MRCompactionEntity.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/MRCompactionEntity.java
@@ -6,17 +6,22 @@ import lombok.Getter;
 
 /**
  * Entity that stores information required for launching an {@link gobblin.compaction.mapreduce.MRCompactor} job
+ *
+ * {@link #primaryKeyInfo}: Comma delimited list of fields to use as primary key
+ * {@link #deltaInfo}: Comma delimited list of fields to use as deltaInfo
+ * {@link #location}: Location of files associated with table
+ * {@link #props}: Other properties to be passed to {@link gobblin.compaction.mapreduce.MRCompactor}
  */
 @Getter
 public class MRCompactionEntity {
-  private final String primaryKey;
-  private final String delta;
+  private final String primaryKeyInfo;
+  private final String deltaInfo;
   private final String location;
   private final Properties props;
 
-  public MRCompactionEntity(String primaryKey, String delta, String location, Properties props) {
-    this.primaryKey = primaryKey;
-    this.delta = delta;
+  public MRCompactionEntity(String primaryKeyInfo, String deltaInfo, String location, Properties props) {
+    this.primaryKeyInfo = primaryKeyInfo;
+    this.deltaInfo = deltaInfo;
     this.location = location;
     this.props = props;
   }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/MRCompactionEntity.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/MRCompactionEntity.java
@@ -1,28 +1,30 @@
 package gobblin.compaction.hivebasedconstructs;
 
+import java.util.List;
 import java.util.Properties;
+import org.apache.hadoop.fs.Path;
 import lombok.Getter;
 
 
 /**
  * Entity that stores information required for launching an {@link gobblin.compaction.mapreduce.MRCompactor} job
  *
- * {@link #primaryKeyInfo}: Comma delimited list of fields to use as primary key
- * {@link #deltaInfo}: Comma delimited list of fields to use as deltaInfo
- * {@link #location}: Location of files associated with table
+ * {@link #primaryKeyList}: Comma delimited list of fields to use as primary key
+ * {@link #deltaList}: Comma delimited list of fields to use as deltaList
+ * {@link #dataFilesPath}: Location of files associated with table
  * {@link #props}: Other properties to be passed to {@link gobblin.compaction.mapreduce.MRCompactor}
  */
 @Getter
 public class MRCompactionEntity {
-  private final String primaryKeyInfo;
-  private final String deltaInfo;
-  private final String location;
+  private final List<String> primaryKeyList;
+  private final List<String> deltaList;
+  private final Path dataFilesPath;
   private final Properties props;
 
-  public MRCompactionEntity(String primaryKeyInfo, String deltaInfo, String location, Properties props) {
-    this.primaryKeyInfo = primaryKeyInfo;
-    this.deltaInfo = deltaInfo;
-    this.location = location;
+  public MRCompactionEntity(List<String> primaryKeyList, List<String> deltaList, Path dataFilesPath, Properties props) {
+    this.primaryKeyList = primaryKeyList;
+    this.deltaList = deltaList;
+    this.dataFilesPath = dataFilesPath;
     this.props = props;
   }
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/MRCompactionEntity.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/MRCompactionEntity.java
@@ -1,0 +1,23 @@
+package gobblin.compaction.hivebasedconstructs;
+
+import java.util.Properties;
+import lombok.Getter;
+
+
+/**
+ * Entity that stores information required for launching an {@link gobblin.compaction.mapreduce.MRCompactor} job
+ */
+@Getter
+public class MRCompactionEntity {
+  private final String primaryKey;
+  private final String delta;
+  private final String location;
+  private final Properties props;
+
+  public MRCompactionEntity(String primaryKey, String delta, String location, Properties props) {
+    this.primaryKey = primaryKey;
+    this.delta = delta;
+    this.location = location;
+    this.props = props;
+  }
+}

--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -14,7 +14,6 @@ dependencies {
   compile project(":gobblin-api")
   compile project(":gobblin-core")
   compile project(":gobblin-hive-registration")
-  compile project(":gobblin-compaction")
   compile project(":gobblin-metrics")
   compile project(":gobblin-utility")
   compile project(":gobblin-config-management:gobblin-config-client")

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveBaseExtractor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveBaseExtractor.java
@@ -1,0 +1,28 @@
+package gobblin.data.management.conversion.hive.extractor;
+
+import java.io.IOException;
+import gobblin.source.extractor.Extractor;
+
+
+/**
+ * Base {@link Extractor} for extracting from {@link gobblin.data.management.conversion.hive.source.HiveSource}
+ */
+public abstract class HiveBaseExtractor<S, D> implements Extractor<S, D> {
+
+
+  @Override
+  public long getExpectedRecordCount() {
+    return 1;
+  }
+
+  /**
+   * Watermark is not managed by this extractor.
+   */
+  @Override
+  public long getHighWatermark() {
+    return 0;
+  }
+
+  @Override
+  public void close() throws IOException {}
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveBaseExtractorFactory.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveBaseExtractorFactory.java
@@ -1,0 +1,16 @@
+package gobblin.data.management.conversion.hive.extractor;
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.thrift.TException;
+import gobblin.configuration.WorkUnitState;
+
+
+/**
+ * Factory interface for {@link HiveBaseExtractor}
+ */
+public interface HiveBaseExtractorFactory {
+  HiveBaseExtractor createExtractor(WorkUnitState state, FileSystem sourceFs)
+      throws IOException, TException, HiveException;
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveConvertExtractor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveConvertExtractor.java
@@ -40,7 +40,6 @@ import gobblin.data.management.conversion.hive.watermarker.PartitionLevelWaterma
 import gobblin.data.management.copy.hive.HiveDatasetFinder;
 import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.source.extractor.DataRecordException;
-import gobblin.source.extractor.Extractor;
 import gobblin.util.AutoReturnableObject;
 
 
@@ -57,7 +56,7 @@ import gobblin.util.AutoReturnableObject;
  * </p>
  */
 @Slf4j
-public class HiveConvertExtractor implements Extractor<Schema, QueryBasedHiveConversionEntity> {
+public class HiveConvertExtractor extends HiveBaseExtractor<Schema, QueryBasedHiveConversionEntity> {
 
   private List<QueryBasedHiveConversionEntity> conversionEntities = Lists.newArrayList();
 
@@ -125,22 +124,4 @@ public class HiveConvertExtractor implements Extractor<Schema, QueryBasedHiveCon
 
     return this.conversionEntities.remove(0);
   }
-
-  @Override
-  public long getExpectedRecordCount() {
-    return 1;
-  }
-
-  /**
-   * Watermark is not managed by this extractor.
-   */
-  @Override
-  public long getHighWatermark() {
-    return 0;
-  }
-
-  @Override
-  public void close() throws IOException {
-  }
-
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveConvertExtractorFactory.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/extractor/HiveConvertExtractorFactory.java
@@ -1,0 +1,18 @@
+package gobblin.data.management.conversion.hive.extractor;
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.thrift.TException;
+import gobblin.configuration.WorkUnitState;
+
+
+/**
+ * Factory for {@link HiveConvertExtractor}
+ */
+public class HiveConvertExtractorFactory implements HiveBaseExtractorFactory {
+  public HiveBaseExtractor createExtractor(WorkUnitState state, FileSystem sourceFs)
+      throws IOException, TException, HiveException {
+    return new HiveConvertExtractor(state, sourceFs);
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/publisher/HiveConvertPublisher.java
@@ -49,7 +49,7 @@ import gobblin.data.management.conversion.hive.source.HiveWorkUnit;
 import gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarker;
 import gobblin.data.management.conversion.hive.watermarker.HiveSourceWatermarkerFactory;
 import gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarker;
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.event.EventSubmitter;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -116,6 +116,9 @@ public class HiveSource implements Source {
   private long maxLookBackTime;
   private long beginGetWorkunitsTime;
 
+  private final ClassAliasResolver<HiveBaseExtractorFactory> classAliasResolver =
+      new ClassAliasResolver<>(HiveBaseExtractorFactory.class);
+
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {
     try {
@@ -333,8 +336,7 @@ public class HiveSource implements Source {
   @Override
   public Extractor getExtractor(WorkUnitState state) throws IOException {
     try {
-      return (new ClassAliasResolver<>(HiveBaseExtractorFactory.class))
-          .resolveClass(state.getProp(HIVE_SOURCE_EXTRACTOR_TYPE, DEFAULT_HIVE_SOURCE_EXTRACTOR_TYPE))
+      return classAliasResolver.resolveClass(state.getProp(HIVE_SOURCE_EXTRACTOR_TYPE, DEFAULT_HIVE_SOURCE_EXTRACTOR_TYPE))
           .newInstance().createExtractor(state, getSourceFs());
     } catch (Exception e) {
       throw new IOException(e);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/validation/ValidationJob.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/validation/ValidationJob.java
@@ -69,7 +69,7 @@ import gobblin.data.management.copy.hive.HiveDataset;
 import gobblin.data.management.copy.hive.HiveDatasetFinder;
 import gobblin.data.management.copy.hive.HiveUtils;
 import gobblin.hive.HiveMetastoreClientPool;
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.event.EventSubmitter;

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/writer/HiveQueryExecutionWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/writer/HiveQueryExecutionWriter.java
@@ -20,7 +20,7 @@ import lombok.AllArgsConstructor;
 import gobblin.configuration.State;
 import gobblin.data.management.conversion.hive.entities.QueryBasedHiveConversionEntity;
 import gobblin.data.management.conversion.hive.events.EventWorkunitUtils;
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 import gobblin.writer.DataWriter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/writer/HiveQueryWriterBuilder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/writer/HiveQueryWriterBuilder.java
@@ -17,7 +17,7 @@ import java.sql.SQLException;
 
 import org.apache.avro.Schema;
 
-import gobblin.hive.util.HiveJdbcConnector;
+import gobblin.util.HiveJdbcConnector;
 import gobblin.writer.DataWriter;
 import gobblin.writer.DataWriterBuilder;
 

--- a/gobblin-utility/src/main/java/gobblin/util/HiveJdbcConnector.java
+++ b/gobblin-utility/src/main/java/gobblin/util/HiveJdbcConnector.java
@@ -10,7 +10,7 @@
  * CONDITIONS OF ANY KIND, either express or implied.
  */
 
-package gobblin.hive.util;
+package gobblin.util;
 
 import java.io.Closeable;
 import java.io.File;


### PR DESCRIPTION
Writer to launch an `MRCompactor` job from a local gobblin job using info obtained from hive.

A workunit is created for each hive table. The extractor gets primary key field, delta key field, and file location from the hive metastore and passes these to the writer, which adds them to config for compaction. Compaction is then run on the entire folder for the table, since watermark management is not added yet.

Changes:

- Created extractor, writer, writerBuilder, compaction entity
- Modified `HiveSource` to make extractor configurable
- Fix bug with compaction tmp folder being used in two places by adding a subfolder in `DatasetsFinder`
- Move `HiveJdbcConnector` to gobblin-util

Config for use:
Source: `HiveSource`
Extractor: `HiveMetadataForCompactionExtractor`
DataWriterBuilder: `CompactionLauncherWriterBuilder`
Converter: `IdentityConverter`
Publisher: `NoopPublisher`
DatasetFinder: `SimpleDatasetsFinder`