### PR TITLE
PasswordManager to support encrypt.key.val

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -635,6 +635,7 @@ public class ConfigurationKeys {
    * Password encryption and decryption properties.
    */
   public static final String ENCRYPT_KEY_FS_URI = "encrypt.key.fs.uri";
+  public static final String ENCRYPT_KEY_VAL = "encrypt.key.val";
   public static final String ENCRYPT_KEY_LOC = "encrypt.key.loc";
   public static final String ENCRYPT_USE_STRONG_ENCRYPTOR = "encrypt.use.strong.encryptor";
   public static final boolean DEFAULT_ENCRYPT_USE_STRONG_ENCRYPTOR = false;

--- a/gobblin-api/src/main/java/gobblin/password/PasswordManager.java
+++ b/gobblin-api/src/main/java/gobblin/password/PasswordManager.java
@@ -29,6 +29,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -109,6 +110,9 @@ public class PasswordManager {
 
   /**
    * Get an instance. The location of the master password file is provided via "encrypt.key.loc".
+   *
+   * Added a support on "encrypt.key.val" key will be fetched from state directly. This is to support a case
+   * to relieve burden of placing key file when plain text crypto key in job property can be safely protected.
    */
   public static PasswordManager getInstance(State state) {
     try {
@@ -191,6 +195,12 @@ public class PasswordManager {
   }
 
   private static Optional<String> getMasterPassword(State state) {
+    if (state.contains(ConfigurationKeys.ENCRYPT_KEY_VAL)) {
+      String cryptoKey = state.getProp(ConfigurationKeys.ENCRYPT_KEY_VAL);
+      Preconditions.checkArgument(!StringUtils.isBlank(cryptoKey), ConfigurationKeys.ENCRYPT_KEY_VAL + " should not be a blank");
+      return Optional.of(cryptoKey);
+    }
+
     if (!state.contains(ConfigurationKeys.ENCRYPT_KEY_LOC)) {
       LOG.warn(String.format("Property %s not set. Cannot decrypt any encrypted password.",
           ConfigurationKeys.ENCRYPT_KEY_LOC));

--- a/gobblin-api/src/test/java/gobblin/password/PasswordManagerTest.java
+++ b/gobblin-api/src/test/java/gobblin/password/PasswordManagerTest.java
@@ -71,6 +71,21 @@ public class PasswordManagerTest {
   }
 
   @Test
+  public void testEncryptDecryptWithKeyVal() throws IOException {
+    String password = UUID.randomUUID().toString();
+    String masterPassword = UUID.randomUUID().toString();
+
+    State state = new State();
+    state.setProp(ConfigurationKeys.ENCRYPT_KEY_VAL, masterPassword);
+    BasicTextEncryptor encryptor = new BasicTextEncryptor();
+    encryptor.setPassword(masterPassword);
+    String encrypted = encryptor.encrypt(password);
+    encrypted = "ENC(" + encrypted + ")";
+    String decrypted = PasswordManager.getInstance(state).readPassword(encrypted);
+    Assert.assertEquals(decrypted, password);
+  }
+
+  @Test
   public void testStrongEncryptionAndDecryption() throws IOException {
     String password = UUID.randomUUID().toString();
     String masterPassword = UUID.randomUUID().toString();


### PR DESCRIPTION
Added a support on "encrypt.key.val" key will be fetched from state directly. This is to support a case
to relieve burden of placing key file when plain text crypto key in job property can be safely protected.