### PR TITLE
Changed access modifier for constructor of FlowConfigsResource to public for RestLI runtime initialization

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/gobblin/service/FlowConfigsResource.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-server/src/main/java/gobblin/service/FlowConfigsResource.java
@@ -62,7 +62,7 @@ public class FlowConfigsResource extends ComplexKeyResourceTemplate<FlowConfigId
   @Named("inUnitTest")
   private boolean inUnitTest;
 
-  FlowConfigsResource() {}
+  public FlowConfigsResource() {}
 
   /**
    * Logs message and throws Rest.li exception


### PR DESCRIPTION
Changed access modifier for constructor of FlowConfigsResource to public for RestLI runtime initialization