### PR TITLE
Get rid of fixed ZK ports in unit tests

### DIFF
--- a/gobblin-runtime/src/test/java/gobblin/runtime/locks/JobLockFactoryTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/locks/JobLockFactoryTest.java
@@ -12,16 +12,16 @@
 
 package gobblin.runtime.locks;
 
-import java.io.Closeable;
 import java.io.IOException;
 import java.util.Properties;
 
-import com.google.common.io.Closer;
 import org.apache.curator.test.TestingServer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
+
+import com.google.common.io.Closer;
 
 import gobblin.configuration.ConfigurationKeys;
 
@@ -102,7 +102,7 @@ public class JobLockFactoryTest {
   public void testGetZookeeperBasedJobLock() throws Exception {
     Closer closer = Closer.create();
     try {
-      TestingServer testingServer = closer.register(new TestingServer(11111));
+      TestingServer testingServer = closer.register(new TestingServer(-1));
       Properties properties = new Properties();
       properties.setProperty(ConfigurationKeys.JOB_NAME_KEY, "JobLockFactoryTest-" + System.currentTimeMillis());
       properties.setProperty(ConfigurationKeys.JOB_LOCK_TYPE, ZookeeperBasedJobLock.class.getName());

--- a/gobblin-runtime/src/test/java/gobblin/runtime/locks/ZookeeperBasedJobLockTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/locks/ZookeeperBasedJobLockTest.java
@@ -1,13 +1,14 @@
 package gobblin.runtime.locks;
 
-import gobblin.configuration.ConfigurationKeys;
+import java.io.IOException;
+import java.util.Properties;
+
 import org.apache.curator.test.TestingServer;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import java.io.IOException;
-import java.util.Properties;
+import gobblin.configuration.ConfigurationKeys;
 
 /**
  * Unit test for {@link ZookeeperBasedJobLock}.
@@ -16,12 +17,11 @@ import java.util.Properties;
  */
 @Test(groups = {"gobblin.runtime"})
 public class ZookeeperBasedJobLockTest extends JobLockTest {
-  private static final int TEST_ZK_PORT = 22222;
   private TestingServer testingServer;
 
   @BeforeClass
   public void setUp() throws Exception {
-    testingServer = new TestingServer(TEST_ZK_PORT);
+    testingServer = new TestingServer(-1);
   }
 
   @Override
@@ -39,6 +39,7 @@ public class ZookeeperBasedJobLockTest extends JobLockTest {
     return lock;
   }
 
+  @Override
   @AfterClass
   public void tearDown() throws IOException {
     if (testingServer != null) {


### PR DESCRIPTION
TestingServer allows using of port -1 which means -- pick a random port. We just have to make sure that job configs are modified dynamically.

@abti Can you verify?