### PR TITLE
Allow building of Java8 modules

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -670,11 +670,11 @@ gradle.taskGraph.whenReady {
    gradle.taskGraph.allTasks.each { task ->
       def taskProject = task.project
       if (taskProject.hasProperty('requiresJavaVersion') && !taskProject.requiresJavaVersion.equals(javaVersion)) {
-        logger.warn(String.format("WARNING: Project %s requres Java version %s which conflicts with build version %s. COMPILATION DISABLED. Please use -PjdkVersion=%s .",
+        logger.warn("WARNING: Project {} requres Java version {} which conflicts with build version {}. COMPILATION DISABLED. Please use -PjdkVersion={} .",
           taskProject.name,
           taskProject.requiresJavaVersion,
           javaVersion,
-          taskProject.requiresJavaVersion))
+          taskProject.requiresJavaVersion)
         task.onlyIf { false }
       }
       

--- a/build.gradle
+++ b/build.gradle
@@ -661,14 +661,26 @@ subprojects {
           restClientCompile externalDependency.pegasus.restliClient,externalDependency.pegasus.restliCommon,externalDependency.pegasus.restliTools
         }
       }
-
-      if (project.hasProperty('requiresJavaVersion') && !project.requiresJavaVersion.equals(javaVersion)) {
-        throw new RuntimeException("Project ${name} requres Java version ${requiresJavaVersion}"
-          + " which conflicts with build version ${javaVersion}. Please use -PjdkVersion=${requiresJavaVersion} .")
-      }
     }
   }
 }
+
+// Disable tasks for projects which hava conflicting Java requirement
+gradle.taskGraph.whenReady {
+   gradle.taskGraph.allTasks.each { task ->
+      def taskProject = task.project
+      if (taskProject.hasProperty('requiresJavaVersion') && !taskProject.requiresJavaVersion.equals(javaVersion)) {
+        logger.warn(String.format("WARNING: Project %s requres Java version %s which conflicts with build version %s. COMPILATION DISABLED. Please use -PjdkVersion=%s .",
+          taskProject.name,
+          taskProject.requiresJavaVersion,
+          javaVersion,
+          taskProject.requiresJavaVersion))
+        task.onlyIf { false }
+      }
+      
+   }
+}
+
 
 allprojects {
   tasks.withType(FindBugs) {

--- a/travis/test-build.sh
+++ b/travis/test-build.sh
@@ -24,4 +24,4 @@
 set -e
 
 echo "Starting $0 at " $(date)
-time ./gradlew clean build -x test -Dorg.gradle.parallel=false
+time ./gradlew clean build -x test -Dorg.gradle.parallel=false $GOBBLIN_GRADLE_OPTS

--- a/travis/test.sh
+++ b/travis/test.sh
@@ -30,7 +30,11 @@ RUN_TEST_GROUP=${RUN_TEST_GROUP:-default}
 script_dir=$(dirname $0)
 echo "Old GRADLE_OPTS=$GRADLE_OPTS"
 
-export GOBBLIN_GRADLE_OPTS="-Dorg.gradle.daemon=false -Dgobblin.metastore.testing.embeddedMysqlEnabled=false -PusePreinstalledMysql=true"
+export java_version=$(java -version 2>&1 | grep 'java version' | sed -e 's/java version "\(1\..\).*/\1/')
+
+echo "Using Java version:${java_version}"
+
+export GOBBLIN_GRADLE_OPTS="-Dorg.gradle.daemon=false -Dgobblin.metastore.testing.embeddedMysqlEnabled=false -PusePreinstalledMysql=true -PjdkVersion=${java_version}"
 
 TEST_SCRIPT=${script_dir}/test-${RUN_TEST_GROUP}.sh
 if [ -x $TEST_SCRIPT ] ; then


### PR DESCRIPTION
- Allow the skipping of Java8-dependent modules . Such modules need to have the following in there build.gradle:
    exp.requiresJavaVersion=JavaVersion.VERSION_1_8
- Modify the travis build to set the jdkVersion flag

@yukuai518 Can you review? 