### PR TITLE
Catch socket exception and suppress connection reset error to prevent…

### DIFF
--- a/gobblin-tunnel/src/test/java/gobblin/tunnel/TestTunnelWithArbitraryTCPTraffic.java
+++ b/gobblin-tunnel/src/test/java/gobblin/tunnel/TestTunnelWithArbitraryTCPTraffic.java
@@ -64,7 +64,7 @@ public class TestTunnelWithArbitraryTCPTraffic {
     delayedDoubleEchoServer = startDoubleEchoServer(1000);
     LOG.info("Delayed DoubleEchoServer on " + delayedDoubleEchoServer.getServerSocketPort());
     talkFirstEchoServer = startTalkFirstEchoServer();
-    LOG.info("TalkFirstEchoServer on " + delayedDoubleEchoServer.getServerSocketPort());
+    LOG.info("TalkFirstEchoServer on " + talkFirstEchoServer.getServerSocketPort());
   }
 
   @AfterClass
@@ -527,7 +527,11 @@ public class TestTunnelWithArbitraryTCPTraffic {
       String response0 = readFromSocket(client);
       LOG.info(response0);
 
-      client.write(ByteBuffer.wrap("Knock\n".getBytes()));
+      // write a lot of data to increase chance of response after close
+      for (int i = 0; i < 1000; i++) {
+        client.write(ByteBuffer.wrap("Knock\n".getBytes()));
+      }
+
       // don't wait for response
       client.close();
 


### PR DESCRIPTION
… the TalkFirstDoubleEchoServer from aborting when the client socket is closed.  There is a test case that closes the client socket before receiving the server response.