### PR TITLE
Handle race conditions involving rename in LocalFileSystem.

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/RateControlledFileSystem.java
+++ b/gobblin-utility/src/main/java/gobblin/util/RateControlledFileSystem.java
@@ -12,6 +12,7 @@
 
 package gobblin.util;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.List;
@@ -23,6 +24,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -139,8 +141,24 @@ public class RateControlledFileSystem extends FileSystem implements Decorator {
 
   @Override
   public boolean rename(Path path0, Path path1) throws IOException {
+    boolean renamed;
+
     this.acquirePermit();
-    return this.fs.rename(path0, path1);
+
+    // Use Java rename when renaming a directory for LocalFileSystem.
+    // This is to avoid the directory being copied into a subdirectory of the same name by LocalFileSystem rename due
+    // to a race condition where another thread created the directory after this one decided to rename.
+    if (fs instanceof LocalFileSystem && fs.isDirectory(path0)) {
+      File srcFile = ((LocalFileSystem)fs).pathToFile(path0);
+      File dstFile = ((LocalFileSystem)fs).pathToFile(path1);
+
+      renamed = srcFile.renameTo(dstFile);
+    }
+    else {
+      renamed = this.fs.rename(path0, path1);
+    }
+
+    return renamed;
   }
 
   @Override


### PR DESCRIPTION
One race condition is when a directory D1/a/b/c/d is renamed to D2/a/b/c/d after another thread created D2/a/b/c/d.
This resulted in D2/a/b/c/d/d. Handle this by using the Java renameTo() method to avoid the LocalFileSystem fallback of copy.
The copy fallback also results in a race condition when a file is opened for copy in one thread and the parent directory is createed in another thread. A file not found exception is encountered in this case. This case is handled by catching the exception and retrying a few times.