### PR TITLE
Issue #1506: Gobblin should use RetryingHiveMetaStoreClient instead of HiveMetaStoreClient

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/HiveMetaStoreClientFactory.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/HiveMetaStoreClientFactory.java
@@ -19,17 +19,30 @@ import org.apache.commons.pool2.BasePooledObjectFactory;
 import org.apache.commons.pool2.PooledObject;
 import org.apache.commons.pool2.impl.DefaultPooledObject;
 import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.HiveMetaHook;
+import org.apache.hadoop.hive.metastore.HiveMetaHookLoader;
 import org.apache.hadoop.hive.metastore.HiveMetaStoreClient;
 import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.RetryingMetaStoreClient;
 import org.apache.hadoop.hive.metastore.api.MetaException;
 
 import com.google.common.base.Optional;
+import org.apache.hadoop.hive.metastore.api.Table;
+import org.apache.hadoop.hive.ql.metadata.HiveException;
+import org.apache.hadoop.hive.ql.metadata.HiveStorageHandler;
+import org.apache.hadoop.hive.ql.metadata.HiveUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.hadoop.hive.metastore.api.hive_metastoreConstants.META_TABLE_STORAGE;
 
 
 /**
  * An implementation of {@link BasePooledObjectFactory} for {@link IMetaStoreClient}.
  */
 public class HiveMetaStoreClientFactory extends BasePooledObjectFactory<IMetaStoreClient> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HiveMetaStoreClientFactory.class);
 
   public static final String HIVE_METASTORE_TOKEN_SIGNATURE = "hive.metastore.token.signature";
   @Getter
@@ -56,10 +69,32 @@ public class HiveMetaStoreClientFactory extends BasePooledObjectFactory<IMetaSto
     this(Optional.<String> absent());
   }
 
+  private IMetaStoreClient createMetaStoreClient() throws MetaException {
+    HiveMetaHookLoader hookLoader = new HiveMetaHookLoader() {
+      @Override
+      public HiveMetaHook getHook(Table tbl) throws MetaException {
+        if (tbl == null) {
+          return null;
+        }
+
+        try {
+          HiveStorageHandler storageHandler =
+              HiveUtils.getStorageHandler(hiveConf, tbl.getParameters().get(META_TABLE_STORAGE));
+          return storageHandler == null ? null : storageHandler.getMetaHook();
+        } catch (HiveException e) {
+          LOG.error(e.toString());
+          throw new MetaException("Failed to get storage handler: " + e);
+        }
+      }
+    };
+
+    return RetryingMetaStoreClient.getProxy(hiveConf, hookLoader, HiveMetaStoreClient.class.getName());
+  }
+
   @Override
   public IMetaStoreClient create() {
     try {
-      return new HiveMetaStoreClient(this.hiveConf);
+      return createMetaStoreClient();
     } catch (MetaException e) {
       throw new RuntimeException("Unable to create " + IMetaStoreClient.class.getSimpleName(), e);
     }

--- a/gobblin-hive-registration/src/test/java/gobblin/hive/HiveMetaStoreClientFactoryTest.java
+++ b/gobblin-hive-registration/src/test/java/gobblin/hive/HiveMetaStoreClientFactoryTest.java
@@ -1,0 +1,30 @@
+package gobblin.hive;
+
+import org.apache.hadoop.hive.conf.HiveConf;
+import org.apache.hadoop.hive.metastore.IMetaStoreClient;
+import org.apache.hadoop.hive.metastore.api.Database;
+import org.apache.thrift.TException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class HiveMetaStoreClientFactoryTest {
+  @Test
+  public void testCreate() throws TException {
+    HiveConf hiveConf = new HiveConf();
+    HiveMetaStoreClientFactory factory = new HiveMetaStoreClientFactory(hiveConf);
+    IMetaStoreClient msc = factory.create();
+
+    String dbName = "test_db";
+    String description = "test database";
+    String location = "file:/tmp/" + dbName;
+    Database db = new Database(dbName, description, location, null);
+
+    msc.dropDatabase(dbName, true, true);
+    msc.createDatabase(db);
+    db = msc.getDatabase(dbName);
+    Assert.assertEquals(db.getName(), dbName);
+    Assert.assertEquals(db.getDescription(), description);
+    Assert.assertEquals(db.getLocationUri(), location);
+  }
+}


### PR DESCRIPTION
Updated the HiveMetaStoreClientFactory implementation to return a RetryingHiveMetaStoreClient instead of a HiveMetaStoreClient. The RetryingHiveMetaStoreClient will automatically retry in case of errors (e.g.: when a metastore is restarted).

Also added a unit test.