### PR TITLE
Removed base64 encoding inside EventhubDataWriter

### DIFF
--- a/gobblin-core-base/src/main/java/gobblin/converter/SerializedRecordToJsonStringConverter.java
+++ b/gobblin-core-base/src/main/java/gobblin/converter/SerializedRecordToJsonStringConverter.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package gobblin.converter;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.type.SerializedRecord;
+import gobblin.writer.StreamCodec;
+
+
+/**
+ * A converter that converts a {@link SerializedRecord} to a JSON String.
+ */
+@Slf4j
+public class SerializedRecordToJsonStringConverter extends Converter<String, String, SerializedRecord, String> {
+    private StreamCodec encryptor;
+
+    @Override
+    public String convertSchema(String inputSchema, WorkUnitState workUnit)
+            throws SchemaConversionException {
+        return "";
+    }
+
+    @Override
+    public Iterable<String> convertRecord(String outputSchema, SerializedRecord inputRecord, WorkUnitState workUnit)
+            throws DataConversionException {
+        return new SingleRecordIterable<>(inputRecord.toJsonString());
+    }
+}

--- a/gobblin-example/src/main/resources/avro-eventhub.job
+++ b/gobblin-example/src/main/resources/avro-eventhub.job
@@ -1,0 +1,33 @@
+# Required overrides
+gobblin.workDir=gobblin
+
+launcher.type=LOCAL
+
+
+job.name=TestSourceToEventhub
+job.group=eventhubTest
+job.description=Pull from Test Source and write to Eventhub
+gobblin.workDir=gobblin
+source.class=gobblin.source.extractor.hadoop.AvroFileSource
+converter.classes=gobblin.converter.AnyToJsonRecordWithMetadataConverter,gobblin.converter.AnyToSerializedRecordConverter,gobblin.converter.SerializedRecordToJsonStringConverter
+
+source.filebased.fs.uri=file://localhost/
+job.lock.dir=/tmp/gobblin-eventhub/locks
+
+extract.table.type=snapshot_append
+source.filebased.data.directory=/tmp/gobblin-eventhub/data
+writer.builder.class=gobblin.eventhub.writer.EventhubDataWriterBuilder
+
+#config for eventhub
+data.publisher.type=gobblin.publisher.NoopPublisher
+state.store.enabled=false
+task.data.root.dir=${gobblin.workDir}
+
+eventhub.namespace=lidatareplicationtest
+eventhub.hubname=myhub
+eventhub.sas.keyname=RootManageSharedAccessKey
+eventhub.sas.keyvalue="ENC(uuM3rLO2GVO1DMH6vwV/HAlmxpKyGL1uymCVvJcxfi7HpXUGnBeNF15ZZ/56AsB1zAPwBmzpiAg=)"
+encrypt.key.loc=gobblin-eventhub/master
+
+writer.eventhub.batch.ttl=3000
+writer.eventhub.batch.size=262144

--- a/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatch.java
+++ b/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatch.java
@@ -30,7 +30,7 @@ import java.util.List;
  * For now we are using LinkedList as our internal memory storage
  */
 @Alpha
-public class EventhubBatch extends Batch<byte[]>{
+public class EventhubBatch extends Batch<String>{
   private RecordMemory memory;
   private final long creationTimestamp;
   private final long memSizeLimit;
@@ -48,12 +48,12 @@ public class EventhubBatch extends Batch<byte[]>{
     return (System.currentTimeMillis() - creationTimestamp) >= ttlInMilliSeconds;
   }
 
-  private long getInternalSize(byte[] record) {
-    return record.length + this.OVERHEAD_SIZE_IN_BYTES;
+  private long getInternalSize(String record) {
+    return record.length() + this.OVERHEAD_SIZE_IN_BYTES;
   }
 
   public  class RecordMemory {
-    private List<byte[]> records;
+    private List<String> records;
     private long byteSize;
 
     public RecordMemory () {
@@ -61,12 +61,12 @@ public class EventhubBatch extends Batch<byte[]>{
       records = new LinkedList<>();
     }
 
-    void append (byte[] record) {
+    void append (String record) {
       byteSize += EventhubBatch.this.getInternalSize(record);
       records.add(record);
     }
 
-    boolean hasRoom (byte[] record) {
+    boolean hasRoom (String record) {
       long recordLen = EventhubBatch.this.getInternalSize(record);
       return (byteSize + recordLen) <= EventhubBatch.this.memSizeLimit;
     }
@@ -75,25 +75,25 @@ public class EventhubBatch extends Batch<byte[]>{
       return byteSize;
     }
 
-    List<byte[]> getRecords() {
+    List<String> getRecords() {
       return records;
     }
   }
 
-  public List<byte[]> getRecords() {
+  public List<String> getRecords() {
     return memory.getRecords();
   }
 
-  public boolean hasRoom(byte[] object) {
+  public boolean hasRoom(String object) {
     return memory.hasRoom(object);
   }
 
-  public void append(byte[] object) {
+  public void append(String object) {
      memory.append(object);
   }
 
-  public int getRecordSizeInByte (byte[] record) {
-    return record.length;
+  public int getRecordSizeInByte (String record) {
+    return record.length();
   }
 
   public long getCurrentSizeInByte() {

--- a/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatch.java
+++ b/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubBatch.java
@@ -21,7 +21,6 @@ package gobblin.eventhub.writer;
 import gobblin.annotation.Alpha;
 import gobblin.writer.Batch;
 
-import java.util.Base64;
 import java.util.LinkedList;
 import java.util.List;
 
@@ -50,7 +49,7 @@ public class EventhubBatch extends Batch<byte[]>{
   }
 
   private long getInternalSize(byte[] record) {
-    return Base64.getEncoder().encodeToString(record).length() + this.OVERHEAD_SIZE_IN_BYTES;
+    return record.length + this.OVERHEAD_SIZE_IN_BYTES;
   }
 
   public  class RecordMemory {

--- a/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubDataWriter.java
+++ b/gobblin-modules/gobblin-eventhub/src/main/java/gobblin/eventhub/writer/EventhubDataWriter.java
@@ -51,8 +51,6 @@ import gobblin.writer.WriteResponse;
 import gobblin.writer.WriteResponseFuture;
 import gobblin.writer.WriteResponseMapper;
 
-import java.util.Base64;
-import java.util.Base64.Encoder;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
@@ -70,8 +68,6 @@ import com.codahale.metrics.Timer;
  *
  * Also this class supports sending multiple records in a batch manner.
  *
- * This class use Base64 to encode any byte array, so the consumer side should use the corresponding
- * decoder to recover the original bytes.
  */
 @Slf4j
 public class EventhubDataWriter implements SyncDataWriter<byte[]>, BatchAsyncDataWriter<byte[]> {
@@ -87,7 +83,6 @@ public class EventhubDataWriter implements SyncDataWriter<byte[]>, BatchAsyncDat
   private final String targetURI;
   private final Timer timer = new Timer();
   private final Meter bytesWritten = new Meter();
-  private final Encoder encoder = Base64.getEncoder();
   private long postStartTimestamp = 0;
   private long sigExpireInMinute = 1;
   private String signature = "";
@@ -232,7 +227,7 @@ public class EventhubDataWriter implements SyncDataWriter<byte[]>, BatchAsyncDat
 
 
     for (byte[] record: records) {
-      arrayList.add(new EventhubRequest(encoder.encodeToString(record)));
+      arrayList.add(new EventhubRequest(new String(record, Charsets.UTF_8)));
     }
     return mapper.writeValueAsString (arrayList);
   }
@@ -246,7 +241,7 @@ public class EventhubDataWriter implements SyncDataWriter<byte[]>, BatchAsyncDat
     // Add new json object to an array and send the whole array to eventhub using REST api
     // Refer to https://docs.microsoft.com/en-us/rest/api/eventhub/send-batch-events
     ArrayList<EventhubRequest> arrayList = new ArrayList<>();
-    arrayList.add(new EventhubRequest(encoder.encodeToString(record)));
+    arrayList.add(new EventhubRequest(new String(record, Charsets.UTF_8)));
 
     return mapper.writeValueAsString (arrayList);
   }

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/BufferedAsyncDataWriterTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/BufferedAsyncDataWriterTest.java
@@ -75,7 +75,7 @@ public class BufferedAsyncDataWriterTest {
     int totalTimes = 500;
     try {
       for (int i=0; i<totalTimes; ++i) {
-        byte[] record = new byte[8];
+        String record = "abcdefgh";
         futures.add(dataWriter.write(record, callback));
       }
 

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubAccumulatorTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubAccumulatorTest.java
@@ -3,7 +3,6 @@ package gobblin.eventhub.writer;
 import java.io.IOException;
 import java.util.Iterator;
 
-import org.bouncycastle.util.encoders.Base64;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -20,7 +19,7 @@ public class EventhubAccumulatorTest {
     byte[] obj = new byte[8];
 
     // overhead has 15 bytes
-    long unit = Base64.encode(obj).length + EventhubBatch.OVERHEAD_SIZE_IN_BYTES;
+    long unit = obj.length + EventhubBatch.OVERHEAD_SIZE_IN_BYTES;
 
     // Assuming batch size is 256K bytes, and each record has (8 + 15) bytes
     // Adding {bytes/unit} records should not overflow the memory of first batch

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubAccumulatorTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubAccumulatorTest.java
@@ -16,10 +16,10 @@ public class EventhubAccumulatorTest {
   public void testAccumulator() throws IOException, InterruptedException{
 
     EventhubBatchAccumulator accumulator = new EventhubBatchAccumulator();
-    byte[] obj = new byte[8];
+    String obj = "abcdefgh";
 
     // overhead has 15 bytes
-    long unit = obj.length + EventhubBatch.OVERHEAD_SIZE_IN_BYTES;
+    long unit = obj.length() + EventhubBatch.OVERHEAD_SIZE_IN_BYTES;
 
     // Assuming batch size is 256K bytes, and each record has (8 + 15) bytes
     // Adding {bytes/unit} records should not overflow the memory of first batch
@@ -29,7 +29,7 @@ public class EventhubAccumulatorTest {
       accumulator.append(obj, WriteCallback.EMPTY);
     }
 
-    Iterator<Batch<byte[]>> iterator = accumulator.iterator();
+    Iterator<Batch<String>> iterator = accumulator.iterator();
     Assert.assertEquals(iterator.hasNext(), false);
 
     // Now add another record, which should result in the overflow of first batch
@@ -46,7 +46,7 @@ public class EventhubAccumulatorTest {
 
     // Now the TTL should be expired, the second batch should be available
     Assert.assertEquals(iterator.hasNext(), true);
-    Batch<byte[]> batch = iterator.next();
+    Batch<String> batch = iterator.next();
     Assert.assertEquals(batch.getRecords().size(), 1);
   }
 }

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubBatchTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubBatchTest.java
@@ -14,7 +14,7 @@ public class EventhubBatchTest {
     // Assume memory size has only 2 bytes
     EventhubBatch batch = new EventhubBatch(8, 3000);
 
-    byte[] record = new byte[8];
+    String record = "abcdefgh";
 
     // Record is larger than the memory size limit, the first append should fail
     Assert.assertNull(batch.tryAppend(record, WriteCallback.EMPTY));
@@ -29,7 +29,7 @@ public class EventhubBatchTest {
     EventhubBatch batch = new EventhubBatch(200, 3000);
 
     // Add additional 15 bytes overhead, total size is 27 bytes
-    byte[] record = new byte[8];
+    String record = "abcdefgh";
 
     Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
     Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubBatchTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubBatchTest.java
@@ -28,7 +28,6 @@ public class EventhubBatchTest {
     // Assume memory size has only 200 bytes
     EventhubBatch batch = new EventhubBatch(200, 3000);
 
-    // single record has 8 bytes, it converts to 12 bytes due to Base64 encoding
     // Add additional 15 bytes overhead, total size is 27 bytes
     byte[] record = new byte[8];
 
@@ -38,12 +37,13 @@ public class EventhubBatchTest {
     Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
     Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
     Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
+    Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
 
-    // Batch has room for 7th record
+    // Batch has room for 8th record
     Assert.assertEquals(batch.hasRoom(record), true);
     Assert.assertNotNull(batch.tryAppend(record, WriteCallback.EMPTY));
 
-    // Batch has no room for 8th record
+    // Batch has no room for 9th record
     Assert.assertEquals(batch.hasRoom(record), false);
     Assert.assertNull(batch.tryAppend(record, WriteCallback.EMPTY));
   }

--- a/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubDataWriterTest.java
+++ b/gobblin-modules/gobblin-eventhub/src/test/java/gobblin/eventhub/writer/EventhubDataWriterTest.java
@@ -64,11 +64,11 @@ public class EventhubDataWriterTest {
     EventhubDataWriter eventhubDataWriter = Mockito.spy(new EventhubDataWriter(props, mockHttpClient));
     Mockito.doNothing().when(eventhubDataWriter).refreshSignature();
 
-    List<byte[]> records = new LinkedList<>();
+    List<String> records = new LinkedList<>();
     for (int i=0; i<50; ++i)
-      records.add(new byte[8]);
+      records.add(new String("abcdefgh"));
 
-    Batch<byte[]> batch = mock(Batch.class);
+    Batch<String> batch = mock(Batch.class);
     WriteCallback callback = mock(WriteCallback.class);
     Mockito.when(batch.getRecords()).thenReturn(records);
 
@@ -86,7 +86,7 @@ public class EventhubDataWriterTest {
     EventhubDataWriter eventhubDataWriter = Mockito.spy(new EventhubDataWriter(props, mockHttpClient));
     Mockito.doNothing().when(eventhubDataWriter).refreshSignature();
 
-    byte[] record = new byte[8];
+    String record = "abcdefgh";
     WriteResponse<Integer> writeResponse = eventhubDataWriter.write(record);
     int returnCode = writeResponse.getRawResponse();
     Assert.assertEquals(returnCode, 201);


### PR DESCRIPTION
Remove base64 encoding inside EventhubDataWriter because we assume the converter already has the encoded string
