### PR TITLE
Add compression and encryption support to SimpleDataWriter

### DIFF
--- a/gobblin-core-base/src/main/java/gobblin/compression/CompressionConfigParser.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/CompressionConfigParser.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compression;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.util.ForkOperatorUtils;
+
+
+/**
+ * Functions for parsing compression configuration
+ */
+public class CompressionConfigParser {
+  private static final String COMPRESSION_TYPE_KEY = "type";
+
+  /**
+   * Retrieve configuration settings for a given branch.
+   * @param taskState Task state
+   * @param numBranches # of branches in the state
+   * @param branch Branch to retrieve
+   * @return Map of properties for compression
+   */
+  public static Map<String, Object> getConfigForBranch(State taskState, int numBranches, int branch) {
+    String typePropertyName =
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_CODEC_TYPE, numBranches, branch);
+    String compressionType = taskState.getProp(typePropertyName);
+    if (compressionType == null) {
+      return null;
+    }
+
+    return ImmutableMap.<String, Object>of(COMPRESSION_TYPE_KEY, compressionType);
+  }
+
+  /**
+   * Return compression type
+   * @param properties Compression config settings
+   * @return String representing compression type, null if none exists
+   */
+  public static String getCompressionType(Map<String, Object> properties) {
+    return (String) properties.get(COMPRESSION_TYPE_KEY);
+  }
+
+  private CompressionConfigParser() {
+
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
@@ -25,7 +25,7 @@ public class CompressionFactory {
   public static StreamCodec buildStreamCompressor(Map<String, Object> properties) {
     String type = CompressionConfigParser.getCompressionType(properties);
     switch (type) {
-      case "gzip":
+      case GzipCodec.TAG:
         return new GzipCodec();
       default:
         throw new IllegalArgumentException("Can't build compressor of type " + type);

--- a/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
@@ -18,12 +18,15 @@ package gobblin.compression;
 
 import java.util.Map;
 
+import gobblin.annotation.Alpha;
 import gobblin.writer.StreamCodec;
 
 
 /**
  * This class has logic to create compression stream codecs based on configuration parameters.
+ * Note: Interface will likely change to support dynamic registration of compression codecs
  */
+@Alpha
 public class CompressionFactory {
   public static StreamCodec buildStreamCompressor(Map<String, Object> properties) {
     String type = CompressionConfigParser.getCompressionType(properties);

--- a/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compression;
+
+import java.util.Map;
+
+import gobblin.writer.StreamCodec;
+
+
+public class CompressionFactory {
+  public static StreamCodec buildStreamCompressor(Map<String, Object> properties) {
+    String type = CompressionConfigParser.getCompressionType(properties);
+    switch (type) {
+      case "gzip":
+        return new GzipCodec();
+      default:
+        throw new IllegalArgumentException("Can't build compressor of type " + type);
+    }
+  }
+
+  private CompressionFactory() {
+    // can't instantiate
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/CompressionFactory.java
@@ -21,6 +21,9 @@ import java.util.Map;
 import gobblin.writer.StreamCodec;
 
 
+/**
+ * This class has logic to create compression stream codecs based on configuration parameters.
+ */
 public class CompressionFactory {
   public static StreamCodec buildStreamCompressor(Map<String, Object> properties) {
     String type = CompressionConfigParser.getCompressionType(properties);

--- a/gobblin-core-base/src/main/java/gobblin/compression/GzipCodec.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/GzipCodec.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compression;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
+import gobblin.writer.StreamCodec;
+
+
+/**
+ * Implement GZIP compression and decompression.
+ */
+public class GzipCodec implements StreamCodec {
+  @Override
+  public OutputStream encodeOutputStream(OutputStream origStream)
+      throws IOException {
+    return new GZIPOutputStream(origStream);
+  }
+
+  @Override
+  public InputStream decodeInputStream(InputStream origStream)
+      throws IOException {
+    return new GZIPInputStream(origStream);
+  }
+
+  @Override
+  public String getTag() {
+    return "gz";
+  }
+}

--- a/gobblin-core-base/src/main/java/gobblin/compression/GzipCodec.java
+++ b/gobblin-core-base/src/main/java/gobblin/compression/GzipCodec.java
@@ -29,6 +29,8 @@ import gobblin.writer.StreamCodec;
  * Implement GZIP compression and decompression.
  */
 public class GzipCodec implements StreamCodec {
+  public static final String TAG = "gzip";
+
   @Override
   public OutputStream encodeOutputStream(OutputStream origStream)
       throws IOException {
@@ -43,6 +45,6 @@ public class GzipCodec implements StreamCodec {
 
   @Override
   public String getTag() {
-    return "gz";
+    return TAG;
   }
 }

--- a/gobblin-core-base/src/main/java/gobblin/crypto/EncryptionFactory.java
+++ b/gobblin-core-base/src/main/java/gobblin/crypto/EncryptionFactory.java
@@ -22,6 +22,7 @@ import java.util.Set;
 
 import com.google.common.collect.ImmutableSet;
 
+import gobblin.annotation.Alpha;
 import gobblin.writer.StreamCodec;
 
 import lombok.extern.slf4j.Slf4j;
@@ -29,8 +30,11 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * Helper and factory methods for encryption algorithms.
+ *
+ * Note: Interface will likely change to support registration of algorithms
  */
 @Slf4j
+@Alpha
 public class EncryptionFactory {
   private final static Set<String> SUPPORTED_STREAMING_ALGORITHMS =
       ImmutableSet.of("insecure_shift", "aes_rotating", EncryptionConfigParser.ENCRYPTION_TYPE_ANY);

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -19,6 +19,8 @@ package gobblin.writer;
 
 import java.io.IOException;
 import java.io.OutputStream;
+import java.util.Collections;
+import java.util.List;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -30,6 +32,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 
 import gobblin.commit.SpeculativeAttemptAwareConstruct;
@@ -75,15 +78,21 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Spec
   protected final Closer closer = Closer.create();
   protected final Optional<String> writerAttemptIdOptional;
   protected Optional<Long> bytesWritten;
+  protected final List<StreamCodec> encoders;
 
   public FsDataWriter(FsDataWriterBuilder<?, D> builder, State properties)
       throws IOException {
+    this(builder, Collections.<StreamCodec>emptyList(), properties);
+  }
+
+  public FsDataWriter(FsDataWriterBuilder<?, D> builder, List<StreamCodec> encoders, State properties) throws IOException {
     this.properties = properties;
     this.id = builder.getWriterId();
     this.numBranches = builder.getBranches();
     this.branchId = builder.getBranch();
     this.fileName = builder.getFileName(properties);
     this.writerAttemptIdOptional = Optional.fromNullable(builder.getWriterAttemptId());
+    this.encoders = encoders;
 
     Configuration conf = new Configuration();
     // Add all job configuration properties so they are picked up by Hadoop
@@ -144,9 +153,17 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Spec
    */
   protected OutputStream createStagingFileOutputStream()
       throws IOException {
-    return this.closer.register(this.fs
+    OutputStream out = this.fs
         .create(this.stagingFile, this.filePermission, true, this.bufferSize, this.replicationFactor, this.blockSize,
-            null));
+            null);
+
+    // encoders need to be attached to the stream in reverse order since we should write to the
+    // innermost encoder first
+    for (StreamCodec encoder : Lists.reverse(encoders)) {
+      out = encoder.encodeOutputStream(out);
+    }
+
+    return this.closer.register(out);
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
@@ -110,9 +110,11 @@ public abstract class FsDataWriterBuilder<S, D> extends PartitionAwareDataWriter
 
   /**
    * Build and cache encoders for the writer based on configured options as encoder
-   * construction can potentially be expensive
+   * construction can potentially be expensive.
    */
   protected List<StreamCodec> buildEncoders() {
+    // Should be overridden by subclasses if their associated writers are
+    // encoder aware
     return Collections.emptyList();
   }
  }

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
@@ -17,6 +17,9 @@
 
 package gobblin.writer;
 
+import java.util.Collections;
+import java.util.List;
+
 import org.apache.avro.Schema;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.fs.Path;
@@ -43,6 +46,7 @@ public abstract class FsDataWriterBuilder<S, D> extends PartitionAwareDataWriter
       ConfigurationKeys.WRITER_PREFIX + ".include.partition.in.file.names";
   public static final String WRITER_REPLACE_PATH_SEPARATORS_IN_PARTITIONS =
       ConfigurationKeys.WRITER_PREFIX + ".replace.path.separators.in.partitions";
+  private List<StreamCodec> encoders;
 
   /**
    * Get the file name to be used by the writer. If a {@link gobblin.writer.partitioner.WriterPartioner} is used,
@@ -56,6 +60,17 @@ public abstract class FsDataWriterBuilder<S, D> extends PartitionAwareDataWriter
 
     if (this.partition.isPresent()) {
       fileName = getPartitionedFileName(properties, fileName);
+    }
+
+    List<StreamCodec> encoders = getEncoders();
+    if (!encoders.isEmpty()) {
+      StringBuilder filenameBuilder = new StringBuilder(fileName);
+      for (StreamCodec codec : encoders) {
+        filenameBuilder.append('.');
+        filenameBuilder.append(codec.getTag());
+      }
+
+      fileName = filenameBuilder.toString();
     }
 
     return fileName;
@@ -81,4 +96,23 @@ public abstract class FsDataWriterBuilder<S, D> extends PartitionAwareDataWriter
   public boolean validatePartitionSchema(Schema partitionSchema) {
     return true;
   }
-}
+
+  /**
+   * Get list of encoders configured for the writer.
+   */
+  public synchronized List<StreamCodec> getEncoders() {
+    if (encoders == null) {
+      encoders = buildEncoders();
+    }
+
+    return encoders;
+  }
+
+  /**
+   * Build and cache encoders for the writer based on configured options as encoder
+   * construction can potentially be expensive
+   */
+  protected List<StreamCodec> buildEncoders() {
+    return Collections.emptyList();
+  }
+ }

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -52,16 +52,15 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
 
   private final Optional<Byte> recordDelimiter; // optional byte to place between each record write
   private final boolean prependSize;
-  private final List<StreamCodec> encoders;
 
   private int recordsWritten;
   private int bytesWritten;
 
   private final OutputStream stagingFileOutputStream;
 
-  public SimpleDataWriter(SimpleDataWriterBuilder builder, List<StreamCodec> encoders, State properties)
+  public SimpleDataWriter(SimpleDataWriterBuilder builder, State properties)
       throws IOException {
-    super(builder, encoders, properties);
+    super(builder, properties);
     String delim;
     if ((delim = properties.getProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, null)) == null || delim.length() == 0) {
       this.recordDelimiter = Optional.absent();
@@ -72,7 +71,6 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
     this.prependSize = properties.getPropAsBoolean(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, false);
     this.recordsWritten = 0;
     this.bytesWritten = 0;
-    this.encoders = encoders;
     this.stagingFileOutputStream = createStagingFileOutputStream();
 
     setStagingFileGroup();

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
+import java.util.List;
 
 import org.apache.commons.lang3.ArrayUtils;
 
@@ -51,14 +52,16 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
 
   private final Optional<Byte> recordDelimiter; // optional byte to place between each record write
   private final boolean prependSize;
+  private final List<StreamCodec> encoders;
 
   private int recordsWritten;
   private int bytesWritten;
 
   private final OutputStream stagingFileOutputStream;
 
-  public SimpleDataWriter(SimpleDataWriterBuilder builder, State properties) throws IOException {
-    super(builder, properties);
+  public SimpleDataWriter(SimpleDataWriterBuilder builder, List<StreamCodec> encoders, State properties)
+      throws IOException {
+    super(builder, encoders, properties);
     String delim;
     if ((delim = properties.getProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, null)) == null || delim.length() == 0) {
       this.recordDelimiter = Optional.absent();
@@ -69,6 +72,7 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
     this.prependSize = properties.getPropAsBoolean(ConfigurationKeys.SIMPLE_WRITER_PREPEND_SIZE, false);
     this.recordsWritten = 0;
     this.bytesWritten = 0;
+    this.encoders = encoders;
     this.stagingFileOutputStream = createStagingFileOutputStream();
 
     setStagingFileGroup();

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriterBuilder.java
@@ -53,6 +53,8 @@ public class SimpleDataWriterBuilder extends FsDataWriterBuilder<String, byte[]>
 
     List<StreamCodec> encoders = new ArrayList<>();
 
+    // TODO: refactor this when capability support comes back in
+
     // Compress first since compressing encrypted data will give no benefit
     Map<String, Object> compressionConfig =
         CompressionConfigParser.getConfigForBranch(this.destination.getProperties(), this.branches, this.branch);

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriterBuilder.java
@@ -18,6 +18,15 @@
 package gobblin.writer;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import gobblin.compression.CompressionConfigParser;
+import gobblin.compression.CompressionFactory;
+import gobblin.configuration.State;
+import gobblin.crypto.EncryptionConfigParser;
+import gobblin.crypto.EncryptionFactory;
 
 
 /**
@@ -26,6 +35,12 @@ import java.io.IOException;
  * @author akshay@nerdwallet.com
  */
 public class SimpleDataWriterBuilder extends FsDataWriterBuilder<String, byte[]> {
+  private final List<StreamCodec> encoders;
+
+  public SimpleDataWriterBuilder() {
+    encoders = new ArrayList<>();
+  }
+
   /**
    * Build a {@link gobblin.writer.DataWriter}.
    *
@@ -34,7 +49,33 @@ public class SimpleDataWriterBuilder extends FsDataWriterBuilder<String, byte[]>
    */
   @Override
   public DataWriter<byte[]> build() throws IOException {
-    return new SimpleDataWriter(this, this.destination.getProperties());
+    buildEncoders();
+    return new SimpleDataWriter(this, encoders, this.destination.getProperties());
   }
 
+  private void buildEncoders() {
+    // Compress first since compressing encrypted data will give no benefit
+    Map<String, Object> compressionConfig =
+        CompressionConfigParser.getConfigForBranch(this.destination.getProperties(), this.branches, this.branch);
+    if (compressionConfig != null) {
+      encoders.add(CompressionFactory.buildStreamCompressor(compressionConfig));
+    }
+
+    Map<String, Object> encryptionConfig =
+        EncryptionConfigParser.getConfigForBranch(this.destination.getProperties(), this.branches, this.branch);
+    if (encryptionConfig != null) {
+      encoders.add(EncryptionFactory.buildStreamEncryptor(encryptionConfig));
+    }
+  }
+
+  @Override
+  public String getFileName(State properties) {
+    StringBuilder filenameBuilder = new StringBuilder(super.getFileName(properties));
+    for (StreamCodec codec : encoders) {
+      filenameBuilder.append('.');
+      filenameBuilder.append(codec.getTag());
+    }
+
+    return filenameBuilder.toString();
+  }
 }

--- a/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
@@ -26,7 +26,10 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URI;
+import java.util.Collections;
+import java.util.zip.GZIPInputStream;
 
+import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FileUtil;
@@ -38,6 +41,8 @@ import org.testng.annotations.Test;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
+import gobblin.crypto.EncryptionConfigParser;
+import gobblin.crypto.InsecureShiftCodec;
 
 
 /**
@@ -50,10 +55,12 @@ public class SimpleDataWriterTest {
   private String filePath;
   private final String schema = "";
   private final int newLine = "\n".getBytes()[0];
-  private final State properties = new State();
+  private State properties;
 
   @BeforeMethod
   public void setUp() throws Exception {
+    properties = new State();
+
     // Making the staging and/or output dirs if necessary
     File stagingDir = new File(TestConstants.TEST_STAGING_DIR);
     File outputDir = new File(TestConstants.TEST_OUTPUT_DIR);
@@ -231,6 +238,58 @@ public class SimpleDataWriterTest {
       Assert.assertEquals(dis.readByte(), '\n');
     }
   }
+
+  @Test
+  public void testSupportsGzip() throws IOException {
+    properties.setProp(ConfigurationKeys.WRITER_CODEC_TYPE, "gzip");
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, "");
+
+    byte[] toWrite = new byte[] { 'a', 'b', 'c', 'd'};
+
+    SimpleDataWriter writer = (SimpleDataWriter) new SimpleDataWriterBuilder()
+        .writeTo(Destination.of(Destination.DestinationType.HDFS, properties)).writeInFormat(WriterOutputFormat.AVRO)
+        .withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema).forBranch(0).build();
+
+    writer.write(toWrite);
+    writer.close();
+    writer.commit();
+
+    File outputFile = new File(writer.getOutputFilePath());
+    InputStream in = new GZIPInputStream(new FileInputStream(outputFile));
+
+    byte[] contents = IOUtils.toByteArray(in);
+    Assert.assertEquals(contents, toWrite, "Expected gzip'd content to be written out");
+    Assert.assertTrue(outputFile.getName().endsWith(".gz"), "Expected gzip'd file to end in .gz");
+  }
+
+  @Test
+  public void testSupportsGzipAndEncryption() throws IOException {
+    properties.setProp(ConfigurationKeys.WRITER_CODEC_TYPE, "gzip");
+    properties.setProp(EncryptionConfigParser.ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_ALGORITHM_KEY,
+        "insecure_shift");
+    properties.setProp(ConfigurationKeys.SIMPLE_WRITER_DELIMITER, "");
+
+    byte[] toWrite = new byte[] { 'a', 'b', 'c', 'd'};
+
+    SimpleDataWriter writer = (SimpleDataWriter) new SimpleDataWriterBuilder()
+        .writeTo(Destination.of(Destination.DestinationType.HDFS, properties)).writeInFormat(WriterOutputFormat.AVRO)
+        .withWriterId(TestConstants.TEST_WRITER_ID).withSchema(this.schema).forBranch(0).build();
+
+    writer.write(toWrite);
+    writer.close();
+    writer.commit();
+
+    File outputFile = new File(writer.getOutputFilePath());
+    Assert.assertTrue(outputFile.getName().endsWith(".gz.encrypted_insecure_shift"),
+        "Expected compression & encryption in file name!");
+
+    InputStream decryptedFile = new InsecureShiftCodec(Collections.<String, Object>emptyMap()).decodeInputStream(
+        new FileInputStream(outputFile));
+    InputStream uncompressedFile = new GZIPInputStream(decryptedFile);
+
+    byte[] contents = IOUtils.toByteArray(uncompressedFile);
+    Assert.assertEquals(contents, toWrite, "expected to decode same contents");
+ }
 
   /**
    * Use the simple writer to write json entries to a file and ensure that

--- a/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
@@ -259,7 +259,7 @@ public class SimpleDataWriterTest {
 
     byte[] contents = IOUtils.toByteArray(in);
     Assert.assertEquals(contents, toWrite, "Expected gzip'd content to be written out");
-    Assert.assertTrue(outputFile.getName().endsWith(".gz"), "Expected gzip'd file to end in .gz");
+    Assert.assertTrue(outputFile.getName().endsWith(".gzip"), "Expected gzip'd file to end in .gzip");
   }
 
   @Test
@@ -280,7 +280,7 @@ public class SimpleDataWriterTest {
     writer.commit();
 
     File outputFile = new File(writer.getOutputFilePath());
-    Assert.assertTrue(outputFile.getName().endsWith(".gz.encrypted_insecure_shift"),
+    Assert.assertTrue(outputFile.getName().endsWith(".gzip.encrypted_insecure_shift"),
         "Expected compression & encryption in file name!");
 
     InputStream decryptedFile = new InsecureShiftCodec(Collections.<String, Object>emptyMap()).decodeInputStream(


### PR DESCRIPTION
The FsDataWriterBuilder changes look a little weird with encoders being created only in the build() method -- however, we can't do it in constructor because the Builder isn't really actually fully initialized until build() is called, and we need to cache the encoder state in the Builder itself because getFileName() exists in the builder and isn't passed down to the writer at construct time. 