### PR TITLE
Fixed bug for metrics.report.interval

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/reporter/ScheduledReporter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/reporter/ScheduledReporter.java
@@ -45,6 +45,7 @@ import com.typesafe.config.ConfigValueFactory;
 
 import lombok.extern.slf4j.Slf4j;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.metrics.InnerMetricContext;
 import gobblin.metrics.context.ReportableContext;
 import gobblin.metrics.metric.filter.MetricFilters;
@@ -62,7 +63,8 @@ public abstract class ScheduledReporter extends ContextAwareReporter {
   /**
    * Interval at which metrics are reported. Format: hours, minutes, seconds. Examples: 1h, 1m, 10s, 1h30m, 2m30s, ...
    */
-  public static final String REPORTING_INTERVAL = "reporting.interval";
+  public static final String REPORTING_INTERVAL =
+      ConfigurationKeys.METRICS_CONFIGURATIONS_PREFIX + "reporting.interval";
   public static final String DEFAULT_REPORTING_INTERVAL_PERIOD = "1M";
 
   public static final PeriodFormatter PERIOD_FORMATTER = new PeriodFormatterBuilder().


### PR DESCRIPTION
Even after setting metrics.report.interval property, reporters were still using the default value of 1 minute. 

ScheduleReporter converts the value of metrics.report.interval from milliseconds to seconds and adds it under the property name reporting.interval. At a later point, all properties relative to metrics are converted to config. This is done by ConfigUtils.propertiesToConfig(), which add all the properties containing the prefix "metrics." to the config and hence reporting.interval is not set in the config which leads it to a default value.

This pull request changes the property name from reporting.interval to metrics.reporting.interval.