### PR TITLE
Error out if mvn is unavailable to build mock-couchbase

### DIFF
--- a/gobblin-modules/gobblin-couchbase/scripts/install_test_deps.sh
+++ b/gobblin-modules/gobblin-couchbase/scripts/install_test_deps.sh
@@ -10,5 +10,9 @@ if [ -d mock-couchbase/.git ];
     git -C mock-couchbase checkout b929a9f99a31a233c43bd94b6a696ad966206e02
   fi
 pushd mock-couchbase
-mvn package -Dmaven.test.skip=true
-popd
+if mvn package -Dmaven.test.skip=true; then
+  popd
+else
+  echo "Error building mock-couchbase"
+  exit 1
+fi

--- a/gobblin-modules/gobblin-couchbase/scripts/install_test_deps.sh
+++ b/gobblin-modules/gobblin-couchbase/scripts/install_test_deps.sh
@@ -10,9 +10,8 @@ if [ -d mock-couchbase/.git ];
     git -C mock-couchbase checkout b929a9f99a31a233c43bd94b6a696ad966206e02
   fi
 pushd mock-couchbase
-if mvn package -Dmaven.test.skip=true; then
-  popd
-else
+if ! mvn package -Dmaven.test.skip=true; then
   echo "Error building mock-couchbase"
   exit 1
 fi
+popd


### PR DESCRIPTION
In case mvn is not installed, the build progresses and CouchbaseWriterTest fails with a "Server is not up!" message.

This fix errors out the build in case mvn is not available to build the mock-couchbase package.