### PR TITLE
Fix PartitionLevelWatermarkerTest time initialization gap...

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/watermarker/PartitionLevelWatermarker.java
@@ -20,6 +20,7 @@ import javax.annotation.Nonnull;
 
 import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 
 import org.apache.hadoop.hive.ql.metadata.Partition;
@@ -84,7 +85,9 @@ public class PartitionLevelWatermarker implements HiveSourceWatermarker {
     }
   };
 
-  private final long leastWatermarkToPersistInState;
+  @Setter(AccessLevel.PACKAGE)
+  @VisibleForTesting
+  private long leastWatermarkToPersistInState;
   // Keep an additional 2 days of updates
   private static int BUFFER_WATERMARK_DAYS_TO_PERSIST = 2;
 


### PR DESCRIPTION
…between test and code

There is a transient test failure in: gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarkerTest

java.lang.AssertionError: Maps do not have the same size:0 != 3
	at org.testng.Assert.fail(Assert.java:94)
	at org.testng.Assert.assertEquals(Assert.java:803)
	at gobblin.data.management.conversion.hive.watermarker.PartitionLevelWatermarkerTest.testRecentlyModifiedPartitionWatermarks(PartitionLevelWatermarkerTest.java:323)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)

This seems to be happening because there is a time gap between the initialization of time5DaysAgo in the test and the leastWatermarkToPersistInState in the PartitionLevelWatermarker. Right now the test data is spaced around 100ms, but the time between these two times in ranging from <100 ms, in which case the test succeeds up to ~2000ms, in which case the test fails because all the test watermark times are older than the very recently initialized leastWatermarkToPersistInState.

This fix uses the same time for both the test and the leastWatermarkToPersistInState to help the test succeed consistently.