### PR TITLE
Adding a factory abstraction for file-based job locks

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/AbstractJobLauncher.java
@@ -57,7 +57,7 @@ import gobblin.runtime.listeners.JobListeners;
 import gobblin.runtime.locks.JobLock;
 import gobblin.runtime.locks.JobLockEventListener;
 import gobblin.runtime.locks.JobLockException;
-import gobblin.runtime.locks.JobLockFactory;
+import gobblin.runtime.locks.LegacyJobLockFactoryManager;
 import gobblin.runtime.util.JobMetrics;
 import gobblin.source.workunit.MultiWorkUnit;
 import gobblin.source.workunit.WorkUnit;
@@ -504,7 +504,7 @@ public abstract class AbstractJobLauncher implements JobLauncher {
    */
   protected JobLock getJobLock(Properties properties, JobLockEventListener jobLockEventListener)
       throws JobLockException {
-    return JobLockFactory.getJobLock(properties, jobLockEventListener);
+    return LegacyJobLockFactoryManager.getJobLock(properties, jobLockEventListener);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/locks/FileBasedJobLock.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/locks/FileBasedJobLock.java
@@ -13,13 +13,11 @@
 package gobblin.runtime.locks;
 
 import java.io.IOException;
-import java.net.URI;
 import java.util.Properties;
 
-import gobblin.configuration.ConfigurationKeys;
-import gobblin.util.HadoopUtils;
-import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+
+import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -33,24 +31,26 @@ import org.apache.hadoop.fs.Path;
  * @author Yinan Li
  */
 public class FileBasedJobLock implements JobLock {
+  /** Legacy */
   public static final String JOB_LOCK_DIR = "job.lock.dir";
   public static final String LOCK_FILE_EXTENSION = ".lock";
 
-  private FileSystem fs;
-  // Empty file associated with the lock
-  private Path lockFile;
+  /** The URI of the file system with the directory for lock files*/
+  public static final String FS_URI_CONFIG = "fsURI";
+  /** The path to the directory for lock files*/
+  public static final String LOCK_DIR_CONFIG = "lockDir";
+
+  private final FileBasedJobLockFactory parent;
+  private final Path lockFile;
 
   public FileBasedJobLock(Properties properties) throws JobLockException {
-    try {
-      this.fs = FileSystem.get(
-          URI.create(properties.getProperty(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI)),
-          HadoopUtils.getConfFromProperties(properties));
-      String jobName = properties.getProperty(ConfigurationKeys.JOB_NAME_KEY);
-      String lockFileDir = properties.getProperty(JOB_LOCK_DIR);
-      this.lockFile = new Path(lockFileDir, jobName + LOCK_FILE_EXTENSION);
-    } catch (IOException e) {
-      throw new JobLockException(e);
-    }
+    this(properties.getProperty(ConfigurationKeys.JOB_NAME_KEY),
+         FileBasedJobLockFactory.createForProperties(properties));
+  }
+
+  FileBasedJobLock(String jobName, FileBasedJobLockFactory parent) {
+    this.parent = parent;
+    this.lockFile = parent.getLockFile(jobName);
   }
 
     /**
@@ -60,13 +60,7 @@ public class FileBasedJobLock implements JobLock {
    */
   @Override
   public void lock() throws JobLockException {
-    try {
-      if (!this.fs.createNewFile(this.lockFile)) {
-        throw new JobLockException("Failed to create lock file " + this.lockFile.getName());
-      }
-    } catch (IOException e) {
-      throw new JobLockException(e);
-    }
+    this.parent.lock(this.lockFile);
   }
 
   /**
@@ -76,15 +70,7 @@ public class FileBasedJobLock implements JobLock {
    */
   @Override
   public void unlock() throws JobLockException {
-    if (!isLocked()) {
-      return;
-    }
-
-    try {
-      this.fs.delete(this.lockFile, false);
-    } catch (IOException e) {
-      throw new JobLockException(e);
-    }
+    this.parent.unlock(this.lockFile);
   }
 
   /**
@@ -96,11 +82,7 @@ public class FileBasedJobLock implements JobLock {
    */
   @Override
   public boolean tryLock() throws JobLockException {
-    try {
-      return this.fs.createNewFile(this.lockFile);
-    } catch (IOException e) {
-      throw new JobLockException(e);
-    }
+    return this.parent.tryLock(this.lockFile);
   }
 
   /**
@@ -111,11 +93,7 @@ public class FileBasedJobLock implements JobLock {
    */
   @Override
   public boolean isLocked() throws JobLockException {
-    try {
-      return this.fs.exists(this.lockFile);
-    } catch (IOException e) {
-      throw new JobLockException(e);
-    }
+    return this.parent.isLocked(this.lockFile);
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/locks/FileBasedJobLockFactory.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/locks/FileBasedJobLockFactory.java
@@ -1,0 +1,108 @@
+/**
+ *
+ */
+package gobblin.runtime.locks;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Properties;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.HadoopUtils;
+
+/**
+ * A factory for file-based job locks
+ */
+public class FileBasedJobLockFactory  {
+
+  private final FileSystem fs;
+  private final String lockFileDir;
+
+  /** */
+  public FileBasedJobLockFactory(FileSystem fs, String lockFileDir) {
+    this.fs = fs;
+    this.lockFileDir = lockFileDir;
+  }
+
+  Path getLockFile(String jobName) {
+    return new Path(lockFileDir, jobName + FileBasedJobLock.LOCK_FILE_EXTENSION);
+  }
+
+  /**
+   * Acquire the lock.
+   *
+   * @throws JobLockException thrown if the {@link JobLock} fails to be acquired
+   */
+  void lock(Path lockFile) throws JobLockException {
+    try {
+      if (!this.fs.createNewFile(lockFile)) {
+        throw new JobLockException("Failed to create lock file " + lockFile.getName());
+      }
+    } catch (IOException e) {
+      throw new JobLockException(e);
+    }
+  }
+
+  /**
+   * Release the lock.
+   *
+   * @throws JobLockException thrown if the {@link JobLock} fails to be released
+   */
+  void unlock(Path lockFile) throws JobLockException {
+    if (!isLocked(lockFile)) {
+      return;
+    }
+
+    try {
+      this.fs.delete(lockFile, false);
+    } catch (IOException e) {
+      throw new JobLockException(e);
+    }
+  }
+
+  /**
+   * Try locking the lock.
+   *
+   * @return <em>true</em> if the lock is successfully locked,
+   *         <em>false</em> if otherwise.
+   * @throws JobLockException thrown if the {@link JobLock} fails to be acquired
+   */
+  boolean tryLock(Path lockFile) throws JobLockException {
+    try {
+      return this.fs.createNewFile(lockFile);
+    } catch (IOException e) {
+      throw new JobLockException(e);
+    }
+  }
+
+  /**
+   * Check if the lock is locked.
+   *
+   * @return if the lock is locked
+   * @throws JobLockException thrown if checking the status of the {@link JobLock} fails
+   */
+  boolean isLocked(Path lockFile) throws JobLockException {
+    try {
+      return this.fs.exists(lockFile);
+    } catch (IOException e) {
+      throw new JobLockException(e);
+    }
+  }
+
+  public static FileBasedJobLockFactory createForProperties(Properties properties)
+         throws JobLockException {
+    try {
+      FileSystem fs = FileSystem.get(
+          URI.create(properties.getProperty(ConfigurationKeys.FS_URI_KEY, ConfigurationKeys.LOCAL_FS_URI)),
+          HadoopUtils.getConfFromProperties(properties));
+      String lockFileDir = properties.getProperty(FileBasedJobLock.JOB_LOCK_DIR);
+      return new FileBasedJobLockFactory(fs, lockFileDir);
+    } catch (IOException e) {
+      throw new JobLockException(e);
+    }
+  }
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/locks/LegacyJobLockFactoryManager.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/locks/LegacyJobLockFactoryManager.java
@@ -15,9 +15,12 @@ package gobblin.runtime.locks;
 import java.lang.reflect.InvocationTargetException;
 import java.util.Properties;
 
-import com.google.common.base.Preconditions;
-import gobblin.configuration.ConfigurationKeys;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import gobblin.configuration.ConfigurationKeys;
 
 
 /**
@@ -25,8 +28,10 @@ import org.apache.commons.lang3.reflect.ConstructorUtils;
  *
  * @author joelbaranick
  */
-public class JobLockFactory {
-  private JobLockFactory() {
+public class LegacyJobLockFactoryManager {
+
+
+  public LegacyJobLockFactoryManager(Config sysConfig) {
   }
 
   /**

--- a/gobblin-runtime/src/test/java/gobblin/runtime/locks/FileBasedJobLockTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/locks/FileBasedJobLockTest.java
@@ -19,7 +19,6 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.log4j.BasicConfigurator;
-
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -56,6 +55,7 @@ public class FileBasedJobLockTest extends JobLockTest {
     return new FileBasedJobLock(properties);
   }
 
+  @Override
   @AfterClass
   public void tearDown() throws IOException {
     if (this.fs.exists(this.path)) {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/locks/LegacyJobLockFactoryManagerTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/locks/LegacyJobLockFactoryManagerTest.java
@@ -27,7 +27,7 @@ import gobblin.configuration.ConfigurationKeys;
 
 
 @Test(groups = {"gobblin.runtime"})
-public class JobLockFactoryTest {
+public class LegacyJobLockFactoryManagerTest {
   @AfterClass
   public void tearDown() throws IOException {
     ZookeeperBasedJobLock.shutdownCuratorFramework();
@@ -37,7 +37,7 @@ public class JobLockFactoryTest {
   public void testNullProperties_ThrowsException() throws JobLockException, IOException {
     Closer closer = Closer.create();
     try {
-      closer.register(JobLockFactory.getJobLock(null, new JobLockEventListener()));
+      closer.register(LegacyJobLockFactoryManager.getJobLock(null, new JobLockEventListener()));
     } finally {
       closer.close();
     }
@@ -47,7 +47,7 @@ public class JobLockFactoryTest {
   public void testNullListener_ThrowsException() throws JobLockException, IOException {
     Closer closer = Closer.create();
     try {
-      closer.register(JobLockFactory.getJobLock(new Properties(), null));
+      closer.register(LegacyJobLockFactoryManager.getJobLock(new Properties(), null));
     } finally {
       closer.close();
     }
@@ -62,7 +62,7 @@ public class JobLockFactoryTest {
       properties.setProperty(FileBasedJobLock.JOB_LOCK_DIR, "JobLockFactoryTest");
       properties.setProperty(ConfigurationKeys.JOB_NAME_KEY, "JobLockFactoryTest-" + System.currentTimeMillis());
       properties.setProperty(ConfigurationKeys.JOB_LOCK_TYPE, FileBasedJobLock.class.getName());
-      JobLock jobLock = closer.register(JobLockFactory.getJobLock(properties, new JobLockEventListener()));
+      JobLock jobLock = closer.register(LegacyJobLockFactoryManager.getJobLock(properties, new JobLockEventListener()));
       MatcherAssert.assertThat(jobLock, Matchers.instanceOf(FileBasedJobLock.class));
     } finally {
       closer.close();
@@ -75,7 +75,7 @@ public class JobLockFactoryTest {
     try {
       Properties properties = new Properties();
       properties.setProperty(ConfigurationKeys.JOB_LOCK_TYPE, "ThisIsATest");
-      JobLock jobLock = closer.register(JobLockFactory.getJobLock(properties, new JobLockEventListener()));
+      JobLock jobLock = closer.register(LegacyJobLockFactoryManager.getJobLock(properties, new JobLockEventListener()));
       MatcherAssert.assertThat(jobLock, Matchers.instanceOf(FileBasedJobLock.class));
     } finally {
       closer.close();
@@ -91,7 +91,7 @@ public class JobLockFactoryTest {
       properties.setProperty(FileBasedJobLock.JOB_LOCK_DIR, "JobLockFactoryTest");
       properties.setProperty(ConfigurationKeys.JOB_NAME_KEY, "JobLockFactoryTest-" + System.currentTimeMillis());
       properties.setProperty(ConfigurationKeys.JOB_LOCK_TYPE, FileBasedJobLock.class.getName());
-      JobLock jobLock = closer.register(JobLockFactory.getJobLock(properties, new JobLockEventListener()));
+      JobLock jobLock = closer.register(LegacyJobLockFactoryManager.getJobLock(properties, new JobLockEventListener()));
       MatcherAssert.assertThat(jobLock, Matchers.instanceOf(FileBasedJobLock.class));
     } finally {
       closer.close();
@@ -112,7 +112,7 @@ public class JobLockFactoryTest {
       properties.setProperty(ZookeeperBasedJobLock.RETRY_BACKOFF_SECONDS, "1");
       properties.setProperty(ZookeeperBasedJobLock.SESSION_TIMEOUT_SECONDS, "180");
       properties.setProperty(ZookeeperBasedJobLock.CONNECTION_TIMEOUT_SECONDS, "30");
-      JobLock jobLock = closer.register(JobLockFactory.getJobLock(properties, new JobLockEventListener()));
+      JobLock jobLock = closer.register(LegacyJobLockFactoryManager.getJobLock(properties, new JobLockEventListener()));
       MatcherAssert.assertThat(jobLock, Matchers.instanceOf(ZookeeperBasedJobLock.class));
     } finally {
       closer.close();


### PR DESCRIPTION
This is part of fixing an issue with using static state in ZookeeperBasedJobLock . This cause hard to find bugs if gobblin runs as continuously running process. This uncovered design issues with job lock instantiation which will be fixed in several commits.

The main issues are:
- Inflexible current implementation of JobLockFactory which has the different implementations hard-coded.
- Lack of per-lock-type factory abstraction. The purpose of such factories will be to keep shared state across locks of the same type. (This is what necessitates ZookeeperBasedJobLock to keep that state as static variables).

The main idea of the new design is to
- Add the above concept of a job lock factory: it can instantiate locks and keep shared state among them
- Add the concept of job lock factory manager. It instantiates and (optionally) configures job lock factories. Factory instance configuration will allow to move some of the properties (e.g. the root directory for file-based locks) from job configs to instance level configs.

The first commit does some refactoring of FileBasedLock to fit the new design. Changes:
- Rename JobLockFactory to LegacyJobLockFactoryManager to free up the name.
- Move shared state out of FileBasedJobLock to FileBasedJobLockFactory which will eventually implement the new factory interface.

@htran1 can you review ?


