### PR TITLE
Added metrics to rest.li limiter.

### DIFF
--- a/gobblin-api/src/main/java/gobblin/broker/iface/ScopeInstance.java
+++ b/gobblin-api/src/main/java/gobblin/broker/iface/ScopeInstance.java
@@ -34,4 +34,9 @@ public interface ScopeInstance<S extends ScopeType<S>> {
    * @return type of {@link ScopeType}.
    */
   S getType();
+
+  /**
+   * @return a String identifying this scope.
+   */
+  String getScopeId();
 }

--- a/gobblin-api/src/main/java/gobblin/broker/iface/SharedResourceFactory.java
+++ b/gobblin-api/src/main/java/gobblin/broker/iface/SharedResourceFactory.java
@@ -36,7 +36,7 @@ public interface SharedResourceFactory<T, K extends SharedResourceKey, S extends
    *    should be used instead (this allows, for example, to use a different factory, or always return a global scoped object.)
    */
   SharedResourceFactoryResponse<T>
-      createResource(SharedResourcesBroker broker, ScopedConfigView<?, K> config) throws NotConfiguredException;
+      createResource(SharedResourcesBroker<S> broker, ScopedConfigView<S, K> config) throws NotConfiguredException;
 
   /**
    * @return The {@link ScopeType} at which an auto scoped resource should be created. A good default is to return

--- a/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/WorkUnitState.java
@@ -31,6 +31,7 @@ import com.google.gson.JsonParser;
 
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.broker.iface.SubscopedBrokerBuilder;
 import gobblin.source.extractor.Watermark;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.ImmutableWorkUnit;
@@ -116,13 +117,22 @@ public class WorkUnitState extends State {
    * instead.
    */
   public WorkUnitState(WorkUnit workUnit, State jobState) {
-    this(workUnit, jobState, null);
+    this(workUnit, jobState, buildTaskBroker(null, jobState, workUnit));
+  }
+
+  public WorkUnitState(WorkUnit workUnit, State jobState, SubscopedBrokerBuilder<GobblinScopeTypes, ?> taskBrokerBuilder) {
+    this(workUnit, jobState, buildTaskBroker(taskBrokerBuilder, jobState, workUnit));
   }
 
   public WorkUnitState(WorkUnit workUnit, State jobState, SharedResourcesBroker<GobblinScopeTypes> taskBroker) {
     this.workUnit = workUnit;
     this.jobState = jobState;
     this.taskBroker = taskBroker;
+  }
+
+  private static SharedResourcesBroker<GobblinScopeTypes> buildTaskBroker(
+      SubscopedBrokerBuilder<GobblinScopeTypes, ?> taskBrokerBuilder, State jobState, WorkUnit workUnit) {
+    return taskBrokerBuilder == null ? null : taskBrokerBuilder.build();
   }
 
   /**

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/Instrumented.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/Instrumented.java
@@ -260,7 +260,7 @@ public class Instrumented implements Instrumentable, Closeable {
    * @param meter an Optional&lt;{@link com.codahale.metrics.Meter}&gt;
    * @param value value to mark
    */
-  public static void markMeter(Optional<Meter> meter, final int value) {
+  public static void markMeter(Optional<Meter> meter, final long value) {
     meter.transform(new Function<Meter, Meter>() {
       @Override
       public Meter apply(@Nonnull Meter input) {

--- a/gobblin-core/src/main/java/gobblin/util/TestUtils.java
+++ b/gobblin-core/src/main/java/gobblin/util/TestUtils.java
@@ -21,6 +21,7 @@ import com.typesafe.config.ConfigFactory;
 
 import gobblin.broker.SharedResourcesBrokerFactory;
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import gobblin.broker.gobblin_scopes.JobScopeInstance;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.source.workunit.WorkUnit;
@@ -37,7 +38,8 @@ public class TestUtils {
    */
   public static WorkUnitState createTestWorkUnitState() {
     return new WorkUnitState(new WorkUnit(), new State(), SharedResourcesBrokerFactory.createDefaultTopLevelBroker(
-        ConfigFactory.empty(), GobblinScopeTypes.GLOBAL.defaultScopeInstance()));
+        ConfigFactory.empty(), GobblinScopeTypes.GLOBAL.defaultScopeInstance()).
+        newSubscopedBuilder(new JobScopeInstance("jobName", "testJob")));
   }
 
 }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -215,7 +215,7 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
 
         StreamCopierSharedLimiterKey key =
             new StreamCopierSharedLimiterKey(copyableFile.getOrigin().getPath().toUri(), this.fs.makeQualified(writeAt).toUri());
-        log.info("Acquiring a limiter for stream copier with key " + key.toConfigurationKey());
+        log.info("Acquiring a limiter for stream copier with key " + Optional.fromNullable(key.toConfigurationKey()).or("null"));
         try {
           Limiter limiter = this.taskBroker.getSharedResource(new SharedLimiterFactory<GobblinScopeTypes>(), key);
           copier.withBytesTransferedLimiter(limiter);

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/broker/MetricContextFactory.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/broker/MetricContextFactory.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metrics.broker;
+
+import com.typesafe.config.ConfigValue;
+import gobblin.broker.ResourceInstance;
+import gobblin.broker.iface.ConfigView;
+import gobblin.broker.iface.NoSuchScopeException;
+import gobblin.broker.iface.NotConfiguredException;
+import gobblin.broker.iface.ScopeType;
+import gobblin.broker.iface.ScopedConfigView;
+import gobblin.broker.iface.SharedResourceFactory;
+import gobblin.broker.iface.SharedResourceFactoryResponse;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.metrics.MetricContext;
+import gobblin.metrics.RootMetricContext;
+import gobblin.metrics.Tag;
+import gobblin.util.ConfigUtils;
+import java.util.Collection;
+import java.util.Map;
+
+
+/**
+ * A {@link SharedResourceFactory} to create {@link MetricContext}.
+ *
+ * The created {@link MetricContext} tree will mimic a sub-tree of the scopes DAG. If each scope has a unique parent,
+ * the metric contexts will have the corresponding parents. If a scope has multiple parents (which is not supported by
+ * {@link MetricContext}), the factory will chose the first parent of the scope.
+ *
+ * Tags can be injected using the configuration {@link Tag}.
+ */
+public class MetricContextFactory<S extends ScopeType<S>> implements SharedResourceFactory<MetricContext, MetricContextKey, S> {
+
+  public static final String NAME = "metricContext";
+
+  public static final String TAG_KEY = "tag";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public SharedResourceFactoryResponse<MetricContext> createResource(SharedResourcesBroker<S> broker,
+      ScopedConfigView<S, MetricContextKey> config) throws NotConfiguredException {
+
+    try {
+      MetricContext parentMetricContext = RootMetricContext.get();
+
+      Collection<S> parents = config.getScope().parentScopes();
+      if (parents != null && !parents.isEmpty()) {
+        S parentScope = parents.iterator().next();
+        parentMetricContext = broker.getSharedResourceAtScope(this, config.getKey(), parentScope);
+      }
+
+      MetricContext.Builder builder = parentMetricContext.childBuilder(broker.selfScope().toString());
+
+      builder.addTag(new Tag<>(config.getScope().name(), broker.getScope(config.getScope()).getScopeId()));
+      for (Map.Entry<String, ConfigValue> entry : ConfigUtils.getConfigOrEmpty(config.getConfig(), TAG_KEY).entrySet()) {
+        builder.addTag(new Tag<>(entry.getKey(), entry.getValue().unwrapped()));
+      }
+
+      return new ResourceInstance<>(builder.build());
+    } catch (NoSuchScopeException nsse) {
+      throw new RuntimeException("Could not create MetricContext.", nsse);
+    }
+  }
+
+  @Override
+  public S getAutoScope(SharedResourcesBroker<S> broker, ConfigView<S, MetricContextKey> config) {
+    return broker.selfScope().getType();
+  }
+}

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/broker/MetricContextKey.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/broker/MetricContextKey.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metrics.broker;
+
+import gobblin.broker.iface.SharedResourceKey;
+import lombok.Data;
+
+
+/**
+ * A {@link SharedResourceKey} used for {@link MetricContextFactory}.
+ */
+@Data
+public class MetricContextKey implements SharedResourceKey {
+  @Override
+  public String toConfigurationKey() {
+    return null;
+  }
+}

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/gobblin/metrics/broker/MetricContextFactoryTest.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/test/java/gobblin/metrics/broker/MetricContextFactoryTest.java
@@ -1,0 +1,69 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metrics.broker;
+
+import java.util.Map;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.broker.BrokerConfigurationKeyGenerator;
+import gobblin.broker.SharedResourcesBrokerFactory;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.metrics.MetricContext;
+import gobblin.metrics.Tag;
+
+
+public class MetricContextFactoryTest {
+
+  @Test
+  public void test() throws Exception {
+
+    MetricContextFactory<SimpleScopeType> factory = new MetricContextFactory<>();
+
+    Config config = ConfigFactory.parseMap(ImmutableMap.of(
+        BrokerConfigurationKeyGenerator.generateKey(factory, null, null, MetricContextFactory.TAG_KEY + ".tag1"), "value1",
+        BrokerConfigurationKeyGenerator.generateKey(factory, null, SimpleScopeType.GLOBAL, MetricContextFactory.TAG_KEY + ".tag2"), "value2",
+        BrokerConfigurationKeyGenerator.generateKey(factory, null, SimpleScopeType.LOCAL, MetricContextFactory.TAG_KEY + ".tag3"), "value3"
+    ));
+
+    SharedResourcesBroker<SimpleScopeType> rootBroker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(config,
+        SimpleScopeType.GLOBAL.defaultScopeInstance());
+    SharedResourcesBroker<SimpleScopeType> localBroker = rootBroker.newSubscopedBuilder(SimpleScopeType.LOCAL.defaultScopeInstance()).build();
+
+    MetricContext localContext = localBroker.getSharedResource(factory, new MetricContextKey());
+
+    Map<String, String> tagMap = (Map<String, String>) Tag.toMap(Tag.tagValuesToString(localContext.getTags()));
+    Assert.assertEquals(tagMap.get("tag1"), "value1");
+    Assert.assertEquals(tagMap.get("tag2"), "value2");
+    Assert.assertEquals(tagMap.get("tag3"), "value3");
+
+    MetricContext globalContext = rootBroker.getSharedResource(factory, new MetricContextKey());
+    Assert.assertEquals(localContext.getParent().get(), globalContext);
+    tagMap = (Map<String, String>) Tag.toMap(Tag.tagValuesToString(globalContext.getTags()));
+    Assert.assertEquals(tagMap.get("tag1"), "value1");
+    Assert.assertEquals(tagMap.get("tag2"), "value2");
+    Assert.assertFalse(tagMap.containsKey("tag3"));
+  }
+
+}

--- a/gobblin-restli/gobblin-restli-utils/src/main/java/gobblin/restli/SharedRestClientFactory.java
+++ b/gobblin-restli/gobblin-restli-utils/src/main/java/gobblin/restli/SharedRestClientFactory.java
@@ -22,6 +22,7 @@ import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Set;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Sets;
 import com.linkedin.r2.transport.common.Client;
@@ -55,7 +56,7 @@ public class SharedRestClientFactory<S extends ScopeType<S>> implements SharedRe
   }
 
   @Override
-  public ResourceInstance<RestClient> createResource(SharedResourcesBroker broker, ScopedConfigView<?, SharedRestClientKey> config)
+  public ResourceInstance<RestClient> createResource(SharedResourcesBroker<S> broker, ScopedConfigView<S, SharedRestClientKey> config)
       throws NotConfiguredException {
     try {
       String uriPrefix = resolveUriPrefix(config);
@@ -65,7 +66,7 @@ public class SharedRestClientFactory<S extends ScopeType<S>> implements SharedRe
 
       return new ResourceInstance<>(new RestClient(r2Client,uriPrefix));
     } catch (URISyntaxException use) {
-      throw new RuntimeException("Could not create a rest client for key " + config.getKey().toConfigurationKey());
+      throw new RuntimeException("Could not create a rest client for key " + Optional.fromNullable(config.getKey().toConfigurationKey()).or("null"));
     }
   }
 
@@ -83,6 +84,6 @@ public class SharedRestClientFactory<S extends ScopeType<S>> implements SharedRe
       return new URI(serverURI.getScheme(), serverURI.getAuthority(), null, null, null).toString() + "/";
     }
 
-    throw new RuntimeException("Could not parse URI prefix for key " + config.getKey().toConfigurationKey());
+    throw new RuntimeException("Could not parse URI prefix for key " + Optional.fromNullable(config.getKey().toConfigurationKey()).or("null"));
   }
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/restli/throttling/RestliServiceBasedLimiterTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/restli/throttling/RestliServiceBasedLimiterTest.java
@@ -79,8 +79,8 @@ public class RestliServiceBasedLimiterTest {
 
       RestClient restClient = new RestClient(r2Client, server.getURIPrefix());
 
-      RestliServiceBasedLimiter limiter =
-          new RestliServiceBasedLimiter(restClient, res1key.getResourceLimited(), "service");
+      RestliServiceBasedLimiter limiter = RestliServiceBasedLimiter.builder().restClient(restClient)
+          .resourceLimited(res1key.getResourceLimited()).serviceIdentifier("service").build();
 
       Assert.assertNotNull(limiter.acquirePermits(20));
       Assert.assertNotNull(limiter.acquirePermits(20));

--- a/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -38,6 +38,7 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import gobblin.annotation.Alpha;
+import gobblin.broker.iface.SubscopedBrokerBuilder;
 import gobblin.commit.CommitStep;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
@@ -283,8 +284,9 @@ public class GobblinMultiTaskAttempt {
     List<Task> tasks = Lists.newArrayList();
     for (WorkUnit workUnit : this.workUnits) {
       String taskId = workUnit.getProp(ConfigurationKeys.TASK_ID_KEY);
-      SharedResourcesBroker<GobblinScopeTypes> taskBroker = this.jobBroker.newSubscopedBuilder(new TaskScopeInstance(taskId)).build();
-      WorkUnitState workUnitState = new WorkUnitState(workUnit, this.jobState, taskBroker);
+      SubscopedBrokerBuilder<GobblinScopeTypes, ?> taskBrokerBuilder =
+          this.jobBroker.newSubscopedBuilder(new TaskScopeInstance(taskId));
+      WorkUnitState workUnitState = new WorkUnitState(workUnit, this.jobState, taskBrokerBuilder);
       workUnitState.setId(taskId);
       workUnitState.setProp(ConfigurationKeys.JOB_ID_KEY, this.jobId);
       workUnitState.setProp(ConfigurationKeys.TASK_ID_KEY, taskId);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobBrokerInjectionTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobBrokerInjectionTest.java
@@ -216,7 +216,8 @@ public class JobBrokerInjectionTest {
     }
 
     @Override
-    public ResourceInstance<MySharedObject> createResource(SharedResourcesBroker broker, ScopedConfigView<?, MySharedKey> config) {
+    public ResourceInstance<MySharedObject> createResource(SharedResourcesBroker<GobblinScopeTypes> broker,
+        ScopedConfigView<GobblinScopeTypes, MySharedKey> config) {
       return new ResourceInstance<>(new MySharedObject());
     }
 

--- a/gobblin-utility/src/main/java/gobblin/broker/KeyedScopedConfigViewImpl.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/KeyedScopedConfigViewImpl.java
@@ -57,11 +57,15 @@ public class KeyedScopedConfigViewImpl<S extends ScopeType<S>, K extends SharedR
   }
 
   public Config getKeyedConfig() {
+    String key = this.key.toConfigurationKey();
+    if (key == null) {
+      return ConfigFactory.empty();
+    }
     return ConfigUtils.getConfigOrEmpty(this.fullConfig, this.key.toConfigurationKey());
   }
 
   public Config getKeyedScopedConfig() {
-    if (this.scope == null) {
+    if (this.scope == null || this.key.toConfigurationKey() == null) {
       return ConfigFactory.empty();
     }
     return ConfigUtils.getConfigOrEmpty(this.fullConfig,

--- a/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerImpl.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerImpl.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.Queue;
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -161,6 +162,8 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
     private Config config = ConfigFactory.empty();
 
     private SubscopedBrokerBuilder(ScopeInstance<S> scope) {
+      Preconditions.checkNotNull(scope, "Subscope instance cannot be null.");
+
       this.scope = scope;
 
       if (SharedResourcesBrokerImpl.this.selfScopeWrapper != null) {

--- a/gobblin-utility/src/main/java/gobblin/util/NoopCloseable.java
+++ b/gobblin-utility/src/main/java/gobblin/util/NoopCloseable.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util;
+
+import java.io.Closeable;
+
+
+/**
+ * A {@link Closeable} that does nothing.
+ */
+public class NoopCloseable implements Closeable {
+
+  public static NoopCloseable INSTANCE = new NoopCloseable();
+
+  @Override
+  public void close() {
+    // Do nothing
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/limiter/broker/SharedLimiterFactory.java
+++ b/gobblin-utility/src/main/java/gobblin/util/limiter/broker/SharedLimiterFactory.java
@@ -69,7 +69,7 @@ public class SharedLimiterFactory<S extends ScopeType<S>> implements SharedResou
 
   @Override
   public SharedResourceFactoryResponse<Limiter>
-    createResource(SharedResourcesBroker broker, ScopedConfigView<?, SharedLimiterKey> configView)
+    createResource(SharedResourcesBroker<S> broker, ScopedConfigView<S, SharedLimiterKey> configView)
       throws NotConfiguredException{
 
     Config config = configView.getConfig();
@@ -112,13 +112,13 @@ public class SharedLimiterFactory<S extends ScopeType<S>> implements SharedResou
       limiter = new NoopLimiter();
     }
 
-    ScopeType<?> scope = configView.getScope();
-    Collection<ScopeType<?>> parentScopes = (Collection<ScopeType<?>>) scope.parentScopes();
+    ScopeType<S> scope = configView.getScope();
+    Collection<S> parentScopes = scope.parentScopes();
     if (parentScopes != null) {
       try {
-        for (ScopeType<?> parentScope : parentScopes) {
+        for (S parentScope : parentScopes) {
           limiter = new MultiLimiter(limiter,
-              (Limiter) broker.<Limiter, SharedLimiterKey>getSharedResourceAtScope(this, configView.getKey(), parentScope));
+              broker.getSharedResourceAtScope(this, configView.getKey(), parentScope));
         }
       } catch (NoSuchScopeException nsse) {
         throw new RuntimeException("Could not get higher scope limiter. This is an error in code.", nsse);

--- a/gobblin-utility/src/test/java/gobblin/broker/TestFactory.java
+++ b/gobblin-utility/src/test/java/gobblin/broker/TestFactory.java
@@ -57,7 +57,7 @@ public class TestFactory<S extends ScopeType<S>> implements SharedResourceFactor
 
   @Override
   public SharedResourceFactoryResponse<SharedResource>
-      createResource(SharedResourcesBroker broker, ScopedConfigView<?, TestResourceKey> config) {
+      createResource(SharedResourcesBroker<S> broker, ScopedConfigView<S, TestResourceKey> config) {
     return new ResourceInstance<>(new SharedResource(config.getKey().getKey(), config.getConfig()));
   }
 


### PR DESCRIPTION
Changes:

* Created a `MetricContextFactory` for broker, along with a `MetricContextKey` and a unit test.
* Rest.li Limiter supports emitting metrics. The factory automatically acquires a metric context from the broker.

* In Gobblin runtime, `WorkUnitState` gets a broker builder instead of a pre-built broker so it can inject its own custom configurations (not done currently). Eventually, I would want to replace all `MetricContext`s in gobblin runtime for ones acquired from the broker.
* Added a scope id to the `ScopeInstance` interface.
* Minor changes to generics in broker (fixes compiler/ide warnings)
