### PR TITLE
Fix some issues for compaction launched from writer

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/CompactionLauncherWriter.java
@@ -4,6 +4,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Properties;
+import org.apache.hadoop.fs.Path;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Joiner;
@@ -32,6 +33,14 @@ public class CompactionLauncherWriter implements DataWriter<MRCompactionEntity> 
     props.setProperty(ConfBasedDeltaFieldProvider.DELTA_FIELDS_KEY,
         Joiner.on(',').join(compactionEntity.getDeltaList()));
     props.setProperty(MRCompactor.COMPACTION_INPUT_DIR, compactionEntity.getDataFilesPath().toString());
+
+    String dbTableName = compactionEntity.getDataFilesPath().getName();
+    String timestamp = String.valueOf(System.currentTimeMillis());
+
+    props.setProperty(MRCompactor.COMPACTION_TMP_DEST_DIR,
+        new Path(props.getProperty(MRCompactor.COMPACTION_TMP_DEST_DIR), dbTableName).toString());
+    props.setProperty(MRCompactor.COMPACTION_DEST_DIR,
+        new Path(new Path(props.getProperty(MRCompactor.COMPACTION_DEST_DIR), dbTableName), timestamp).toString());
 
     MRCompactor compactor = new MRCompactor(props, list, Optional.<CompactorListener>absent());
     compactor.compact();

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
@@ -11,12 +11,10 @@ import org.apache.thrift.TException;
 import com.google.common.base.Splitter;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
-import gobblin.data.management.conversion.hive.avro.AvroSchemaManager;
 import gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarker;
 import gobblin.source.extractor.Extractor;
 import gobblin.util.AutoReturnableObject;
 import gobblin.data.management.conversion.hive.extractor.HiveBaseExtractor;
-import gobblin.publisher.TimestampDataPublisher;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -50,9 +48,7 @@ public class HiveMetadataForCompactionExtractor extends HiveBaseExtractor<Void, 
       String deltaString = table.getParameters().get(state.getProp(COMPACTION_DELTA));
       List<String> deltaList = Splitter.on(',').omitEmptyStrings().trimResults().splitToList(deltaString);
 
-      String dbTableName = TimestampDataPublisher.getDbTableName(
-          AvroSchemaManager.getSchemaFromUrl(this.hiveWorkUnit.getTableSchemaUrl(), fs).getName());
-      Path dataFilesPath = new Path(table.getSd().getLocation(), dbTableName);
+      Path dataFilesPath = new Path(table.getSd().getLocation());
 
       compactionEntity = new MRCompactionEntity(primaryKeyList, deltaList, dataFilesPath, state.getProperties());
     }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/hivebasedconstructs/HiveMetadataForCompactionExtractor.java
@@ -16,6 +16,7 @@ import gobblin.data.management.conversion.hive.watermarker.PartitionLevelWaterma
 import gobblin.source.extractor.Extractor;
 import gobblin.util.AutoReturnableObject;
 import gobblin.data.management.conversion.hive.extractor.HiveBaseExtractor;
+import gobblin.publisher.TimestampDataPublisher;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -49,8 +50,9 @@ public class HiveMetadataForCompactionExtractor extends HiveBaseExtractor<Void, 
       String deltaString = table.getParameters().get(state.getProp(COMPACTION_DELTA));
       List<String> deltaList = Splitter.on(',').omitEmptyStrings().trimResults().splitToList(deltaString);
 
-      String topicName = AvroSchemaManager.getSchemaFromUrl(this.hiveWorkUnit.getTableSchemaUrl(), fs).getName();
-      Path dataFilesPath = new Path(table.getSd().getLocation(), topicName);
+      String dbTableName = TimestampDataPublisher.getDbTableName(
+          AvroSchemaManager.getSchemaFromUrl(this.hiveWorkUnit.getTableSchemaUrl(), fs).getName());
+      Path dataFilesPath = new Path(table.getSd().getLocation(), dbTableName);
 
       compactionEntity = new MRCompactionEntity(primaryKeyList, deltaList, dataFilesPath, state.getProperties());
     }

--- a/gobblin-core/src/main/java/gobblin/publisher/TimestampDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimestampDataPublisher.java
@@ -82,7 +82,7 @@ public class TimestampDataPublisher extends BaseDataPublisher {
    * @param schemaName In format "dbname_tablename_xxxxx"
    * @return db and table name in format "dbname.tablename"
    */
-  public static String getDbTableName(String schemaName) {
+  private String getDbTableName(String schemaName) {
     Preconditions.checkArgument(schemaName.matches(".+_.+_.+"));
     return schemaName.replaceFirst("_", ".").substring(0, schemaName.lastIndexOf('_'));
   }

--- a/gobblin-core/src/main/java/gobblin/publisher/TimestampDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/TimestampDataPublisher.java
@@ -82,7 +82,7 @@ public class TimestampDataPublisher extends BaseDataPublisher {
    * @param schemaName In format "dbname_tablename_xxxxx"
    * @return db and table name in format "dbname.tablename"
    */
-  private String getDbTableName(String schemaName) {
+  public static String getDbTableName(String schemaName) {
     Preconditions.checkArgument(schemaName.matches(".+_.+_.+"));
     return schemaName.replaceFirst("_", ".").substring(0, schemaName.lastIndexOf('_'));
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -106,6 +106,9 @@ public class HiveSource implements Source {
   public static final String HIVE_SOURCE_EXTRACTOR_TYPE = "hive.source.extractorType";
   public static final String DEFAULT_HIVE_SOURCE_EXTRACTOR_TYPE = HiveConvertExtractorFactory.class.getName();
 
+  public static final String HIVE_SOURCE_CREATE_WORKUNITS_FOR_PARTITIONS = "hive.source.createWorkunitsForPartitions";
+  public static final boolean DEFAULT_HIVE_SOURCE_CREATE_WORKUNITS_FOR_PARTITIONS = true;
+
   /***
    * Comma separated list of keywords to look for in path of table (in non-partitioned case) / partition (in partitioned case)
    * and if the keyword is found then ignore the table / partition from processing.
@@ -153,7 +156,9 @@ public class HiveSource implements Source {
           log.debug(String.format("Processing dataset: %s", hiveDataset));
 
           // Create workunits for partitions
-          if (HiveUtils.isPartitioned(hiveDataset.getTable())) {
+          if (HiveUtils.isPartitioned(hiveDataset.getTable())
+              && state.getPropAsBoolean(HIVE_SOURCE_CREATE_WORKUNITS_FOR_PARTITIONS,
+              DEFAULT_HIVE_SOURCE_CREATE_WORKUNITS_FOR_PARTITIONS)) {
             createWorkunitsForPartitionedTable(hiveDataset, client);
           } else {
             createWorkunitForNonPartitionedTable(hiveDataset);


### PR DESCRIPTION
Changes:

In `CompactionLauncherWriter`
- Add table name as a subdir to compaction tmp path to avoid workunits using conflicting tmp paths
- Add table name and timestamp to compaction destination path

In `HiveMetadataForCompactionExtractor`
- Convert db/table name to "db.table" format in the path to match `TimestampDataPublisher` output

In `HiveSource`
- Add config key to allow a partitioned table to have one workunit per table instead of one workunit per partition