### PR TITLE
Implement MessageHandlerFactory.getMessageTypes() that is required in…

### DIFF
--- a/gobblin-aws/src/main/java/gobblin/aws/GobblinAWSClusterManager.java
+++ b/gobblin-aws/src/main/java/gobblin/aws/GobblinAWSClusterManager.java
@@ -17,6 +17,9 @@
 
 package gobblin.aws;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -92,6 +95,10 @@ public class GobblinAWSClusterManager extends GobblinClusterManager {
     @Override
     public String getMessageType() {
       return Message.MessageType.USER_DEFINE_MSG.toString();
+    }
+
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
     }
 
     @Override

--- a/gobblin-aws/src/main/java/gobblin/aws/GobblinAWSTaskRunner.java
+++ b/gobblin-aws/src/main/java/gobblin/aws/GobblinAWSTaskRunner.java
@@ -107,6 +107,10 @@ public class GobblinAWSTaskRunner extends GobblinTaskRunner {
       return Message.MessageType.USER_DEFINE_MSG.toString();
     }
 
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
+    }
+
     @Override
     public void reset() {
 

--- a/gobblin-cluster/src/main/java/gobblin/cluster/GobblinClusterManager.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/GobblinClusterManager.java
@@ -21,6 +21,7 @@ import com.typesafe.config.ConfigValueFactory;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -484,6 +485,10 @@ public class GobblinClusterManager implements ApplicationLauncher {
       return GobblinHelixConstants.SHUTDOWN_MESSAGE_TYPE;
     }
 
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
+    }
+
     @Override
     public void reset() {
 
@@ -563,6 +568,10 @@ public class GobblinClusterManager implements ApplicationLauncher {
     @Override
     public String getMessageType() {
       return Message.MessageType.USER_DEFINE_MSG.toString();
+    }
+
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
     }
 
     @Override

--- a/gobblin-cluster/src/main/java/gobblin/cluster/GobblinTaskRunner.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/GobblinTaskRunner.java
@@ -20,6 +20,7 @@ package gobblin.cluster;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -312,6 +313,10 @@ public class GobblinTaskRunner {
       return GobblinHelixConstants.SHUTDOWN_MESSAGE_TYPE;
     }
 
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
+    }
+
     @Override
     public void reset() {
 
@@ -392,6 +397,10 @@ public class GobblinTaskRunner {
     @Override
     public String getMessageType() {
       return Message.MessageType.USER_DEFINE_MSG.toString();
+    }
+
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
     }
 
     @Override

--- a/gobblin-cluster/src/test/java/gobblin/cluster/TestShutdownMessageHandlerFactory.java
+++ b/gobblin-cluster/src/test/java/gobblin/cluster/TestShutdownMessageHandlerFactory.java
@@ -17,6 +17,9 @@
 
 package gobblin.cluster;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.helix.NotificationContext;
 import org.apache.helix.messaging.handling.HelixTaskResult;
 import org.apache.helix.messaging.handling.MessageHandler;
@@ -47,6 +50,10 @@ public class TestShutdownMessageHandlerFactory implements MessageHandlerFactory 
   @Override
   public String getMessageType() {
     return GobblinHelixConstants.SHUTDOWN_MESSAGE_TYPE;
+  }
+
+  public List<String> getMessageTypes() {
+    return Collections.singletonList(getMessageType());
   }
 
   @Override

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinApplicationMaster.java
@@ -17,6 +17,9 @@
 
 package gobblin.yarn;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.cli.DefaultParser;
 import org.apache.commons.cli.HelpFormatter;
@@ -122,6 +125,10 @@ public class GobblinApplicationMaster extends GobblinClusterManager {
     @Override
     public String getMessageType() {
       return Message.MessageType.USER_DEFINE_MSG.toString();
+    }
+
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
     }
 
     @Override

--- a/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnTaskRunner.java
+++ b/gobblin-yarn/src/main/java/gobblin/yarn/GobblinYarnTaskRunner.java
@@ -18,6 +18,7 @@
 package gobblin.yarn;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.cli.CommandLine;
@@ -91,6 +92,10 @@ public class GobblinYarnTaskRunner extends GobblinTaskRunner {
     @Override
     public String getMessageType() {
       return Message.MessageType.USER_DEFINE_MSG.toString();
+    }
+
+    public List<String> getMessageTypes() {
+      return Collections.singletonList(getMessageType());
     }
 
     @Override


### PR DESCRIPTION
… helix 0.6.7.1.