### PR TITLE
Adding gobblin-compliance module

### DIFF
--- a/gobblin-core/gobblin-flavor-full.gradle
+++ b/gobblin-core/gobblin-flavor-full.gradle
@@ -3,5 +3,6 @@ dependencies {
   compile project(':gobblin-modules:gobblin-couchbase')
   // For backwards compatibility
   compile project(':gobblin-modules:google-ingestion')
+  compile project(':gobblin-modules:gobblin-compliance')
 }
 

--- a/gobblin-core/gobblin-flavor-standard.gradle
+++ b/gobblin-core/gobblin-flavor-standard.gradle
@@ -2,5 +2,6 @@ dependencies {
   compile project(':gobblin-modules:gobblin-kafka-08')
   // For backwards compatibility
   compile project(':gobblin-modules:google-ingestion')
+  compile project(':gobblin-modules:gobblin-compliance')
 }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -13,6 +13,7 @@
 package gobblin.data.management.copy.hive;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -27,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.ql.metadata.Partition;
 import org.apache.hadoop.hive.ql.metadata.Table;
 
 import com.google.common.annotations.VisibleForTesting;
@@ -52,6 +55,7 @@ import gobblin.hive.HiveMetastoreClientPool;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.metrics.Tag;
+import gobblin.util.AutoReturnableObject;
 import gobblin.util.ConfigUtils;
 import gobblin.util.PathUtils;
 import gobblin.util.request_allocation.PushDownRequestor;
@@ -280,5 +284,29 @@ public class HiveDataset implements PrioritizedCopyableDataset {
     }
 
     return ConfigUtils.propertiesToConfig(resolvedProperties);
+  }
+
+  /**
+   * Sort all partitions inplace on the basis of complete name ie dbName.tableName.partitionName
+   */
+  public static List<Partition> sortPartitions(List<Partition> partitions) {
+    Collections.sort(partitions, new Comparator<Partition>() {
+      @Override
+      public int compare(Partition o1, Partition o2) {
+        return o1.getCompleteName().compareTo(o2.getCompleteName());
+      }
+    });
+    return partitions;
+  }
+
+  /**
+   * This method returns a sorted list of partitions.
+   */
+  public List<Partition> getPartitionsFromDataset() throws IOException{
+    try (AutoReturnableObject<IMetaStoreClient> client = getClientPool().getClient()) {
+      List<Partition> partitions =
+          HiveUtils.getPartitions(client.get(), getTable(), Optional.<String>absent());
+      return sortPartitions(partitions);
+    }
   }
 }

--- a/gobblin-modules/gobblin-compliance/build.gradle
+++ b/gobblin-modules/gobblin-compliance/build.gradle
@@ -1,0 +1,22 @@
+// Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+// this file except in compliance with the License. You may obtain a copy of the
+// License at  http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software distributed
+// under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+// CONDITIONS OF ANY KIND, either express or implied.
+
+apply plugin: 'java'
+
+dependencies {
+  compile project(":gobblin-data-management")
+}
+
+test {
+  workingDir rootProject.rootDir
+}
+
+ext.classification="library"
+

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/ComplianceRecord.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/ComplianceRecord.java
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.ImmutableList;
+
+import lombok.Builder;
+import lombok.Getter;
+
+
+/**
+ * Record type used by gobblin-compliance.
+ * It contains all the necessary information needed for purging.
+ *
+ * @author adsharma
+ */
+@Getter
+@Builder
+public class ComplianceRecord extends QueryBaseHivePartitionRecord {
+  private static final Splitter EQUALITY_SPLITTER = Splitter.on("=").omitEmptyStrings().trimResults();
+  private static final Splitter SLASH_SPLITTER = Splitter.on("/").omitEmptyStrings().trimResults();
+  private static final Splitter AT_SPLITTER = Splitter.on("@").omitEmptyStrings().trimResults();
+  private static final String SINGLE_QUOTE = "'";
+
+  private String complianceIdTable;
+  private String complianceIdentifier;
+  private String stagingDir;
+  private String stagingDb;
+  private Boolean commit;
+  private String timeStamp;
+  private String datasetComplianceId;
+
+  public void setPurgeQueries(List<String> purgeQueries) {
+    this.queries = purgeQueries;
+  }
+
+  public String getDbName() {
+    return this.hivePartition.getTable().getDbName();
+  }
+
+  public String getTableName() {
+    return this.hivePartition.getTable().getTableName();
+  }
+
+  public String getCompleteStagingTableName() {
+    return this.stagingDb + "." + HivePurgerConfigurationKeys.STAGING_PREFIX + this.timeStamp + "_" + getTableName();
+  }
+
+  public String getCompleteOriginalTableName() {
+    return getDbName() + "." + getTableName();
+  }
+
+  public String getStagingTableLocation() {
+    return this.stagingDir + this.timeStamp + "/" + getTableName();
+  }
+
+  public String getPartitionName() {
+    return this.hivePartition.getName();
+  }
+
+  public String getStagingPartitionLocation() {
+    return getStagingTableLocation() + "/" + getPartitionName();
+  }
+
+  public String getTableLocation() {
+    return this.hivePartition.getTable().getDataLocation().toString();
+  }
+
+  public String getFinalDirLocation() {
+    return getTableLocation() + "/" + this.timeStamp;
+  }
+
+  public String getFinalPartitionLocation() {
+    return getFinalDirLocation() + "/" + getPartitionName();
+  }
+
+  /**
+   * Add single quotes to the string, if not present.
+   * TestString will be converted to 'TestString'
+   */
+  public static String getQuotedString(String st) {
+    Preconditions.checkNotNull(st);
+    String quotedString = "";
+    if (!st.startsWith(SINGLE_QUOTE)) {
+      quotedString += SINGLE_QUOTE;
+    }
+    quotedString += st;
+    if (!st.endsWith(SINGLE_QUOTE)) {
+      quotedString += SINGLE_QUOTE;
+    }
+    return quotedString;
+  }
+
+  /**
+   * This method splits the multiple partitions separated by '/' to list.
+   * datepartition=2016-01-01-00/size=12345 will be [datepartition=2016-01-01-00, size=12345]
+   * All "/" in the partition values are converted to %2 by Hive.
+   */
+  public List<String> getPartitionValues() {
+    return ImmutableList.<String>builder().addAll(SLASH_SPLITTER.splitToList(getPartitionName())).build();
+  }
+
+  /**
+   * This method splits the string on the basis of '=' into key value pairs and also add quotes to the values.
+   * [datepartition=2016-01-01-00, size=12345] will be [datepartition : '2016-01-01-00', size : '12345']
+   * All "=" in the partition values are converted to %3 by Hive.
+   */
+  public Map<String, String> getPartitionMap() {
+    Map<String, String> partitionMap = new LinkedHashMap<>();
+    for (String st : getPartitionValues()) {
+      final List<String> list = EQUALITY_SPLITTER.splitToList(st);
+      Preconditions.checkArgument(list.size() == 2, "Wrong partitioned value " + st);
+      String key = list.get(0);
+      String value = list.get(1);
+      value = getQuotedString(value);
+      partitionMap.put(key, value);
+    }
+    return partitionMap;
+  }
+
+  /**
+   * This method returns partitioning column names separated by comma.
+   * [datepartition=2016-01-01-00, size=12345] will be datepartition, size
+   */
+  public String getCommaSeparatedPartitionColumnNames() {
+    StringBuilder sb = new StringBuilder();
+    for (String partitionName : getPartitionMap().keySet()) {
+      if (!sb.toString().isEmpty()) {
+        sb.append(",");
+      }
+      sb.append(partitionName);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * This method builds the where clause for the insertion query.
+   * If prefix is a, then it builds a.datepartition='2016-01-01-00' AND a.size='12345' from [datepartition : '2016-01-01-00', size : '12345']
+   */
+  public String getWhereClauseForPartition(String prefix) {
+    StringBuilder sb = new StringBuilder();
+    for (String partitionName : getPartitionMap().keySet()) {
+      if (!sb.toString().isEmpty()) {
+        sb.append(" AND ");
+      }
+      sb.append(prefix + partitionName);
+      sb.append("=");
+      sb.append(getPartitionMap().get(partitionName));
+    }
+    return sb.toString();
+  }
+
+  /**
+   * This method returns the partition spec of the partition.
+   * Example : (datepartition='2016-01-01-00', size='12345')
+   */
+  public String getPartitionSpec() {
+    StringBuilder sb = new StringBuilder();
+    for (String partitionName : getPartitionMap().keySet()) {
+      if (!sb.toString().isEmpty()) {
+        sb.append(",");
+      }
+      sb.append(partitionName);
+      sb.append("=");
+      sb.append(getPartitionMap().get(partitionName));
+    }
+    return sb.toString();
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/ComplianceRecordSchema.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/ComplianceRecordSchema.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+/**
+ * Dummy class for the {@link ComplianceRecord} schema.
+ *
+ * @author adsharma
+ */
+public class ComplianceRecordSchema {
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/DatasetDescriptor.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/DatasetDescriptor.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+/**
+ * Each Hive Dataset using gobblin-compliance for their compliance needs, must contain a dataset.descriptor property
+ * in the tblproperties of a Hive Dataset.
+ *
+ * A dataset.descriptor is a description of a Hive dataset in the Json format.
+ *
+ * A compliance id is a column name in a Hive dataset to decide which records should be purged.
+ *
+ * A dataset.descriptor must contain an identifier whose value corresponds the column name containing compliance id.
+ *
+ * Path to the identifier must be specified in the job properties file
+ * via property dataset.descriptor.identifier.
+ *
+ * Example : dataset.descriptor = {Database : Repos, Owner : GitHub, ComplianceInfo : {IdentifierType : GitHubId}}
+ * If IdentifierType corresponds to the identifier and GithubId is the compliance id column name, then
+ * dataset.descriptor.identifier = ComplianceInfo.IdentifierType
+ *
+ * @author adsharma
+ */
+public interface DatasetDescriptor {
+  public String getComplianceId();
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/DatasetDescriptorImpl.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/DatasetDescriptorImpl.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.util.List;
+
+import com.google.common.base.Splitter;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+
+/**
+ * This is the default implementation of {@link DatasetDescriptor}
+ *
+ * @author adsharma
+ */
+public class DatasetDescriptorImpl implements DatasetDescriptor {
+  private static final Splitter DOT_SPLITTER = Splitter.on(".").omitEmptyStrings().trimResults();
+  private String complianceId;
+
+  /**
+   *
+   * @param descriptor is the JsonString corresponding to the value of dataset.descriptor.
+   * @param identifierField is the path to the identifier in the dataset.descriptor.
+   */
+  public DatasetDescriptorImpl(String descriptor, String identifierField) {
+    JsonObject descriptorObject = new JsonParser().parse(descriptor).getAsJsonObject();
+    List<String> list = DOT_SPLITTER.splitToList(identifierField);
+    for (int i = 0; i < list.size() - 1; i++) {
+      descriptorObject = descriptorObject.getAsJsonObject(list.get(i));
+    }
+    this.complianceId = descriptorObject.get(list.get(list.size() - 1)).getAsString();
+  }
+
+  /**
+   * Array is not supported
+   */
+  public String getComplianceId() {
+    return this.complianceId;
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerConfigurationKeys.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerConfigurationKeys.java
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+/**
+ * A central place for all configuration property keys required for purging Hive tables.
+ *
+ * @author adsharma
+ */
+public class HivePurgerConfigurationKeys {
+
+  public static final String HIVE_PURGER_PREFIX = "hive.purger";
+  public static final String STAGING_PREFIX = "staging_";
+  public static final String EXTERNAL = "EXTERNAL";
+  public static final String PARTITION_NAME = HIVE_PURGER_PREFIX + ".partition.name";
+  public static final String HIVE_DATASET_WHITELIST = "hive.dataset.whitelist";
+  public static final String HIVE_PURGER_JOB_TIMESTAMP = HIVE_PURGER_PREFIX + ".job.timestamp";
+
+  public static final String COMMIT_KEY = HIVE_PURGER_PREFIX + ".commit";
+  public static final Boolean DEFAULT_COMMIT = true;
+
+  // Name of the directory for writing staging data.
+  public static final String STAGING_DIR_KEY = HIVE_PURGER_PREFIX + ".staging.dir";
+
+  // Name of the db for creating staging tables.
+  public static final String STAGING_DB_KEY = HIVE_PURGER_PREFIX + ".staging.db";
+
+  public static final String HIVE_PURGER_WATERMARK = HIVE_PURGER_PREFIX + ".watermark";
+  public static final String MAX_WORKUNITS_KEY = HIVE_PURGER_PREFIX + ".maxWorkunits";
+
+  public static final String NO_PREVIOUS_WATERMARK = HIVE_PURGER_PREFIX + ".noWatermark";
+
+  /**
+   * Configuration keys for the execution attempts of a work unit.
+   */
+  public static final String EXECUTION_ATTEMPTS = HIVE_PURGER_PREFIX + "execution.attempts";
+  public static final String MAX_WORKUNIT_EXECUTION_ATTEMPTS_KEY = HIVE_PURGER_PREFIX + ".maxExecutionAttempts";
+  public static final int DEFAULT_EXECUTION_ATTEMPTS = 1;
+  public static final int DEFAULT_MAX_WORKUNIT_EXECUTION_ATTEMPTS = 3;
+  public static final int DEFAULT_MAX_WORKUNITS = 5;
+
+  public static final String HIVE_SOURCE_DATASET_FINDER_CLASS_KEY = "hive.dataset.finder.class";
+
+  /**
+   * Configuration keys for the dataset descriptor which will be present in tblproperties of a Hive table.
+   */
+  public static final String DATASET_DESCRIPTOR_KEY = "dataset.descriptor";
+
+  // Path to the compliance id in the dataset descriptor json object.
+  public static final String DATASET_DESCRIPTOR_IDENTIFIER = "dataset.descriptor.identifier";
+  public static final String DATASET_DESCRIPTOR_CLASS = "dataset.descriptor.class";
+  public static final String DEFAULT_DATASET_DESCRIPTOR_CLASS = "gobblin.compliance.DatasetDescriptorImpl";
+
+  // Name of the table containing the compliance ids based on which purging will take place.
+  public static final String COMPLIANCE_ID_TABLE_KEY = HIVE_PURGER_PREFIX + ".complianceId.table";
+
+  // Name of the column in the compliance id table containing compliance id.
+  public static final String COMPLIANCE_IDENTIFIER_KEY = HIVE_PURGER_PREFIX + ".compliance.identifier";
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerConverter.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerConverter.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.converter.SingleRecordIterable;
+
+
+/**
+ * A {@link Converter} to build compliance queries. Queries are added to the {@link ComplianceRecord}.
+ *
+ * @author adsharma
+ */
+public class HivePurgerConverter extends Converter<Class<?>, Class<?>, ComplianceRecord, ComplianceRecord> {
+
+  @Override
+  public Class<?> convertSchema(Class<?> schema, WorkUnitState state) {
+    return schema;
+  }
+
+  @Override
+  public Iterable<ComplianceRecord> convertRecord(Class<?> schema, ComplianceRecord record,
+      WorkUnitState state) {
+    record.setPurgeQueries(HivePurgerQueryTemplate.getPurgeQueries(record));
+    return new SingleRecordIterable<>(record);
+  }
+}
+

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerExtractor.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerExtractor.java
@@ -1,0 +1,175 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.base.Throwables;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.dataset.IterableDatasetFinder;
+import gobblin.source.extractor.Extractor;
+import gobblin.util.HadoopUtils;
+import gobblin.util.reflection.GobblinConstructorUtils;
+
+
+/**
+ * This extractor doesn't extract anything, but is used to instantiate and pass {@link ComplianceRecord}
+ * to the converter.
+ *
+ * @author adsharma
+ */
+public class HivePurgerExtractor implements Extractor<ComplianceRecordSchema, ComplianceRecord> {
+  private static final Splitter AT_SPLITTER = Splitter.on("@").omitEmptyStrings().trimResults();
+
+  private boolean read = false;
+  private ComplianceRecord record;
+
+  public HivePurgerExtractor(WorkUnitState state) {
+    this.record = createComplianceRecord(state);
+  }
+
+  @Override
+  public ComplianceRecordSchema getSchema() {
+    return new ComplianceRecordSchema();
+  }
+
+  /**
+   * There is only one record {@link ComplianceRecord} to be read per partition, and must return null
+   * after that to indicate end of reading.
+   */
+  @Override
+  public ComplianceRecord readRecord(ComplianceRecord record)
+      throws IOException {
+    if (read) {
+      return null;
+    }
+    read = true;
+    return this.record;
+  }
+
+  @Override
+  public long getExpectedRecordCount() {
+    return 1;
+  }
+
+  /**
+   * Watermark is not managed by this extractor.
+   */
+  @Override
+  public long getHighWatermark() {
+    return 0;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+
+  @VisibleForTesting
+  public void setRecord(ComplianceRecord record) {
+    this.record = record;
+  }
+
+  private ComplianceRecord createComplianceRecord(WorkUnitState state) {
+    Partition hiveTablePartition =
+        getHiveTablePartition(state.getWorkunit().getProp(HivePurgerConfigurationKeys.PARTITION_NAME),
+            state.getProperties());
+    Map<String, String> partitionParameters = hiveTablePartition.getTable().getParameters();
+    Preconditions.checkArgument(state.contains(HivePurgerConfigurationKeys.STAGING_DB_KEY),
+        "Missing property " + HivePurgerConfigurationKeys.STAGING_DB_KEY);
+    Preconditions.checkArgument(state.contains(HivePurgerConfigurationKeys.STAGING_DIR_KEY),
+        "Missing property " + HivePurgerConfigurationKeys.STAGING_DIR_KEY);
+    Preconditions.checkArgument(state.contains(HivePurgerConfigurationKeys.COMPLIANCE_IDENTIFIER_KEY),
+        "Missing property " + HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_IDENTIFIER);
+    Preconditions.checkArgument(state.contains(HivePurgerConfigurationKeys.COMPLIANCE_ID_TABLE_KEY),
+        "Missing property " + HivePurgerConfigurationKeys.COMPLIANCE_ID_TABLE_KEY);
+    Preconditions.checkArgument(state.contains(HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_IDENTIFIER),
+        "Missing property " + HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_IDENTIFIER);
+    Preconditions.checkArgument(partitionParameters.containsKey(HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_KEY),
+        "Missing table property " + HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_KEY);
+    Preconditions.checkArgument(state.contains(HivePurgerConfigurationKeys.HIVE_PURGER_JOB_TIMESTAMP),
+        "Missing table property " + HivePurgerConfigurationKeys.HIVE_PURGER_JOB_TIMESTAMP);
+
+    String datasetDescriptorClass = state.getProp(HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_CLASS,
+        HivePurgerConfigurationKeys.DEFAULT_DATASET_DESCRIPTOR_CLASS);
+    DatasetDescriptor descriptor = GobblinConstructorUtils
+        .invokeConstructor(DatasetDescriptor.class, datasetDescriptorClass,
+            partitionParameters.get(HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_KEY),
+            state.getProp(HivePurgerConfigurationKeys.DATASET_DESCRIPTOR_IDENTIFIER));
+
+    Boolean commit =
+        state.getPropAsBoolean(HivePurgerConfigurationKeys.COMMIT_KEY, HivePurgerConfigurationKeys.DEFAULT_COMMIT);
+    String stagingDir = state.getProp(HivePurgerConfigurationKeys.STAGING_DIR_KEY);
+    String stagingDb = state.getProp(HivePurgerConfigurationKeys.STAGING_DB_KEY);
+    String complianceIdentifier = state.getProp(HivePurgerConfigurationKeys.COMPLIANCE_IDENTIFIER_KEY);
+    String complianceIdTable = state.getProp(HivePurgerConfigurationKeys.COMPLIANCE_ID_TABLE_KEY);
+
+    ComplianceRecord complianceRecord =
+        ComplianceRecord.builder().complianceIdentifier(complianceIdentifier).complianceIdTable(complianceIdTable)
+            .commit(commit).stagingDb(stagingDb).stagingDir(stagingDir)
+            .datasetComplianceId(descriptor.getComplianceId())
+            .timeStamp(state.getProp(HivePurgerConfigurationKeys.HIVE_PURGER_JOB_TIMESTAMP)).build();
+    complianceRecord.setHivePartition(hiveTablePartition);
+    return complianceRecord;
+  }
+
+  /**
+   * @throws IOException
+   * @Returns Partition from the partition name.
+   */
+  private Partition getHiveTablePartition(String partitionName, Properties properties) {
+    Partition hiveTablePartition = null;
+    try {
+      properties.setProperty(HivePurgerConfigurationKeys.HIVE_DATASET_WHITELIST, getCompleteTableName(partitionName));
+      IterableDatasetFinder<HiveDataset> datasetFinder =
+          new HiveDatasetFinder(FileSystem.newInstance(HadoopUtils.newConfiguration()), properties);
+      Iterator<HiveDataset> hiveDatasetIterator = datasetFinder.getDatasetsIterator();
+      Preconditions.checkArgument(hiveDatasetIterator.hasNext(), "Unable to find table to update from");
+      HiveDataset hiveDataset = hiveDatasetIterator.next();
+      List<Partition> partitions = hiveDataset.getPartitionsFromDataset();
+      Preconditions
+          .checkArgument(!partitions.isEmpty(), "No partitions found for " + getCompleteTableName(partitionName));
+      for (Partition partition : partitions) {
+        if (partition.getCompleteName().equals(partitionName)) {
+          hiveTablePartition = partition;
+        }
+      }
+    } catch (IOException e) {
+      Throwables.propagate(e);
+    }
+    Preconditions.checkNotNull(hiveTablePartition, "Cannot find the required partition " + partitionName);
+    return hiveTablePartition;
+  }
+
+  /**
+   * @param completePartitionName String with dbName.tableName.partitionName
+   * @return String with dbName.tableName
+   */
+  private String getCompleteTableName(String completePartitionName) {
+    List<String> list = AT_SPLITTER.splitToList(completePartitionName);
+    Preconditions.checkArgument(list.size() == 3, "Incorrect partition name format " + completePartitionName);
+    return list.get(0) + "." + list.get(1);
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerPublisher.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerPublisher.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.util.Collection;
+
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.publisher.DataPublisher;
+
+
+/**
+ * The Publisher moves COMMITTED WorkUnitState to SUCCESSFUL, otherwise FAILED.
+ *
+ * @author adsharma
+ */
+public class HivePurgerPublisher extends DataPublisher {
+  public HivePurgerPublisher(State state) {
+    super(state);
+  }
+
+  public void initialize() {
+  }
+
+  @Override
+  public void publishData(Collection<? extends WorkUnitState> states) {
+    for (WorkUnitState state : states) {
+      if (state.getWorkingState() == WorkUnitState.WorkingState.SUCCESSFUL) {
+        state.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
+      } else {
+        state.setWorkingState(WorkUnitState.WorkingState.FAILED);
+      }
+    }
+  }
+
+  public void publishMetadata(Collection<? extends WorkUnitState> states) {
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerQueryExecutor.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerQueryExecutor.java
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.sql.SQLException;
+import java.util.List;
+
+import gobblin.util.HiveJdbcConnector;
+
+
+/**
+ * This class is responsible for executing Hive queries by initializing {@link HiveJdbcConnector}
+ *
+ * @author adsharma
+ */
+public class HivePurgerQueryExecutor {
+  private final HiveJdbcConnector hiveJdbcConnector;
+  private static final int HIVE_SERVER_VERSION = 2;
+
+  public HivePurgerQueryExecutor()
+      throws SQLException {
+    this.hiveJdbcConnector = HiveJdbcConnector.newEmbeddedConnector(HIVE_SERVER_VERSION);
+  }
+
+  public void executeQueries(List<String> queries)
+      throws SQLException {
+    this.hiveJdbcConnector.executeStatements(queries.toArray(new String[queries.size()]));
+  }
+
+  public void executeQuery(String query)
+      throws SQLException {
+    this.hiveJdbcConnector.executeStatements(query);
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerQueryTemplate.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerQueryTemplate.java
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.util.ArrayList;
+import java.util.List;
+
+
+/**
+ * This class creates all queries required by {@link HivePurgerConverter}
+ *
+ * @author adsharma
+ */
+public class HivePurgerQueryTemplate {
+
+  /**
+   * Use the staging db for creating staging tables.
+   * Alter query doesn't work with dbName.tableName.
+   */
+  private static String getUseDbQuery(String dbName) {
+    return "USE " + dbName;
+  }
+
+  private static String getAutoConvertJoinProperty() {
+    return "SET hive.auto.convert.join=false";
+  }
+
+  /**
+   * Will allow insert query to specify only partition coloumn names instead of partition spec.
+   */
+  private static String getDynamicPartitionNonStrictModeProperty() {
+    return "SET hive.exec.dynamic.partition.mode=nonstrict";
+  }
+
+  /**
+   * If staging table doesn't exist, it will create a staging table.
+   */
+  private static String getCreateStagingTableQuery(ComplianceRecord record) {
+    return "CREATE EXTERNAL TABLE IF NOT EXISTS " +
+        record.getCompleteStagingTableName() + " LIKE " +
+        record.getDbName() + "." + record.getTableName() +
+        " LOCATION " + ComplianceRecord.getQuotedString(record.getStagingTableLocation());
+  }
+
+  /**
+   * This query will create a partition in staging table and insert the records whose compliance id is not
+   * contained in the compliance id table.
+   */
+  private static String getInsertQuery(ComplianceRecord record) {
+    return "INSERT OVERWRITE" +
+        " TABLE " + record.getCompleteStagingTableName() +
+        " PARTITION (" + record.getCommaSeparatedPartitionColumnNames() + ")" +
+        " SELECT /*+MAPJOIN(b) */ a.* FROM " +
+        record.getDbName() + "." + record.getTableName() +
+        " a LEFT JOIN " + record.getComplianceIdTable() + " b" +
+        " ON a." + record.getDatasetComplianceId() + "=b." + record.getComplianceIdentifier() +
+        " WHERE b." + record.getComplianceIdentifier() + " IS NULL AND " + record.getWhereClauseForPartition("a.");
+  }
+
+  /**
+   * This query will alter the location of original table partition to point to the final partition location.
+   */
+  private static String getAlterTableQuery(ComplianceRecord record) {
+    return "ALTER TABLE " +
+        record.getTableName() +
+        " PARTITION (" + record.getPartitionSpec() + ")" +
+        " SET LOCATION " + ComplianceRecord.getQuotedString(record.getFinalPartitionLocation());
+  }
+
+  /**
+   * Will return all the queries needed to populate the staging table partition.
+   * This won't include alter table partition location query.
+   */
+  public static List<String> getPurgeQueries(ComplianceRecord record) {
+    List<String> queries = new ArrayList<>();
+    queries.add(getUseDbQuery(record.getStagingDb()));
+    queries.add(getDynamicPartitionNonStrictModeProperty());
+    queries.add(getAutoConvertJoinProperty());
+    queries.add(getCreateStagingTableQuery(record));
+    queries.add(getInsertQuery(record));
+    return queries;
+  }
+
+  /**
+   * Will return all the queries needed to alter the location of the table partition.
+   * Alter table partition query doesn't work with syntax dbName.tableName
+   */
+  public static List<String> getAlterTableQueries(ComplianceRecord record) {
+    List<String> queries = new ArrayList<>();
+    queries.add(getUseDbQuery(record.getDbName()));
+    queries.add(getAlterTableQuery(record));
+    return queries;
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerSource.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerSource.java
@@ -1,0 +1,286 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Splitter;
+import com.google.common.collect.Iterables;
+
+import com.google.common.base.Throwables;
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.configuration.SourceState;
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
+import gobblin.dataset.IterableDatasetFinder;
+import gobblin.source.Source;
+import gobblin.source.extractor.Extractor;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.HadoopUtils;
+
+
+/**
+ * This class creates {@link WorkUnit}s and assigns exactly one partition to each of them.
+ * It iterates over all Hive Tables specified via whitelist and blacklist, list all partitions, and create
+ * workunits accordingly based on jobWatermark.
+ *
+ * It revive {@link WorkUnit}s if their execution attempts are not exhausted.
+ *
+ * @author adsharma
+ */
+@Slf4j
+public class HivePurgerSource implements Source {
+  private static final Splitter AT_SPLITTER = Splitter.on("@").omitEmptyStrings().trimResults();
+
+  protected IterableDatasetFinder<HiveDataset> datasetFinder;
+  protected Map<String, WorkUnit> workUnitMap = new HashMap<>();
+  protected int maxWorkUnitExecutionAttempts;
+  protected int maxWorkUnits;
+  protected int workUnitsCreatedCount = 0;
+  protected String lowWatermark;
+  private String timeStamp;
+
+  // These datasets are lexicographically sorted by their name
+  protected List<HiveDataset> datasets = new ArrayList<>();
+
+  @VisibleForTesting
+  protected void initialize(SourceState state)
+      throws IOException {
+    setTimeStamp();
+    this.setLowWatermark(state);
+    this.maxWorkUnits = state
+        .getPropAsInt(HivePurgerConfigurationKeys.MAX_WORKUNITS_KEY, HivePurgerConfigurationKeys.DEFAULT_MAX_WORKUNITS);
+    this.maxWorkUnitExecutionAttempts = state
+        .getPropAsInt(HivePurgerConfigurationKeys.MAX_WORKUNIT_EXECUTION_ATTEMPTS_KEY,
+            HivePurgerConfigurationKeys.DEFAULT_MAX_WORKUNIT_EXECUTION_ATTEMPTS);
+    // TODO: Event submitter and metrics will be added later
+    this.datasetFinder =
+        new HiveDatasetFinder(FileSystem.newInstance(HadoopUtils.newConfiguration()), state.getProperties());
+    populateDatasets();
+  }
+
+  @Override
+  public List<WorkUnit> getWorkunits(SourceState state) {
+    try {
+      initialize(state);
+      createWorkUnits(state);
+    } catch (IOException e) {
+      Throwables.propagate(e);
+    }
+    return new ArrayList<>(this.workUnitMap.values());
+  }
+
+  private WorkUnit createNewWorkUnit(String partitionName, int executionAttempts) {
+    WorkUnit workUnit = WorkUnit.createEmpty();
+    workUnit.setProp(HivePurgerConfigurationKeys.PARTITION_NAME, partitionName);
+    workUnit.setProp(HivePurgerConfigurationKeys.EXECUTION_ATTEMPTS, executionAttempts);
+    workUnit.setProp(HivePurgerConfigurationKeys.HIVE_PURGER_JOB_TIMESTAMP, this.timeStamp);
+    return workUnit;
+  }
+
+  private WorkUnit createNewWorkUnit(String partitionName) {
+    return createNewWorkUnit(partitionName, HivePurgerConfigurationKeys.DEFAULT_EXECUTION_ATTEMPTS);
+  }
+
+  /**
+   * This method creates the list of all work units needed for the current execution.
+   * Fresh work units are created for each partition starting from watermark and failed work units from the
+   * previous run will be added to the list.
+   */
+  protected void createWorkUnits(SourceState state)
+      throws IOException {
+    createWorkunitsFromPreviousState(state);
+    if (this.datasets.isEmpty()) {
+      return;
+    }
+    for (HiveDataset hiveDataset : this.datasets) {
+      if (!shouldPurgeDataset(hiveDataset)) {
+        continue;
+      }
+      for (Partition partition : hiveDataset.getPartitionsFromDataset()) {
+        if (workUnitsExceeded()) {
+          setJobWatermark(state, partition.getCompleteName());
+          return;
+        }
+        if (!shouldPurgePartition(partition, state)) {
+          continue;
+        }
+        WorkUnit workUnit = createNewWorkUnit(partition.getCompleteName());
+        log.info(
+            "Created new work unit with partition " + workUnit.getProp(HivePurgerConfigurationKeys.PARTITION_NAME));
+        this.workUnitMap.put(workUnit.getProp(HivePurgerConfigurationKeys.PARTITION_NAME), workUnit);
+        this.workUnitsCreatedCount++;
+      }
+    }
+    if (!state.contains(HivePurgerConfigurationKeys.HIVE_PURGER_WATERMARK)) {
+      this.setJobWatermark(state, HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK);
+    }
+  }
+
+  private boolean workUnitsExceeded() {
+    return !(this.workUnitsCreatedCount < this.maxWorkUnits);
+  }
+
+  /**
+   * Find all datasets on the basis on whitelist and blacklist, and then add them in a list in lexicographical order.
+   */
+  protected void populateDatasets()
+      throws IOException {
+    Iterator<HiveDataset> iterator = this.datasetFinder.getDatasetsIterator();
+    while (iterator.hasNext()) {
+      this.datasets.add(iterator.next());
+    }
+    sortHiveDatasets(datasets);
+  }
+
+  /**
+   * Sort all HiveDatasets on the basis of complete name ie dbName.tableName
+   */
+  private List<HiveDataset> sortHiveDatasets(List<HiveDataset> hiveDatasets) {
+    Collections.sort(hiveDatasets, new Comparator<HiveDataset>() {
+      @Override
+      public int compare(HiveDataset o1, HiveDataset o2) {
+        return o1.getTable().getCompleteName().compareTo(o2.getTable().getCompleteName());
+      }
+    });
+    return hiveDatasets;
+  }
+
+  /**
+   * Fetches the value of a watermark given its key from the previous run.
+   */
+  protected String getWatermarkFromPreviousWorkUnits(SourceState state, String watermark) {
+    if (state.getPreviousWorkUnitStates().isEmpty()) {
+      return HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK;
+    }
+    return state.getPreviousWorkUnitStates().get(0)
+        .getProp(watermark, HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK);
+  }
+
+  /**
+   * Job watermark corresponds to the complete partition name ie dbName.tableName.partitionName
+   * This method returns the complete table name ie dbName.tableName
+   */
+  private String getCompleteTableNameFromJobWatermark(String jobWatermark) {
+    if (jobWatermark.equalsIgnoreCase(HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK)) {
+      return HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK;
+    }
+    List<String> list = AT_SPLITTER.splitToList(jobWatermark);
+    Preconditions.checkArgument(list.size() == 3, "Job watermark is not in correct format");
+    return list.get(0) + "@" + list.get(1);
+  }
+
+  /**
+   * Decides if the given dataset should be purged in the current run.
+   * If a Hive table is not an EXTERNAL table, it won't be purged.
+   * The dataset must lie after the job watermark in the dictionary order.
+   */
+  protected boolean shouldPurgeDataset(HiveDataset hiveDataset) {
+    if (!hiveDataset.getTable().getMetadata().containsKey(HivePurgerConfigurationKeys.EXTERNAL)) {
+      return false;
+    }
+
+    String tableName = hiveDataset.getTable().getCompleteName();
+    if (getLowWatermark().equals(HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK)) {
+      return true;
+    }
+    return tableName.compareTo(getCompleteTableNameFromJobWatermark(getLowWatermark())) >= 0;
+  }
+
+  /**
+   * Decides if the given partition should be purged in the current run.
+   * The partition must lie after the job watermark in the dictionary order.
+   */
+  protected boolean shouldPurgePartition(Partition partition, SourceState state) {
+    if (getLowWatermark().equals(HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK)) {
+      return true;
+    }
+    return partition.getCompleteName().compareTo(getLowWatermark()) >= 0;
+  }
+
+  /**
+   * Add failed work units in a workUnitMap with partition name as Key.
+   * New work units are created using required configuration from the old work unit.
+   */
+  protected void createWorkunitsFromPreviousState(SourceState state) {
+    if (getLowWatermark().equalsIgnoreCase(HivePurgerConfigurationKeys.NO_PREVIOUS_WATERMARK)) {
+      return;
+    }
+    if (Iterables.isEmpty(state.getPreviousWorkUnitStates())) {
+      return;
+    }
+    for (WorkUnitState workUnitState : state.getPreviousWorkUnitStates()) {
+      if (workUnitState.getWorkingState() == WorkUnitState.WorkingState.COMMITTED) {
+        continue;
+      }
+      WorkUnit workUnit = workUnitState.getWorkunit();
+      Preconditions.checkArgument(workUnit.contains(HivePurgerConfigurationKeys.PARTITION_NAME),
+          "Older WorkUnit doesn't contain property partition name.");
+      int executionAttempts = workUnit.getPropAsInt(HivePurgerConfigurationKeys.EXECUTION_ATTEMPTS,
+          HivePurgerConfigurationKeys.DEFAULT_EXECUTION_ATTEMPTS);
+      if (executionAttempts < this.maxWorkUnitExecutionAttempts) {
+        workUnit = createNewWorkUnit(workUnit.getProp(HivePurgerConfigurationKeys.PARTITION_NAME), ++executionAttempts);
+        log.info("Revived old Work Unit for partiton " + workUnit.getProp(HivePurgerConfigurationKeys.PARTITION_NAME)
+            + " having execution attempt " + workUnit.getProp(HivePurgerConfigurationKeys.EXECUTION_ATTEMPTS));
+        workUnitMap.put(workUnit.getProp(HivePurgerConfigurationKeys.PARTITION_NAME), workUnit);
+      }
+    }
+  }
+
+  @Override
+  public Extractor getExtractor(WorkUnitState state) {
+    return new HivePurgerExtractor(state);
+  }
+
+  @Override
+  public void shutdown(SourceState state) {
+  }
+
+  /**
+   * Sets the local watermark, which is a class variable. Local watermark is a complete partition name which act as the starting point for the creation of fresh work units.
+   */
+  protected void setLowWatermark(SourceState state) {
+    this.lowWatermark = getWatermarkFromPreviousWorkUnits(state, HivePurgerConfigurationKeys.HIVE_PURGER_WATERMARK);
+    log.info("Setting low watermark for the job: " + this.lowWatermark);
+  }
+
+  protected String getLowWatermark() {
+    return this.lowWatermark;
+  }
+
+  /**
+   * Sets Job Watermark in the SourceState which will be copied to all WorkUnitStates. Job Watermark is a complete partition name.
+   * During next run of this job, fresh work units will be created starting from this partition.
+   */
+  protected void setJobWatermark(SourceState state, String watermark) {
+    state.setProp(HivePurgerConfigurationKeys.HIVE_PURGER_WATERMARK, watermark);
+    log.info("Setting job watermark for the job: " + watermark);
+  }
+
+  protected void setTimeStamp() {
+    this.timeStamp = Long.toString(System.currentTimeMillis());
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerWriter.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerWriter.java
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.writer.DataWriter;
+
+
+/**
+ * This class is responsible for executing all purge queries and altering the partition location if the original
+ * partition is not modified during the current execution.
+ *
+ * @author adsharma
+ */
+@Slf4j
+@AllArgsConstructor
+public class HivePurgerWriter implements DataWriter<ComplianceRecord> {
+  private FileSystem fs;
+  private HivePurgerQueryExecutor hivePurgerQueryExecutor;
+
+  /**
+   * This method is responsible for actual purging.
+   *  - It first creates a staging table partition with the same schema as of original table partition.
+   *  - Staging table partition is then populated by original table left outer joined with compliance id table.
+   *
+   *  -  Staging partition data will be moved to the final location if the original table is not modified
+   *     during the job run.
+   *  - Alter query will then change the partition location to the final location.
+   *  - In flight queries won't get affected due to alter partition query.
+   * @throws IOException
+   */
+  @Override
+  public void write(ComplianceRecord record)
+      throws IOException {
+    try {
+      List<String> purgeQueries = record.getQueries();
+      if (record.getCommit()) {
+        String finalPartitionLocation = record.getFinalPartitionLocation();
+        String stagingPartitionLocation = record.getStagingPartitionLocation();
+        String originalPartitionLocation = record.getHivePartition().getLocation();
+        String finalDirLocation = record.getFinalDirLocation();
+        long lastModificationTimeAtExecutionStart = getLastModifiedTime(originalPartitionLocation);
+        long lastModificationTimeAfterQueriesExecution = getLastModifiedTime(originalPartitionLocation);
+        hivePurgerQueryExecutor.executeQueries(purgeQueries);
+
+        boolean canCommit =
+            commitPolicy(lastModificationTimeAtExecutionStart, lastModificationTimeAfterQueriesExecution);
+        if (!canCommit) {
+          log.info("Last modified time before start of execution : " + lastModificationTimeAtExecutionStart);
+          log.info(
+              "Last modified time after execution of purge queries : " + lastModificationTimeAfterQueriesExecution);
+          throw new RuntimeException("Failed to commit. File modified during job run.");
+        }
+        this.fs.mkdirs(new Path(finalDirLocation));
+        log.info("Moving from " + stagingPartitionLocation + " to " + finalPartitionLocation);
+        this.fs.rename(new Path(stagingPartitionLocation), new Path(finalDirLocation));
+        this.hivePurgerQueryExecutor.executeQueries(HivePurgerQueryTemplate.getAlterTableQueries(record));
+        return;
+      }
+      hivePurgerQueryExecutor.executeQueries(purgeQueries);
+    } catch (SQLException e) {
+      log.info("Failed to execute hive queries : " + e.getMessage());
+      throw new IOException(e);
+    }
+  }
+
+  private long getLastModifiedTime(String file)
+      throws IOException {
+    return this.fs.getFileStatus(new Path(file)).getModificationTime();
+  }
+
+  /**
+   * This method checks if the last modification time has changed during the course of execution if the result should be committed.
+   */
+  private boolean commitPolicy(long oldTime, long newTime) {
+    return newTime == oldTime;
+  }
+
+  @Override
+  public long recordsWritten() {
+    return 1;
+  }
+
+  /**
+   * Following methods are not implemented by this class
+   * @throws IOException
+   */
+  @Override
+  public void commit()
+      throws IOException {
+
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+
+  @Override
+  public void cleanup()
+      throws IOException {
+  }
+
+  @Override
+  public long bytesWritten()
+      throws IOException {
+    return 0;
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerWriterBuilder.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerWriterBuilder.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.io.IOException;
+import java.sql.SQLException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+
+import gobblin.util.WriterUtils;
+import gobblin.writer.DataWriter;
+import gobblin.writer.DataWriterBuilder;
+
+
+/**
+ * Initializes {@link HivePurgerWriter} with {@link FileSystem} and {@link HivePurgerQueryExecutor}
+ *
+ * @author adsharma
+ */
+public class HivePurgerWriterBuilder extends DataWriterBuilder<ComplianceRecordSchema, ComplianceRecord> {
+
+  @Override
+  public DataWriter<ComplianceRecord> build()
+      throws IOException {
+    try {
+      return new HivePurgerWriter(WriterUtils.getWriterFS(this.destination.getProperties(), this.branches, this.branch), new HivePurgerQueryExecutor());
+    } catch (IOException | SQLException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/QueryBaseHivePartitionRecord.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/QueryBaseHivePartitionRecord.java
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.util.List;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+
+/**
+ * Record corresponding to a hive partition. It also contains a list of queries to be executed on this partition.
+ */
+@Getter
+@Setter
+public abstract class QueryBaseHivePartitionRecord {
+  protected Partition hivePartition;
+  protected List<String> queries;
+}

--- a/gobblin-modules/gobblin-compliance/src/test/java/gobblin/compliance/HivePurgerExtractorTest.java
+++ b/gobblin-modules/gobblin-compliance/src/test/java/gobblin/compliance/HivePurgerExtractorTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.io.IOException;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.workunit.WorkUnit;
+
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.when;
+
+
+public class HivePurgerExtractorTest {
+  private ComplianceRecord recordMock = Mockito.mock(ComplianceRecord.class);
+  private HivePurgerExtractor extractorMock = Mockito.mock(HivePurgerExtractor.class);
+
+  @BeforeTest
+  public void initialize()
+      throws IOException {
+    Mockito.doCallRealMethod().when(this.extractorMock).getSchema();
+    Mockito.doCallRealMethod().when(this.extractorMock).readRecord(null);
+    Mockito.doCallRealMethod().when(this.extractorMock).getExpectedRecordCount();
+    Mockito.doCallRealMethod().when(this.extractorMock).setRecord(this.recordMock);
+    this.extractorMock.setRecord(this.recordMock);
+  }
+
+  @Test
+  public void getSchemaTest() {
+    Assert.assertNotNull(this.extractorMock.getSchema());
+  }
+
+  @Test
+  public void readRecordTest()
+      throws IOException {
+    Assert.assertNotNull(this.extractorMock.readRecord(null));
+    Assert.assertNull(this.extractorMock.readRecord(null));
+    Assert.assertEquals(1, this.extractorMock.getExpectedRecordCount());
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/test/java/gobblin/compliance/HivePurgerWriterTest.java
+++ b/gobblin-modules/gobblin-compliance/src/test/java/gobblin/compliance/HivePurgerWriterTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class HivePurgerWriterTest {
+  private ComplianceRecord recordMock = Mockito.mock(ComplianceRecord.class);
+  private HivePurgerQueryExecutor hivePurgerQueryExecutorMock = Mockito.mock(HivePurgerQueryExecutor.class);
+  private FileSystem fsMock = Mockito.mock(FileSystem.class);
+  private HivePurgerWriter hivePurgerExecutionWriter;
+  private Partition partitionMock = Mockito.mock(Partition.class);
+  private FileStatus statusMock = Mockito.mock(FileStatus.class);
+
+  private final String FINAL_LOCATION = "finalLocation";
+  private final String STAGING_LOCATION = "stagingLocation";
+  private final String ORIGINAL_LOCATION = "originalLocation";
+
+  @BeforeTest
+  public void initialize()
+      throws IOException {
+    Mockito.doReturn(new ArrayList<>()).when(this.recordMock).getQueries();
+    Mockito.doReturn(this.partitionMock).when(this.recordMock).getHivePartition();
+    Mockito.doReturn(FINAL_LOCATION).when(this.recordMock).getFinalPartitionLocation();
+    Mockito.doReturn(STAGING_LOCATION).when(this.recordMock).getStagingPartitionLocation();
+    Mockito.doReturn(ORIGINAL_LOCATION).when(this.partitionMock).getLocation();
+    Mockito.doReturn(statusMock).when(this.fsMock).getFileStatus(any(Path.class));
+    Mockito.doReturn((long)12345).doReturn((long)123456).when(this.statusMock).getModificationTime();
+    this.hivePurgerExecutionWriter = new HivePurgerWriter(this.fsMock, this.hivePurgerQueryExecutorMock);
+  }
+
+  @Test
+  public void getPurgeQueriesTest()
+      throws IOException {
+    when(recordMock.getCommit()).thenReturn(false);
+    this.hivePurgerExecutionWriter.write(this.recordMock);
+    verify(this.recordMock, times(1)).getQueries();
+  }
+
+  @Test(expectedExceptions = RuntimeException.class)
+  public void testCommit()
+      throws IOException {
+    when(recordMock.getCommit()).thenReturn(true);
+    this.hivePurgerExecutionWriter.write(this.recordMock);
+  }
+}


### PR DESCRIPTION
gobblin consumers can use gobblin-compliance module to meet their compliance requisites. Current support is to achieve the compliance requirements for Hive Datasets, irrespective of the data format underneath.