### PR TITLE
Use date partition filter in HiveSource

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDataset.java
@@ -87,8 +87,8 @@ public class ConvertibleHiveDataset extends HiveDataset {
    * @param table
    * @param config
    */
-  public ConvertibleHiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Config config) {
-    super(fs, clientPool, table, config);
+  public ConvertibleHiveDataset(FileSystem fs, HiveMetastoreClientPool clientPool, Table table, Properties jobProps, Config config) {
+    super(fs, clientPool, table, jobProps, config);
 
     Preconditions.checkArgument(config.hasPath(DESTINATION_CONVERSION_FORMATS_KEY), String.format(
         "Atleast one destination format should be specified at %s.%s. If you do not intend to convert this dataset set %s.%s to true",

--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetFinder.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetFinder.java
@@ -39,6 +39,6 @@ public class ConvertibleHiveDatasetFinder extends HiveDatasetFinder {
 
   protected ConvertibleHiveDataset createHiveDataset(Table table, Config config) {
     return new ConvertibleHiveDataset(super.fs, super.clientPool, new org.apache.hadoop.hive.ql.metadata.Table(table),
-        config);
+        this.properties, config);
   }
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -18,7 +18,6 @@
 package gobblin.data.management.copy.hive;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -96,7 +95,6 @@ public class HiveDataset implements PrioritizedCopyableDataset {
   private transient final MetricContext metricContext;
   protected transient final Table table;
   protected transient final Config datasetConfig;
-
 
   // Only set if table has exactly one location
   protected final Optional<Path> tableRootPath;

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/dataset/ConvertibleHiveDatasetTest.java
@@ -158,7 +158,7 @@ public class ConvertibleHiveDatasetTest {
     Table table = getTestTable("db1", "tb1");
     ConvertibleHiveDataset cd =
         new ConvertibleHiveDataset(Mockito.mock(FileSystem.class), Mockito.mock(HiveMetastoreClientPool.class), new org.apache.hadoop.hive.ql.metadata.Table(
-            table), config);
+            table), new Properties(), config);
     return cd;
   }
 


### PR DESCRIPTION
Currently `HiveSource` uses `HivePartition`'s createTime to check if it is within lookback. This can cause reprocessing when old source partitions are dropped and recreated.
This change is to use the logical time represented by partition's name for lookback.

@abti can you review?