### PR TITLE
Include ThrottleWriter state in FinalState

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/RetryWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/RetryWriter.java
@@ -48,7 +48,7 @@ public class RetryWriter<D> implements DataWriter<D>, FinalState, SpeculativeAtt
   public static final String RETRY_MULTIPLIER = RETRY_CONF_PREFIX + "multiplier";
   public static final String RETRY_MAX_WAIT_MS_PER_INTERVAL = RETRY_CONF_PREFIX + "max_wait_ms_per_interval";
   public static final String RETRY_MAX_ATTEMPTS = RETRY_CONF_PREFIX + "max_attempts";
-  public static final String FAILED_WRITES_KEY = "failedWrites";
+  public static final String FAILED_WRITES_KEY = "FailedWrites";
 
   private final DataWriter<D> writer;
   private final Retryer<Void> retryer;

--- a/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
@@ -39,7 +39,7 @@ public class ThrottleWriter<D> implements DataWriter<D>, FinalState, Retriable {
   public static final String WRITER_THROTTLE_TYPE_KEY = "gobblin.writer.throttle_type";
   public static final String WRITER_LIMIT_RATE_LIMIT_KEY = "gobblin.writer.throttle_rate";
   public static final String WRITES_THROTTLED_TIMER = "gobblin.writer.throttled_time";
-  public static final String THROTTLED_TIME_KEY = "throttledTime";
+  public static final String THROTTLED_TIME_KEY = "ThrottledTime";
 
   private static final String LOCAL_JOB_LAUNCHER_TYPE = "LOCAL";
 
@@ -190,7 +190,7 @@ public class ThrottleWriter<D> implements DataWriter<D>, FinalState, Retriable {
     State state = new State();
 
     if (this.writer instanceof FinalState) {
-      return ((FinalState)this.writer).getFinalState();
+      state.addAll(((FinalState)this.writer).getFinalState());
     } else {
       LOG.warn("Wrapped writer does not implement FinalState: " + this.writer.getClass());
     }

--- a/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/RetryWriterTest.java
@@ -69,8 +69,9 @@ public class RetryWriterTest {
 
     DataWriterWrapperBuilder<Void> builder = new DataWriterWrapperBuilder<>(writer, new State());
     DataWriter<Void> retryWriter = builder.build();
-    ((FinalState)retryWriter).getFinalState();
+    State state = ((FinalState) retryWriter).getFinalState();
 
     verify(writer, times(1)).getFinalState();
+    Assert.assertTrue(state.contains(RetryWriter.FAILED_WRITES_KEY));
   }
 }

--- a/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/ThrottleWriterTest.java
@@ -88,9 +88,10 @@ public class ThrottleWriterTest {
     int qps = 4;
     DataWriter<Void> throttleWriter = setup(writer, parallelism, qps, ThrottleType.QPS);
 
-    ((FinalState)throttleWriter).getFinalState();
+    State state = ((FinalState) throttleWriter).getFinalState();
 
     verify(writer, times(1)).getFinalState();
+    Assert.assertTrue(state.contains(ThrottleWriter.THROTTLED_TIME_KEY));
   }
 
   private DataWriter<Void> setup(DataWriter<Void> writer, int parallelism, int rate, ThrottleType type) throws IOException {


### PR DESCRIPTION
Missed including ThrottleTime in the ThrottleWriter FinalState. Correct, and include tests.

Also, correct casing to be aligned with the existing conventions.