### PR TITLE
Base64Codec: perf improvement for RotatingAESCodec

### DIFF
--- a/gobblin-core-base/src/jmh/java/gobblin/crypto/EncodingBenchmark.java
+++ b/gobblin-core-base/src/jmh/java/gobblin/crypto/EncodingBenchmark.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.security.SecureRandom;
+import java.util.Map;
+import java.util.Random;
+import javax.crypto.Cipher;
+import javax.crypto.CipherOutputStream;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import org.apache.commons.codec.binary.Base64OutputStream;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+
+
+/**
+ * Benchmarks around the RotatingAESEncoder algorithm.
+ *
+ * It turns out after running some of these that Base64 encoding of the output stream also incurs a large
+ * performance cost, so there are benchmarks in here to test the efficacy of the algorithm with a few Base64
+ * encoder providers too.
+ */
+@Fork(3)
+public class EncodingBenchmark {
+  @State(value = Scope.Benchmark)
+  public static class EncodingBenchmarkState {
+    public byte[] OneKBytes;
+
+    public SimpleCredentialStore credStore;
+
+    @Setup
+    public void setup() throws Exception {
+      Random r = new Random();
+      OneKBytes = new byte[1024];
+      credStore = new SimpleCredentialStore();
+      r.nextBytes(OneKBytes);
+    }
+  }
+
+ @Benchmark
+  public byte[] write1KRecordsKeyOldBase64(EncodingBenchmarkState state) throws IOException {
+    Base64Codec.forceApacheBase64();
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+
+    OutputStream os = new RotatingAESCodec(state.credStore).encodeOutputStream(sink);
+    os.write(state.OneKBytes);
+    os.close();
+
+    return sink.toByteArray();
+  }
+
+  @Benchmark
+  public byte[] write1KRecordsNewBase64(EncodingBenchmarkState state) throws IOException {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+
+    OutputStream os = new RotatingAESCodec(state.credStore).encodeOutputStream(sink);
+    os.write(state.OneKBytes);
+    os.close();
+
+    return sink.toByteArray();
+  }
+
+  @Benchmark
+  public byte[] write1KRecordsBase64Only(EncodingBenchmarkState state) throws IOException {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStream os = new Base64OutputStream(sink);
+    os.write(state.OneKBytes);
+    os.close();
+
+    return sink.toByteArray();
+  }
+
+  // the 'reflector' codec will use java8's Base64 classes if available, else fallback to Apache
+  // this benchmark is only relevant if being run on a Java 8 or later JVM
+  @Benchmark
+  public byte[] write1KRecordsBase64Reflector(EncodingBenchmarkState state) throws IOException {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStream os = new Base64Codec().encodeOutputStream(sink);
+    os.write(state.OneKBytes);
+    os.close();
+
+    return sink.toByteArray();
+  }
+
+  @Benchmark
+  public byte[] write1KRecordsDirectCipherStream(EncodingBenchmarkState state) throws Exception {
+    Cipher cipher = Cipher.getInstance("AES/CBC/PKCS5Padding");
+    cipher.init(Cipher.ENCRYPT_MODE, state.credStore.getKey());
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStream os = new CipherOutputStream(sink, cipher);
+    os.write(state.OneKBytes);
+    os.close();
+
+    return sink.toByteArray();
+  }
+
+  // just for comparison; how fast can we stream records with only lightweight processing?
+  @Benchmark
+  public byte[] write1KRecordsInsecureCipher(EncodingBenchmarkState state) throws Exception {
+    ByteArrayOutputStream sink = new ByteArrayOutputStream();
+    OutputStream os = new InsecureShiftCodec(null).encodeOutputStream(sink);
+    os.write(state.OneKBytes);
+    os.close();
+
+    return sink.toByteArray();
+  }
+
+  static class SimpleCredentialStore implements CredentialStore {
+    private final SecretKey key;
+    private final byte[] keyEncoded;
+
+    public SimpleCredentialStore() {
+      SecureRandom r = new SecureRandom();
+      byte[] keyBytes = new byte[16];
+      r.nextBytes(keyBytes);
+
+      key = new SecretKeySpec(keyBytes, "AES");
+      keyEncoded = key.getEncoded();
+    }
+
+    @Override
+    public byte[] getEncodedKey(String id) {
+      if (id.equals("1")) {
+        return keyEncoded;
+      }
+
+      return null;
+    }
+
+    @Override
+    public Map<String, byte[]> getAllEncodedKeys() {
+      return ImmutableMap.of("1", keyEncoded);
+    }
+
+    public SecretKey getKey() {
+      return key;
+    }
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/crypto/Base64Codec.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/Base64Codec.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.crypto;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Method;
+
+import org.apache.commons.codec.binary.Base64OutputStream;
+
+import gobblin.writer.StreamCodec;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A class that can encode and decrypt Base64 streams.
+ *
+ * This class will delegate to the Java 8+ java.util.Base64 algorithm if it can be found;
+ * otherwise it relies on Apache Common Codec's Base64OutputStream. The Java 8 classes
+ * are preferred because they are noticeably faster in benchmarking.
+ */
+@Slf4j
+public class Base64Codec implements StreamCodec {
+  private final static Method java8GetEncoder;
+  private final static Method java8WrapStream;
+  private static boolean forceApacheBase64 = false;
+
+  @Override
+  public OutputStream encodeOutputStream(OutputStream origStream) throws IOException {
+    try {
+      if (canUseJava8()) {
+        Object encoder = java8GetEncoder.invoke(null);
+        return (OutputStream) java8WrapStream.invoke(encoder, origStream);
+      } else {
+        return encodeOutputStreamWithApache(origStream);
+      }
+    } catch (ReflectiveOperationException e) {
+      log.warn("Error invoking java8 methods, falling back to Apache", e);
+      return encodeOutputStreamWithApache(origStream);
+    }
+  }
+
+  @Override
+  public InputStream decodeInputStream(InputStream origStream) throws IOException {
+    throw new UnsupportedOperationException("not implemented yet");
+  }
+
+  static {
+    java8GetEncoder = getBase64EncoderMethod();
+    java8WrapStream = getBase64EncoderWrapMethod();
+    if (java8GetEncoder == null || java8WrapStream == null) {
+      log.info("Couldn't find java.util.Base64, falling back to Apache Commons");
+    }
+  }
+
+  private static Method getBase64EncoderMethod() {
+    try {
+      Class<?> java8Base64 = Class.forName("java.util.Base64");
+      return java8Base64.getMethod("getEncoder");
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  private static Method getBase64EncoderWrapMethod() {
+    try {
+      Class<?> java8Encoder = Class.forName("java.util.Base64$Encoder");
+      return java8Encoder.getMethod("wrap", OutputStream.class);
+    } catch (ClassNotFoundException | NoSuchMethodException e) {
+      return null;
+    }
+  }
+
+  private OutputStream encodeOutputStreamWithApache(OutputStream origStream) {
+    return new Base64OutputStream(origStream, true, 0, null);
+  }
+
+  // Force use of the Apache Base64 codec -- used only for benchmarking
+  static void forceApacheBase64() {
+    forceApacheBase64 = true;
+  }
+
+  private boolean canUseJava8() {
+    return !forceApacheBase64 && java8WrapStream != null && java8GetEncoder != null;
+  }
+
+  @Override
+  public String getTag() {
+    return "base64";
+  }
+}


### PR DESCRIPTION
- Based on benchmarks, add a new Base64Codec class that can delegate to java8's Base64 classes if we are running on a new enough JRE. This provides a 15-20% bump in throughput of the RotatingAESCodec
- Add some benchmarks for RotatingAESCodec