### PR TITLE
Making AsynchronousFork honor shutdown record

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/fork/AsynchronousFork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/fork/AsynchronousFork.java
@@ -89,7 +89,7 @@ public class AsynchronousFork extends Fork {
   boolean processRecord() throws IOException, DataConversionException {
     try {
       Object record = this.recordQueue.get();
-      if (record == null) {
+      if (record == null || record == Fork.SHUTDOWN_RECORD) {
         // The parent task has already done pulling records so no new record means this fork is done
         if (this.isParentTaskDone()) {
           return false;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/fork/Fork.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/fork/Fork.java
@@ -122,7 +122,7 @@ public abstract class Fork implements Closeable, Runnable, FinalState {
   private final AtomicReference<ForkState> forkState;
 
   private static final String FORK_METRICS_BRANCH_NAME_KEY = "forkBranchName";
-  private static final Object SHUTDOWN_RECORD = new Object();
+  protected static final Object SHUTDOWN_RECORD = new Object();
 
   public Fork(TaskContext taskContext, Object schema, int branches, int index, ExecutionModel executionModel)
       throws Exception {


### PR DESCRIPTION
This is a short-term fix to ensure that tasks shutdown right away. 
Will do a more thorough refactoring later.