### PR TITLE
Upgrade to latest wix-embedded-mysql so that build continues to work.

### DIFF
--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -149,7 +149,7 @@ ext.externalDependency = [
     "jsonAssert": "org.skyscreamer:jsonassert:1.3.0",
     "reflections" : "org.reflections:reflections:0.9.10",
     "embeddedProcess": "de.flapdoodle.embed:de.flapdoodle.embed.process:1.50.2",
-    "testMysqlServer": "com.wix:wix-embedded-mysql:2.0.1",
+    "testMysqlServer": "com.wix:wix-embedded-mysql:2.1.4",
     "flyway": "org.flywaydb:flyway-core:3.2.1",
     "oltu": "org.apache.oltu.oauth2:org.apache.oltu.oauth2.client:1.0.2",
     "googleAnalytics": "com.google.apis:google-api-services-analytics:v3-rev134-1.22.0",


### PR DESCRIPTION
Fixes problem where the build fails because mysql cannot be downloaded as the URL has changed.