### PR TITLE
Fix over-eager EncryptionConfigParser

### DIFF
--- a/gobblin-core-base/src/test/java/gobblin/crypto/EncryptionConfigParserTest.java
+++ b/gobblin-core-base/src/test/java/gobblin/crypto/EncryptionConfigParserTest.java
@@ -44,6 +44,39 @@ public class EncryptionConfigParserTest {
     testWithWriterPrefix(3, 1);
   }
 
+  @Test
+  public void testAlgorithmNotPresent() {
+    Properties properties = new Properties();
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PATH_KEY,
+        "/tmp/foobar");
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PASSWORD_KEY,
+        "abracadabra");
+
+    State s = new State(properties);
+
+    Map<String, Object> parsedProperties = EncryptionConfigParser.getConfigForBranch(s, 1, 0);
+    Assert.assertNull(parsedProperties, "Expected encryption be empty if no algorithm specified");
+  }
+
+  @Test
+  public void testProperPrefix() {
+    Properties properties = new Properties();
+    properties.put(
+        EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_ALGORITHM_KEY,
+        "any");
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PATH_KEY,
+        "/tmp/foobar");
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PASSWORD_KEY,
+        "abracadabra");
+    properties.put(EncryptionConfigParser.ENCRYPT_PREFIX + "abc.def", "foobar");
+
+    State s = new State(properties);
+
+    Map<String, Object> parsedProperties = EncryptionConfigParser.getConfigForBranch(s, 1, 0);
+    Assert.assertNotNull(parsedProperties, "Expected parser to only return one record");
+    Assert.assertEquals(parsedProperties.size(), 3, "Did not expect abc.def to be picked up in config");
+  }
+
   private void testWithWriterPrefix(int numBranches, int branch) {
     String branchString = "";
     if (numBranches > 1) {


### PR DESCRIPTION
@jinhyukchang 

- EncryptionConfigParser parser was picking up config settings it shouldn't care about

- Don't return a half-filled in config if mandatory parameters (like algorithm) aren't present