### PR TITLE
Workaround for inconsistent behavior of MysqlExtractor with tinyint(1)

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/MysqlExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/MysqlExtractor.java
@@ -12,15 +12,6 @@
 
 package gobblin.source.extractor.extract.jdbc;
 
-import gobblin.source.extractor.DataRecordException;
-import gobblin.source.extractor.exception.HighWatermarkException;
-import gobblin.source.extractor.exception.RecordCountException;
-import gobblin.source.extractor.exception.SchemaException;
-import gobblin.source.extractor.extract.Command;
-import gobblin.source.extractor.utils.Utils;
-import gobblin.source.extractor.watermark.Predicate;
-import gobblin.source.extractor.watermark.WatermarkType;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -35,7 +26,16 @@ import com.google.gson.JsonElement;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.extractor.exception.HighWatermarkException;
+import gobblin.source.extractor.exception.RecordCountException;
+import gobblin.source.extractor.exception.SchemaException;
+import gobblin.source.extractor.extract.Command;
+import gobblin.source.extractor.utils.Utils;
+import gobblin.source.extractor.watermark.Predicate;
+import gobblin.source.extractor.watermark.WatermarkType;
 import gobblin.source.workunit.WorkUnit;
+
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -175,6 +175,12 @@ public class MysqlExtractor extends JdbcExtractor {
       return url + "?useCompression=true";
     }
     return url;
+  }
+
+  /** {@inheritdoc} */
+  @Override
+  protected boolean convertBitToBoolean() {
+    return false;
   }
 
   @Override


### PR DESCRIPTION
… columns

See ETL-5244

There is a bug in the MysqlExtractor where tinyint columns are always treated as ints.
There are MySQL jdbc driver setting (tinyInt1isBit=true and transformedBitIsBoolean=false) that
 can cause tinyint(1) columns to be treated as BIT/BOOLEAN columns. The default behavior is to
 treat tinyint(1) as BIT.
 
 Currently, {@link MysqlExtractor#getDataTypeMap()} uses the information_schema to check types.
 That does not do the above conversion. {@link #parseColumnAsString(ResultSet, ResultSetMetaData, int)}
 which does the above type mapping.
 
 On the other hand, SqlServerExtractor treats BIT columns as Booleans. So we can be in a bind
 where sometimes BIT has to be converted to an int (for backwards compatibility in MySQL) and
 sometimes to a Boolean (for SqlServer).

The fix is to add gobblin.source.extractor.extract.jdbc.JdbcExtractor.convertBitToBoolean() which returns true for everything but MySQL.