### PR TITLE
Encryption support for distcp only

### DIFF
--- a/gobblin-api/src/main/java/gobblin/crypto/CredentialStore.java
+++ b/gobblin-api/src/main/java/gobblin/crypto/CredentialStore.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.util.Map;
+
+
+/**
+ * Interface for a simple CredentialStore that simply has a set of byte-encoded keys. Format
+ * of the underlying keys is left to the implementor.
+ */
+public interface CredentialStore {
+  /**
+   * Get the binary encoded key with the given key
+   * @param id Key to lookup
+   * @return null if the key does not exist; encoded-key if it does
+   */
+  byte[] getEncodedKey(String id);
+
+  /**
+   * List all binary encoded keys in the credential store
+   * @return all binary encoded keys in the credential store
+   */
+  Map<String, byte[]> getAllEncodedKeys();
+}

--- a/gobblin-api/src/main/java/gobblin/writer/StreamCodec.java
+++ b/gobblin-api/src/main/java/gobblin/writer/StreamCodec.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.writer;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
+import gobblin.annotation.Alpha;
+
+
+/**
+ * Interface for an object that can encrypt a bytestream.
+ */
+@Alpha
+public interface StreamCodec {
+  /**
+   * Wrap a bytestream and return a new stream that encodes the bytes written to it and writes
+   * the result into origStream
+   * @param origStream Stream to wrap
+   * @return A wrapped stream for encoding
+   */
+  OutputStream encodeOutputStream(OutputStream origStream) throws IOException;
+
+  /**
+   * Wrap a bytestream and return a new stream that will decode
+   * any bytes from origStream when read from.
+   * @param origStream Stream to wrap
+   * @return A wrapped stream for decoding
+   */
+  InputStream decodeInputStream(InputStream origStream) throws IOException;
+
+  /**
+   * Get tag/file extension associated with encoder. This may be added to
+   * the file extension or other metadata by various writers in the system.
+   */
+  String getTag();
+}

--- a/gobblin-core-base/src/main/java/gobblin/crypto/EncryptionConfigParser.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/EncryptionConfigParser.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.password.PasswordManager;
+
+
+/**
+ * Extract encryption related information from taskState
+ */
+public class EncryptionConfigParser {
+  /**
+   * Encryption parameters for converters
+   *  Algorithm: Encryption algorithm. Can be 'any' to let the system choose one.
+   *  keystore_path: Location for the java keystore where encryption keys can be found
+   *  keystore_password: Password the keystore is encrypted with
+   */
+  public static final String ENCRYPT_PREFIX = ConfigurationKeys.WRITER_PREFIX + ".encrypt";
+
+  public static final String ENCRYPTION_ALGORITHM_KEY = "algorithm";
+  public static final String ENCRYPTION_KEYSTORE_PATH_KEY = "keystore_path";
+  public static final String ENCRYPTION_KEYSTORE_PASSWORD_KEY = "keystore_password";
+
+  public static final String ENCRYPTION_TYPE_ANY = "any";
+
+  public static Map<String, Object> getConfigForBranch(State taskState, int numBranches, int branch) {
+    Map<String, Object> properties = extractPropertiesForBranch(taskState.getProperties(), ENCRYPT_PREFIX,
+        numBranches, branch);
+    if (properties.isEmpty()) {
+      return null;
+    }
+
+    PasswordManager passwordManager = PasswordManager.getInstance(taskState);
+    if (properties.containsKey(ENCRYPTION_KEYSTORE_PASSWORD_KEY)) {
+      properties.put(ENCRYPTION_KEYSTORE_PASSWORD_KEY,
+          passwordManager.readPassword((String)properties.get(ENCRYPTION_KEYSTORE_PASSWORD_KEY)));
+    }
+
+    return properties;
+  }
+
+  public static String getEncryptionType(Map<String, Object> properties) {
+    return (String)properties.get(ENCRYPTION_ALGORITHM_KEY);
+  }
+
+  public static String getKeystorePath(Map<String, Object> properties) {
+    return (String)properties.get(ENCRYPTION_KEYSTORE_PATH_KEY);
+  }
+
+  public static String getKeystorePassword(Map<String, Object> properties) {
+    return (String)properties.get(ENCRYPTION_KEYSTORE_PASSWORD_KEY);
+  }
+
+  /**
+   * Extract a set of properties for a given branch, stripping out the prefix and branch
+   * suffix.
+   *
+   * Eg - original output:
+   *  writer.encrypt.1 -> foo
+   *  writer.encrypt.something.1 -> bar
+   *
+   *  will transform to
+   *
+   *  "" -> foo
+   *  something - bar
+   * this is very similar to ConfigUtils and typesafe config; need to figure out config story
+   * @param properties Properties to extract data from
+   * @param prefix Prefix to match; all other properties will be ignored
+   * @param numBranches # of branches
+   * @param branch Branch # to extract
+   * @return Transformed properties as described above
+   */
+  private static Map<String, Object> extractPropertiesForBranch(
+      Properties properties, String prefix, int numBranches, int branch) {
+
+    Map<String, Object> ret = new HashMap<>();
+    String branchSuffix = (numBranches > 1) ? String.format(".%d", branch) : "";
+
+    for (Map.Entry<Object, Object> prop: properties.entrySet()) {
+      String key = (String)prop.getKey();
+      if (key.startsWith(prefix) && (branchSuffix.length() == 0 || key.endsWith(branchSuffix))) {
+        int strippedKeyStart =  Math.min(key.length(), prefix.length() + 1);
+        int strippedKeyEnd = Math.max(strippedKeyStart, key.length() - branchSuffix.length());
+        String strippedKey = key.substring(strippedKeyStart, strippedKeyEnd);
+        ret.put(strippedKey, prop.getValue());
+      }
+    }
+
+    return ret;
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/crypto/EncryptionFactory.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/EncryptionFactory.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.common.collect.ImmutableSet;
+
+import gobblin.writer.StreamCodec;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Helper and factory methods for encryption algorithms.
+ */
+@Slf4j
+public class EncryptionFactory {
+  private final static Set<String> SUPPORTED_STREAMING_ALGORITHMS =
+      ImmutableSet.of("insecure_shift", "aes_rotating", EncryptionConfigParser.ENCRYPTION_TYPE_ANY);
+
+  /**
+   * Return a set of streaming algorithms (StreamEncoders) that this factory knows how to build
+   * @return Set of streaming algorithms the factory knows how to build
+   */
+  public static Set<String> supportedStreamingAlgorithms() {
+    return SUPPORTED_STREAMING_ALGORITHMS;
+  }
+
+  /**
+   * Return a StreamEncryptor for the given parameters. The algorithm type to use will be extracted
+   * from the parameters object.
+   * @param parameters Configured parameters for algorithm.
+   * @return A StreamCodec for the requested algorithm
+   * @throws IllegalArgumentException If the given algorithm/parameter pair cannot be built
+   */
+  public static StreamCodec buildStreamEncryptor(Map<String, Object> parameters) {
+    String encryptionType = EncryptionConfigParser.getEncryptionType(parameters);
+    if (encryptionType == null) {
+      throw new IllegalArgumentException("Encryption type not present in parameters!");
+    }
+
+    return buildStreamEncryptor(encryptionType, parameters);
+  }
+
+  /**
+   * Return a StreamEncryptor for the given algorithm and with appropriate parameters.
+   * @param algorithm ALgorithm to build
+   * @param parameters Parameters for algorithm
+   * @return A SreamEncoder for that algorithm
+   * @throws IllegalArgumentException If the given algorithm/parameter pair cannot be built
+   */
+  public static StreamCodec buildStreamEncryptor(String algorithm, Map<String, Object> parameters) {
+    /* TODO - Ideally this would dynamically discover plugins somehow which would let us move
+     * move crypto algorithms into gobblin-modules and just keep the factory in core. (The factory
+     * would fail to build anything if the corresponding gobblin-modules aren't included).
+     */
+    switch (algorithm) {
+      case "insecure_shift":
+        return new InsecureShiftCodec(parameters);
+      case EncryptionConfigParser.ENCRYPTION_TYPE_ANY:
+      case "aes_rotating":
+        CredentialStore cs = buildCredentialStore(parameters);
+        if (cs == null) {
+          throw new IllegalArgumentException("Failed to build credential store; can't instantiate AES");
+        }
+
+        return new RotatingAESCodec(cs);
+      default:
+        throw new IllegalArgumentException("Do not support encryption type " + algorithm);
+    }
+  }
+
+  private static CredentialStore buildCredentialStore(Map<String, Object> parameters) {
+    String ks_path = EncryptionConfigParser.getKeystorePath(parameters);
+    String ks_password = EncryptionConfigParser.getKeystorePassword(parameters);
+
+    try {
+      return new JCEKSKeystoreCredentialStore(ks_path, ks_password);
+    } catch (IOException e) {
+      log.error("Error building credential store, returning null", e);
+      return null;
+    }
+  }
+
+  private EncryptionFactory() {
+    // helper functions only, can't instantiate
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/crypto/InsecureShiftCodec.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/InsecureShiftCodec.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import gobblin.writer.StreamCodec;
+
+
+/**
+ * Simple encryption algorithm that just increments every byte sent
+ * through it by 1. Useful for unit tests or proof of concept, but is not actually secure.
+ */
+public class InsecureShiftCodec implements StreamCodec {
+  public InsecureShiftCodec(Map<String, Object> parameters) {
+    // InsecureShiftCodec doesn't care about parameters
+  }
+
+  @Override
+  public OutputStream encodeOutputStream(OutputStream origStream) {
+    return new FilterOutputStream(origStream) {
+      @Override
+      public void write(int b) throws IOException {
+        out.write((b + 1) % 256);
+      }
+
+      @Override
+      public void write(byte[] b) throws IOException {
+        this.write(b, 0, b.length);
+      }
+
+      @Override
+      public void write(byte[] b, int off, int len) throws IOException {
+        for (int i = off; i < off + len; i++) {
+          this.write(b[i]);
+        }
+      }
+
+      @Override
+      public void close() throws IOException {
+        out.close();
+      }
+    };
+  }
+
+  @Override
+  public InputStream decodeInputStream(InputStream in) {
+    return new FilterInputStream(in) {
+      @Override
+      public int read() throws IOException {
+        int upstream = in.read();
+        if (upstream == 0) {
+          upstream = 255;
+        } else if (upstream > 0) {
+          upstream--;
+        }
+
+        return upstream;
+      }
+
+      @Override
+      public int read(byte[] b) throws IOException {
+        return read(b, 0, b.length);
+      }
+
+      @Override
+      public int read(byte[] b, int off, int len) throws IOException {
+        for (int i = 0; i < len; i++) {
+          int result = read();
+          if (result == -1) {
+            return (i == 0) ? -1 : i;
+          }
+
+          b[off + i] = (byte) result;
+        }
+
+        return len;
+      }
+    };
+  }
+
+  @Override
+  public String getTag() {
+    return "encrypted_insecure_shift";
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/crypto/JCEKSKeystoreCredentialStore.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/JCEKSKeystoreCredentialStore.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.Key;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.security.UnrecoverableKeyException;
+import java.security.cert.CertificateException;
+import java.util.EnumSet;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A CredentialStore that uses Java's Keystore implementation to store and retrieve keys.
+ */
+@Slf4j
+public class JCEKSKeystoreCredentialStore implements CredentialStore {
+  private final KeyStore ks;
+  private final char[] password;
+  private final Path path;
+  private final FileSystem fs;
+
+  /**
+   * Options that can be used while instantiating a new keystore
+   */
+  enum CreationOptions {
+    /**
+     * Create an empty keystore if one can't be found. Otherwise an exception will be thrown.
+     */
+    CREATE_IF_MISSING
+  }
+
+  /**
+   * Instantiate a new keystore at the given path protected by a password.
+   * @param path Path to find the keystore
+   * @param passwordStr Password the keystore is protected with
+   * @throws IOException If the keystore cannot be loaded because the password is wrong or the file has been corrupted.
+   * @throws IllegalArgumentException If the keystore does not exist at the given path.
+   */
+  public JCEKSKeystoreCredentialStore(String path, String passwordStr) throws IOException {
+    this(path, passwordStr, EnumSet.noneOf(CreationOptions.class));
+  }
+
+  /**
+   * Instantiate a new keystore at the given path protected by a password.
+   * @param path Path to find the keystore
+   * @param passwordStr Password the keystore is protected with
+   * @param options Flags for keystore creation
+   * @throws IOException If the keystore cannot be loaded because of a corrupt file or the password is wrong
+   * @throws IllegalArgumentException If CREATE_IF_MISSING is not present in options and the keystore does not exist
+   * at the given path.
+   */
+  public JCEKSKeystoreCredentialStore(String path, String passwordStr, EnumSet<CreationOptions> options) throws IOException {
+    this(new Path(path), passwordStr, options);
+  }
+
+  /**
+   * Instantiate a new keystore at the given path protected by a password.
+   * @param path Path to find the keystore
+   * @param passwordStr Password the keystore is protected with
+   * @param options Flags for keystore creation
+   * @throws IOException If the keystore cannot be loaded because of a corrupt file or the password is wrong
+   * @throws IllegalArgumentException If CREATE_IF_MISSING is not present in options and the keystore does not exist
+   * at the given path.
+   */
+  public JCEKSKeystoreCredentialStore(Path path, String passwordStr, EnumSet<CreationOptions> options) throws IOException {
+    try {
+      this.ks = KeyStore.getInstance("JCEKS");
+      this.password = passwordStr.toCharArray();
+      this.path = path;
+      this.fs = path.getFileSystem(new Configuration());
+
+      if (!fs.exists(path)) {
+        if (options.contains(CreationOptions.CREATE_IF_MISSING)) {
+          log.info("No keystore found at " + path + ", creating from scratch");
+          ks.load(null, password);
+        } else {
+          throw new IllegalArgumentException("Keystore " + path + " does not exist");
+        }
+      } else {
+        try (InputStream fis = fs.open(path)) {
+          ks.load(fis, password);
+          log.info("Successfully loaded keystore from " + path);
+        }
+      }
+    } catch (KeyStoreException | CertificateException | NoSuchAlgorithmException e) {
+      throw new IllegalStateException("Unexpected failure initializing keystore", e);
+    }
+  }
+
+  @Override
+  public byte[] getEncodedKey(String id) {
+    try {
+      Key k = ks.getKey(id, password);
+      return (k == null) ? null : k.getEncoded();
+    } catch (KeyStoreException | NoSuchAlgorithmException | UnrecoverableKeyException e) {
+      log.warn("Error trying to decode key " + id, e);
+      return null;
+    }
+  }
+
+  @Override
+  public Map<String, byte[]> getAllEncodedKeys() {
+    Map<String, byte[]> ret = new HashMap<>();
+    try {
+      Enumeration<String> aliases = ks.aliases();
+      while (aliases.hasMoreElements()) {
+        String key = aliases.nextElement();
+        try {
+          if (ks.isKeyEntry(key)) {
+            ret.put(key, getEncodedKey(key));
+          }
+        } catch (KeyStoreException e) {
+          log.warn("Error trying to decode key id " + key + ", not returning in list", e);
+        }
+      }
+    } catch (KeyStoreException e) {
+      log.warn("Error retrieving all aliases in keystore; treating as empty", e);
+      return ret;
+    }
+
+    return ret;
+  }
+
+  /**
+   * Generate a set of AES keys for the store. The key ids will simple be (startOffset ... startOffset + numKeys).
+   * @param numKeys Number of keys to generate
+   * @param startOffset ID to start generating keys with
+   * @throws IOException If there is an error serializing the keystore back to disk
+   * @throws KeyStoreException If there is an error serializing the keystore back to disk
+   */
+  public void generateAesKeys(int numKeys, int startOffset) throws IOException, KeyStoreException {
+    for (int i = 1; i <= numKeys; i++) {
+      SecretKey key = generateKey();
+      ks.setEntry(String.valueOf(i + startOffset), new KeyStore.SecretKeyEntry(key),
+          new KeyStore.PasswordProtection(password));
+    }
+
+    saveKeystore();
+  }
+
+  private SecretKey generateKey() {
+    SecureRandom r = new SecureRandom();
+    byte[] keyBytes = new byte[16];
+    r.nextBytes(keyBytes);
+
+    return new SecretKeySpec(keyBytes, "AES");
+  }
+
+  private void saveKeystore() throws IOException {
+    try (OutputStream fOs = fs.create(path, true)) {
+      ks.store(fOs, password);
+    } catch (KeyStoreException | NoSuchAlgorithmException | CertificateException e) {
+      throw new IOException("Error serializing keystore", e);
+    }
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/crypto/RotatingAESCodec.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/RotatingAESCodec.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+
+import org.apache.commons.codec.binary.Base64OutputStream;
+
+import gobblin.writer.StreamCodec;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Implementation of an encryption algorithm that works in the following way:
+ *
+ * 1. A credentialStore is provisioned with a set of AES keys
+ * 2. When encodeOutputStream() is called, an AES key will be picked at random and a new initialization vector (IV)
+ *    will be generated.
+ * 3. A header will be written [keyId][ivLength][base64 encoded iv]
+ * 4. Ciphertext will be base64 encoded and written out. We do not insert linebreaks.
+ */
+@Slf4j
+public class RotatingAESCodec implements StreamCodec {
+  private static final int AES_KEY_LEN = 16;
+
+  private final Random random;
+  private final CredentialStore credentialStore;
+  private volatile List<KeyRecord> keyRecords_cache;
+
+  /**
+   * Create a new encryptor
+   * @param credentialStore Credential store where keys can be found
+   */
+  public RotatingAESCodec(CredentialStore credentialStore) {
+    this.credentialStore = credentialStore;
+    this.random = new Random();
+  }
+
+  @Override
+  public OutputStream encodeOutputStream(OutputStream origStream) {
+    return new StreamInstance(selectRandomKey(), origStream).wrapOutputStream();
+  }
+
+  @Override
+  public InputStream decodeInputStream(InputStream origStream) throws IOException {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
+
+  private synchronized List<KeyRecord> getKeyRecords() {
+    if (keyRecords_cache == null) {
+      keyRecords_cache = new ArrayList<>();
+      for (Map.Entry<String, byte[]> entry : credentialStore.getAllEncodedKeys().entrySet()) {
+        if (entry.getValue().length != AES_KEY_LEN) {
+          log.debug("Skipping keyId {} because it is length {}; expected {}",
+              entry.getKey(),
+              entry.getValue().length,
+              AES_KEY_LEN);
+          continue;
+        }
+
+        try {
+          Integer keyId = Integer.parseInt(entry.getKey());
+          SecretKey key = new SecretKeySpec(entry.getValue(), "AES");
+
+          keyRecords_cache.add(new KeyRecord(keyId, key));
+        } catch (NumberFormatException e) {
+          log.debug("Skipping keyId {} because this algorithm can only use numeric key ids", entry.getKey());
+        }
+      }
+    }
+
+    return keyRecords_cache;
+  }
+
+  private synchronized KeyRecord selectRandomKey() {
+    List<KeyRecord> keyRecords = getKeyRecords();
+    if (keyRecords.size() == 0) {
+      throw new IllegalStateException("Couldn't find any valid keys in store!");
+    }
+
+    return keyRecords.get(random.nextInt(keyRecords.size()));
+  }
+
+  @Override
+  public String getTag() {
+    return "aes_rotating";
+  }
+
+  /**
+   * Represents a set of parsed AES keys that we can choose from when encrypting.
+   */
+  static class KeyRecord {
+    private final int keyId;
+    private final SecretKey secretKey;
+
+    KeyRecord(int keyId, SecretKey secretKey) {
+      this.keyId = keyId;
+      this.secretKey = secretKey;
+    }
+
+    int getKeyId() {
+      return keyId;
+    }
+
+    SecretKey getSecretKey() {
+      return secretKey;
+    }
+  }
+
+  /**
+   * Helper class that keeps state around for a wrapped output stream. Each stream will have a different
+   * selected key, IV, and cipher state.
+   */
+  static class StreamInstance {
+    private final OutputStream origStream;
+    private final KeyRecord secretKey;
+
+    private Cipher cipher;
+    private String base64Iv;
+    private boolean headerWritten = false;
+
+
+    StreamInstance(KeyRecord secretKey, OutputStream origStream) {
+      this.secretKey = secretKey;
+      this.origStream = origStream;
+    }
+
+    OutputStream wrapOutputStream() {
+      initCipher();
+      final Base64OutputStream base64OutputStream = new Base64OutputStream(origStream, true, 0, null);
+      final CipherOutputStream encryptedStream = new CipherOutputStream(base64OutputStream, cipher);
+
+      return new FilterOutputStream(origStream) {
+        @Override
+        public void write(int b) throws IOException {
+          writeHeaderIfNecessary();
+          encryptedStream.write(b);
+        }
+
+        @Override
+        public void write(byte[] b) throws IOException {
+          writeHeaderIfNecessary();
+          encryptedStream.write(b);
+        }
+
+        @Override
+        public void write(byte[] b, int off, int len) throws IOException {
+          writeHeaderIfNecessary();
+          encryptedStream.write(b, off, len);
+        }
+
+        @Override
+        public void close() throws IOException {
+          encryptedStream.close();
+        }
+      };
+    }
+
+    private void initCipher() {
+      if (origStream == null) {
+        throw new IllegalStateException("Can't initCipher stream before encodeOutputStream() has been called!");
+      }
+
+      try {
+        cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+        cipher.init(Cipher.ENCRYPT_MODE, secretKey.getSecretKey());
+        byte[] iv = cipher.getIV();
+        base64Iv = DatatypeConverter.printBase64Binary(iv);
+        this.headerWritten = false;
+      } catch (NoSuchAlgorithmException | NoSuchPaddingException e) {
+        throw new IllegalStateException("Error creating AES algorithm? Should always exist in JRE");
+      } catch (InvalidKeyException e) {
+        throw new IllegalStateException("Key " + secretKey.getKeyId() + " is illegal - please check credential store");
+      }
+    }
+
+    private void writeHeaderIfNecessary() throws IOException {
+      if (!headerWritten) {
+        String header = String.format("%04d%03d%s", secretKey.getKeyId(), base64Iv.length(), base64Iv);
+
+        origStream.write(header.getBytes("UTF-8"));
+        this.headerWritten = true;
+      }
+    }
+  }
+}

--- a/gobblin-core-base/src/test/java/gobblin/crypto/EncryptionConfigParserTest.java
+++ b/gobblin-core-base/src/test/java/gobblin/crypto/EncryptionConfigParserTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.util.Map;
+import java.util.Properties;
+
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.State;
+
+
+public class EncryptionConfigParserTest {
+  private EncryptionConfigParser parser;
+
+  @BeforeTest
+  public void initParser() {
+    parser = new EncryptionConfigParser();
+  }
+
+  @Test
+  public void testValidConfigOneBranch() {
+    testWithWriterPrefix(1, 0);
+  }
+
+  @Test
+  public void testValidConfigSeparateBranch() {
+    testWithWriterPrefix(3, 1);
+  }
+
+  private void testWithWriterPrefix(int numBranches, int branch) {
+    String branchString = "";
+    if (numBranches > 1) {
+      branchString = String.format(".%d", branch);
+    }
+
+    Properties properties = new Properties();
+    properties.put(
+        EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_ALGORITHM_KEY + branchString,
+        "any");
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PATH_KEY
+        + branchString, "/tmp/foobar");
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PASSWORD_KEY
+        + branchString, "abracadabra");
+
+    State s = new State(properties);
+
+    Map<String, Object> parsedProperties = EncryptionConfigParser.getConfigForBranch(s, numBranches, branch);
+    Assert.assertNotNull(parsedProperties, "Expected parser to only return one record");
+
+    Assert.assertEquals(EncryptionConfigParser.getEncryptionType(parsedProperties), "any");
+    Assert.assertEquals(EncryptionConfigParser.getKeystorePath(parsedProperties), "/tmp/foobar");
+    Assert.assertEquals(EncryptionConfigParser.getKeystorePassword(parsedProperties), "abracadabra");
+  }
+}

--- a/gobblin-core-base/src/test/java/gobblin/crypto/JCEKSKeystoreCredentialStoreTest.java
+++ b/gobblin-core-base/src/test/java/gobblin/crypto/JCEKSKeystoreCredentialStoreTest.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.crypto;
+
+import java.io.File;
+import java.io.IOException;
+import java.security.KeyStoreException;
+import java.util.EnumSet;
+
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+
+public class JCEKSKeystoreCredentialStoreTest {
+  private File tempFile;
+
+  @BeforeTest
+  public void generateTempPath() throws IOException {
+    tempFile = File.createTempFile("keystore_unit_test", null);
+    tempFile.delete();
+  }
+
+  @AfterTest
+  public void deleteTempPath() throws IOException {
+    tempFile.delete();
+  }
+
+  @Test
+  public void testGenerateKeys() throws KeyStoreException, IOException {
+    final String path = tempFile.getAbsolutePath();
+    final String password = "abcd";
+
+    try {
+      JCEKSKeystoreCredentialStore cs = new JCEKSKeystoreCredentialStore(path, password);
+      Assert.fail("Expected exception to be thrown because keystore doesn't exist");
+    } catch (IllegalArgumentException e) {
+      // pass
+    }
+
+    JCEKSKeystoreCredentialStore cs = new JCEKSKeystoreCredentialStore(path, password, EnumSet.of(
+        JCEKSKeystoreCredentialStore.CreationOptions.CREATE_IF_MISSING));
+    cs.generateAesKeys(20, 0);
+
+    cs = new JCEKSKeystoreCredentialStore(path, password);
+    Assert.assertEquals(cs.getAllEncodedKeys().size(), 20);
+  }
+}

--- a/gobblin-core-base/src/test/java/gobblin/crypto/RotatingAESCodecTest.java
+++ b/gobblin-core-base/src/test/java/gobblin/crypto/RotatingAESCodecTest.java
@@ -1,0 +1,139 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.security.InvalidAlgorithmParameterException;
+import java.security.InvalidKeyException;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.Map;
+
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+
+import javax.crypto.Cipher;
+import javax.crypto.CipherInputStream;
+import javax.crypto.NoSuchPaddingException;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.IvParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.xml.bind.DatatypeConverter;
+
+
+public class RotatingAESCodecTest {
+  @Test
+  public void testStream() throws IOException, NoSuchAlgorithmException, NoSuchPaddingException, InvalidKeyException,
+                           InvalidAlgorithmParameterException{
+    final byte[] toWrite = "hello world".getBytes();
+
+    SimpleCredentialStore credStore = new SimpleCredentialStore();
+    RotatingAESCodec encryptor = new RotatingAESCodec(credStore);
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStream os = encryptor.encodeOutputStream(sink);
+    os.write(toWrite);
+    os.close();
+
+    InputStream in = new ByteArrayInputStream(sink.toByteArray());
+    verifyKeyId(in, 1);
+
+    Integer ivLen = verifyIvLen(in);
+
+    byte[] ivBinary = verifyAndExtractIv(in, ivLen);
+
+    byte[] body = readAndBase64DecodeBody(in);
+
+    // feed back into cipheroutput stream
+    Cipher inputCipher =  Cipher.getInstance("AES/CBC/PKCS5Padding");
+    IvParameterSpec ivParameterSpec =  new IvParameterSpec(ivBinary);
+    inputCipher.init(Cipher.DECRYPT_MODE, credStore.getKey(), ivParameterSpec);
+
+    CipherInputStream cis = new CipherInputStream(new ByteArrayInputStream(body), inputCipher);
+    byte[] decoded = IOUtils.toByteArray(cis);
+    Assert.assertEquals(decoded, toWrite, "Expected decoded output to match encoded output");
+  }
+
+  private byte[] readAndBase64DecodeBody(InputStream in) throws IOException {
+    byte[] body = IOUtils.toByteArray(in);
+    body = DatatypeConverter.parseBase64Binary(new String(body, "UTF-8"));
+    return body;
+  }
+
+  private byte[] verifyAndExtractIv(InputStream in, Integer ivLen) throws IOException {
+    int bytesRead;
+    byte[] base64Iv = new byte[ivLen];
+    bytesRead = in.read(base64Iv);
+    Assert.assertEquals(Integer.valueOf(bytesRead), Integer.valueOf(ivLen), "Expected to read IV");
+    return DatatypeConverter.parseBase64Binary(new String(base64Iv, "UTF-8"));
+  }
+
+  private Integer verifyIvLen(InputStream in) throws IOException {
+    int bytesRead;
+    byte[] ivLenBytes = new byte[3];
+    bytesRead = in.read(ivLenBytes);
+    Assert.assertEquals(bytesRead, ivLenBytes.length, "Expected to be able to iv length");
+    Integer ivLen = Integer.valueOf(new String(ivLenBytes, "UTF-8"));
+    Assert.assertEquals(Integer.valueOf(ivLen), Integer.valueOf(24), "Always expect IV to be 24 bytes base64 encoded");
+    return ivLen;
+  }
+
+  private void verifyKeyId(InputStream in, int expectedKeyId) throws IOException {
+    // Verify keyId is properly padded
+    byte[] keyIdBytes = new byte[4];
+    int bytesRead = in.read(keyIdBytes);
+    Assert.assertEquals(bytesRead, keyIdBytes.length, "Expected to be able to read key id");
+    String keyId = new String(keyIdBytes, "UTF-8");
+    Assert.assertEquals(Integer.valueOf(keyId), Integer.valueOf(expectedKeyId), "Expected keyId to equal 1");
+  }
+
+  static class SimpleCredentialStore implements CredentialStore {
+    private final SecretKey key;
+
+    public SimpleCredentialStore() {
+      SecureRandom r = new SecureRandom();
+      byte[] keyBytes = new byte[16];
+      r.nextBytes(keyBytes);
+
+      key = new SecretKeySpec(keyBytes, "AES");
+    }
+
+    @Override
+    public byte[] getEncodedKey(String id) {
+      if (id.equals("1")) {
+        return key.getEncoded();
+      }
+
+      return null;
+    }
+
+    @Override
+    public Map<String, byte[]> getAllEncodedKeys() {
+      return ImmutableMap.of("1", key.getEncoded());
+    }
+
+    public SecretKey getKey() {
+      return key;
+    }
+  }
+}

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -18,14 +18,15 @@
 package gobblin.data.management.copy.writer;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -46,6 +47,8 @@ import gobblin.commit.SpeculativeAttemptAwareConstruct;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
+import gobblin.crypto.EncryptionConfigParser;
+import gobblin.crypto.EncryptionFactory;
 import gobblin.data.management.copy.CopyConfiguration;
 import gobblin.data.management.copy.CopyEntity;
 import gobblin.data.management.copy.CopySource;
@@ -86,6 +89,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   protected final Path stagingDir;
   protected final Path outputDir;
   protected final Closer closer = Closer.create();
+  private final Map<String, Object> encryptionConfig;
   protected CopyableDatasetMetadata copyableDatasetMetadata;
   protected final RecoveryHelper recoveryHelper;
   protected final SharedResourcesBroker<GobblinScopeTypes> taskBroker;
@@ -135,6 +139,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
     this.copySpeedMeter = getMetricContext().meter(GOBBLIN_COPY_BYTES_COPIED_METER);
 
     this.bufferSize = state.getPropAsInt(CopyConfiguration.BUFFER_SIZE, StreamCopier.DEFAULT_BUFFER_SIZE);
+    this.encryptionConfig = EncryptionConfigParser.getConfigForBranch(this.state, numBranches, branchId);
   }
 
   public FileAwareInputStreamDataWriter(State state, int numBranches, int branchId)
@@ -146,6 +151,10 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public final void writeImpl(FileAwareInputStream fileAwareInputStream)
       throws IOException {
     CopyableFile copyableFile = fileAwareInputStream.getFile();
+    if (encryptionConfig != null) {
+      copyableFile.setDestination(PathUtils.addExtension(copyableFile.getDestination(),
+          "." + EncryptionConfigParser.getEncryptionType(encryptionConfig)));
+    }
     Path stagingFile = getStagingFilePath(copyableFile);
     if (this.actualProcessedCopyableFile.isPresent()) {
       throw new IOException(this.getClass().getCanonicalName() + " can only process one file.");
@@ -195,8 +204,11 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
       this.fs.rename(persistedFile.get().getPath(), writeAt);
     } else {
 
-      FSDataOutputStream os =
+      OutputStream os =
           this.fs.create(writeAt, true, this.fs.getConf().getInt("io.file.buffer.size", 4096), replication, blockSize);
+      if (encryptionConfig != null) {
+        os = EncryptionFactory.buildStreamEncryptor(encryptionConfig).encodeOutputStream(os);
+      }
       try {
 
         StreamCopier copier = new StreamCopier(inputStream, os).withBufferSize(this.bufferSize);


### PR DESCRIPTION
@ibuenros - simpler version

  - Add concept of StreamCodec which can encode/decode streams flowing through them
  - InsecureShiftCodec which just increments everything going through it by 1
  - RotatingAESCodec with CredentialStore that picks a random AES session key from a CredentialStore and uses it for encryption
  - Update FileAwareInputStreamDataWriter to wrap the output stream with a StreamCodec if encryption is specified in config

Stripped out:
 - capability concept, encode/decode support for kafka + record-based hdfs writers

