### PR TITLE
ThreadPool leak in HttpWriter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
@@ -42,6 +42,7 @@ import com.google.common.util.concurrent.ListeningExecutorService;
 import com.google.common.util.concurrent.MoreExecutors;
 
 import gobblin.instrumented.writer.InstrumentedDataWriter;
+import gobblin.util.ExecutorsUtils;
 
 /**
  * Base class for HTTP writers. Defines the main extension points for different implementations.
@@ -94,12 +95,24 @@ public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> im
     }
   }
 
-  /** {@inheritDoc} */
+  /**
+   * {@inheritDoc}
+   */
   @Override
   public void cleanup() throws IOException {
     this.client.close();
+    ExecutorsUtils.shutdownExecutorService(this.singleThreadPool, Optional.of(log));
   }
-
+ 
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() throws IOException {
+    cleanup();
+    super.close();
+  }
+  
   /**
    * {@inheritDoc}
    */


### PR DESCRIPTION
A Gobblin job that outputs data to http, for instance to a REST endpoint using `gobblin.writer.http.RestJsonWriterBuilder` returns successfully as expected. 
However, after subsequent runs such errors may be seen in the Yarn container logs:
```
Error: A JNI error has occurred, please check your installation and try again
Exception in thread "main" java.lang.InternalError: java.io.FileNotFoundException: 
/Library/Java/JavaVirtualMachines/jdk1.8.0_77.jdk/Contents/Home/jre/lib/ext/localedata.jar
(Too many open files in system)
```
The `YarnChild` processes are still running for each previous job and they never terminate.
In the thread dumps I see that **DestroyJavaVM** just desperately waits for other threads to complete.
After analyzing the heap dump, it turned out that `singleThreadPool` in `gobblin.writer.http.AbstractHttpWriter` is not shut down at all, thus it can never be reclaimed by the GC.
Also, when `gobblin.instrumented.writer.InstrumentedDataWriterBase#close` calls to `RestJsonWriter#close`, nothing happens as close is not overridden in any of RestjsonWriter, HttpWriter, AbstractHttpWriter.

The patch tries to address this issue by adding `AbstractHttpWriter#close` which calls to cleanup() to close CloseableHttpClient and ListeningExecutorService objects.
