### PR TITLE
Fix to stop travis build from failing

### DIFF
--- a/gobblin-cluster/src/main/java/gobblin/cluster/ScheduledJobConfigurationManager.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/ScheduledJobConfigurationManager.java
@@ -20,6 +20,7 @@ package gobblin.cluster;
 import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
 import java.util.Map;
+import java.util.Properties;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -135,7 +136,7 @@ public class ScheduledJobConfigurationManager extends JobConfigurationManager {
 
         // Handle delete
         Spec anonymousSpec = (Spec) entry.getValue();
-        postDeleteJobConfigArrival(anonymousSpec.getUri().toString(), null);
+        postDeleteJobConfigArrival(anonymousSpec.getUri().toString(), new Properties());
         jobSpecs.remove(entry.getValue().getUri());
       }
     }

--- a/gobblin-data-management/build.gradle
+++ b/gobblin-data-management/build.gradle
@@ -44,6 +44,7 @@ dependencies {
   compile externalDependency.typesafeConfig
   compile externalDependency.findBugsAnnotations
   compile externalDependency.testng
+  compile externalDependency.junit
 
   testCompile externalDependency.calciteCore
   testCompile externalDependency.calciteAvatica

--- a/gobblin-modules/google-ingestion/build.gradle
+++ b/gobblin-modules/google-ingestion/build.gradle
@@ -30,6 +30,7 @@ dependencies {
   compile externalDependency.gson
   compile externalDependency.guava
   compile externalDependency.slf4j
+  compile externalDependency.junit
 
   testCompile externalDependency.mockito
   testCompile externalDependency.testng


### PR DESCRIPTION
Travis build was failing because of two reasons. If something else fails I will add it in this PR
1) Package junit was not found for modules gobblin-data-management and gobblin-ingestion
  Fix is to add junit as a dependency.
2) Once above is fixed it starts failing due to findbugs
Bug type NP_NULL_PARAM_DEREF_ALL_TARGETS_DANGEROUS (click for details) 
In class gobblin.cluster.ScheduledJobConfigurationManager
In method gobblin.cluster.ScheduledJobConfigurationManager.fetchJobSpecs()
Called method gobblin.cluster.JobConfigurationManager.postDeleteJobConfigArrival(String, Properties)
At ScheduledJobConfigurationManager.java:[line 138]
Argument 2 is definitely null but must not be null
Definite null passed to dangerous method call target gobblin.cluster.JobConfigurationManager.postDeleteJobConfigArrival(String, Properties)

Fix is to add new Properties() instead of passing null