### PR TITLE
Fixing an issue in QueryBasedSource with handling tables with $

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -88,7 +88,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
 
   /** A class that encapsulates a source entity (aka dataset) to be processed */
   @Data
-  static final class SourceEntity {
+  public static final class SourceEntity {
     /**
      * The name of the source entity (as specified in the source) to be processed. For example,
      * this can be a table name.
@@ -229,11 +229,16 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
     return pack(workUnits, numOfMultiWorkunits);
   }
 
-  public static Set<SourceEntity> getFilteredSourceEntities(SourceState state) {
+  protected Set<SourceEntity> getFilteredSourceEntities(SourceState state) {
+    Set<SourceEntity> unfilteredEntities = getSourceEntities(state);
+    return getFilteredSourceEntitiesHelper(state, unfilteredEntities);
+  }
+
+  static Set<SourceEntity> getFilteredSourceEntitiesHelper(SourceState state, Iterable<SourceEntity> unfilteredEntities) {
     Set<SourceEntity> entities = new HashSet<>();
     List<Pattern> blacklist = DatasetFilterUtils.getPatternList(state, ENTITY_BLACKLIST);
     List<Pattern> whitelist = DatasetFilterUtils.getPatternList(state, ENTITY_WHITELIST);
-    for (SourceEntity entity : getSourceEntities(state)) {
+    for (SourceEntity entity : unfilteredEntities) {
       if (DatasetFilterUtils.survived(entity.getSourceEntityName(), blacklist, whitelist)) {
         entities.add(entity);
       }
@@ -257,7 +262,11 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
     return res;
   }
 
-  static Set<SourceEntity> getSourceEntities(State state) {
+  protected Set<SourceEntity> getSourceEntities(State state) {
+    return getSourceEntitiesHelper(state);
+  }
+
+  static Set<SourceEntity> getSourceEntitiesHelper(State state) {
     if (state.contains(ConfigurationKeys.SOURCE_ENTITIES)) {
       log.info("Using entity names in " + ConfigurationKeys.SOURCE_ENTITIES);
       HashSet<SourceEntity> res = new HashSet<>();

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -12,6 +12,9 @@
 
 package gobblin.source.extractor.extract;
 
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -21,6 +24,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.MDC;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
@@ -50,6 +54,8 @@ import gobblin.util.ConfigUtils;
 import gobblin.util.DatasetFilterUtils;
 import gobblin.util.PathUtils;
 import gobblin.util.dataset.DatasetUtils;
+
+import lombok.Data;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -66,6 +72,91 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
       "source.obtain_table_props_from_config_store";
   public static final boolean DEFAULT_SOURCE_OBTAIN_TABLE_PROPS_FROM_CONFIG_STORE = false;
   private static final String QUERY_BASED_SOURCE = "query_based_source";
+  public static final String WORK_UNIT_STATE_VERSION_KEY = "source.querybased.workUnitState.version";
+  /**
+   * WorkUnit Version 3:
+   *    SOURCE_ENTITY = as specified in job config
+   *    EXTRACT_TABLE_NAME_KEY = as specified in job config or sanitized version of SOURCE_ENTITY
+   * WorkUnit Version 2 (implicit):
+   *    SOURCE_ENTITY = sanitized version of SOURCE_ENTITY in job config
+   *    EXTRACT_TABLE_NAME_KEY = as specified in job config
+   * WorkUnit Version 1 (implicit):
+   *    SOURCE_ENTITY = as specified in job config
+   *    EXTRACT_TABLE_NAME_KEY = as specified in job config
+   */
+  public static final Integer CURRENT_WORK_UNIT_STATE_VERSION = 3;
+
+  /** A class that encapsulates a source entity (aka dataset) to be processed */
+  @Data
+  static final class SourceEntity {
+    /**
+     * The name of the source entity (as specified in the source) to be processed. For example,
+     * this can be a table name.
+     */
+    private final String sourceEntityName;
+    /**
+     * The destination table name. This is explicitly specified in the config or is derived from
+     *  the sourceEntityName.
+     */
+    private final String destTableName;
+
+    /** A string that identifies the source entity */
+    public String getDatasetName() {
+      return sourceEntityName;
+    }
+
+    static String sanitizeEntityName(String entity) {
+      return Utils.escapeSpecialCharacters(entity, ConfigurationKeys.ESCAPE_CHARS_IN_TABLE_NAME, "_");
+    }
+
+    public static SourceEntity fromSourceEntityName(String sourceEntityName) {
+      return new SourceEntity(sourceEntityName, sanitizeEntityName(sourceEntityName));
+    }
+
+    public static Optional<SourceEntity> fromState(State state) {
+      String sourceEntityName;
+      String destTableName;
+      if (state.contains(ConfigurationKeys.SOURCE_ENTITY)) {
+        sourceEntityName = state.getProp(ConfigurationKeys.SOURCE_ENTITY);
+        destTableName = state.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY,
+            sanitizeEntityName(sourceEntityName));
+      }
+      else if (state.contains(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY)) {
+        destTableName = state.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY);
+        sourceEntityName = destTableName;
+      }
+      else {
+        return Optional.absent();
+      }
+
+      return Optional.of(new SourceEntity(sourceEntityName, destTableName));
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj)
+        return true;
+      if (obj == null)
+        return false;
+      if (getClass() != obj.getClass())
+        return false;
+      SourceEntity other = (SourceEntity) obj;
+      if (getDatasetName() == null) {
+        if (other.getDatasetName() != null)
+          return false;
+      } else if (!getDatasetName().equals(other.getDatasetName()))
+        return false;
+      return true;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      int result = 1;
+      result = prime * result + ((getDatasetName() == null) ? 0 : getDatasetName().hashCode());
+      return result;
+    }
+  }
 
   @Override
   public List<WorkUnit> getWorkunits(SourceState state) {
@@ -74,37 +165,31 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
     List<WorkUnit> workUnits = Lists.newArrayList();
     String nameSpaceName = state.getProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY);
 
-    Map<String, String> tableNameToEntityMap = Maps.newHashMap();
-    Set<String> entities = getSourceEntities(state);
-    List<Pattern> blacklist = DatasetFilterUtils.getPatternList(state, ENTITY_BLACKLIST);
-    List<Pattern> whitelist = DatasetFilterUtils.getPatternList(state, ENTITY_WHITELIST);
-    for (String entity : DatasetFilterUtils.filter(entities, blacklist, whitelist)) {
-      tableNameToEntityMap.put(Utils.escapeSpecialCharacters(entity, ConfigurationKeys.ESCAPE_CHARS_IN_TABLE_NAME, "_"),
-          entity);
-    }
+    // Map<String, String> tableNameToEntityMap = Maps.newHashMap();
+    Set<SourceEntity> entities = getFilteredSourceEntities(state);
 
-    Map<String, State> tableSpecificPropsMap = shouldObtainTablePropsFromConfigStore(state)
-        ? getTableSpecificPropsFromConfigStore(tableNameToEntityMap.keySet(), state)
-        : DatasetUtils.getDatasetSpecificProps(tableNameToEntityMap.keySet(), state);
-    Map<String, Long> prevWatermarksByTable = getPreviousWatermarksForAllTables(state);
+    Map<SourceEntity, State> tableSpecificPropsMap = shouldObtainTablePropsFromConfigStore(state)
+        ? getTableSpecificPropsFromConfigStore(entities, state)
+        : getTableSpecificPropsFromState(entities, state);
+    Map<SourceEntity, Long> prevWatermarksByTable = getPreviousWatermarksForAllTables(state);
 
-    for (String tableName : Sets.union(tableNameToEntityMap.keySet(), prevWatermarksByTable.keySet())) {
+    for (SourceEntity sourceEntity : Sets.union(entities, prevWatermarksByTable.keySet())) {
 
-      log.info(String.format("Table to be processed: %s, %s", tableName,
-          tableNameToEntityMap.containsKey(tableName) ? "source entity = " + tableNameToEntityMap.get(tableName)
-              : "which does not have source entity but has previous watermark"));
+      log.info("Source entity to be processed: {}, carry-over from previous state: {} ",
+               sourceEntity, !entities.contains(sourceEntity));
 
-      SourceState combinedState = getCombinedState(state, tableSpecificPropsMap.get(tableName));
+      SourceState combinedState = getCombinedState(state, tableSpecificPropsMap.get(sourceEntity));
       TableType tableType =
           TableType.valueOf(combinedState.getProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY).toUpperCase());
 
-      long previousWatermark = prevWatermarksByTable.containsKey(tableName) ? prevWatermarksByTable.get(tableName)
+      long previousWatermark = prevWatermarksByTable.containsKey(sourceEntity) ?
+          prevWatermarksByTable.get(sourceEntity)
           : ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
 
       // If a table name exists in prevWatermarksByTable (i.e., it has a previous watermark) but does not exist
       // in talbeNameToEntityMap, create an empty workunit for it, so that its previous watermark is preserved.
       // This is done by overriding the high watermark to be the same as the previous watermark.
-      if (!tableNameToEntityMap.containsKey(tableName)) {
+      if (!entities.contains(sourceEntity)) {
         combinedState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, previousWatermark);
       }
 
@@ -112,8 +197,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
       sortedPartitions.putAll(new Partitioner(combinedState).getPartitions(previousWatermark));
 
       // {@link ConfigurationKeys.EXTRACT_TABLE_NAME_KEY} specify the output path for Extract
-      String outputTableName = state.contains(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY)?
-          state.getProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY) : tableName;
+      String outputTableName = sourceEntity.getDestTableName();
 
       log.info("Create extract output with table name is " + outputTableName);
       Extract extract = createExtract(tableType, nameSpaceName, outputTableName);
@@ -125,9 +209,11 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
 
       for (Entry<Long, Long> entry : sortedPartitions.entrySet()) {
         WorkUnit workunit = WorkUnit.create(extract);
-        workunit.setProp(ConfigurationKeys.SOURCE_ENTITY, tableName);
+        workunit.setProp(ConfigurationKeys.SOURCE_ENTITY, sourceEntity.getSourceEntityName());
+        workunit.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, sourceEntity.getDestTableName());
         workunit.setWatermarkInterval(
             new WatermarkInterval(new LongWatermark(entry.getKey()), new LongWatermark(entry.getValue())));
+        workunit.setProp(WORK_UNIT_STATE_VERSION_KEY, CURRENT_WORK_UNIT_STATE_VERSION);
         workUnits.add(workunit);
       }
     }
@@ -143,13 +229,48 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
     return pack(workUnits, numOfMultiWorkunits);
   }
 
-  protected Set<String> getSourceEntities(State state) {
+  public static Set<SourceEntity> getFilteredSourceEntities(SourceState state) {
+    Set<SourceEntity> entities = new HashSet<>();
+    List<Pattern> blacklist = DatasetFilterUtils.getPatternList(state, ENTITY_BLACKLIST);
+    List<Pattern> whitelist = DatasetFilterUtils.getPatternList(state, ENTITY_WHITELIST);
+    for (SourceEntity entity : getSourceEntities(state)) {
+      if (DatasetFilterUtils.survived(entity.getSourceEntityName(), blacklist, whitelist)) {
+        entities.add(entity);
+      }
+    }
+    return entities;
+  }
+
+  public static Map<SourceEntity, State> getTableSpecificPropsFromState(
+          Iterable<SourceEntity> entities,
+          SourceState state) {
+    Map<String, SourceEntity> sourceEntityByName = new HashMap<>();
+    for (SourceEntity entity: entities) {
+      sourceEntityByName.put(entity.getDatasetName(), entity);
+    }
+    Map<String, State> datasetProps =
+        DatasetUtils.getDatasetSpecificProps(sourceEntityByName.keySet(), state);
+    Map<SourceEntity, State> res = new HashMap<>();
+    for (Map.Entry<String, State> entry: datasetProps.entrySet()) {
+      res.put(sourceEntityByName.get(entry.getKey()), entry.getValue());
+    }
+    return res;
+  }
+
+  static Set<SourceEntity> getSourceEntities(State state) {
     if (state.contains(ConfigurationKeys.SOURCE_ENTITIES)) {
       log.info("Using entity names in " + ConfigurationKeys.SOURCE_ENTITIES);
-      return state.getPropAsSet(ConfigurationKeys.SOURCE_ENTITIES);
-    } else if (state.contains(ConfigurationKeys.SOURCE_ENTITY)) {
-      log.info("Using entity name in " + ConfigurationKeys.SOURCE_ENTITY);
-      return ImmutableSet.of(state.getProp(ConfigurationKeys.SOURCE_ENTITY));
+      HashSet<SourceEntity> res = new HashSet<>();
+      for (String sourceEntityName: state.getPropAsList(ConfigurationKeys.SOURCE_ENTITIES)) {
+        res.add(SourceEntity.fromSourceEntityName(sourceEntityName));
+      }
+      return res;
+    } else if (state.contains(ConfigurationKeys.SOURCE_ENTITY) ||
+               state.contains(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY)) {
+      Optional<SourceEntity> sourceEntity = SourceEntity.fromState(state);
+      // Guaranteed to be present
+      log.info("Using entity name in " + sourceEntity.get());
+      return ImmutableSet.of(sourceEntity.get());
     }
 
     throw new IllegalStateException(String.format("One of the following properties must be specified: %s, %s.",
@@ -161,17 +282,18 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
         DEFAULT_SOURCE_OBTAIN_TABLE_PROPS_FROM_CONFIG_STORE);
   }
 
-  private static Map<String, State> getTableSpecificPropsFromConfigStore(Set<String> tables, State state) {
+  private static Map<SourceEntity, State> getTableSpecificPropsFromConfigStore(
+          Collection<SourceEntity> tables, State state) {
     ConfigClient client = ConfigClientCache.getClient(VersionStabilityPolicy.STRONG_LOCAL_STABILITY);
     String configStoreUri = state.getProp(ConfigurationKeys.CONFIG_MANAGEMENT_STORE_URI);
     Preconditions.checkNotNull(configStoreUri);
 
-    Map<String, State> result = Maps.newHashMap();
+    Map<SourceEntity, State> result = Maps.newHashMap();
 
-    for (String table : tables) {
+    for (SourceEntity table : tables) {
       try {
         result.put(table, ConfigUtils.configToState(
-            client.getConfig(PathUtils.combinePaths(configStoreUri, QUERY_BASED_SOURCE, table).toUri())));
+            client.getConfig(PathUtils.combinePaths(configStoreUri, QUERY_BASED_SOURCE, table.getDatasetName()).toUri())));
       } catch (VersionDoesNotExistException | ConfigStoreFactoryDoesNotExistsException
           | ConfigStoreCreationException e) {
         throw new RuntimeException("Unable to get table config for " + table, e);
@@ -222,27 +344,21 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
    * previous run, return the lowest low watermark among all previous {@code WorkUnitState}s of the table.
    * Otherwise, return the highest high watermark among all previous {@code WorkUnitState}s of the table.
    */
-  private static Map<String, Long> getPreviousWatermarksForAllTables(SourceState state) {
-    Map<String, Long> result = Maps.newHashMap();
-    Map<String, Long> prevLowWatermarksByTable = Maps.newHashMap();
-    Map<String, Long> prevActualHighWatermarksByTable = Maps.newHashMap();
-    Set<String> tablesWithFailedTasks = Sets.newHashSet();
-    Set<String> tablesWithNoUpdatesOnPreviousRun = Sets.newHashSet();
+  static Map<SourceEntity, Long> getPreviousWatermarksForAllTables(SourceState state) {
+    Map<SourceEntity, Long> result = Maps.newHashMap();
+    Map<SourceEntity, Long> prevLowWatermarksByTable = Maps.newHashMap();
+    Map<SourceEntity, Long> prevActualHighWatermarksByTable = Maps.newHashMap();
+    Set<SourceEntity> tablesWithFailedTasks = Sets.newHashSet();
+    Set<SourceEntity> tablesWithNoUpdatesOnPreviousRun = Sets.newHashSet();
     boolean commitOnFullSuccess = JobCommitPolicy.getCommitPolicy(state) == JobCommitPolicy.COMMIT_ON_FULL_SUCCESS;
 
     for (WorkUnitState previousWus : state.getPreviousWorkUnitStates()) {
-      String table;
-
-      // current code will use {@link ConfigurationKeys.SOURCE_ENTITY} to defined the table name
-      if(previousWus.getWorkunit().contains(ConfigurationKeys.SOURCE_ENTITY)){
-        table = previousWus.getWorkunit().getProp(ConfigurationKeys.SOURCE_ENTITY);
+      Optional<SourceEntity> sourceEntity = SourceEntity.fromState(previousWus);
+      if (!sourceEntity.isPresent()) {
+        log.warn("Missing source entity for WorkUnit state: " + previousWus);
+        continue;
       }
-      // previous format
-      else {
-        table = previousWus.getExtract().getTable();
-        log.warn(String.format("Can not find %s entry in workunit, based on %s to set table name as %s", ConfigurationKeys.SOURCE_ENTITY,
-            ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, table));
-      }
+      SourceEntity table = sourceEntity.get();
 
       long lowWm = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
       LongWatermark waterMarkObj = previousWus.getWorkunit().getLowWatermark(LongWatermark.class);
@@ -290,7 +406,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
       }
     }
 
-    for (Map.Entry<String, Long> entry : prevLowWatermarksByTable.entrySet()) {
+    for (Map.Entry<SourceEntity, Long> entry : prevLowWatermarksByTable.entrySet()) {
       if (tablesWithFailedTasks.contains(entry.getKey())) {
         log.info("Resetting low watermark to {} because previous run failed.", entry.getValue());
         result.put(entry.getKey(), entry.getValue());

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedSourceTest.java
@@ -73,6 +73,11 @@ public class QueryBasedSourceTest {
     Assert.assertEquals(se5.get(), SourceEntity.fromSourceEntityName("Table5"));
   }
 
+  private Set<SourceEntity> getFilteredEntities(SourceState state) {
+    Set<SourceEntity> unfiltered = QueryBasedSource.getSourceEntitiesHelper(state);
+    return QueryBasedSource.getFilteredSourceEntitiesHelper(state, unfiltered);
+  }
+
   @Test
   public void testGetFilteredSourceEntities() {
     {
@@ -81,7 +86,7 @@ public class QueryBasedSourceTest {
       state.setProp(ConfigurationKeys.SOURCE_ENTITIES, "Table1,Table2,BadTable1,Table3");
       state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldBeIgnored");
 
-      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Set<SourceEntity> res = getFilteredEntities(state);
       Assert.assertEquals(res.size(), 2);
       Assert.assertTrue(res.contains(SourceEntity.fromSourceEntityName("Table2")),
                        "Missing Table2 in " + res);
@@ -96,7 +101,7 @@ public class QueryBasedSourceTest {
       state.setProp(ConfigurationKeys.SOURCE_ENTITIES, "Table1,Table2,BadTable1,Table3");
       state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldBeIgnored");
 
-      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Set<SourceEntity> res = getFilteredEntities(state);
       Assert.assertEquals(res.size(), 1);
       Assert.assertTrue(res.contains(SourceEntity.fromSourceEntityName("Table3")),
           "Missing Table3 in " + res);
@@ -109,7 +114,7 @@ public class QueryBasedSourceTest {
       state.setProp(ConfigurationKeys.SOURCE_ENTITY, "Table3");
       state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldNotBeIgnored");
 
-      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Set<SourceEntity> res = getFilteredEntities(state);
       SourceEntity expected = new SourceEntity("Table3", "PropShouldNotBeIgnored");
       Assert.assertEquals(res.size(), 1);
       Assert.assertTrue(res.contains(expected), "Missing Table3 in " + res);
@@ -122,7 +127,7 @@ public class QueryBasedSourceTest {
       state.setProp(ConfigurationKeys.SOURCE_ENTITY, "Table3");
       state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldNotBeIgnored");
 
-      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Set<SourceEntity> res = getFilteredEntities(state);
       Assert.assertEquals(res.size(), 0);
     }
   }

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedSourceTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedSourceTest.java
@@ -1,0 +1,195 @@
+/*
+ * Copyright (C) 2014-2016 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+package gobblin.source.extractor.extract;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.configuration.WorkUnitState.WorkingState;
+import gobblin.source.extractor.extract.QueryBasedSource.SourceEntity;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.Extract.TableType;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.util.dataset.DatasetUtils;
+
+/**
+ * Unit tests for {@link QueryBasedSource}
+ */
+public class QueryBasedSourceTest {
+
+  @Test
+  public void testSourceEntity() {
+    SourceEntity se1 = SourceEntity.fromSourceEntityName("SourceEntity1");
+    Assert.assertEquals(se1.getSourceEntityName(), "SourceEntity1");
+    Assert.assertEquals(se1.getDestTableName(), "SourceEntity1");
+    Assert.assertEquals(se1.getDatasetName(), "SourceEntity1");
+
+    SourceEntity se2 = SourceEntity.fromSourceEntityName("SourceEntity$2");
+    Assert.assertEquals(se2.getSourceEntityName(), "SourceEntity$2");
+    Assert.assertEquals(se2.getDestTableName(), "SourceEntity_2");
+    Assert.assertEquals(se2.getDatasetName(), "SourceEntity$2");
+
+    State st1 = new State();
+    st1.setProp(ConfigurationKeys.SOURCE_ENTITY, "SourceEntity3");
+    st1.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "SourceEntity3_Table");
+    Optional<SourceEntity> se3 = SourceEntity.fromState(st1);
+    Assert.assertTrue(se3.isPresent());
+    Assert.assertEquals(se3.get().getSourceEntityName(), "SourceEntity3");
+    Assert.assertEquals(se3.get().getDestTableName(), "SourceEntity3_Table");
+    Assert.assertEquals(se3.get().getDatasetName(), "SourceEntity3");
+    Assert.assertEquals(se3.get(), new SourceEntity("SourceEntity3", "SourceEntity3_Table"));
+
+    State st2 = new State();
+    st2.setProp(ConfigurationKeys.SOURCE_ENTITY, "SourceEntity$4");
+    Optional<SourceEntity> se4 = SourceEntity.fromState(st2);
+    Assert.assertTrue(se4.isPresent());
+    Assert.assertEquals(se4.get(), SourceEntity.fromSourceEntityName("SourceEntity$4"));
+
+    State st3 = new State();
+    st3.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "Table5");
+    Optional<SourceEntity> se5 = SourceEntity.fromState(st3);
+    Assert.assertTrue(se5.isPresent());
+    Assert.assertEquals(se5.get(), SourceEntity.fromSourceEntityName("Table5"));
+  }
+
+  @Test
+  public void testGetFilteredSourceEntities() {
+    {
+      SourceState state = new SourceState();
+      state.setProp(QueryBasedSource.ENTITY_BLACKLIST, "Table1,BadTable.*");
+      state.setProp(ConfigurationKeys.SOURCE_ENTITIES, "Table1,Table2,BadTable1,Table3");
+      state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldBeIgnored");
+
+      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Assert.assertEquals(res.size(), 2);
+      Assert.assertTrue(res.contains(SourceEntity.fromSourceEntityName("Table2")),
+                       "Missing Table2 in " + res);
+      Assert.assertTrue(res.contains(SourceEntity.fromSourceEntityName("Table3")),
+          "Missing Table3 in " + res);
+    }
+
+    {
+      SourceState state = new SourceState();
+      state.setProp(QueryBasedSource.ENTITY_BLACKLIST, "Table1,BadTable.*");
+      state.setProp(QueryBasedSource.ENTITY_WHITELIST, "Table3");
+      state.setProp(ConfigurationKeys.SOURCE_ENTITIES, "Table1,Table2,BadTable1,Table3");
+      state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldBeIgnored");
+
+      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Assert.assertEquals(res.size(), 1);
+      Assert.assertTrue(res.contains(SourceEntity.fromSourceEntityName("Table3")),
+          "Missing Table3 in " + res);
+    }
+
+    {
+      SourceState state = new SourceState();
+      state.setProp(QueryBasedSource.ENTITY_BLACKLIST, "Table1,BadTable.*");
+      state.setProp(QueryBasedSource.ENTITY_WHITELIST, "Table3");
+      state.setProp(ConfigurationKeys.SOURCE_ENTITY, "Table3");
+      state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldNotBeIgnored");
+
+      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      SourceEntity expected = new SourceEntity("Table3", "PropShouldNotBeIgnored");
+      Assert.assertEquals(res.size(), 1);
+      Assert.assertTrue(res.contains(expected), "Missing Table3 in " + res);
+    }
+
+    {
+      SourceState state = new SourceState();
+      state.setProp(QueryBasedSource.ENTITY_BLACKLIST, "Table1,BadTable.*");
+      state.setProp(QueryBasedSource.ENTITY_WHITELIST, "Table5");
+      state.setProp(ConfigurationKeys.SOURCE_ENTITY, "Table3");
+      state.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, "PropShouldNotBeIgnored");
+
+      Set<SourceEntity> res = QueryBasedSource.getFilteredSourceEntities(state);
+      Assert.assertEquals(res.size(), 0);
+    }
+  }
+
+  @Test
+  public void testGetTableSpecificPropsFromState() {
+    SourceState state = new SourceState();
+    state.setProp(DatasetUtils.DATASET_SPECIFIC_PROPS,
+        "[{\"dataset\":\"Entity1\", \"value\": 1}, {\"dataset\":\"Table2\", \"value\":2}]");
+    // We should look in the dataset specific properties using the entity name, not table name
+    SourceEntity se1 = new SourceEntity("Entity1", "Table2");
+    SourceEntity se3 = new SourceEntity("Entity3", "Table3");
+    Set<SourceEntity> entities = ImmutableSet.of(se1, se3);
+    Map<SourceEntity, State> datasetProps =
+        QueryBasedSource.getTableSpecificPropsFromState(entities, state);
+    // Value 1 should be returned for se1, no prpos should be returned for se3
+    Assert.assertEquals(datasetProps.size(), 1);
+    Assert.assertTrue(datasetProps.containsKey(se1));
+    State se1Props = datasetProps.get(se1);
+    Assert.assertEquals(se1Props.getProp("value"), "1");
+  }
+
+  @Test
+  public void testGetPreviousWatermarksForAllTables() {
+    {
+      State prevJobState = new SourceState();
+      prevJobState.setProp(ConfigurationKeys.JOB_COMMIT_POLICY_KEY, "full");
+
+      Extract[] extracts = new Extract[3];
+      SourceEntity[] sourceEntities = new SourceEntity[extracts.length];
+      List<WorkUnitState> prevWuStates = new ArrayList<>();
+      // Simulate previous execution with 3 tables and 9 workunits
+      // All work units for the Table1 failed.
+      // Workunit 0 for Table0 returned no results
+      for (int i = 0; i < extracts.length; ++i) {
+        String sourceEntityName = "Table$" + i;
+        SourceEntity sourceEntity = SourceEntity.fromSourceEntityName(sourceEntityName);
+        sourceEntities[i] = sourceEntity;
+        extracts[i] = new Extract(TableType.APPEND_ONLY, "", sourceEntity.getDestTableName());
+        for (int j = 0; j < 3; ++j) {
+          WorkUnit wu = new WorkUnit(extracts[i]);
+          wu.setProp(ConfigurationKeys.SOURCE_ENTITY, sourceEntity.getSourceEntityName());
+          wu.setProp(ConfigurationKeys.WORK_UNIT_LOW_WATER_MARK_KEY, 10 * i);
+          wu.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, sourceEntity.getDestTableName());
+          WorkUnitState wuState = new WorkUnitState(wu, prevJobState);
+          wuState.setProp(ConfigurationKeys.WORK_UNIT_STATE_RUNTIME_HIGH_WATER_MARK, 20 * i);
+          wuState.setProp(ConfigurationKeys.WORK_UNIT_WORKING_STATE_KEY,
+              i == 1 ? WorkingState.FAILED.toString() : WorkingState.SUCCESSFUL.toString() );
+          wuState.setProp(ConfigurationKeys.EXTRACTOR_ROWS_EXPECTED, (i + j) * 5);
+
+          prevWuStates.add(wuState);
+        }
+      }
+
+      SourceState prevState = new SourceState(prevJobState, prevWuStates);
+      Map<SourceEntity, Long> previousWM =
+          QueryBasedSource.getPreviousWatermarksForAllTables(prevState);
+      Assert.assertEquals(previousWM.size(), 3);
+      // No records read for one WU for Table0: min of all LWM
+      Assert.assertEquals(previousWM.get(sourceEntities[0]), Long.valueOf(0L));
+      // Failure for Table 1: min of all LWM
+      Assert.assertEquals(previousWM.get(sourceEntities[1]), Long.valueOf(10L));
+      // Success for Table 2: max of all HWM
+      Assert.assertEquals(previousWM.get(sourceEntities[2]), Long.valueOf(40L));
+
+    }
+
+  }
+
+}

--- a/gobblin-salesforce/src/main/java/gobblin/salesforce/SalesforceSource.java
+++ b/gobblin-salesforce/src/main/java/gobblin/salesforce/SalesforceSource.java
@@ -56,8 +56,7 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
     }
   }
 
-  @Override
-  protected Set<String> getSourceEntities(State state) {
+  protected Set<SourceEntity> getSourceEntities(State state) {
     if (!state.getPropAsBoolean(USE_ALL_OBJECTS, DEFAULT_USE_ALL_OBJECTS)) {
       return super.getSourceEntities(state);
     }
@@ -86,12 +85,13 @@ public class SalesforceSource extends QueryBasedSource<JsonArray, JsonElement> {
 
   }
 
-  private static Set<String> getSourceEntities(String response) {
-    Set<String> result = Sets.newHashSet();
+  private static Set<SourceEntity> getSourceEntities(String response) {
+    Set<SourceEntity> result = Sets.newHashSet();
     JsonObject jsonObject = new Gson().fromJson(response, JsonObject.class).getAsJsonObject();
     JsonArray array = jsonObject.getAsJsonArray("sobjects");
     for (JsonElement element : array) {
-      result.add(element.getAsJsonObject().get("name").getAsString());
+      String sourceEntityName = element.getAsJsonObject().get("name").getAsString();
+      result.add(SourceEntity.fromSourceEntityName(sourceEntityName));
     }
     return result;
   }


### PR DESCRIPTION
Fixing an issue in QueryBasedSource with handling tables with $ in the name.

Originally, code kept track of two properties: SOURCE_ENTITY (used to access the source table) and EXTRACT_TABLE_NAME_KEY used as the table name in the extract (for writing to the destination). Often those are the same but they may differ if SOURCE_ENTITY has certain characters like $.

Later commit changed the above behavior, always replacing SOURCE_ENTITY with a sanitized version. This broke access to tables whose names contain blacklisted characters like $.

The current commit fixes that by reverting to the original behavior. It also adds SourceEntity class to encapsulate the mapping between SOURCE_ENTITY and EXTRACT_TABLE_NAME_KEY.

The tests also adds a bunch of unit tests as QueryBasedSource sorely lacks those.

@ibuenros @ydai1124  can you review ?