### PR TITLE
Refactor methods from AbstractJobLauncher to GobblinMultiTaskAttempt

### DIFF
--- a/gobblin-cluster/src/main/java/gobblin/cluster/GobblinHelixTask.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/GobblinHelixTask.java
@@ -17,12 +17,10 @@ import java.util.List;
 
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-
 import org.apache.helix.task.Task;
 import org.apache.helix.task.TaskCallbackContext;
 import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskResult;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -35,6 +33,7 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
 import gobblin.runtime.AbstractJobLauncher;
+import gobblin.runtime.GobblinMultiTaskAttempt;
 import gobblin.runtime.JobState;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskState;
@@ -131,8 +130,8 @@ public class GobblinHelixTask implements Task {
         workUnits.add(workUnit);
       }
 
-      AbstractJobLauncher.runWorkUnits(this.jobId, this.participantId, this.jobState, workUnits, this.taskStateTracker,
-          this.taskExecutor, this.taskStateStore, LOGGER, AbstractJobLauncher.MULTI_TASK_ATTEMPT_COMMIT_POLICY.IMMEDIATE);
+      GobblinMultiTaskAttempt.runWorkUnits(this.jobId, this.participantId, this.jobState, workUnits, this.taskStateTracker,
+          this.taskExecutor, this.taskStateStore, GobblinMultiTaskAttempt.CommitPolicy.IMMEDIATE);
       return new TaskResult(TaskResult.Status.COMPLETED, String.format("completed tasks: %d", workUnits.size()));
     } catch (InterruptedException ie) {
       Thread.currentThread().interrupt();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -29,6 +29,7 @@ import com.google.common.util.concurrent.ServiceManager;
 import gobblin.metrics.Tag;
 import gobblin.metrics.event.TimingEvent;
 import gobblin.runtime.AbstractJobLauncher;
+import gobblin.runtime.GobblinMultiTaskAttempt;
 import gobblin.runtime.JobState;
 import gobblin.runtime.TaskExecutor;
 import gobblin.runtime.TaskStateTracker;
@@ -116,8 +117,8 @@ public class LocalJobLauncher extends AbstractJobLauncher {
 
     TimingEvent workUnitsRunTimer = this.eventSubmitter.getTimingEvent(TimingEvent.RunJobTimings.WORK_UNITS_RUN);
 
-    AbstractJobLauncher.runWorkUnits(this.jobContext.getJobId(), this.jobContext.getJobState(), workUnitsToRun,
-        this.taskStateTracker, this.taskExecutor, MULTI_TASK_ATTEMPT_COMMIT_POLICY.IMMEDIATE);
+    GobblinMultiTaskAttempt.runWorkUnits(this.jobContext.getJobId(), this.jobContext.getJobState(), workUnitsToRun,
+        this.taskStateTracker, this.taskExecutor, GobblinMultiTaskAttempt.CommitPolicy.IMMEDIATE);
 
     workUnitsRunTimer.stop();
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -52,7 +52,6 @@ import com.google.common.util.concurrent.ServiceManager;
 
 import gobblin.commit.CommitStep;
 import gobblin.configuration.ConfigurationKeys;
-import gobblin.configuration.State;
 import gobblin.metastore.FsStateStore;
 import gobblin.metastore.StateStore;
 import gobblin.metrics.GobblinMetrics;
@@ -72,7 +71,6 @@ import gobblin.runtime.util.JobMetrics;
 import gobblin.runtime.util.MetricGroup;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
-import gobblin.util.ConfigUtils;
 import gobblin.util.HadoopUtils;
 import gobblin.util.JobConfigurationUtils;
 import gobblin.util.JobLauncherUtils;
@@ -594,13 +592,13 @@ public class MRJobLauncher extends AbstractJobLauncher {
         while (context.nextKeyValue()) {
           this.map(context.getCurrentKey(), context.getCurrentValue(), context);
         }
-        MULTI_TASK_ATTEMPT_COMMIT_POLICY multiTaskAttemptCommitPolicy =
-            isSpeculativeEnabled ? MULTI_TASK_ATTEMPT_COMMIT_POLICY.CUSTOMIZED
-                : MULTI_TASK_ATTEMPT_COMMIT_POLICY.IMMEDIATE;
+        GobblinMultiTaskAttempt.CommitPolicy multiTaskAttemptCommitPolicy =
+            isSpeculativeEnabled ? GobblinMultiTaskAttempt.CommitPolicy.CUSTOMIZED
+                : GobblinMultiTaskAttempt.CommitPolicy.IMMEDIATE;
         // Actually run the list of WorkUnits
         gobblinMultiTaskAttempt =
-            runWorkUnits(this.jobState.getJobId(), context.getTaskAttemptID().toString(), this.jobState, this.workUnits,
-                this.taskStateTracker, this.taskExecutor, this.taskStateStore, LOG, multiTaskAttemptCommitPolicy);
+            GobblinMultiTaskAttempt.runWorkUnits(this.jobState.getJobId(), context.getTaskAttemptID().toString(), this.jobState, this.workUnits,
+                this.taskStateTracker, this.taskExecutor, this.taskStateStore, multiTaskAttemptCommitPolicy);
 
         if (this.isSpeculativeEnabled) {
           LOG.info("will not commit in task attempt");


### PR DESCRIPTION
* Move enum AbstractJobLauncher.MULTI_TASK_ATTEMPT_COMMIT_POLICY to GobblinMultiTaskAttempt since even the name suggests it pertains to GobblinMultiTaskAttempt; Rename to CommitPolicy to conform to the naming conventions.
* Move static AbstractJobLauncher.runWorkUnits methods to GobblinMultiTaskAttempt since those deal mostly with GobblinMultiTaskAttempt.

@ydai1124 can you review?