### PR TITLE
Change instance check to class name check since returned instance fro…

### DIFF
--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestImmutableFSJobCatalog.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/TestImmutableFSJobCatalog.java
@@ -41,7 +41,8 @@ public class TestImmutableFSJobCatalog {
 
     Assert.assertEquals(cfgAccessor1.getJobConfDir(), "/tmp");
     Assert.assertEquals(cfgAccessor1.getJobConfDirPath(), new Path("/tmp"));
-    Assert.assertEquals(cfgAccessor1.getJobConfDirFileSystem(), FileSystem.get(new Configuration()));
+    Assert.assertEquals(cfgAccessor1.getJobConfDirFileSystem().getClass(),
+        FileSystem.get(new Configuration()).getClass());
     Assert.assertEquals(cfgAccessor1.getPollingInterval(),
         ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL);
 


### PR DESCRIPTION
…m cache is not guaranteed to match.