### PR TITLE
Fixing flavored builds

### DIFF
--- a/gobblin-core/gobblin-flavor-custom.gradle
+++ b/gobblin-core/gobblin-flavor-custom.gradle
@@ -2,8 +2,5 @@ dependencies {
   // Kafka integration (source, writer, metrics) -- choose one
   // compile project(':gobblin-modules:gobblin-kafka-08')
   // compile project(':gobblin-modules:gobblin-kafka-09')
-
-  // Google ingestion integration: Drive, Analytics, Webmaster
-  // compile project(':gobblin-modules:google-ingestion')
 }
 

--- a/gobblin-core/gobblin-flavor-full.gradle
+++ b/gobblin-core/gobblin-flavor-full.gradle
@@ -1,8 +1,4 @@
 dependencies {
   compile project(':gobblin-modules:gobblin-kafka-08')
-  compile project(':gobblin-modules:gobblin-couchbase')
-  // For backwards compatibility
-  compile project(':gobblin-modules:google-ingestion')
-  compile project(':gobblin-modules:gobblin-compliance')
 }
 

--- a/gobblin-core/gobblin-flavor-standard.gradle
+++ b/gobblin-core/gobblin-flavor-standard.gradle
@@ -1,7 +1,4 @@
 dependencies {
   compile project(':gobblin-modules:gobblin-kafka-08')
-  // For backwards compatibility
-  compile project(':gobblin-modules:google-ingestion')
-  compile project(':gobblin-modules:gobblin-compliance')
 }
 

--- a/gobblin-distribution/gobblin-flavor-custom.gradle
+++ b/gobblin-distribution/gobblin-flavor-custom.gradle
@@ -5,6 +5,12 @@ dependencies {
   // Gobblin Azkaban integration
   // compile project(':gobblin-modules:gobblin-azkaban')
 
+  // Source/converters for compliance-related processing
+  // compile project(':gobblin-modules:gobblin-compliance')
+
+  // Couchbase writer
+  // compile project(':gobblin-modules:gobblin-couchbase')
+
   // Google ingestion integration: Drive, Analytics, Webmaster
   // compile project(':gobblin-modules:google-ingestion')
 }

--- a/gobblin-distribution/gobblin-flavor-full.gradle
+++ b/gobblin-distribution/gobblin-flavor-full.gradle
@@ -1,6 +1,8 @@
 dependencies {
-  compile project(':gobblin-modules:gobblin-azkaban')
   compile project(':gobblin-example')
+  compile project(':gobblin-modules:gobblin-azkaban')
+  compile project(':gobblin-modules:gobblin-compliance')
+  compile project(':gobblin-modules:gobblin-couchbase')
   compile project(':gobblin-modules:google-ingestion')
 }
 

--- a/gobblin-distribution/gobblin-flavor-standard.gradle
+++ b/gobblin-distribution/gobblin-flavor-standard.gradle
@@ -3,5 +3,4 @@ dependencies {
   compile project(':gobblin-modules:gobblin-compliance')
   compile project(':gobblin-example')
   compile project(':gobblin-modules:google-ingestion')
- }
-
+}

--- a/gobblin-distribution/gobblin-flavor-standard.gradle
+++ b/gobblin-distribution/gobblin-flavor-standard.gradle
@@ -1,6 +1,7 @@
 dependencies {
   compile project(':gobblin-modules:gobblin-azkaban')
+  compile project(':gobblin-modules:gobblin-compliance')
   compile project(':gobblin-example')
   compile project(':gobblin-modules:google-ingestion')
-}
+ }
 

--- a/gobblin-flavored-build.gradle
+++ b/gobblin-flavored-build.gradle
@@ -1,7 +1,7 @@
 
 // Check for build customizations
 if (project.hasProperty('gobblinFlavor')) {
-    def gobblinFlavorFileName = project.rootDir.toString() + '/gobblin-flavor-' + project.gobblinFlavor + '.gradle'
+    def gobblinFlavorFileName = project.projectDir.toString() + '/gobblin-flavor-' + project.gobblinFlavor + '.gradle'
     if (file(gobblinFlavorFileName).exists()) { 
         println "Using flavor:" + project.gobblinFlavor + " for project " + project.name
         apply from: gobblinFlavorFileName


### PR DESCRIPTION
Flavored builds were not working correctly as they were checking the wrong directories. There were also circular dependencies.