### PR TITLE
Move kafka module dependency from gobblin-core to gobblin-distribution

### DIFF
--- a/gobblin-core/gobblin-flavor-custom.gradle
+++ b/gobblin-core/gobblin-flavor-custom.gradle
@@ -1,6 +1,0 @@
-dependencies {
-  // Kafka integration (source, writer, metrics) -- choose one
-  // compile project(':gobblin-modules:gobblin-kafka-08')
-  // compile project(':gobblin-modules:gobblin-kafka-09')
-}
-

--- a/gobblin-core/gobblin-flavor-full.gradle
+++ b/gobblin-core/gobblin-flavor-full.gradle
@@ -1,4 +1,0 @@
-dependencies {
-  compile project(':gobblin-modules:gobblin-kafka-08')
-}
-

--- a/gobblin-core/gobblin-flavor-minimal.gradle
+++ b/gobblin-core/gobblin-flavor-minimal.gradle
@@ -1,3 +1,0 @@
-dependencies {
-}
-

--- a/gobblin-core/gobblin-flavor-standard.gradle
+++ b/gobblin-core/gobblin-flavor-standard.gradle
@@ -1,4 +1,0 @@
-dependencies {
-  compile project(':gobblin-modules:gobblin-kafka-08')
-}
-

--- a/gobblin-distribution/gobblin-flavor-custom.gradle
+++ b/gobblin-distribution/gobblin-flavor-custom.gradle
@@ -13,5 +13,9 @@ dependencies {
 
   // Google ingestion integration: Drive, Analytics, Webmaster
   // compile project(':gobblin-modules:google-ingestion')
+
+  // Kafka integration (source, writer, metrics) -- choose one
+  // compile project(':gobblin-modules:gobblin-kafka-08')
+  // compile project(':gobblin-modules:gobblin-kafka-09')
 }
 

--- a/gobblin-distribution/gobblin-flavor-full.gradle
+++ b/gobblin-distribution/gobblin-flavor-full.gradle
@@ -3,6 +3,7 @@ dependencies {
   compile project(':gobblin-modules:gobblin-azkaban')
   compile project(':gobblin-modules:gobblin-compliance')
   compile project(':gobblin-modules:gobblin-couchbase')
+  compile project(':gobblin-modules:gobblin-kafka-08')
   compile project(':gobblin-modules:google-ingestion')
 }
 

--- a/gobblin-distribution/gobblin-flavor-standard.gradle
+++ b/gobblin-distribution/gobblin-flavor-standard.gradle
@@ -1,6 +1,7 @@
 dependencies {
+  compile project(':gobblin-example')
   compile project(':gobblin-modules:gobblin-azkaban')
   compile project(':gobblin-modules:gobblin-compliance')
-  compile project(':gobblin-example')
+  compile project(':gobblin-modules:gobblin-kafka-08')
   compile project(':gobblin-modules:google-ingestion')
 }


### PR DESCRIPTION
This is to avoid circular dependencies in IDEs for gobblin-kafka-08 .