### PR TITLE
Specify explicit schema class in HivePurgerConverter

### DIFF
--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerConverter.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePurgerConverter.java
@@ -21,15 +21,15 @@ import gobblin.converter.SingleRecordIterable;
  *
  * @author adsharma
  */
-public class HivePurgerConverter extends Converter<Class<?>, Class<?>, ComplianceRecord, ComplianceRecord> {
+public class HivePurgerConverter extends Converter<ComplianceRecordSchema, ComplianceRecordSchema, ComplianceRecord, ComplianceRecord> {
 
   @Override
-  public Class<?> convertSchema(Class<?> schema, WorkUnitState state) {
+  public ComplianceRecordSchema convertSchema(ComplianceRecordSchema schema, WorkUnitState state) {
     return schema;
   }
 
   @Override
-  public Iterable<ComplianceRecord> convertRecord(Class<?> schema, ComplianceRecord record,
+  public Iterable<ComplianceRecord> convertRecord(ComplianceRecordSchema schema, ComplianceRecord record,
       WorkUnitState state) {
     record.setPurgeQueries(HivePurgerQueryTemplate.getPurgeQueries(record));
     return new SingleRecordIterable<>(record);

--- a/gobblin-modules/gobblin-compliance/src/test/java/gobblin/compliance/HivePurgerConverterTest.java
+++ b/gobblin-modules/gobblin-compliance/src/test/java/gobblin/compliance/HivePurgerConverterTest.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.compliance;
+
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.WorkUnitState;
+
+
+@Test
+public class HivePurgerConverterTest {
+  private WorkUnitState stateMock = Mockito.mock(WorkUnitState.class);
+  private ComplianceRecordSchema schemaMock = Mockito.mock(ComplianceRecordSchema.class);
+  private HivePurgerConverter hivePurgerConverterMock = Mockito.mock(HivePurgerConverter.class);
+  private ComplianceRecord recordMock = Mockito.mock(ComplianceRecord.class);
+
+  @BeforeTest
+  public void initialize() {
+    Mockito.doCallRealMethod().when(this.hivePurgerConverterMock).convertSchema(this.schemaMock, this.stateMock);
+  }
+
+  public void convertSchemaTest() {
+    Assert.assertNotNull(this.hivePurgerConverterMock.convertSchema(this.schemaMock, this.stateMock));
+  }
+}


### PR DESCRIPTION
Changing to ComplianceRecordSchema, else it throws ClassCastException.
java.lang.ClassCastException: gobblin.compliance.ComplianceRecordSchema cannot be cast to java.lang.Class
22-12-2016 03:48:05 PST revy INFO - 	at gobblin.compliance.HivePurgerConverter.convertSchema(HivePurgerConverter.java:24)
22-12-2016 03:48:05 PST revy INFO - 	at gobblin.instrumented.converter.InstrumentedConverterDecorator.convertSchema(InstrumentedConverterDecorator.java:72)
22-12-2016 03:48:05 PST revy INFO - 	at gobblin.runtime.MultiConverter.convertSchema(MultiConverter.java:68)
22-12-2016 03:48:05 PST revy INFO - 	at gobblin.runtime.Task.run(Task.java:160)
22-12-2016 03:48:05 PST revy INFO - 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
22-12-2016 03:48:05 PST revy INFO - 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
22-12-2016 03:48:05 PST revy INFO - 	at java.lang.Thread.run(Thread.java:745)