### PR TITLE
Changing metrics file suffix to attempt id

### DIFF
--- a/gobblin-metrics/src/main/java/gobblin/metrics/GobblinMetrics.java
+++ b/gobblin-metrics/src/main/java/gobblin/metrics/GobblinMetrics.java
@@ -445,10 +445,6 @@ public class GobblinMetrics {
     this.metricsReportingStarted = false;
   }
 
-  protected String getMetricsFileNameIdentifier() {
-    return this.id;
-  }
-
   private void buildFileMetricReporter(Properties properties) {
     if (!Boolean.valueOf(properties.getProperty(ConfigurationKeys.METRICS_REPORTING_FILE_ENABLED_KEY,
         ConfigurationKeys.DEFAULT_METRICS_REPORTING_FILE_ENABLED))) {
@@ -482,7 +478,7 @@ public class GobblinMetrics {
 
       // Each job run gets its own metric log file
       Path metricLogFile =
-          new Path(metricsLogDir, this.getMetricsFileNameIdentifier() + metricsFileSuffix + ".metrics.log");
+          new Path(metricsLogDir, this.id + metricsFileSuffix + ".metrics.log");
       boolean append = false;
       // Append to the metric file if it already exists
       if (fs.exists(metricLogFile)) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -105,6 +105,7 @@ public class TaskState extends WorkUnitState {
     addAll(taskState);
     this.jobId = taskState.getProp(ConfigurationKeys.JOB_ID_KEY);
     this.taskId = taskState.getProp(ConfigurationKeys.TASK_ID_KEY);
+    this.taskAttemptId = taskState.getTaskAttemptId();
     this.setId(this.taskId);
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -580,7 +580,7 @@ public class MRJobLauncher extends AbstractJobLauncher {
           configuration.get(ConfigurationKeys.METRICS_ENABLED_KEY, ConfigurationKeys.DEFAULT_METRICS_ENABLED))) {
         this.jobMetrics = Optional.of(JobMetrics.get(this.jobState));
         this.jobMetrics.get().startMetricReportingWithFileSuffix(HadoopUtils.getStateFromConf(configuration),
-            context.getTaskAttemptID().getTaskID().toString());
+            context.getTaskAttemptID().toString());
       }
     }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
@@ -15,7 +15,6 @@ package gobblin.runtime.util;
 import java.util.List;
 import java.util.concurrent.Callable;
 
-import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
 
 import gobblin.configuration.ConfigurationKeys;
@@ -34,12 +33,10 @@ import gobblin.runtime.TaskState;
 public class TaskMetrics extends GobblinMetrics {
 
   protected final String jobId;
-  private final Optional<String> taskAttemptId;
 
   protected TaskMetrics(TaskState taskState) {
     super(name(taskState), parentContextForTask(taskState), tagsForTask(taskState));
     this.jobId = taskState.getJobId();
-    this.taskAttemptId = taskState.getTaskAttemptId();
   }
 
   /**
@@ -69,11 +66,6 @@ public class TaskMetrics extends GobblinMetrics {
 
   private static String name(TaskState taskState) {
     return "gobblin.metrics." + taskState.getJobId() + "." + taskState.getTaskId();
-  }
-
-  @Override
-  protected String getMetricsFileNameIdentifier() {
-    return this.id + (this.taskAttemptId.isPresent() ? "." + this.taskAttemptId.get() : "");
   }
 
   protected static List<Tag<?>> tagsForTask(TaskState taskState) {


### PR DESCRIPTION
Revert the change of having a customized `getMetricsFileNameIdentifier` from #1382 since it is not necessary. Change `MRJobLauncher` to use `AttemptId` as file suffix. 

@ibuenros Can you review? 