### PR TITLE
Fix bytesWritten in FsDataWriter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -88,15 +88,6 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
     return this.count.get();
   }
 
-  @Override
-  public synchronized long bytesWritten() throws IOException {
-    if (!this.fs.exists(this.outputFile)) {
-      return 0;
-    }
-
-    return this.fs.getFileStatus(this.outputFile).getLen();
-  }
-
   /**
    * Create a new {@link DataFileWriter} for writing Avro records.
    *

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTaskStateTracker.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTaskStateTracker.java
@@ -64,9 +64,6 @@ public class MRTaskStateTracker extends AbstractTaskStateTracker {
   @Override
   public void onTaskRunCompletion(Task task) {
     task.markTaskCompletion();
-    LOG.info(String
-        .format("Task %s completed running in %dms with state %s", task.getTaskId(), task.getTaskState().getTaskDuration(),
-            task.getTaskState().getWorkingState()));
   }
 
   @Override
@@ -82,6 +79,9 @@ public class MRTaskStateTracker extends AbstractTaskStateTracker {
         updateCounters(task);
       }
     }
+    LOG.info(String
+        .format("Task %s completed running in %dms with state %s", task.getTaskId(), task.getTaskState().getTaskDuration(),
+            task.getTaskState().getWorkingState()));
   }
 
   /**


### PR DESCRIPTION
Current `AvroHdfsDataWriter` checks `outputFile` length to get the `bytesWritten`. This is a issue when `TaskPublisher` is enabled, because `outputFile` is moved by `TaskPublisher`, and `bytesWritten` always returns 0 or throws `FileNotFoundException`.

To fix this issue, `FileStatus` is recorded in `FsDataWriter`, and so is `bytesWritten`. Also, `synchronized` in the method `bytesWritten()` is no longer necessary here, which is added in #494. 
