### PR TITLE
CopyableDatasetRequestor will catch any Dataset exception and skip (p…

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/partition/CopyableDatasetRequestor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/partition/CopyableDatasetRequestor.java
@@ -85,8 +85,8 @@ public class CopyableDatasetRequestor implements PushDownRequestor<FileSet<CopyE
   public Iterator<FileSet<CopyEntity>> iterator() {
     try {
       return injectRequestor(this.dataset.getFileSetIterator(this.targetFs, this.copyConfiguration));
-    } catch (IOException ioe) {
-      log.error(String.format("Could not get FileSets for dataset %s. Skipping.", this.dataset.datasetURN()), ioe);
+    } catch (Throwable exc) {
+      log.error(String.format("Could not get FileSets for dataset %s. Skipping.", this.dataset.datasetURN()), exc);
       return Iterators.emptyIterator();
     }
   }


### PR DESCRIPTION
…reviously would only catch IOExceptions causing copy failure).