### PR TITLE
Kafka streaming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ out/
 gobblin-dist/
 gobblin-distribution-*.tar.gz
 gobblin.tar.gz
+*~

--- a/gobblin-example/src/main/resources/SampleStreamingJobConfig.pull
+++ b/gobblin-example/src/main/resources/SampleStreamingJobConfig.pull
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* This is a sample pull file to be used for streaming */
+job.name=PullFromKafka
+job.group=KafkaRunForver-test
+job.description=this is a job that runs forever and consumes from kafka
+job.lock.enabled=false
+gobblin.task.executionMode=STREAMING
+gobblin.streaming.kafka.topic.key.deserializer=org.apache.kafka.common.serialization.StringDeserializer
+gobblin.streaming.kafka.topic.value.deserializer=org.apache.kafka.common.serialization.ByteArrayDeserializer
+
+source.class=gobblin.source.extractor.extract.kafka.KafkaSimpleStreamingSource
+gobblin.streaming.kafka.topic.singleton=test
+kafka.brokers=localhost:9092
+
+writer.builder.class=gobblin.writer.ConsoleWriterBuilder
+
+
+data.publisher.type=gobblin.publisher.NoopPublisher

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleStreamingExtractor.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleStreamingExtractor.java
@@ -1,0 +1,235 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import java.io.IOException;
+import java.nio.channels.ClosedChannelException;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonElement;
+
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.configuration.State;
+import gobblin.metrics.kafka.KafkaSchemaRegistry;
+import gobblin.metrics.kafka.SchemaRegistryException;
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.extractor.Watermark;
+import gobblin.source.extractor.WatermarkSerializerHelper;
+import gobblin.source.extractor.extract.EventBasedExtractor;
+import gobblin.source.extractor.StreamingExtractor;
+import gobblin.source.extractor.RecordEnvelope;
+import gobblin.source.extractor.CheckpointableWatermark;
+import gobblin.source.extractor.ComparableWatermark;
+import gobblin.source.extractor.extract.LongWatermark;
+import gobblin.metrics.Tag;
+import gobblin.writer.WatermarkStorage;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of {@link StreamingExtractor}  which reads from Kafka and returns records . Type of record depends on deserializer set.
+ *
+ * @author Shrikanth Shankar
+ *
+ *
+ */
+public class KafkaSimpleStreamingExtractor<S, D> extends EventBasedExtractor<S, RecordEnvelope<D>> implements StreamingExtractor<S, D>, WatermarkStorage {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaSimpleStreamingExtractor.class);
+  public static class KafkaWatermark implements CheckpointableWatermark {
+    TopicPartition _topicPartition;
+    LongWatermark _lwm;
+
+    @VisibleForTesting
+    public KafkaWatermark(TopicPartition topicPartition, LongWatermark lwm) {
+      _topicPartition = topicPartition;
+      _lwm = lwm;
+    }
+
+    @Override
+    public String getSource() {
+      return _topicPartition.toString();
+    }
+
+    @Override
+    public ComparableWatermark getWatermark() {
+      return _lwm;
+    }
+
+    @Override
+    public short calculatePercentCompletion(Watermark lowWatermark, Watermark highWatermark) {
+      return 0;
+    }
+
+    @Override
+    public JsonElement toJson() {
+      return WatermarkSerializerHelper.convertWatermarkToJson(this);
+    }
+
+    @Override
+    public int compareTo(CheckpointableWatermark o) {
+      Preconditions.checkArgument(o instanceof KafkaWatermark);
+      KafkaWatermark ko = (KafkaWatermark)o;
+      Preconditions.checkArgument(_topicPartition.equals(ko._topicPartition));
+      return _lwm.compareTo(ko._lwm);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (obj == null)
+        return false;
+      if (!(obj instanceof KafkaWatermark))
+          return false;
+      return this.compareTo((CheckpointableWatermark)obj) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+      final int prime = 31;
+      return _topicPartition.hashCode() * prime + _lwm.hashCode();
+    }
+
+    public TopicPartition getTopicPartition() {return _topicPartition;};
+
+    public LongWatermark getLwm() {return  _lwm;};
+  }
+
+
+  private final Consumer<S, D> _consumer;
+  private final TopicPartition _partition;
+  private Iterator<ConsumerRecord<S, D>> _records;
+  AtomicLong _rowCount = new AtomicLong(0);
+  protected final Optional<KafkaSchemaRegistry<String, S>> _schemaRegistry;
+  protected AtomicBoolean _close = new AtomicBoolean(false);
+
+  public KafkaSimpleStreamingExtractor(WorkUnitState state) {
+    super(state);
+    _consumer = KafkaSimpleStreamingSource.getKafkaConsumer(state);
+    closer.register(_consumer);
+    _partition = new TopicPartition(KafkaSimpleStreamingSource.getTopicNameFromState(state),
+                                    KafkaSimpleStreamingSource.getPartitionIdFromState(state));
+    _consumer.assign(Collections.singletonList(_partition));
+    OffsetAndMetadata offset = _consumer.committed(_partition);
+    if (offset == null) {
+      LOG.info("Offset is null - seeking to beginning of topic");
+      _consumer.seekToBeginning(_partition);
+    }
+    else {
+      LOG.info("Offset found in consumer. Seeking to {}", offset);
+      _consumer.seek(_partition, offset.offset());
+    }
+
+    this._schemaRegistry = state.contains(KafkaSchemaRegistry.KAFKA_SCHEMA_REGISTRY_CLASS)
+        ? Optional.of(KafkaSchemaRegistry.<String, S> get(state.getProperties()))
+        : Optional.<KafkaSchemaRegistry<String, S>> absent();
+  }
+
+  /**
+  * Get the schema (metadata) of the extracted data records.
+  *
+  * @return the schema of Kafka topic being extracted
+  * @throws IOException if there is problem getting the schema
+  */
+  @Override
+  public S getSchema() throws IOException {
+    try {
+      if (_schemaRegistry.isPresent())
+        return _schemaRegistry.get().getLatestSchemaByTopic(this._partition.topic());
+    } catch (SchemaRegistryException e) {
+      throw new RuntimeException(e);
+    }
+    return ((S)this._partition.topic());
+  }
+
+  @Override
+  public List<Tag<?>> generateTags(State state) {
+    List<Tag<?>> tags = super.generateTags(state);
+    tags.add(new Tag<>("kafkaTopic", state.getProp(KafkaSimpleStreamingSource.TOPIC_WHITELIST)));
+    return tags;
+  }
+
+  /**
+   * Return the next record when available. Will never time out since this is a streaming source.
+   */
+  @Override
+  public RecordEnvelope<D> readRecordImpl(RecordEnvelope<D> reuse) throws DataRecordException, IOException {
+    while ((_records == null) || (!_records.hasNext())) {
+      synchronized (_consumer) {
+        if (_close.get())
+          throw new ClosedChannelException();
+        _records = _consumer.poll(100).iterator();
+      }
+    }
+    ConsumerRecord<S, D> record = _records.next();
+    _rowCount.getAndIncrement();
+    return new RecordEnvelope<D>(record.value(), new KafkaWatermark(_partition, new LongWatermark(record.offset())));
+  }
+
+  @Override
+  public long getExpectedRecordCount() {
+    return _rowCount.get();
+  }
+
+  @Override
+  public void close() throws IOException {
+    _close.set(true);
+    _consumer.wakeup();
+    synchronized (_consumer) {
+      closer.close();
+    }
+  }
+
+  @Deprecated
+  @Override
+  public long getHighWatermark() {
+    return 0;
+  }
+
+  @Override
+  public void commitWatermarks(Iterable<CheckpointableWatermark> watermarks) throws IOException {
+    Map<TopicPartition, OffsetAndMetadata> wmToCommit = new HashMap<TopicPartition, OffsetAndMetadata>();
+    for (CheckpointableWatermark cwm : watermarks) {
+      Preconditions.checkArgument(cwm instanceof KafkaWatermark);
+      KafkaWatermark kwm = ((KafkaWatermark)cwm);
+      // seek requires moving offset past last record
+      wmToCommit.put(kwm.getTopicPartition(), new OffsetAndMetadata(kwm.getLwm().getValue()+1));
+    }
+    synchronized (_consumer) {
+      if (_close.get())
+        throw new ClosedChannelException();
+      _consumer.commitSync(wmToCommit);
+    }
+  }
+}

--- a/gobblin-modules/gobblin-kafka-09/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleStreamingSource.java
+++ b/gobblin-modules/gobblin-kafka-09/src/main/java/gobblin/source/extractor/extract/kafka/KafkaSimpleStreamingSource.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.source.extractor.extract.kafka;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Properties;
+
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.PartitionInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Throwables;
+import com.google.common.io.Closer;
+import com.google.common.base.Joiner;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.RecordEnvelope;
+import gobblin.source.extractor.extract.EventBasedSource;
+import gobblin.source.workunit.Extract;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.source.extractor.Extractor;
+import gobblin.configuration.SourceState;
+
+
+/**
+ * A {@link Source} implementation for a simple streaming kafka extractor.
+ *
+ * @author Shrikanth Shankar
+ *
+ */
+public class KafkaSimpleStreamingSource<S, D> extends EventBasedSource<S, RecordEnvelope<D>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaSimpleStreamingSource.class);
+
+  /**
+   * This is the topic name used by this source . Currently only supports singleton.
+   */
+  public static final String TOPIC_WHITELIST = "gobblin.streaming.kafka.topic.singleton";
+  /**
+   * Deserializer to be used by this source.
+   */
+  public static final String TOPIC_KEY_DESERIALIZER = "gobblin.streaming.kafka.topic.key.deserializer";
+  public static final String TOPIC_VALUE_DESERIALIZER = "gobblin.streaming.kafka.topic.value.deserializer";
+
+  /**
+   * Private config keys used to pass data into work unit state
+   */
+  private static final String TOPIC_NAME = "gobblin.streaming.topicName";
+  private static final String PARTITION_ID = "gobblin.streaming.partitionId";
+
+  public static String getTopicNameFromState(State s) {
+    return s.getProp(TOPIC_NAME);
+  }
+
+  public static int getPartitionIdFromState(State s) {
+    return s.getPropAsInt(PARTITION_ID);
+  }
+
+  public static void setTopicNameInState(State s, String topic) {
+    s.setProp(TOPIC_NAME, topic);
+  }
+
+  public static void setPartitionId(State s, int partitionId) {
+    s.setProp(PARTITION_ID, partitionId);
+  }
+
+  private final Closer closer = Closer.create();
+  public static final Extract.TableType DEFAULT_TABLE_TYPE = Extract.TableType.APPEND_ONLY;
+  public static final String DEFAULT_NAMESPACE_NAME = "KAFKA";
+
+  static public Consumer getKafkaConsumer(State state) {
+
+    List<String> brokers = state.getPropAsList(ConfigurationKeys.KAFKA_BROKERS);
+    Properties props = new Properties();
+    props.put("bootstrap.servers", Joiner.on(",").join(brokers));
+    props.put("group.id", state.getProp(ConfigurationKeys.JOB_NAME_KEY));
+    props.put("enable.auto.commit", "false");
+    Preconditions.checkArgument(state.getProp(TOPIC_KEY_DESERIALIZER) != null);
+    props.put("key.deserializer", state.getProp(TOPIC_KEY_DESERIALIZER));
+    Preconditions.checkArgument(state.getProp(TOPIC_VALUE_DESERIALIZER) != null);
+    props.put("value.deserializer", state.getProp(TOPIC_VALUE_DESERIALIZER));
+    Consumer consumer = null;
+    try {
+      consumer = new KafkaConsumer<>(props);
+    } catch (Exception e) {
+      LOG.error("Exception when creating Kafka consumer - {}", e);
+      throw Throwables.propagate(e);
+    }
+    return consumer;
+  }
+
+  @Override
+  public List<WorkUnit> getWorkunits(SourceState state) {
+      Consumer<String, byte[]> consumer = getKafkaConsumer(state);
+      LOG.debug("Consumer is {}", consumer);
+      String topic = state.getProp(TOPIC_WHITELIST); // TODO: fix this to use the new API when KafkaWrapper is fixed
+      List<WorkUnit> workUnits = new ArrayList<WorkUnit>();
+      List<PartitionInfo> topicPartitions;
+      topicPartitions = consumer.partitionsFor(topic);
+      LOG.debug("Partition count is {}", topicPartitions.size());
+      for (PartitionInfo topicPartition : topicPartitions){
+        Extract extract = this.createExtract(DEFAULT_TABLE_TYPE, DEFAULT_NAMESPACE_NAME, topicPartition.topic());
+        LOG.debug("Partition info is {}", topicPartition);
+        WorkUnit workUnit = WorkUnit.create(extract);
+        setTopicNameInState(workUnit, topicPartition.topic());
+        workUnit.setProp(ConfigurationKeys.EXTRACT_TABLE_NAME_KEY, topicPartition.topic());
+        setPartitionId(workUnit, topicPartition.partition());
+        workUnits.add(workUnit);
+      }
+      return workUnits;
+    }
+
+
+  @Override
+  public Extractor getExtractor(WorkUnitState state) throws IOException {
+    return new KafkaSimpleStreamingExtractor<S, D>(state);
+    }
+}

--- a/gobblin-modules/gobblin-kafka-09/src/test/java/gobblin/kafka/source/extractor/extract/kafka/KafkaSimpleStreamingTest.java
+++ b/gobblin-modules/gobblin-kafka-09/src/test/java/gobblin/kafka/source/extractor/extract/kafka/KafkaSimpleStreamingTest.java
@@ -1,0 +1,260 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.kafka.source.extractor.extract.kafka;
+
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.nio.channels.ClosedChannelException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Properties;
+import java.util.Arrays;
+
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.testng.annotations.AfterSuite;
+import org.testng.annotations.BeforeSuite;
+import org.testng.annotations.Test;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+import com.sun.tools.javac.util.Assert;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.source.extractor.DataRecordException;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.WorkUnitState;
+import gobblin.kafka.KafkaTestBase;
+import gobblin.configuration.State;
+import gobblin.configuration.SourceState;
+import gobblin.source.extractor.extract.kafka.KafkaSimpleStreamingExtractor;
+import gobblin.source.extractor.extract.kafka.KafkaSimpleStreamingSource;
+import gobblin.source.extractor.RecordEnvelope;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.source.extractor.extract.LongWatermark;
+
+
+import static org.mockito.Mockito.verify;
+
+
+/**
+ * Simple unit tests for the streaming kafka producer.Covers very simple scenarios
+ */
+@Slf4j
+public class KafkaSimpleStreamingTest {
+  private final KafkaTestBase _kafkaTestHelper;
+  public KafkaSimpleStreamingTest()
+      throws InterruptedException, RuntimeException {
+    _kafkaTestHelper = new KafkaTestBase();
+  }
+
+  @BeforeSuite
+  public void beforeSuite() {
+    log.info("Process id = " + ManagementFactory.getRuntimeMXBean().getName());
+
+    _kafkaTestHelper.startServers();
+  }
+
+  @AfterSuite
+  public void afterSuite()
+      throws IOException {
+    try {
+      _kafkaTestHelper.stopClients();
+    }
+    finally {
+      _kafkaTestHelper.stopServers();
+    }
+  }
+
+  /**
+   * Tests that the source creates workUnits appropriately. Sets up a topic with a single partition and checks that a
+   * single workUnit is returned with the right parameters sets
+   * @throws IOException
+   * @throws InterruptedException
+   */
+  @Test
+  public void testSource()
+      throws IOException, InterruptedException {
+    String topic = "testSimpleStreamingSource";
+    _kafkaTestHelper.provisionTopic(topic);
+    SourceState ss = new SourceState();
+    ss.setProp(ConfigurationKeys.KAFKA_BROKERS, "localhost:" + _kafkaTestHelper.getKafkaServerPort());
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_WHITELIST, topic);
+    ss.setProp(ConfigurationKeys.JOB_NAME_KEY, topic);
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    KafkaSimpleStreamingSource<String, byte[]> simpleSource = new KafkaSimpleStreamingSource<String, byte[]>();
+    List<WorkUnit> lWu = simpleSource.getWorkunits(ss);
+    // Check we have a single WorkUnit with the right properties setup.
+    Assert.check(lWu.size() == 1);
+    WorkUnit wU = lWu.get(0);
+    Assert.check(KafkaSimpleStreamingSource.getTopicNameFromState(wU).equals(topic));
+    Assert.check(KafkaSimpleStreamingSource.getPartitionIdFromState(wU) == 0);
+  }
+
+  /**
+   * testExtractor checks that the extractor code does the right thing. First it creates a topic, and sets up a source to point
+   * to it. workUnits are generated from the source (only a single wU should be returned). Then it writes a record to this topic
+   * and reads back from the extractor to verify the right record is returned. A second record is then written and read back
+   * through the extractor to verify poll works as expected. Finally we test the commit api by forcing a commit and then starting
+   * a new extractor to ensure we fetch data from after the commit. The commit is also verified in Kafka directly
+   * @throws IOException
+   * @throws InterruptedException
+   * @throws DataRecordException
+   */
+  @Test(timeOut = 10000)
+  public void testExtractor()
+      throws IOException, InterruptedException, DataRecordException {
+    final String topic = "testSimpleStreamingExtractor";
+    _kafkaTestHelper.provisionTopic(topic);
+
+    Properties props = new Properties();
+    props.put("bootstrap.servers", "localhost:" + _kafkaTestHelper.getKafkaServerPort());
+    props.put("key.serializer", "org.apache.kafka.common.serialization.StringSerializer");
+    props.put("value.serializer", "org.apache.kafka.common.serialization.ByteArraySerializer");
+    Producer<String, byte[]> producer = new KafkaProducer<>(props);
+
+    final byte [] record_1 = {0, 1, 3};
+    final byte [] record_2 = {2, 4, 6};
+    final byte [] record_3 = {5, 7, 9};
+
+    // Write a sample record to the topic
+    producer.send(new ProducerRecord<String, byte[]>(topic, topic, record_1));
+    producer.flush();
+
+    SourceState ss = new SourceState();
+    ss.setProp(ConfigurationKeys.KAFKA_BROKERS, "localhost:" + _kafkaTestHelper.getKafkaServerPort());
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_WHITELIST, topic);
+    ss.setProp(ConfigurationKeys.JOB_NAME_KEY, topic);
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    KafkaSimpleStreamingSource<String, byte[]> simpleSource = new KafkaSimpleStreamingSource<String, byte[]>();
+
+    List<WorkUnit> lWu = simpleSource.getWorkunits(ss);
+    WorkUnit wU = lWu.get(0);
+    WorkUnitState wSU = new WorkUnitState(wU, new State());
+    wSU.setProp(ConfigurationKeys.KAFKA_BROKERS, "localhost:" + _kafkaTestHelper.getKafkaServerPort());
+
+    wSU.setProp(KafkaSimpleStreamingSource.TOPIC_WHITELIST, topic);
+    wSU.setProp(ConfigurationKeys.JOB_NAME_KEY, topic);
+    wSU.setProp(KafkaSimpleStreamingSource.TOPIC_KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+    wSU.setProp(KafkaSimpleStreamingSource.TOPIC_VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    // Create an extractor
+    KafkaSimpleStreamingExtractor<String, byte[]> kSSE = new KafkaSimpleStreamingExtractor<String, byte[]>(wSU);
+    TopicPartition tP = new TopicPartition(topic, 0);
+    KafkaSimpleStreamingExtractor.KafkaWatermark kwm =
+        new KafkaSimpleStreamingExtractor.KafkaWatermark(tP, new LongWatermark(0));
+    byte [] reuse = new byte[1];
+    RecordEnvelope<byte[]> oldRecord = new RecordEnvelope<>(reuse, kwm);
+
+    // read and verify the record matches we just wrote
+    RecordEnvelope<byte[]> record = kSSE.readRecord(oldRecord);
+    Assert.check(Arrays.equals(record.getRecord(), record_1));
+
+    // write a second record.
+    producer.send(new ProducerRecord<String, byte[]>(topic, topic, record_2));
+    producer.flush();
+
+    // read the second record using same extractor to verify it matches whats expected
+    record = kSSE.readRecord(oldRecord);
+    Assert.check(Arrays.equals(record.getRecord(), record_2));
+
+    // Call the commit watermark
+    kSSE.commitWatermarks(Collections.singletonList(record.getWatermark()));
+
+    Consumer<String, byte[]> kC = KafkaSimpleStreamingSource.getKafkaConsumer(wSU);
+    OffsetAndMetadata oM = kC.committed(tP);
+
+
+    // verify committed watermark matches whats expected.
+    Assert.check(record.getWatermark() instanceof KafkaSimpleStreamingExtractor.KafkaWatermark);
+    KafkaSimpleStreamingExtractor.KafkaWatermark kWM = (KafkaSimpleStreamingExtractor.KafkaWatermark)record.getWatermark();
+    Assert.check(oM.offset() == kWM.getLwm().getValue()+1);
+
+    // write a third record.
+    producer.send(new ProducerRecord<String, byte[]>(topic, topic, record_3));
+    producer.flush();
+
+    // recreate extractor to force a seek.
+    kSSE = new KafkaSimpleStreamingExtractor(wSU);
+
+    record = kSSE.readRecord(oldRecord);
+
+    // check it matches the data written
+    Assert.check(Arrays.equals(record.getRecord(), record_3));
+  }
+
+  /**
+   * testThreadedExtractor verifies its safe to call close from a different thread when the original thread is stuck in poll
+   * We create a topic and then wait for the extractor to return a record (which it never does) in a side thread. The
+   * original thread calls close on the extractor and verifies the waiting thread gets an expected exception and exits
+   * as expected.
+   */
+  @Test(timeOut = 10000)
+  public void testThreadedExtractor() {
+    final String topic = "testThreadedExtractor";
+    _kafkaTestHelper.provisionTopic(topic);
+
+    SourceState ss = new SourceState();
+    ss.setProp(ConfigurationKeys.KAFKA_BROKERS, "localhost:" + _kafkaTestHelper.getKafkaServerPort());
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_WHITELIST, topic);
+    ss.setProp(ConfigurationKeys.JOB_NAME_KEY, topic);
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+    ss.setProp(KafkaSimpleStreamingSource.TOPIC_VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    KafkaSimpleStreamingSource<String, byte[]> simpleSource = new KafkaSimpleStreamingSource<String, byte[]>();
+
+    List<WorkUnit> lWu = simpleSource.getWorkunits(ss);
+    WorkUnit wU = lWu.get(0);
+    WorkUnitState wSU = new WorkUnitState(wU, new State());
+    wSU.setProp(ConfigurationKeys.KAFKA_BROKERS, "localhost:" + _kafkaTestHelper.getKafkaServerPort());
+
+    wSU.setProp(KafkaSimpleStreamingSource.TOPIC_WHITELIST, topic);
+    wSU.setProp(ConfigurationKeys.JOB_NAME_KEY, topic);
+    wSU.setProp(KafkaSimpleStreamingSource.TOPIC_KEY_DESERIALIZER, "org.apache.kafka.common.serialization.StringDeserializer");
+    wSU.setProp(KafkaSimpleStreamingSource.TOPIC_VALUE_DESERIALIZER, "org.apache.kafka.common.serialization.ByteArrayDeserializer");
+    // Create an extractor
+    final KafkaSimpleStreamingExtractor<String, byte[]> kSSE = new KafkaSimpleStreamingExtractor<String, byte[]>(wSU);
+
+    Thread waitingThread = new Thread () {
+      public void run () {
+        TopicPartition tP = new TopicPartition(topic, 0);
+        KafkaSimpleStreamingExtractor.KafkaWatermark kwm =
+            new KafkaSimpleStreamingExtractor.KafkaWatermark(tP, new LongWatermark(0));
+        byte[] reuse = new byte[1];
+        RecordEnvelope<byte[]> oldRecord = new RecordEnvelope<>(reuse, kwm);
+        try {
+          RecordEnvelope<byte[]> record = kSSE.readRecord(oldRecord);
+        } catch (Exception e) {
+          Assert.check((e instanceof WakeupException) || (e instanceof ClosedChannelException));
+        }
+      }
+    };
+    waitingThread.start();
+    try {
+      kSSE.close();
+      waitingThread.join();
+    } catch (Exception e) {
+      // should never come here
+      throw new Error(e);
+    }
+  }
+
+}


### PR DESCRIPTION
This PR creates a simple streaming Kafka consumer. This uses 09 (and later) Consumer api and conforms to the StreamingExtractor and WatermarkStorage interfaces. One follow on needed is that we need to conform to the gobblin kafka way of specifying topics. This can be fixed after we have implemented the KafkaNewApi in KafkaWrapper.

