### PR TITLE
Fix a race condition in KafkaJobMonitorTest

### DIFF
--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_monitor/KafkaJobMonitorTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_monitor/KafkaJobMonitorTest.java
@@ -18,7 +18,6 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
-import com.typesafe.config.ConfigFactory;
 
 import gobblin.runtime.kafka.HighLevelConsumerTest;
 
@@ -47,7 +46,7 @@ public class KafkaJobMonitorTest {
     Assert.assertFalse(monitor.getJobSpecs().containsKey(new URI("job1")));
     Assert.assertTrue(monitor.getJobSpecs().containsKey(new URI("job2")));
 
-    monitor.getMockKafkaStream().pushToStream("job1:2,job2:2");
+    monitor.getMockKafkaStream().pushToStream("job2:2,job1:2");
     monitor.awaitExactlyNSpecs(2);
     Assert.assertTrue(monitor.getJobSpecs().containsKey(new URI("job1")));
     Assert.assertEquals(monitor.getJobSpecs().get(new URI("job1")).getVersion(), "2");

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_monitor/MockedKafkaJobMonitor.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_monitor/MockedKafkaJobMonitor.java
@@ -19,6 +19,8 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
+import javax.annotation.Nullable;
+
 import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -36,7 +38,6 @@ import gobblin.runtime.api.MutableJobCatalog;
 import gobblin.testing.AssertWithBackoff;
 import gobblin.util.Either;
 
-import javax.annotation.Nullable;
 import kafka.consumer.KafkaStream;
 import kafka.javaapi.consumer.ConsumerConnector;
 import lombok.Getter;
@@ -141,6 +142,6 @@ class MockedKafkaJobMonitor extends KafkaJobMonitor {
       public boolean apply(@Nullable Void input) {
         return MockedKafkaJobMonitor.this.jobSpecs.size() == n;
       }
-    }, 1000, n + " specs", log, 2, 1000);
+    }, 30000, n + " specs", log, 2, 1000);
   }
 }


### PR DESCRIPTION
There is a slight race condition in KafkaJobMonitorTest, where monitor.awaitExactlyNSpecs(2) can pass right after job1:2 is added and before job2:2 is added. In that case, the assert Assert.assertEquals(monitor.getJobSpecs().get(new URI("job2")).getVersion(), "2") might fail.

This changes the order of adding the new JobSpecs.

@ibuenros can you review?