### PR TITLE
Propagate FinalState from RetryWriter and ThrottleWriter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/RetryWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/RetryWriter.java
@@ -187,7 +187,7 @@ public class RetryWriter<D> implements DataWriter<D>, FinalState, SpeculativeAtt
       LOG.warn("Wrapped writer does not implement FinalState: " + this.writer.getClass());
     }
 
-    state.setProp(FAILED_WRITES_KEY, failedWrites);
+    state.setProp(FAILED_WRITES_KEY, this.failedWrites);
     return state;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
@@ -146,7 +146,7 @@ public class ThrottleWriter<D> implements DataWriter<D>, FinalState, Retriable {
     if (throttledTimer.isPresent()) { // Metrics enabled
       Instrumented.updateTimer(throttledTimer, permitAcquisitionTime, TimeUnit.MILLISECONDS);
     }
-    throttledTime += permitAcquisitionTime;
+    this.throttledTime += permitAcquisitionTime;
   }
 
 
@@ -195,7 +195,7 @@ public class ThrottleWriter<D> implements DataWriter<D>, FinalState, Retriable {
       LOG.warn("Wrapped writer does not implement FinalState: " + this.writer.getClass());
     }
 
-    state.setProp(THROTTLED_TIME_KEY, throttledTime);
+    state.setProp(THROTTLED_TIME_KEY, this.throttledTime);
     return state;
   }
 }

--- a/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
@@ -17,6 +17,7 @@ import java.io.IOException;
 
 import gobblin.configuration.State;
 import gobblin.writer.exception.NonTransientException;
+import gobblin.util.FinalState;
 
 import org.junit.Assert;
 import org.testng.annotations.Test;
@@ -60,5 +61,15 @@ public class RetryWriterTest {
     retryWriter.write(null);
 
     verify(writer, times(1)).write(null);
+  }
+
+  public void retryGetFinalState() throws IOException {
+    PartitionedDataWriter writer = mock(PartitionedDataWriter.class);
+
+    DataWriterWrapperBuilder<Void> builder = new DataWriterWrapperBuilder<>(writer, new State());
+    DataWriter<Void> retryWriter = builder.build();
+    ((FinalState)retryWriter).getFinalState();
+
+    verify(writer, times(1)).getFinalState();
   }
 }

--- a/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
@@ -64,7 +64,7 @@ public class RetryWriterTest {
   }
 
   public void retryGetFinalState() throws IOException {
-    PartitionedDataWriter writer = mock(PartitionedDataWriter.class);
+    PartitionedDataWriter writer = mock(PartitionedDataWriter.class, Mockito.CALLS_REAL_METHODS);
 
     DataWriterWrapperBuilder<Void> builder = new DataWriterWrapperBuilder<>(writer, new State());
     DataWriter<Void> retryWriter = builder.build();

--- a/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
@@ -64,7 +64,8 @@ public class RetryWriterTest {
   }
 
   public void retryGetFinalState() throws IOException {
-    PartitionedDataWriter writer = mock(PartitionedDataWriter.class, Mockito.CALLS_REAL_METHODS);
+    PartitionedDataWriter writer = mock(PartitionedDataWriter.class);
+    when(writer.getFinalState()).thenReturn(new State());
 
     DataWriterWrapperBuilder<Void> builder = new DataWriterWrapperBuilder<>(writer, new State());
     DataWriter<Void> retryWriter = builder.build();

--- a/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
@@ -19,6 +19,7 @@ import java.util.concurrent.TimeUnit;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.writer.ThrottleWriter.ThrottleType;
+import gobblin.util.FinalState;
 
 import org.apache.commons.lang3.mutable.MutableLong;
 import org.mockito.invocation.InvocationOnMock;
@@ -46,7 +47,6 @@ public class ThrottleWriterTest {
       count++;
     }
 
-    System.out.println(count);
     int expected = (int) (qps * duration);
     Assert.assertTrue(count <= expected + qps * 2, "Request too high " + count + " , QPS " + qps + " for duration " + duration + " second ");
     Assert.assertTrue(count >= expected - qps * 2, "Request too low " + count + " , QPS " + qps + " for duration " + duration + " second ");
@@ -75,10 +75,20 @@ public class ThrottleWriterTest {
       count++;
     }
 
-    System.out.println(count);
     int expected = (int) (bps * duration);
     Assert.assertTrue(count <= expected + bps * 2);
     Assert.assertTrue(count >= expected - bps * 2);
+  }
+
+  public void testGetFinalState() throws IOException {
+    PartitionedDataWriter writer = mock(PartitionedDataWriter.class);
+    int parallelism = 2;
+    int qps = 4;
+    DataWriter<Void> throttleWriter = setup(writer, parallelism, qps, ThrottleType.QPS);
+
+    ((FinalState)throttleWriter).getFinalState();
+
+    verify(writer, times(1)).getFinalState();
   }
 
   private DataWriter<Void> setup(DataWriter<Void> writer, int parallelism, int rate, ThrottleType type) throws IOException {

--- a/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
@@ -81,7 +81,9 @@ public class ThrottleWriterTest {
   }
 
   public void testGetFinalState() throws IOException {
-    PartitionedDataWriter writer = mock(PartitionedDataWriter.class, Mockito.CALLS_REAL_METHODS);
+    PartitionedDataWriter writer = mock(PartitionedDataWriter.class);
+    when(writer.getFinalState()).thenReturn(new State());
+
     int parallelism = 2;
     int qps = 4;
     DataWriter<Void> throttleWriter = setup(writer, parallelism, qps, ThrottleType.QPS);

--- a/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
@@ -81,7 +81,7 @@ public class ThrottleWriterTest {
   }
 
   public void testGetFinalState() throws IOException {
-    PartitionedDataWriter writer = mock(PartitionedDataWriter.class);
+    PartitionedDataWriter writer = mock(PartitionedDataWriter.class, Mockito.CALLS_REAL_METHODS);
     int parallelism = 2;
     int qps = 4;
     DataWriter<Void> throttleWriter = setup(writer, parallelism, qps, ThrottleType.QPS);


### PR DESCRIPTION
Writer bytesWritten and recordsWritten metrics are not being propagated through because DataWriters are now wrapped with RetryWriter, and ThrottleWriter depending on the configuration.

The call hierarchy is now RetryWriter -> [ThrottleWriter ->] DataWriter. Since RetryWriter and ThrottleWriter are not implementing the FinalState interface, Fork.getFinalState is skipping the getFinalState invocation to include the Writer Constructs into the state.

This fix implements FinalState in the RetryWriter and ThrottleWriter to address the issue.