### PR TITLE
Ignore single Json record if size is larger than 256KB which is size limit for eventhub

### DIFF
--- a/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatch.java
+++ b/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatch.java
@@ -39,7 +39,7 @@ public class EventhubBatch extends Batch<JsonObject>{
   private final long creationTimestamp;
   private final long memSizeLimit;
   private final long ttlInMilliSeconds;
-  public static final int overheadSizeInByte = 15;
+  public static final int OVERHEAD_SIZE_IN_BYTES = 15;
 
   public EventhubBatch (long memSizeLimit, long ttlInMilliSeconds) {
     this.creationTimestamp = System.currentTimeMillis();
@@ -53,7 +53,7 @@ public class EventhubBatch extends Batch<JsonObject>{
   }
 
   private long getInternalSize(JsonObject record) {
-    return  record.toString().getBytes(Charsets.UTF_8).length + this.overheadSizeInByte;
+    return  record.toString().getBytes(Charsets.UTF_8).length + this.OVERHEAD_SIZE_IN_BYTES;
   }
 
   public  class RecordMemory {

--- a/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatchAccumulator.java
+++ b/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatchAccumulator.java
@@ -25,20 +25,19 @@ import java.util.Deque;
 import java.util.HashSet;
 import java.util.Properties;
 import java.util.Set;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.Iterator;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.Futures;
 import com.google.gson.JsonObject;
 import com.typesafe.config.Config;
 
 import gobblin.util.ConfigUtils;
 import gobblin.writer.Batch;
 import gobblin.writer.BatchAccumulator;
-import gobblin.writer.RecordFuture;
 import gobblin.writer.RecordMetadata;
 import gobblin.writer.WriteCallback;
 import gobblin.writer.WriteResponse;
@@ -109,7 +108,7 @@ public class EventhubBatchAccumulator extends BatchAccumulator<JsonObject> {
       // Ignore the record because Eventhub can only accept payload less than 256KB
       if (future == null) {
         LOG.warn ("Batch " + batch.getId() + " is marked as complete because it contains a huge record: " + record.toString());
-        future = new RecordFuture(new CountDownLatch(0), 0);
+        future = Futures.immediateFuture(new RecordMetadata(0));
         callback.onSuccess(WriteResponse.EMPTY);
         return future;
       }

--- a/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubDataWriterBuilder.java
+++ b/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubDataWriterBuilder.java
@@ -67,7 +67,7 @@ public class EventhubDataWriterBuilder extends DataWriterBuilder {
           .commitStepWaitTimeInMillis(commitStepWaitTimeMillis)
           .failureAllowanceRatio(failureAllowance)
           .retriesEnabled(false)
-          .asyncDataWriter(getAsyncDataWriter(taskProps))
+          .asyncDataWriter(getAsyncDataWriter(taskProps)).maxOutstandingWrites(10000).retriesEnabled(false)
           .build();
     }
 }

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubAccumulatorTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubAccumulatorTest.java
@@ -17,13 +17,15 @@ public class EventhubAccumulatorTest {
   @Test
   public void testAccumulator() throws IOException, InterruptedException{
 
-    EventhubBatchAccumulator accumulator = new EventhubBatchAccumulator(128 * 1024, 3000);
+    EventhubBatchAccumulator accumulator = new EventhubBatchAccumulator();
     JsonObject obj = new JsonObject();
-    obj.addProperty("id", 1); // size is 8 bytes
-    long unit = obj.toString().getBytes(Charsets.UTF_8).length;
+    obj.addProperty("id", 1);
 
-    // Assuming batch size is 128K, and each record has 8 bytes
-    // Adding 16K records should not overflow the memory of first batch
+    // overhead has 15 bytes
+    long unit = obj.toString().getBytes(Charsets.UTF_8).length + 15;
+
+    // Assuming batch size is 256K bytes, and each record has (8 + 15) bytes
+    // Adding {bytes/unit} records should not overflow the memory of first batch
     // The first batch is still waiting for more incoming records so it is not ready to be sent out
     long bytes = accumulator.getMemSizeLimit();
     for (int i=0; i<bytes/unit; ++i) {

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubBatchTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubBatchTest.java
@@ -13,41 +13,43 @@ public class EventhubBatchTest {
   @Test
   public void testBatchWithLargeRecord() throws IOException {
     // Assume memory size has only 2 bytes
-    EventhubBatch batch = new EventhubBatch(2, 3000);
+    EventhubBatch batch = new EventhubBatch(8, 3000);
 
     JsonObject obj = new JsonObject();
     obj.addProperty("id", 1); // size is 8 bytes
 
-    // Although record is larger than the memory size limit, the first append still succeed
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
+    // Record is larger than the memory size limit, the first append should fail
+    Assert.assertNull(batch.tryAppend(obj, WriteCallback.EMPTY));
 
-    // The second append should fail
+    // The second append should still fail
     Assert.assertNull(batch.tryAppend(obj, WriteCallback.EMPTY));
   }
 
   @Test
   public void testBatch() throws IOException {
-    // Assume memory size has only 64 bytes
-    EventhubBatch batch = new EventhubBatch(64, 3000);
+    // Assume memory size has only 200 bytes
+    EventhubBatch batch = new EventhubBatch(200, 3000);
 
-    JsonObject obj = new JsonObject();
-    obj.addProperty("id", 1); // size is 8 bytes
+    JsonObject record = new JsonObject();
+
+    // single record has 8 bytes, but overhead has 15 bytes, total size is 23 bytes
+    record.addProperty("id", 1);
 
     // Add 8 records into batch
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
 
     // Batch has room for 8th record
-    Assert.assertEquals(batch.hasRoom(obj), true);
-    Assert.assertNotNull(batch.tryAppend(obj, WriteCallback.EMPTY));
+    Assert.assertEquals(batch.hasRoom(record), true);
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
 
     // Batch has no room for 9th record
-    Assert.assertEquals(batch.hasRoom(obj), false);
-    Assert.assertNull(batch.tryAppend(obj, WriteCallback.EMPTY));
+    Assert.assertEquals(batch.hasRoom(record), false);
+    Assert.assertNull(batch.tryAppend(record, WriteCallback.EMPTY));
   }
 }


### PR DESCRIPTION
Tolerance is chosen to be 95% so the internal size limit will be (256K * 0.95)