### PR TITLE
Changed shared resource broker scopes to be less restrictive.

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/broker/DefaultBrokerCache.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/DefaultBrokerCache.java
@@ -47,7 +47,7 @@ import lombok.extern.slf4j.Slf4j;
 class DefaultBrokerCache<S extends ScopeType<S>> {
 
   private final Cache<RawJobBrokerKey, Object> sharedResourceCache;
-  private final Cache<RawJobBrokerKey, ScopeImpl<S>> autoScopeCache;
+  private final Cache<RawJobBrokerKey, ScopeWrapper<S>> autoScopeCache;
 
   public DefaultBrokerCache() {
     this.sharedResourceCache = CacheBuilder.newBuilder().build();
@@ -60,7 +60,7 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
   @Data
   class RawJobBrokerKey {
     // Left if the key represents
-    private final ScopeImpl<S> scope;
+    private final ScopeWrapper<S> scope;
     private final String factoryName;
     private final String key;
   }
@@ -75,11 +75,11 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
       throws ExecutionException {
 
     // figure out auto scope
-    RawJobBrokerKey autoscopeCacheKey = new RawJobBrokerKey((ScopeImpl) broker.selfScope(), factory.getName(), key.toConfigurationKey());
-    ScopeImpl<S> selectedScope = this.autoScopeCache.get(autoscopeCacheKey, new Callable<ScopeImpl<S>>() {
+    RawJobBrokerKey autoscopeCacheKey = new RawJobBrokerKey(broker.getWrappedSelfScope(), factory.getName(), key.toConfigurationKey());
+    ScopeWrapper<S> selectedScope = this.autoScopeCache.get(autoscopeCacheKey, new Callable<ScopeWrapper<S>>() {
       @Override
-      public ScopeImpl<S> call() throws Exception {
-        return broker.getScope(factory.getAutoScope(broker, broker.getConfigView(null, key, factory.getName())));
+      public ScopeWrapper<S> call() throws Exception {
+        return broker.getWrappedScope(factory.getAutoScope(broker, broker.getConfigView(null, key, factory.getName())));
       }
     });
 
@@ -93,7 +93,7 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
    */
   @SuppressWarnings(value = "unchecked")
   <T, K extends SharedResourceKey> T getScoped(final SharedResourceFactory<T, K, S> factory, @Nonnull final K key,
-      @Nonnull final ScopeImpl<S> scope, final SharedResourcesBrokerImpl<S> broker)
+      @Nonnull final ScopeWrapper<S> scope, final SharedResourcesBrokerImpl<S> broker)
       throws ExecutionException {
 
     RawJobBrokerKey fullKey = new RawJobBrokerKey(scope, factory.getName(), key.toConfigurationKey());
@@ -111,7 +111,7 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
    * {@link Closeable} will be closed, and any such object which is a {@link Service} will be shutdown.
    * @throws IOException
    */
-  public void close(ScopeImpl<S> scope)
+  public void close(ScopeWrapper<S> scope)
       throws IOException {
     List<Service> awaitShutdown = Lists.newArrayList();
 
@@ -144,11 +144,11 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
   }
 
   /**
-   * Filter {@link RawJobBrokerKey} that are not descendants of the input {@link ScopeImpl}.
+   * Filter {@link RawJobBrokerKey} that are not descendants of the input {@link ScopeWrapper}.
    */
   @AllArgsConstructor
   private class ScopeIsAncestorFilter implements Predicate<RawJobBrokerKey> {
-    private final ScopeImpl<S> scope;
+    private final ScopeWrapper<S> scope;
 
     @Override
     public boolean apply(RawJobBrokerKey input) {

--- a/gobblin-utility/src/main/java/gobblin/broker/ScopeWrapper.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/ScopeWrapper.java
@@ -21,11 +21,12 @@ import lombok.Data;
 
 
 /**
- * Simple implementation of {@link ScopeInstance}.
+ * A wrapper around a {@link ScopeInstance} used by {@link SharedResourcesBrokerImpl} to store a
+ * {@link ScopeInstance} and its descendants.
  */
 @Data
-class ScopeImpl<S extends ScopeType<S>> implements ScopeInstance<S> {
+class ScopeWrapper<S extends ScopeType<S>> {
   private final S type;
-  private final String scopeId;
-  private final Collection<ScopeImpl<S>> parentScopes;
+  private final ScopeInstance<S> scope;
+  private final Collection<ScopeWrapper<S>> parentScopes;
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerImpl.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerImpl.java
@@ -34,7 +34,6 @@ import gobblin.broker.iface.SharedResourceKey;
 import gobblin.broker.iface.SharedResourcesBroker;
 import gobblin.util.ConfigUtils;
 
-import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Data;
 
@@ -51,29 +50,26 @@ import lombok.Data;
 public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements SharedResourcesBroker<S> {
 
   private final DefaultBrokerCache<S> brokerCache;
-  private final ScopeImpl<S> selfScope;
+  private final ScopeWrapper<S> selfScopeWrapper;
   private final List<ScopedConfig<S>> scopedConfigs;
-  private final ImmutableMap<S, ScopeImpl<S>> ancestorScopesByType;
+  private final ImmutableMap<S, ScopeWrapper<S>> ancestorScopesByType;
 
-  SharedResourcesBrokerImpl(DefaultBrokerCache<S> brokerCache, ScopeImpl<S> selfScope,
+  SharedResourcesBrokerImpl(DefaultBrokerCache<S> brokerCache, ScopeWrapper<S> selfScope,
       List<ScopedConfig<S>> scopedConfigs) {
     this.brokerCache = brokerCache;
-    this.selfScope = selfScope;
+    this.selfScopeWrapper = selfScope;
     this.scopedConfigs = scopedConfigs;
     this.ancestorScopesByType = computeScopeMap(selfScope);
   }
 
   @Override
   public ScopeInstance<S> selfScope() {
-    return this.selfScope;
+    return this.selfScopeWrapper.getScope();
   }
 
   @Override
-  public ScopeImpl<S> getScope(S scopeType) throws NoSuchScopeException {
-    if (!this.ancestorScopesByType.containsKey(scopeType)) {
-      throw new NoSuchScopeException(scopeType);
-    }
-    return this.ancestorScopesByType.get(scopeType);
+  public ScopeInstance<S> getScope(S scopeType) throws NoSuchScopeException {
+    return getWrappedScope(scopeType).getScope();
   }
 
   @Override
@@ -90,7 +86,7 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
   public <T, K extends SharedResourceKey> T getSharedResourceAtScope(SharedResourceFactory<T, K, S> factory, K key,
       S scope) throws NotConfiguredException, NoSuchScopeException {
     try {
-      return this.brokerCache.getScoped(factory, key, getScope(scope), this);
+      return this.brokerCache.getScoped(factory, key, getWrappedScope(scope), this);
     } catch (ExecutionException ee) {
       throw new RuntimeException(ee);
     }
@@ -103,7 +99,7 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
 
     Config config = ConfigFactory.empty();
     for (ScopedConfig<S> scopedConfig : this.scopedConfigs) {
-      if (scopedConfig.getScopeType() == null) {
+      if (scopedConfig.getScopeType().equals(scopedConfig.getScopeType().rootScope())) {
         config = ConfigUtils.getConfigOrEmpty(scopedConfig.getConfig(), factoryName).withFallback(config);
       } else if (scope != null && SharedResourcesBrokerUtils.isScopeTypeAncestor(scope, scopedConfig.getScopeType())) {
         config = ConfigUtils.getConfigOrEmpty(scopedConfig.getConfig(), factoryName).getConfig(scope.name())
@@ -114,12 +110,22 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
     return new KeyedScopedConfigViewImpl<>(scope, key, factoryName, config);
   }
 
+  ScopeWrapper<S> getWrappedScope(S scopeType) throws NoSuchScopeException {
+    if (!this.ancestorScopesByType.containsKey(scopeType)) {
+      throw new NoSuchScopeException(scopeType);
+    }
+    return this.ancestorScopesByType.get(scopeType);
+  }
+
+  ScopeWrapper<S> getWrappedSelfScope() {
+    return this.selfScopeWrapper;
+  }
+
   /**
    * Stores overrides of {@link Config} applicable to a specific {@link ScopeType} and its descendants.
    */
   @Data
   static class ScopedConfig<T extends ScopeType<T>> {
-    @Nullable
     private final T scopeType;
     private final Config config;
   }
@@ -128,42 +134,41 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
    * Get a builder to create a descendant {@link SharedResourcesBrokerImpl} (i.e. its leaf scope is a descendant of this
    * broker's leaf scope) and the same backing {@link DefaultBrokerCache}.
    *
-   * @param scopeType {@link ScopeType} of the leaf scope of the new {@link SharedResourcesBrokerImpl}.
-   * @param scopeId id of the leaf scope of the new {@link SharedResourcesBrokerImpl}.
+   * @param subscope the {@link ScopeInstance} of the new {@link SharedResourcesBroker}.
    * @return a {@link SubscopedBrokerBuilder}.
    */
-  public SubscopedBrokerBuilder newSubscopedBuilder(S scopeType, String scopeId) {
-    return new SubscopedBrokerBuilder(scopeType, scopeId);
+  @Override
+  public SubscopedBrokerBuilder newSubscopedBuilder(ScopeInstance<S> subscope) {
+    return new SubscopedBrokerBuilder(subscope);
   }
 
   /**
    * A builder used to create a descendant {@link SharedResourcesBrokerImpl} with the same backing {@link DefaultBrokerCache}.
    */
   @NotThreadSafe
-  public class SubscopedBrokerBuilder {
-    private final S scopeType;
-    private final String scopeId;
-    private final Map<S, ScopeImpl<S>> ancestorScopes = Maps.newHashMap();
+  public class SubscopedBrokerBuilder implements gobblin.broker.iface.SubscopedBrokerBuilder<S, SharedResourcesBrokerImpl<S>> {
+    private final ScopeInstance<S> scope;
+    private final Map<S, ScopeWrapper<S>> ancestorScopes = Maps.newHashMap();
     private Config config = ConfigFactory.empty();
 
-    private SubscopedBrokerBuilder(S scopeType, String scopeId) {
-      this.scopeType = scopeType;
-      this.scopeId = scopeId;
+    private SubscopedBrokerBuilder(ScopeInstance<S> scope) {
+      this.scope = scope;
 
-      if (SharedResourcesBrokerImpl.this.selfScope != null) {
-        ancestorScopes.put(SharedResourcesBrokerImpl.this.selfScope.getType(), SharedResourcesBrokerImpl.this.selfScope);
+      if (SharedResourcesBrokerImpl.this.selfScopeWrapper != null) {
+        ancestorScopes.put(SharedResourcesBrokerImpl.this.selfScopeWrapper.getType(), SharedResourcesBrokerImpl.this.selfScopeWrapper);
       }
     }
 
     /**
      * Specify additional ancestor {@link SharedResourcesBrokerImpl}. Useful when a {@link ScopeType} has multiple parents.
      */
-    public SubscopedBrokerBuilder withAdditionalParentBroker(SharedResourcesBrokerImpl<S> broker) {
-      if (!broker.brokerCache.equals(SharedResourcesBrokerImpl.this.brokerCache)) {
+    public SubscopedBrokerBuilder withAdditionalParentBroker(SharedResourcesBroker<S> broker) {
+      if (!(broker instanceof SharedResourcesBrokerImpl) ||
+          !((SharedResourcesBrokerImpl) broker).brokerCache.equals(SharedResourcesBrokerImpl.this.brokerCache)) {
         throw new IllegalArgumentException("Additional parent broker is not compatible.");
       }
 
-      this.ancestorScopes.put(broker.selfScope().getType(), (ScopeImpl<S>) broker.selfScope());
+      this.ancestorScopes.put(broker.selfScope().getType(), ((SharedResourcesBrokerImpl<S>) broker).selfScopeWrapper);
       return this;
     }
 
@@ -182,32 +187,39 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
      */
     public SharedResourcesBrokerImpl<S> build() {
 
-      ScopeImpl<S> newScope = createScope(this.scopeType, this.scopeId, this.ancestorScopes, this.scopeType);
+      ScopeWrapper<S> newScope = createWrappedScope(this.scope, this.ancestorScopes, this.scope.getType());
 
-      if (SharedResourcesBrokerImpl.this.selfScope != null && !SharedResourcesBrokerUtils.isScopeAncestor(newScope, SharedResourcesBrokerImpl.this.selfScope)) {
-        throw new IllegalArgumentException(String.format("Child scope %s must be a child of leaf scope %s.", scopeType,
-            SharedResourcesBrokerImpl.this.selfScope.getType()));
+      if (SharedResourcesBrokerImpl.this.selfScopeWrapper != null && !SharedResourcesBrokerUtils.isScopeAncestor(newScope, SharedResourcesBrokerImpl.this.selfScopeWrapper)) {
+        throw new IllegalArgumentException(String.format("Child scope %s must be a child of leaf scope %s.", newScope.getType(),
+            SharedResourcesBrokerImpl.this.selfScopeWrapper.getType()));
       }
 
       List<ScopedConfig<S>> scopedConfigs = Lists.newArrayList(SharedResourcesBrokerImpl.this.scopedConfigs);
       if (!this.config.isEmpty()) {
-        scopedConfigs.add(new ScopedConfig<>(this.scopeType, this.config));
+        scopedConfigs.add(new ScopedConfig<>(newScope.getType(), this.config));
       }
 
       return new SharedResourcesBrokerImpl<>(SharedResourcesBrokerImpl.this.brokerCache, newScope, scopedConfigs);
     }
 
-    private ScopeImpl<S> createScope(S scopeType, String scopeId, Map<S, ScopeImpl<S>> ancestorScopes, S mainScopeType)
+    private ScopeWrapper<S> createWrappedScope(ScopeInstance<S> scope, Map<S, ScopeWrapper<S>> ancestorScopes, S mainScopeType)
         throws IllegalArgumentException {
 
-      List<ScopeImpl<S>> parentScopes = Lists.newArrayList();
+      List<ScopeWrapper<S>> parentScopes = Lists.newArrayList();
+
+      ScopeType<S> scopeType = scope.getType();
 
       if (scopeType.parentScopes() != null) {
         for (S tpe : scopeType.parentScopes()) {
           if (ancestorScopes.containsKey(tpe)) {
             parentScopes.add(ancestorScopes.get(tpe));
-          } else if (tpe.defaultId() != null) {
-            parentScopes.add(createScope(tpe, tpe.defaultId(), ancestorScopes, mainScopeType));
+          } else if (tpe.defaultScopeInstance() != null) {
+            ScopeInstance<S> defaultInstance = tpe.defaultScopeInstance();
+            if (!defaultInstance.getType().equals(tpe)) {
+              throw new RuntimeException(String.format("Default scope instance %s for scope type %s is not of type %s.",
+                  defaultInstance, tpe, tpe));
+            }
+            parentScopes.add(createWrappedScope(tpe.defaultScopeInstance(), ancestorScopes, mainScopeType));
           } else {
             throw new IllegalArgumentException(String.format(
                 "Scope %s is an ancestor of %s, however it does not have a default id and is not provided as an acestor scope.",
@@ -216,29 +228,29 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
         }
       }
 
-      return new ScopeImpl<>(scopeType, scopeId, parentScopes);
+      return new ScopeWrapper<>(scope.getType(), scope, parentScopes);
     }
 
   }
 
-  private ImmutableMap<S, ScopeImpl<S>> computeScopeMap(ScopeImpl<S> leafScope) {
-    Map<S, ScopeImpl<S>> scopeMap = Maps.newHashMap();
+  private ImmutableMap<S, ScopeWrapper<S>> computeScopeMap(ScopeWrapper<S> leafScope) {
+    Map<S, ScopeWrapper<S>> scopeMap = Maps.newHashMap();
 
     if (leafScope == null) {
       return ImmutableMap.copyOf(scopeMap);
     }
 
-    Queue<ScopeImpl<S>> ancestors = new LinkedList<>();
+    Queue<ScopeWrapper<S>> ancestors = new LinkedList<>();
     ancestors.add(leafScope);
 
     while (!ancestors.isEmpty()) {
-      ScopeImpl<S> scope = ancestors.poll();
+      ScopeWrapper<S> scope = ancestors.poll();
       if (!scopeMap.containsKey(scope.getType())) {
         scopeMap.put(scope.getType(), scope);
       } else if (!scopeMap.get(scope.getType()).equals(scope)) {
         throw new IllegalStateException(String.format("Scope %s:%s has two ancestors with scope %s but different identity: %s and %s.",
-            leafScope.getType(), leafScope.getScopeId(), scope.getType(), scope.getScopeId(),
-            scopeMap.get(scope.getType()).getScopeId()));
+            leafScope.getType(), leafScope.getScope(), scope.getType(), scope.getScope(),
+            scopeMap.get(scope.getType()).getScope()));
       }
       ancestors.addAll(scope.getParentScopes());
     }
@@ -263,20 +275,20 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
     if (!ancestorScopesByType.equals(that.ancestorScopesByType)) {
       return false;
     }
-    return selfScope != null ? selfScope.equals(that.selfScope) : that.selfScope == null;
+    return selfScopeWrapper != null ? selfScopeWrapper.equals(that.selfScopeWrapper) : that.selfScopeWrapper == null;
   }
 
   @Override
   public int hashCode() {
     int result = brokerCache.hashCode();
     result = 31 * result + ancestorScopesByType.hashCode();
-    result = 31 * result + (selfScope != null ? selfScope.hashCode() : 0);
+    result = 31 * result + (selfScopeWrapper != null ? selfScopeWrapper.hashCode() : 0);
     return result;
   }
 
   @Override
   public void close()
       throws IOException {
-    this.brokerCache.close(this.selfScope);
+    this.brokerCache.close(this.selfScopeWrapper);
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerUtils.java
@@ -45,10 +45,10 @@ public class SharedResourcesBrokerUtils {
   }
 
   /**
-   * Determine if a {@link ScopeImpl} is an ancestor of another {@link ScopeImpl}.
+   * Determine if a {@link ScopeWrapper} is an ancestor of another {@link ScopeWrapper}.
    */
-  static <S extends ScopeType<S>> boolean isScopeAncestor(ScopeImpl<S> scope, ScopeImpl<S> possibleAncestor) {
-    Queue<ScopeImpl<S>> ancestors = new LinkedList<>();
+  static <S extends ScopeType<S>> boolean isScopeAncestor(ScopeWrapper<S> scope, ScopeWrapper<S> possibleAncestor) {
+    Queue<ScopeWrapper<S>> ancestors = new LinkedList<>();
     ancestors.add(scope);
     while (true) {
       if (ancestors.isEmpty()) {

--- a/gobblin-utility/src/main/java/gobblin/broker/SimpleScope.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SimpleScope.java
@@ -12,52 +12,17 @@
 
 package gobblin.broker;
 
-import java.util.Collection;
-import java.util.List;
-import java.util.Set;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Sets;
-
+import gobblin.broker.iface.ScopeInstance;
 import gobblin.broker.iface.ScopeType;
 
-import javax.annotation.Nullable;
-import lombok.AllArgsConstructor;
+import lombok.Data;
 
 
 /**
- * Simple {@link ScopeType} topology with only two levels.
+ * A simple {@link ScopeInstance} implementation containing just a {@link ScopeType} and an string id.
  */
-@AllArgsConstructor
-public enum  SimpleScope implements ScopeType {
-
-  GLOBAL("global"),
-  LOCAL("local", GLOBAL);
-
-  private static final Set<SimpleScope> LOCAL_SCOPES = Sets.newHashSet(LOCAL);
-
-  private final List<SimpleScope> parentScopes;
-  private final String defaultId;
-
-  SimpleScope(String defaultId, SimpleScope... parentScopes) {
-    this.defaultId = defaultId;
-    this.parentScopes = Lists.newArrayList(parentScopes);
-  }
-
-  @Override
-  public boolean isLocal() {
-    return LOCAL_SCOPES.contains(this);
-  }
-
-  @Override
-  public Collection<SimpleScope> parentScopes() {
-    return this.parentScopes;
-  }
-
-  @Nullable
-  @Override
-  public String defaultId() {
-    return this.defaultId;
-  }
-
+@Data
+public class SimpleScope<S extends ScopeType<S>> implements ScopeInstance<S> {
+  private final S type;
+  private final String scopeId;
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/SimpleScopeType.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SimpleScopeType.java
@@ -19,29 +19,28 @@ import java.util.Set;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 
+import gobblin.broker.iface.ScopeInstance;
 import gobblin.broker.iface.ScopeType;
 
 import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
 
 
 /**
- * Scope topology for Gobblin ingestion applications.
+ * Simple {@link ScopeType} topology with only two levels.
  */
-public enum GobblinScopes implements ScopeType<GobblinScopes> {
+@AllArgsConstructor
+public enum SimpleScopeType implements ScopeType {
 
   GLOBAL("global"),
-  INSTANCE("instance", GLOBAL),
-  JOB(null, INSTANCE),
-  CONTAINER("container", INSTANCE),
-  MULTI_TASK_ATTEMPT("multiTask", JOB, CONTAINER),
-  TASK(null, MULTI_TASK_ATTEMPT);
+  LOCAL("local", GLOBAL);
 
-  private static final Set<GobblinScopes> LOCAL_SCOPES = Sets.newHashSet(CONTAINER, TASK, MULTI_TASK_ATTEMPT);
+  private static final Set<SimpleScopeType> LOCAL_SCOPES = Sets.newHashSet(LOCAL);
 
-  private final List<GobblinScopes> parentScopes;
+  private final List<SimpleScopeType> parentScopes;
   private final String defaultId;
 
-  GobblinScopes(String defaultId, GobblinScopes... parentScopes) {
+  SimpleScopeType(String defaultId, SimpleScopeType... parentScopes) {
     this.defaultId = defaultId;
     this.parentScopes = Lists.newArrayList(parentScopes);
   }
@@ -52,14 +51,19 @@ public enum GobblinScopes implements ScopeType<GobblinScopes> {
   }
 
   @Override
-  public Collection<GobblinScopes> parentScopes() {
+  public Collection<SimpleScopeType> parentScopes() {
     return this.parentScopes;
   }
 
   @Nullable
   @Override
-  public String defaultId() {
-    return this.defaultId;
+  public ScopeInstance defaultScopeInstance() {
+    return this.defaultId == null ? null : new SimpleScope(this, this.defaultId);
+  }
+
+  @Override
+  public ScopeType rootScope() {
+    return GLOBAL;
   }
 
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/GobblinScopeInstance.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/GobblinScopeInstance.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2014-2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.broker.gobblin_scopes;
+
+import gobblin.broker.SimpleScope;
+
+
+/**
+ * {@link gobblin.broker.iface.ScopeInstance} superclass for scopes used in Gobblin ingestion jobs.
+ */
+public class GobblinScopeInstance extends SimpleScope<GobblinScopeTypes> {
+
+  public GobblinScopeInstance(GobblinScopeTypes type, String scopeId) {
+    super(type, scopeId);
+
+    if (!type.getBaseInstanceClass().isAssignableFrom(this.getClass())) {
+      throw new IllegalArgumentException(String.format("A scope with type %s must be a subclass of %s.", type,
+          type.getBaseInstanceClass()));
+    }
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/GobblinScopeTypes.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/GobblinScopeTypes.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2014-2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.broker.gobblin_scopes;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+
+import gobblin.broker.iface.ScopeInstance;
+import gobblin.broker.iface.ScopeType;
+
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+
+/**
+ * Scope topology for Gobblin ingestion applications.
+ */
+public enum GobblinScopeTypes implements ScopeType<GobblinScopeTypes> {
+
+  GLOBAL("global", GobblinScopeInstance.class),
+  INSTANCE("instance", GobblinScopeInstance.class, GLOBAL),
+  JOB(null, JobScopeInstance.class, INSTANCE),
+  CONTAINER("container", GobblinScopeInstance.class, INSTANCE),
+  MULTI_TASK_ATTEMPT("multiTask", GobblinScopeInstance.class, JOB, CONTAINER),
+  TASK(null, TaskScopeInstance.class, MULTI_TASK_ATTEMPT);
+
+  private static final Set<GobblinScopeTypes> LOCAL_SCOPES = Sets.newHashSet(CONTAINER, TASK, MULTI_TASK_ATTEMPT);
+
+  private final List<GobblinScopeTypes> parentScopes;
+  private final String defaultId;
+  @Getter(AccessLevel.PACKAGE)
+  private final Class<?> baseInstanceClass;
+
+  GobblinScopeTypes(String defaultId, Class<?> baseInstanceClass, GobblinScopeTypes... parentScopes) {
+    this.defaultId = defaultId;
+    this.parentScopes = Lists.newArrayList(parentScopes);
+    this.baseInstanceClass = baseInstanceClass;
+  }
+
+  @Override
+  public boolean isLocal() {
+    return LOCAL_SCOPES.contains(this);
+  }
+
+  @Override
+  public Collection<GobblinScopeTypes> parentScopes() {
+    return this.parentScopes;
+  }
+
+  @Nullable
+  @Override
+  public ScopeInstance<GobblinScopeTypes> defaultScopeInstance() {
+    return this.defaultId == null ? null : new GobblinScopeInstance(this, this.defaultId);
+  }
+
+  @Override
+  public GobblinScopeTypes rootScope() {
+    return GLOBAL;
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/JobScopeInstance.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/JobScopeInstance.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2014-2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.broker.gobblin_scopes;
+
+import lombok.Getter;
+
+
+/**
+ * A {@link gobblin.broker.iface.ScopeInstance} for a Gobblin job.
+ */
+@Getter
+public class JobScopeInstance extends GobblinScopeInstance {
+
+  private final String jobName;
+  private final String jobId;
+
+  public JobScopeInstance(String jobName, String jobId) {
+    super(GobblinScopeTypes.JOB, jobName + ", id=" + jobId);
+    this.jobName = jobName;
+    this.jobId = jobId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    JobScopeInstance that = (JobScopeInstance) o;
+
+    if (!jobName.equals(that.jobName)) {
+      return false;
+    }
+    return jobId.equals(that.jobId);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + jobName.hashCode();
+    result = 31 * result + jobId.hashCode();
+    return result;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/TaskScopeInstance.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/gobblin_scopes/TaskScopeInstance.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2014-2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.broker.gobblin_scopes;
+
+import lombok.Getter;
+
+
+/**
+ * A {@link gobblin.broker.iface.ScopeInstance} for a Gobblin task.
+ */
+public class TaskScopeInstance extends GobblinScopeInstance {
+
+  @Getter
+  private final String taskId;
+
+  public TaskScopeInstance(String taskId) {
+    super(GobblinScopeTypes.TASK, taskId);
+    this.taskId = taskId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    TaskScopeInstance that = (TaskScopeInstance) o;
+
+    return taskId.equals(that.taskId);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + taskId.hashCode();
+    return result;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/broker/iface/ScopeInstance.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/iface/ScopeInstance.java
@@ -13,7 +13,15 @@
 package gobblin.broker.iface;
 
 /**
- * A specific scope: {@link ScopeType} and id. For example, each task in a process could be a different scope.
+ * A specific scope for a {@link ScopeType}. For example, each task in a process could be a different scope.
+ *
+ * <p>
+ *   Note: {@link ScopeInstance}s will be rendered using {@link #toString()}, and will be compared using
+ *   {@link #equals(Object)}. It is important to implement appropriate {@link #equals(Object)} and {@link #hashCode()}
+ *   for correct functionality of {@link SharedResourcesBroker}. For example, if a scope for the same task is created
+ *   in two different locations, they should still be equal under {@link #equals(Object)}.
+ * </p>
+ *
  * @param <S> the {@link ScopeType} tree that this scope belongs to.
  */
 public interface ScopeInstance<S extends ScopeType<S>> {
@@ -21,9 +29,4 @@ public interface ScopeInstance<S extends ScopeType<S>> {
    * @return type of {@link ScopeType}.
    */
   S getType();
-
-  /**
-   * @return an id specific for this {@link ScopeInstance}.
-   */
-  String getScopeId();
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/iface/ScopeType.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/iface/ScopeType.java
@@ -51,7 +51,12 @@ public interface ScopeType<S extends ScopeType<S>> {
   Collection<S> parentScopes();
 
   /**
-   * @return a default id for this {@link ScopeType} if applicable.
+   * @return a default {@link ScopeInstance} for this {@link ScopeType}, or null if no such default exists.
    */
-  @Nullable String defaultId();
+  @Nullable ScopeInstance<S> defaultScopeInstance();
+
+  /**
+   * @return the root {@link ScopeType} in the DAG.
+   */
+  S rootScope();
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/iface/SharedResourcesBroker.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/iface/SharedResourcesBroker.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  *
  * {@link SharedResourcesBroker} guarantees that multiple requests for objects with the same factory,
  * {@link ScopeInstance} and {@link SharedResourceKey} return the same object, even if called for different {@link SharedResourcesBroker}
- * instances (as long as the instances were created in the way specified by the {@link SharedResourcesBroker} implementation).
+ * instances. This guarantee requires that new brokers are created using {@link #newSubscopedBuilder(ScopeInstance)} only.
  *
  * @param <S> the {@link ScopeType} tree used by this {@link SharedResourcesBroker}.
  */
@@ -72,7 +72,7 @@ public interface SharedResourcesBroker<S extends ScopeType<S>> extends Closeable
    *
    * @param factory The {@link SharedResourceFactory} used to create the shared object.
    * @param key Identifies different objects from the same factory in the same {@link ScopeInstance}.
-   * @param scope {@link ScopeType} at which the object will be obtained.
+   * @param scopeType {@link ScopeType} at which the object will be obtained.
    * @param <T> type of object created by the factory.
    * @param <K> type of factory accepted by the factory.
    * @return an object of type T.
@@ -80,7 +80,7 @@ public interface SharedResourcesBroker<S extends ScopeType<S>> extends Closeable
    * @throws NoSuchScopeException
    */
   <T, K extends SharedResourceKey> T getSharedResourceAtScope(SharedResourceFactory<T, K, S> factory, K key,
-      S scope) throws NotConfiguredException, NoSuchScopeException;
+      S scopeType) throws NotConfiguredException, NoSuchScopeException;
 
   /**
    * Close all resources at this and descendant scopes, meaning {@link Closeable}s will be closed and
@@ -94,4 +94,12 @@ public interface SharedResourcesBroker<S extends ScopeType<S>> extends Closeable
   @Override
   void close()
       throws IOException;
+
+  /**
+   * Get a builder to create a descendant {@link SharedResourcesBroker}.
+   *
+   * @param subscope the {@link ScopeInstance} of the new {@link SharedResourcesBroker}.
+   * @return a {@link SubscopedBrokerBuilder}.
+   */
+  SubscopedBrokerBuilder<S, ?> newSubscopedBuilder(ScopeInstance<S> subscope);
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/iface/SubscopedBrokerBuilder.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/iface/SubscopedBrokerBuilder.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2014-2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.broker.iface;
+
+import com.typesafe.config.Config;
+
+import gobblin.broker.BrokerConstants;
+
+
+/**
+ * A builder used to create new {@link SharedResourcesBroker} compatible with an existing {@link SharedResourcesBroker}
+ * (i.e. guaranteeing objects are correctly shared among scopes).
+ */
+public interface SubscopedBrokerBuilder<S extends ScopeType<S>, B extends SharedResourcesBroker<S>> {
+
+  /**
+   * Specify additional ancestor {@link SharedResourcesBroker}. Useful when a {@link ScopeType} has multiple parents.
+   */
+  SubscopedBrokerBuilder<S, B> withAdditionalParentBroker(SharedResourcesBroker<S> broker);
+
+  /**
+   * Specify {@link Config} overrides. Note these overrides will only be applicable at the new leaf scope and descendant
+   * scopes. {@link Config} entries must start with {@link BrokerConstants#GOBBLIN_BROKER_CONFIG_PREFIX} (any entries
+   * not satisfying that condition will be ignored).
+   */
+  SubscopedBrokerBuilder<S, B> withOverridingConfig(Config config);
+
+  /**
+   * @return the new {@link SharedResourcesBroker}.
+   */
+  B build();
+}

--- a/gobblin-utility/src/test/java/gobblin/broker/AutoscopedFactoryTest.java
+++ b/gobblin-utility/src/test/java/gobblin/broker/AutoscopedFactoryTest.java
@@ -17,6 +17,10 @@ import com.typesafe.config.ConfigFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import gobblin.broker.gobblin_scopes.JobScopeInstance;
+import gobblin.broker.gobblin_scopes.TaskScopeInstance;
+
 
 public class AutoscopedFactoryTest {
 
@@ -24,21 +28,23 @@ public class AutoscopedFactoryTest {
   public void testAutoscoping() throws Exception {
     Config config = ConfigFactory.empty();
 
-    config = TestFactory.setAutoScopeLevel(config, GobblinScopes.JOB);
+    config = TestFactory.setAutoScopeLevel(config, GobblinScopeTypes.JOB);
 
-    SharedResourcesBrokerImpl<GobblinScopes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config);
-    SharedResourcesBrokerImpl<GobblinScopes> jobBroker = topBroker.newSubscopedBuilder(GobblinScopes.JOB, "job123").build();
-    SharedResourcesBrokerImpl<GobblinScopes>
-        containerBroker = topBroker.newSubscopedBuilder(GobblinScopes.CONTAINER, "thisContainer").build();
-    SharedResourcesBrokerImpl<GobblinScopes> taskBroker = jobBroker.newSubscopedBuilder(GobblinScopes.TASK, "taskabc")
+    SharedResourcesBrokerImpl<GobblinScopeTypes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config,
+        GobblinScopeTypes.GLOBAL.defaultScopeInstance());
+    SharedResourcesBrokerImpl<GobblinScopeTypes> jobBroker =
+        topBroker.newSubscopedBuilder(new JobScopeInstance("myJob", "job123")).build();
+    SharedResourcesBrokerImpl<GobblinScopeTypes>
+        containerBroker = topBroker.newSubscopedBuilder(GobblinScopeTypes.CONTAINER.defaultScopeInstance()).build();
+    SharedResourcesBrokerImpl<GobblinScopeTypes> taskBroker = jobBroker.newSubscopedBuilder(new TaskScopeInstance("taskabc"))
         .withAdditionalParentBroker(containerBroker).build();
 
     TestFactory.SharedResource jobScopedResource =
-        taskBroker.getSharedResourceAtScope(new TestFactory<GobblinScopes>(), new TestResourceKey("myKey"), GobblinScopes.JOB);
+        taskBroker.getSharedResourceAtScope(new TestFactory<GobblinScopeTypes>(), new TestResourceKey("myKey"), GobblinScopeTypes.JOB);
     TestFactory.SharedResource taskScopedResource =
-        taskBroker.getSharedResourceAtScope(new TestFactory<GobblinScopes>(), new TestResourceKey("myKey"), GobblinScopes.TASK);
+        taskBroker.getSharedResourceAtScope(new TestFactory<GobblinScopeTypes>(), new TestResourceKey("myKey"), GobblinScopeTypes.TASK);
     TestFactory.SharedResource autoscopedResource =
-        taskBroker.getSharedResource(new TestFactory<GobblinScopes>(), new TestResourceKey("myKey"));
+        taskBroker.getSharedResource(new TestFactory<GobblinScopeTypes>(), new TestResourceKey("myKey"));
 
     Assert.assertEquals(jobScopedResource, autoscopedResource);
     Assert.assertNotEquals(taskScopedResource, autoscopedResource);
@@ -48,17 +54,19 @@ public class AutoscopedFactoryTest {
   public void testAutoscopedResourcesOnlyClosedInCorrectScope() throws Exception {
     Config config = ConfigFactory.empty();
 
-    config = TestFactory.setAutoScopeLevel(config, GobblinScopes.JOB);
+    config = TestFactory.setAutoScopeLevel(config, GobblinScopeTypes.JOB);
 
-    SharedResourcesBrokerImpl<GobblinScopes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config);
-    SharedResourcesBrokerImpl<GobblinScopes> jobBroker = topBroker.newSubscopedBuilder(GobblinScopes.JOB, "job123").build();
-    SharedResourcesBrokerImpl<GobblinScopes>
-        containerBroker = topBroker.newSubscopedBuilder(GobblinScopes.CONTAINER, "thisContainer").build();
-    SharedResourcesBrokerImpl<GobblinScopes> taskBroker = jobBroker.newSubscopedBuilder(GobblinScopes.TASK, "taskabc")
+    SharedResourcesBrokerImpl<GobblinScopeTypes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config,
+        GobblinScopeTypes.GLOBAL.defaultScopeInstance());
+    SharedResourcesBrokerImpl<GobblinScopeTypes> jobBroker =
+        topBroker.newSubscopedBuilder(new JobScopeInstance("myJob", "job123")).build();
+    SharedResourcesBrokerImpl<GobblinScopeTypes>
+        containerBroker = topBroker.newSubscopedBuilder(GobblinScopeTypes.CONTAINER.defaultScopeInstance()).build();
+    SharedResourcesBrokerImpl<GobblinScopeTypes> taskBroker = jobBroker.newSubscopedBuilder(new TaskScopeInstance("taskabc"))
         .withAdditionalParentBroker(containerBroker).build();
 
     TestFactory.SharedResource autoscopedResource =
-        taskBroker.getSharedResource(new TestFactory<GobblinScopes>(), new TestResourceKey("myKey"));
+        taskBroker.getSharedResource(new TestFactory<GobblinScopeTypes>(), new TestResourceKey("myKey"));
 
     // since object autoscopes at job level, it should not be closed if we close the task broker
     taskBroker.close();

--- a/gobblin-utility/src/test/java/gobblin/broker/GobblinBrokerConfTest.java
+++ b/gobblin-utility/src/test/java/gobblin/broker/GobblinBrokerConfTest.java
@@ -12,6 +12,8 @@
 
 package gobblin.broker;
 
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import gobblin.broker.gobblin_scopes.JobScopeInstance;
 import gobblin.broker.iface.ScopedConfigView;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -34,17 +36,18 @@ public class GobblinBrokerConfTest {
     Config config = ConfigFactory.parseMap(ImmutableMap.of(
         JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, "key1"), "value1",
         JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, "key2"), "value2",
-        JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.CONTAINER.name(), "key2"), "value2scope",
+        JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.CONTAINER.name(), "key2"), "value2scope",
         JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, key, "key2"), "value2key",
-        JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.CONTAINER.name(), key, "key2"), "value2scopekey"
+        JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.CONTAINER.name(), key, "key2"), "value2scopekey"
     ));
 
-    SharedResourcesBrokerImpl<GobblinScopes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config);
+    SharedResourcesBrokerImpl<GobblinScopeTypes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config,
+        GobblinScopeTypes.GLOBAL.defaultScopeInstance());
 
-    KeyedScopedConfigViewImpl<GobblinScopes, TestResourceKey> configView =
-        topBroker.getConfigView(GobblinScopes.CONTAINER, new TestResourceKey(key), TestFactory.NAME);
+    KeyedScopedConfigViewImpl<GobblinScopeTypes, TestResourceKey> configView =
+        topBroker.getConfigView(GobblinScopeTypes.CONTAINER, new TestResourceKey(key), TestFactory.NAME);
 
-    Assert.assertEquals(configView.getScope(), GobblinScopes.CONTAINER);
+    Assert.assertEquals(configView.getScope(), GobblinScopeTypes.CONTAINER);
     Assert.assertEquals(configView.getKey().toConfigurationKey(), key);
     Assert.assertEquals(configView.getKeyedConfig().getString("key2"), "value2key");
     Assert.assertEquals(configView.getScopedConfig().getString("key2"), "value2scope");
@@ -55,7 +58,7 @@ public class GobblinBrokerConfTest {
     Assert.assertEquals(configView.getConfig().getString("key1"), "value1");
 
     configView =
-        topBroker.getConfigView(GobblinScopes.TASK, new TestResourceKey(key), TestFactory.NAME);
+        topBroker.getConfigView(GobblinScopeTypes.TASK, new TestResourceKey(key), TestFactory.NAME);
     Assert.assertEquals(configView.getConfig().getString("key2"), "value2key");
 
   }
@@ -68,35 +71,37 @@ public class GobblinBrokerConfTest {
     Config config = ConfigFactory.parseMap(ImmutableMap.<String, String>builder()
         .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, "key1"), "value1")
         .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, "key2"), "value2")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.CONTAINER.name(), "key2"), "value2scope")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.CONTAINER.name(), "key2"), "value2scope")
         .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, key, "key2"), "value2key")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.CONTAINER.name(), key, "key2"), "value2scopekey")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.JOB.name(), "key2"), "value2scope")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.JOB.name(), key, "key2"), "value2scopekey")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.CONTAINER.name(), key, "key2"), "value2scopekey")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.JOB.name(), "key2"), "value2scope")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.JOB.name(), key, "key2"), "value2scopekey")
         .build());
 
-    SharedResourcesBrokerImpl<GobblinScopes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config);
+    SharedResourcesBrokerImpl<GobblinScopeTypes> topBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config,
+        GobblinScopeTypes.GLOBAL.defaultScopeInstance());
 
     Config overrides = ConfigFactory.parseMap(ImmutableMap.<String, String>builder()
         .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, "key1"), "value1_o")
         .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, "key2"), "value2_o")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.CONTAINER.name(), "key2"), "value2scope_o")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.CONTAINER.name(), "key2"), "value2scope_o")
         .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, key, "key2"), "value2key_o")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.CONTAINER.name(), key, "key2"), "value2scopekey_o")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.JOB.name(), "key2"), "value2scope_o")
-        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopes.JOB.name(), key, "key2"), "value2scopekey_o")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.CONTAINER.name(), key, "key2"), "value2scopekey_o")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.JOB.name(), "key2"), "value2scope_o")
+        .put(JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, TestFactory.NAME, GobblinScopeTypes.JOB.name(), key, "key2"), "value2scopekey_o")
         .build());
 
-    SharedResourcesBrokerImpl<GobblinScopes> jobBroker = topBroker.newSubscopedBuilder(GobblinScopes.JOB, "job1")
-        .withOverridingConfig(overrides).build();
+    SharedResourcesBrokerImpl<GobblinScopeTypes> jobBroker =
+        topBroker.newSubscopedBuilder(new JobScopeInstance("myJob", "job123")).
+            withOverridingConfig(overrides).build();
 
-    ScopedConfigView<GobblinScopes, TestResourceKey> configView =
-        jobBroker.getConfigView(GobblinScopes.CONTAINER, new TestResourceKey(key), TestFactory.NAME);
+    ScopedConfigView<GobblinScopeTypes, TestResourceKey> configView =
+        jobBroker.getConfigView(GobblinScopeTypes.CONTAINER, new TestResourceKey(key), TestFactory.NAME);
     Assert.assertEquals(configView.getConfig().getString("key1"), "value1");
     Assert.assertEquals(configView.getConfig().getString("key2"), "value2scopekey");
 
     configView =
-        jobBroker.getConfigView(GobblinScopes.JOB, new TestResourceKey(key), TestFactory.NAME);
+        jobBroker.getConfigView(GobblinScopeTypes.JOB, new TestResourceKey(key), TestFactory.NAME);
     Assert.assertEquals(configView.getConfig().getString("key1"), "value1");
     Assert.assertEquals(configView.getConfig().getString("key2"), "value2scopekey_o");
 

--- a/gobblin-utility/src/test/java/gobblin/broker/KeyedScopedConfigViewImplTest.java
+++ b/gobblin-utility/src/test/java/gobblin/broker/KeyedScopedConfigViewImplTest.java
@@ -20,6 +20,8 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+
 
 public class KeyedScopedConfigViewImplTest {
 
@@ -35,14 +37,14 @@ public class KeyedScopedConfigViewImplTest {
         .put("key1", "value1")
         .put("key2", "value2")
         .put(JOINER.join(key, "key2"), "value2key")
-        .put(JOINER.join(GobblinScopes.JOB.name(), "key2"), "value2scope")
-        .put(JOINER.join(GobblinScopes.JOB.name(), key, "key2"), "value2scopekey")
+        .put(JOINER.join(GobblinScopeTypes.JOB.name(), "key2"), "value2scope")
+        .put(JOINER.join(GobblinScopeTypes.JOB.name(), key, "key2"), "value2scopekey")
         .build());
 
-    KeyedScopedConfigViewImpl<GobblinScopes, TestResourceKey> configView =
-        new KeyedScopedConfigViewImpl<>(GobblinScopes.JOB, new TestResourceKey(key), TestFactory.NAME, config);
+    KeyedScopedConfigViewImpl<GobblinScopeTypes, TestResourceKey> configView =
+        new KeyedScopedConfigViewImpl<>(GobblinScopeTypes.JOB, new TestResourceKey(key), TestFactory.NAME, config);
 
-    Assert.assertEquals(configView.getScope(), GobblinScopes.JOB);
+    Assert.assertEquals(configView.getScope(), GobblinScopeTypes.JOB);
     Assert.assertEquals(configView.getKey().toConfigurationKey(), key);
     Assert.assertEquals(configView.getKeyedConfig().getString("key2"), "value2key");
     Assert.assertEquals(configView.getScopedConfig().getString("key2"), "value2scope");

--- a/gobblin-utility/src/test/java/gobblin/broker/TestFactory.java
+++ b/gobblin-utility/src/test/java/gobblin/broker/TestFactory.java
@@ -21,6 +21,7 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.ConfigView;
 import gobblin.broker.iface.ScopeType;
 import gobblin.broker.iface.ScopedConfigView;
@@ -37,7 +38,7 @@ public class TestFactory<S extends ScopeType<S>> implements SharedResourceFactor
 
   public static final String NAME = TestFactory.class.getSimpleName();
 
-  public static Config setAutoScopeLevel(Config config, GobblinScopes level) {
+  public static Config setAutoScopeLevel(Config config, GobblinScopeTypes level) {
     return ConfigFactory.parseMap(ImmutableMap.of(
         JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, NAME, AUTOSCOPE_AT), level.name()))
         .withFallback(config);
@@ -56,7 +57,7 @@ public class TestFactory<S extends ScopeType<S>> implements SharedResourceFactor
   @Override
   public S getAutoScope(SharedResourcesBroker<S> broker, ConfigView<S, TestResourceKey> config) {
     if (config.getConfig().hasPath(AUTOSCOPE_AT)) {
-      return (S) GobblinScopes.valueOf(config.getConfig().getString(AUTOSCOPE_AT));
+      return (S) GobblinScopeTypes.valueOf(config.getConfig().getString(AUTOSCOPE_AT));
     } else {
       return broker.selfScope().getType();
     }

--- a/gobblin-utility/src/test/java/gobblin/broker/gobblin_scopes/GobblinScopesTest.java
+++ b/gobblin-utility/src/test/java/gobblin/broker/gobblin_scopes/GobblinScopesTest.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014-2017 LinkedIn Corp. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use
+ * this file except in compliance with the License. You may obtain a copy of the
+ * License at  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR
+ * CONDITIONS OF ANY KIND, either express or implied.
+ */
+
+package gobblin.broker.gobblin_scopes;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class GobblinScopesTest {
+
+  @Test
+  public void test() {
+
+    GobblinScopeInstance containerScope = new GobblinScopeInstance(GobblinScopeTypes.CONTAINER, "myContainer");
+    Assert.assertEquals(containerScope.getScopeId(), "myContainer");
+
+    JobScopeInstance jobScope = new JobScopeInstance("myJob", "job123");
+    Assert.assertEquals(jobScope.getJobId(), "job123");
+    Assert.assertEquals(jobScope.getJobName(), "myJob");
+
+    TaskScopeInstance taskScope = new TaskScopeInstance("myTask");
+    Assert.assertEquals(taskScope.getTaskId(), "myTask");
+
+    try {
+      new GobblinScopeInstance(GobblinScopeTypes.JOB, "myJob");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      // expected because should use JobScopeInstance
+    }
+
+    try {
+      new GobblinScopeInstance(GobblinScopeTypes.TASK, "myJob");
+      Assert.fail();
+    } catch (IllegalArgumentException iae) {
+      // expected because should use TaskScopeInstance
+    }
+  }
+
+}


### PR DESCRIPTION
This PR changes `ScopeInstance` to make them less restrictive.

* `ScopeInstance` is now an even more generic interface, and the broker only interacts with it using `equals`, `hashCode`, `getType`, and `toString` methods. This allows scopes to store additional metadata, for example a job name and job id, instead of a single generic id.
* `ScopeType` now has a method `rootScope()` that returns the root of the DAG of scope types.
* Brokers with `null` scope are no longer allowed. The top level broker is now at the `rootScope()` level.

The effective changes in code are as follows:
* `ScopeInstanceImpl` becomes `ScopeWrapper` which is used internally to store a `ScopeInstance` and references to its ancestors. A lot of changes are just renaming this.
* Public methods on the broker still return `ScopeInstance`. `SharedResourcesBrokerImpl` additionally has package-private methods to get the wrapped scope.
* Added `SubscopedBrokerBuilder` interface (equivalent to the existing `SharedResourcesBrokerImpl.SubscopedBrokerBuilder`) as the only correct way of creating sub brokers.
* `GobblinScopes` became `GobblinScopeTypes`. Added `GobblinScopeInstance`, `JobScopeInstance`, and `TaskScopeInstance` that will have job and task metadata respectively (as needed).
* Changes in tests are just updates to the slightly different way of creating brokers.
* Added a test for `GobblinScopeInstance`.