### PR TITLE
Remove confluent dependencies from gobblin-core

### DIFF
--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -45,9 +45,6 @@ dependencies {
   compile externalDependency.typesafeConfig
   compile externalDependency.guavaretrying
   compile externalDependency.findBugsAnnotations
-  compile externalDependency.confluentSchemaRegistryClient
-  compile externalDependency.confluentAvroSerializer
-  compile externalDependency.confluentJsonSerializer
   compile externalDependency.oltu
   compile externalDependency.googleAnalytics
   compile externalDependency.googleDrive


### PR DESCRIPTION
@shirshanka  Can you confirm that those are no longer needed with the gobblin-kafka refactoring?