### PR TITLE
Remove data pull upper bound for the last work unit of query based task

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
@@ -188,14 +188,8 @@ public abstract class QueryBasedExtractor<S, D> implements Extractor<S, D>, Prot
 
     // Don't remove if user specifies one or is recorded in previous run
     if (this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE) != null ||
+        this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT) != null ||
         this.workUnitState.getProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY) != null) {
-      return false;
-    }
-
-    ExtractType extractType =
-        ExtractType.valueOf(this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_EXTRACT_TYPE).toUpperCase());
-    // Don't remove if the run is for "APPEND"
-    if (extractType != ExtractType.SNAPSHOT) {
       return false;
     }
 

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
@@ -22,6 +22,7 @@ import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.extractor.exception.ExtractPrepareException;
 import gobblin.source.extractor.exception.HighWatermarkException;
+import gobblin.source.extractor.partition.Partitioner;
 import gobblin.source.extractor.schema.ArrayDataType;
 import gobblin.source.extractor.schema.DataType;
 import gobblin.source.extractor.schema.EnumDataType;
@@ -187,8 +188,7 @@ public abstract class QueryBasedExtractor<S, D> implements Extractor<S, D>, Prot
     }
 
     // Don't remove if user specifies one or is recorded in previous run
-    if (this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE) != null ||
-        this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT) != null ||
+    if (this.workUnit.getPropAsBoolean(Partitioner.HAS_USER_SPECIFIED_HIGH_WATERMARK) ||
         this.workUnitState.getProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY) != null) {
       return false;
     }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedExtractor.java
@@ -68,6 +68,7 @@ public abstract class QueryBasedExtractor<S, D> implements Extractor<S, D>, Prot
   private S outputSchema;
   private long sourceRecordCount = 0;
   private long highWatermark;
+  private long estimatedActualHighWatermark = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
 
   private Iterator<D> iterator;
   protected final List<String> columnList = new ArrayList<>();
@@ -145,6 +146,11 @@ public abstract class QueryBasedExtractor<S, D> implements Extractor<S, D>, Prot
     try {
       if (isInitialPull()) {
         log.info("Initial pull");
+
+        if (shouldRemoveDataPullUpperBounds()) {
+          this.removeDataPullUpperBounds();
+          this.setEstimatedActualHighWatermark();
+        }
         this.iterator = this.getIterator();
       }
 
@@ -163,6 +169,72 @@ public abstract class QueryBasedExtractor<S, D> implements Extractor<S, D>, Prot
       throw new DataRecordException("Failed to get records using rest api; error - " + e.getMessage(), e);
     }
     return nextElement;
+  }
+
+  /**
+   * Check if it's appropriate to remove data pull upper bounds in the last work unit, fetching as much data as possible
+   * from the source. As between the time when data query was created and that was executed, there might be some
+   * new data generated in the source. Removing the upper bounds will help us grab the new data. It might result in a
+   * conservative high watermark, which is mitigated by {@link #setEstimatedActualHighWatermark()}
+   *
+   * Note: It's expected that there might be some duplicate data between runs because of removing the upper bounds
+   *
+   * @return should remove or not
+   */
+  private boolean shouldRemoveDataPullUpperBounds() {
+    // Only consider the last work unit
+    if (!this.workUnit.getPropAsBoolean(QueryBasedSource.IS_LAST_WORK_UNIT)) {
+      return false;
+    }
+
+    // Don't remove if the run is for 'APPEND'
+    if (!this.isFullDump()) {
+      return false;
+    }
+
+    // Don't remove if user specifies one or is recorded in previous run
+    if (this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE) != null ||
+        this.workUnitState.getProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY) != null) {
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * Remove all upper bounds in the predicateList used for pulling data
+   */
+  private void removeDataPullUpperBounds() {
+    log.info("Removing data pull upper bound for last work unit");
+    Iterator<Predicate> it = predicateList.iterator();
+    while (it.hasNext()) {
+      Predicate predicate = it.next();
+      if (predicate.getType() == Predicate.PredicateType.HWM) {
+        log.info("Remove predicate: " + predicate.condition);
+        it.remove();
+      }
+    }
+  }
+
+  /**
+   * Set an estimated actual high watermark when the work unit is the last one
+   * and its upper bounds to fetch data are removed
+   */
+  private void setEstimatedActualHighWatermark() {
+    String watermarkType = this.workUnitState.getProp(ConfigurationKeys.SOURCE_QUERYBASED_WATERMARK_TYPE, "TIMESTAMP");
+    WatermarkType wmType = WatermarkType.valueOf(watermarkType.toUpperCase());
+    switch (wmType) {
+      case TIMESTAMP:
+      case DATE:
+      case HOUR:
+        String timeZone = this.workUnitState.getProp(ConfigurationKeys.SOURCE_TIMEZONE);
+        this.estimatedActualHighWatermark = Long.parseLong(
+            Utils.dateTimeToString(Utils.getCurrentTime(timeZone), "yyyyMMddHHmmss", timeZone));
+        break;
+      case SIMPLE:
+        this.estimatedActualHighWatermark = this.highWatermark;
+        break;
+    }
   }
 
   /**
@@ -210,8 +282,13 @@ public abstract class QueryBasedExtractor<S, D> implements Extractor<S, D>, Prot
    */
   @Override
   public void close() {
-    log.info("Updating the current state high water mark with " + this.highWatermark);
-    this.workUnitState.setActualHighWatermark(new LongWatermark(this.highWatermark));
+    long actualHighWatermark = this.estimatedActualHighWatermark;
+    if (actualHighWatermark == ConfigurationKeys.DEFAULT_WATERMARK_VALUE) {
+      actualHighWatermark = this.highWatermark;
+    }
+
+    log.info("Updating the current state high water mark with " + actualHighWatermark);
+    this.workUnitState.setActualHighWatermark(new LongWatermark(actualHighWatermark));
     try {
       this.closeConnection();
     } catch (Exception e) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -79,7 +79,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
   public static final boolean DEFAULT_SOURCE_OBTAIN_TABLE_PROPS_FROM_CONFIG_STORE = false;
   private static final String QUERY_BASED_SOURCE = "query_based_source";
   public static final String WORK_UNIT_STATE_VERSION_KEY = "source.querybased.workUnitState.version";
-  public static final String IS_LAST_WORK_UNIT = "source.querybased.is.last.work.unit";
+  public static final String IS_LAST_WORK_UNIT = "source.querybased.isLastWorkUnit";
   /**
    * WorkUnit Version 3:
    *    SOURCE_ENTITY = as specified in job config

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -201,7 +201,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
       }
 
       List<Partition> partitions = new Partitioner(combinedState).getPartitionList(previousWatermark);
-      Collections.sort(partitions, Partitioner.getAscendingComparator());
+      Collections.sort(partitions, Partitioner.ascendingComparator);
 
       // {@link ConfigurationKeys.EXTRACT_TABLE_NAME_KEY} specify the output path for Extract
       String outputTableName = sourceEntity.getDestTableName();

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -78,7 +78,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
   public static final boolean DEFAULT_SOURCE_OBTAIN_TABLE_PROPS_FROM_CONFIG_STORE = false;
   private static final String QUERY_BASED_SOURCE = "query_based_source";
   public static final String WORK_UNIT_STATE_VERSION_KEY = "source.querybased.workUnitState.version";
-  public static final String IS_LAST_WORK_UNIT = "is.last.work.unit";
+  public static final String IS_LAST_WORK_UNIT = "source.querybased.is.last.work.unit";
   /**
    * WorkUnit Version 3:
    *    SOURCE_ENTITY = as specified in job config

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/QueryBasedSource.java
@@ -78,6 +78,7 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
   public static final boolean DEFAULT_SOURCE_OBTAIN_TABLE_PROPS_FROM_CONFIG_STORE = false;
   private static final String QUERY_BASED_SOURCE = "query_based_source";
   public static final String WORK_UNIT_STATE_VERSION_KEY = "source.querybased.workUnitState.version";
+  public static final String IS_LAST_WORK_UNIT = "is.last.work.unit";
   /**
    * WorkUnit Version 3:
    *    SOURCE_ENTITY = as specified in job config
@@ -223,6 +224,9 @@ public abstract class QueryBasedSource<S, D> extends AbstractSource<S, D> {
       }
     }
     log.info("Total number of workunits for the current run: " + workUnits.size());
+
+    // Mark last work unit of the current run
+    workUnits.get(workUnits.size() - 1).setProp(IS_LAST_WORK_UNIT, true);
 
     List<WorkUnit> previousWorkUnits = this.getPreviousWorkUnitsForRetry(state);
     log.info("Total number of incomplete tasks from the previous run: " + previousWorkUnits.size());

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
@@ -1,0 +1,35 @@
+package gobblin.source.extractor.partition;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+@AllArgsConstructor
+public class Partition {
+  @Getter
+  private long lowWatermark;
+  @Getter private long highWatermark;
+  private boolean hasUserSpecifiedHighWatermark;
+
+  public Partition(long lowWatermark, long highWatermark) {
+    this(lowWatermark, highWatermark, false);
+  }
+
+  public boolean getHasUserSpecifiedHighWatermark() {
+    return hasUserSpecifiedHighWatermark;
+  }
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj instanceof Partition) {
+      Partition partition = (Partition) obj;
+      return lowWatermark == partition.getLowWatermark() && highWatermark == partition.getHighWatermark()
+          && hasUserSpecifiedHighWatermark == partition.getHasUserSpecifiedHighWatermark();
+    }
+    return false;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
@@ -1,10 +1,12 @@
 package gobblin.source.extractor.partition;
 
 import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 
 @AllArgsConstructor
+@EqualsAndHashCode
 public class Partition {
   @Getter
   private long lowWatermark;
@@ -17,19 +19,5 @@ public class Partition {
 
   public boolean getHasUserSpecifiedHighWatermark() {
     return hasUserSpecifiedHighWatermark;
-  }
-
-  @Override
-  public boolean equals(Object obj) {
-    if (this == obj) {
-      return true;
-    }
-
-    if (obj instanceof Partition) {
-      Partition partition = (Partition) obj;
-      return lowWatermark == partition.getLowWatermark() && highWatermark == partition.getHighWatermark()
-          && hasUserSpecifiedHighWatermark == partition.getHasUserSpecifiedHighWatermark();
-    }
-    return false;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
@@ -8,9 +8,10 @@ import lombok.Getter;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class Partition {
-  @Getter
-  private long lowWatermark;
+  @Getter private long lowWatermark;
   @Getter private long highWatermark;
+
+  // Indicate if the Partition highWatermark is set as user specifies, not computed on the fly
   private boolean hasUserSpecifiedHighWatermark;
 
   public Partition(long lowWatermark, long highWatermark) {

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partition.java
@@ -1,18 +1,34 @@
 package gobblin.source.extractor.partition;
 
+import gobblin.source.Source;
+import gobblin.source.workunit.WorkUnit;
+
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 
 
+/**
+ * This class encapsulates the two ends, {@link #lowWatermark} and {@link #highWatermark}, of a partition and some
+ * metadata, e.g. {@link #hasUserSpecifiedHighWatermark}, to describe the partition.
+ *
+ * <p>
+ *   A {@link Source} partitions its data into a collection of {@link Partition}, each of which will be used to create
+ *   a {@link WorkUnit}.
+ * </p>
+ *
+ * @author zhchen
+ */
 @AllArgsConstructor
 @EqualsAndHashCode
 public class Partition {
-  @Getter private long lowWatermark;
-  @Getter private long highWatermark;
+  @Getter private final long lowWatermark;
+  @Getter private final long highWatermark;
 
-  // Indicate if the Partition highWatermark is set as user specifies, not computed on the fly
-  private boolean hasUserSpecifiedHighWatermark;
+  /**
+   * Indicate if the Partition highWatermark is set as user specifies, not computed on the fly
+   */
+  private final boolean hasUserSpecifiedHighWatermark;
 
   public Partition(long lowWatermark, long highWatermark) {
     this(lowWatermark, highWatermark, false);

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -45,7 +45,7 @@ import gobblin.source.extractor.watermark.WatermarkType;
 public class Partitioner {
   private static final String WATERMARKTIMEFORMAT = "yyyyMMddHHmmss";
   private static final Logger LOG = LoggerFactory.getLogger(Partitioner.class);
-  public static final String HAS_USER_SPECIFIED_HIGH_WATERMARK = "has.user.specified.high.watermark";
+  public static final String HAS_USER_SPECIFIED_HIGH_WATERMARK = "partitioner.hasUserSpecifiedHighWatermark";
 
   public static final Comparator<Partition> ascendingComparator = new Comparator<Partition>() {
     @Override
@@ -59,6 +59,7 @@ public class Partitioner {
       if (p2 == null) {
         return 1;
       }
+      // For compactness, treat the '==' case as '<'
       return p1.getLowWatermark() > p2.getLowWatermark() ? 1 : -1;
     }
   };

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -59,14 +59,15 @@ public class Partitioner {
       if (p2 == null) {
         return 1;
       }
-      // For compactness, treat the '==' case as '<'
-      return p1.getLowWatermark() > p2.getLowWatermark() ? 1 : -1;
+      return Long.compare(p1.getLowWatermark(), p2.getLowWatermark());
     }
   };
 
   private SourceState state;
 
-  // Indicate if the user specifies a high watermark for the current run
+  /**
+   * Indicate if the user specifies a high watermark for the current run
+   */
   @VisibleForTesting
   protected boolean hasUserSpecifiedHighWatermark;
 
@@ -151,7 +152,8 @@ public class Partitioner {
       if (partitionHighWatermark.equals(highestWatermark)) {
         partitions.add(new Partition(entry.getKey(), partitionHighWatermark, hasUserSpecifiedHighWatermark));
       } else {
-        partitions.add(new Partition(entry.getKey(), partitionHighWatermark));
+        // The partitionHighWatermark was computed on the fly not what user specifies
+        partitions.add(new Partition(entry.getKey(), partitionHighWatermark, false));
       }
     }
     return partitions;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -46,9 +46,26 @@ public class Partitioner {
   private static final String WATERMARKTIMEFORMAT = "yyyyMMddHHmmss";
   private static final Logger LOG = LoggerFactory.getLogger(Partitioner.class);
   public static final String HAS_USER_SPECIFIED_HIGH_WATERMARK = "has.user.specified.high.watermark";
-  private static Comparator<Partition> ascendingComparator = null;
+
+  public static final Comparator<Partition> ascendingComparator = new Comparator<Partition>() {
+    @Override
+    public int compare(Partition p1, Partition p2) {
+      if (p1 == null && p2 == null) {
+        return 0;
+      }
+      if (p1 == null) {
+        return -1;
+      }
+      if (p2 == null) {
+        return 1;
+      }
+      return p1.getLowWatermark() > p2.getLowWatermark() ? 1 : -1;
+    }
+  };
 
   private SourceState state;
+
+  // Indicate if the user specifies a high watermark for the current run
   @VisibleForTesting
   protected boolean hasUserSpecifiedHighWatermark;
 
@@ -489,26 +506,5 @@ public class Partitioner {
   @VisibleForTesting
   public DateTime getCurrentTime(String timeZone) {
     return Utils.getCurrentTime(timeZone);
-  }
-
-  public static Comparator<Partition> getAscendingComparator() {
-    if (ascendingComparator == null) {
-      ascendingComparator = new Comparator<Partition>() {
-        @Override
-        public int compare(Partition p1, Partition p2) {
-          if (p1 == null && p2 == null) {
-            return 0;
-          }
-          if (p1 == null) {
-            return -1;
-          }
-          if (p2 == null) {
-            return 1;
-          }
-          return p1.getLowWatermark() > p2.getLowWatermark() ? 1 : -1;
-        }
-      };
-    }
-    return ascendingComparator;
   }
 }

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedExtractorTest.java
@@ -67,9 +67,9 @@ public class QueryBasedExtractorTest {
     testExtractor.setRangePredicates(1, 3);
     this.verify(testExtractor, 3);
 
-    // It's a last work unit but it's an "APPEND"
+    // It's a last work unit but it has SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT
     workUnit.removeProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY);
-    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_EXTRACT_TYPE, "APPEND_DAILY");
+    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT, "CURRENT_DATE-3");
     testExtractor.reset();
     testExtractor.setRangePredicates(1, 3);
     this.verify(testExtractor, 3);

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedExtractorTest.java
@@ -7,6 +7,7 @@ import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.exception.HighWatermarkException;
 import gobblin.source.extractor.exception.RecordCountException;
 import gobblin.source.extractor.exception.SchemaException;
+import gobblin.source.extractor.partition.Partitioner;
 import gobblin.source.extractor.watermark.Predicate;
 import gobblin.source.extractor.watermark.WatermarkPredicate;
 import gobblin.source.extractor.watermark.WatermarkType;
@@ -53,23 +54,16 @@ public class QueryBasedExtractorTest {
     testExtractor.setRangePredicates(1, 3);
     this.verify(testExtractor, 3);
 
-    // It's a last work unit but user specifies SOURCE_QUERYBASED_END_VALUE
+    // It's a last work unit but user specifies high watermark
     workUnit.setProp(QueryBasedSource.IS_LAST_WORK_UNIT, true);
-    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, "3");
+    workUnit.setProp(Partitioner.HAS_USER_SPECIFIED_HIGH_WATERMARK, true);
     testExtractor.reset();
     testExtractor.setRangePredicates(1, 3);
     this.verify(testExtractor, 3);
 
     // It's a last work unit but it has WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY on record
-    workUnit.removeProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE);
+    workUnit.removeProp(Partitioner.HAS_USER_SPECIFIED_HIGH_WATERMARK);
     workUnit.setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, "3");
-    testExtractor.reset();
-    testExtractor.setRangePredicates(1, 3);
-    this.verify(testExtractor, 3);
-
-    // It's a last work unit but it has SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT
-    workUnit.removeProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY);
-    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT, "CURRENT_DATE-3");
     testExtractor.reset();
     testExtractor.setRangePredicates(1, 3);
     this.verify(testExtractor, 3);

--- a/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/extract/QueryBasedExtractorTest.java
@@ -1,0 +1,238 @@
+package gobblin.source.extractor.extract;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.source.extractor.DataRecordException;
+import gobblin.source.extractor.exception.HighWatermarkException;
+import gobblin.source.extractor.exception.RecordCountException;
+import gobblin.source.extractor.exception.SchemaException;
+import gobblin.source.extractor.watermark.Predicate;
+import gobblin.source.extractor.watermark.WatermarkPredicate;
+import gobblin.source.extractor.watermark.WatermarkType;
+import gobblin.source.workunit.WorkUnit;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Unit tests for {@link QueryBasedExtractor}
+ */
+public class QueryBasedExtractorTest {
+  @Test
+  public void testDataPullUpperBoundsRemovedInLastWorkUnit() {
+    int totalCount = 5;
+    ArrayList<DataRecord> records = this.generateRecords(totalCount);
+
+    WorkUnit workUnit = WorkUnit.createEmpty();
+    workUnit.setProp(QueryBasedSource.IS_LAST_WORK_UNIT, true);
+    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_EXTRACT_TYPE, "SNAPSHOT");
+    WorkUnitState workUnitState = new WorkUnitState(workUnit, new State());
+    workUnitState.setId("testDataPullUpperBoundsRemovedInLastWorkUnit");
+
+    TestQueryBasedExtractor testExtractor = new TestQueryBasedExtractor(workUnitState, records);
+    testExtractor.setRangePredicates(1, 3);
+    this.verify(testExtractor, totalCount);
+  }
+
+  @Test
+  public void testDataPullUpperBoundsNotRemovedInLastWorkUnit() {
+    int totalCount = 5;
+    ArrayList<DataRecord> records = this.generateRecords(totalCount);
+
+    WorkUnit workUnit = WorkUnit.createEmpty();
+    WorkUnitState workUnitState = new WorkUnitState(workUnit, new State());
+    workUnitState.setId("testDataPullUpperBoundsNotRemovedInLastWorkUnit");
+
+    // It's not a last work unit
+    TestQueryBasedExtractor testExtractor = new TestQueryBasedExtractor(workUnitState, records);
+    testExtractor.setRangePredicates(1, 3);
+    this.verify(testExtractor, 3);
+
+    // It's a last work unit but user specifies SOURCE_QUERYBASED_END_VALUE
+    workUnit.setProp(QueryBasedSource.IS_LAST_WORK_UNIT, true);
+    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, "3");
+    testExtractor.reset();
+    testExtractor.setRangePredicates(1, 3);
+    this.verify(testExtractor, 3);
+
+    // It's a last work unit but it has WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY on record
+    workUnit.removeProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE);
+    workUnit.setProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY, "3");
+    testExtractor.reset();
+    testExtractor.setRangePredicates(1, 3);
+    this.verify(testExtractor, 3);
+
+    // It's a last work unit but it's an "APPEND"
+    workUnit.removeProp(ConfigurationKeys.WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY);
+    workUnit.setProp(ConfigurationKeys.SOURCE_QUERYBASED_EXTRACT_TYPE, "APPEND_DAILY");
+    testExtractor.reset();
+    testExtractor.setRangePredicates(1, 3);
+    this.verify(testExtractor, 3);
+  }
+
+  private ArrayList<DataRecord> generateRecords(int count) {
+    ArrayList<DataRecord> records = new ArrayList<>();
+    while (count > 0) {
+      records.add(new DataRecord(count, count));
+      count--;
+    }
+    return records;
+  }
+
+  private void verify(TestQueryBasedExtractor testExtractor, int expectedCount) {
+    int actualCount = 0;
+    try {
+      while (testExtractor.readRecord(null) != null) {
+        actualCount++;
+      }
+    } catch (Exception e) {
+      Assert.fail("There should not incur any exception");
+    }
+    Assert.assertEquals(actualCount, expectedCount, "Expect " + expectedCount + " records!");
+  }
+
+  private class TestQueryBasedExtractor extends QueryBasedExtractor<ArrayList, DataRecord> {
+    private final ArrayList<DataRecord> records;
+    private long previousActualHwmValue;
+
+    TestQueryBasedExtractor(WorkUnitState workUnitState, ArrayList<DataRecord> records) {
+      super(workUnitState);
+      this.records = records;
+      previousActualHwmValue = -1;
+    }
+
+    void setRangePredicates(long lwmValue, long hwmValue) {
+      WatermarkPredicate watermark = new WatermarkPredicate("timeStamp", WatermarkType.SIMPLE);
+      predicateList.add(watermark.getPredicate(this, lwmValue, ">=", Predicate.PredicateType.LWM));
+      predicateList.add(watermark.getPredicate(this, hwmValue, "<=", Predicate.PredicateType.HWM));
+    }
+
+    void reset() {
+      previousActualHwmValue = -1;
+      predicateList.clear();
+      setFetchStatus(true);
+    }
+
+    @Override
+    public void extractMetadata(String schema, String entity, WorkUnit workUnit) throws SchemaException, IOException {
+
+    }
+
+    @Override
+    public long getMaxWatermark(String schema, String entity, String watermarkColumn,
+        List<Predicate> snapshotPredicateList, String watermarkSourceFormat) throws HighWatermarkException {
+      return 0;
+    }
+
+    @Override
+    public long getSourceCount(String schema, String entity, WorkUnit workUnit, List<Predicate> predicateList)
+        throws RecordCountException {
+      return records.size();
+    }
+
+    @Override
+    public Iterator<DataRecord> getRecordSet(String schema, String entity, WorkUnit workUnit, List<Predicate> predicateList)
+        throws DataRecordException, IOException {
+      if (records == null || predicateList == null) {
+        // No new data to pull
+        return null;
+      }
+
+      long lwmValue = -1;
+      long hwmValue = Long.MAX_VALUE;
+      long actualHwmValue = -1;
+      // Adjust watermarks from predicate list
+      for (Predicate predicate: predicateList) {
+        if (predicate.getType() == Predicate.PredicateType.HWM) {
+          hwmValue = predicate.value;
+        }
+        if (predicate.getType() == Predicate.PredicateType.LWM) {
+          lwmValue = predicate.value;
+        }
+      }
+
+      ArrayList<DataRecord> filteredRecords = new ArrayList<>();
+      for (DataRecord record : records) {
+        if (record.timeStamp <= previousActualHwmValue) {
+          // The record has been pulled previously
+          continue;
+        }
+        if (record.timeStamp >= lwmValue && record.timeStamp <= hwmValue) {
+          // Make a copy
+          filteredRecords.add(new DataRecord(record.value, record.timeStamp));
+          // Mark actual high watermark
+          if (record.timeStamp > actualHwmValue) {
+            actualHwmValue = record.timeStamp;
+          }
+        }
+      }
+
+      if (filteredRecords.isEmpty()) {
+        return null;
+      }
+      previousActualHwmValue = actualHwmValue;
+      return filteredRecords.iterator();
+    }
+
+    @Override
+    public String getWatermarkSourceFormat(WatermarkType watermarkType) {
+      return null;
+    }
+
+    @Override
+    public String getHourPredicateCondition(String column, long value, String valueFormat, String operator) {
+      return null;
+    }
+
+    @Override
+    public String getDatePredicateCondition(String column, long value, String valueFormat, String operator) {
+      return null;
+    }
+
+    @Override
+    public String getTimestampPredicateCondition(String column, long value, String valueFormat, String operator) {
+      return null;
+    }
+
+    @Override
+    public void setTimeOut(int timeOut) {
+
+    }
+
+    @Override
+    public Map<String, String> getDataTypeMap() {
+      return null;
+    }
+
+    @Override
+    public void closeConnection() throws Exception {
+
+    }
+
+    @Override
+    public Iterator<DataRecord> getRecordSetFromSourceApi(String schema, String entity, WorkUnit workUnit,
+        List<Predicate> predicateList) throws IOException {
+      try {
+        return getRecordSet(schema, entity, workUnit, predicateList);
+      } catch (DataRecordException e) {
+        e.printStackTrace();
+        return null;
+      }
+    }
+  }
+
+  private class DataRecord {
+    int value;
+    long timeStamp;
+
+    DataRecord(int value, long timeStamp) {
+      this.value = value;
+      this.timeStamp = timeStamp;
+    }
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/partition/PartitionerTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/partition/PartitionerTest.java
@@ -53,7 +53,7 @@ public class PartitionerTest {
     expectedPartitions.add(new Partition(20170101000000L, 20170101060000L));
     expectedPartitions.add(new Partition(20170101070000L, 20170101120000L, true));
     List<Partition> partitions = partitioner.getPartitionList(-1);
-    Collections.sort(partitions, Partitioner.getAscendingComparator());
+    Collections.sort(partitions, Partitioner.ascendingComparator);
     Assert.assertEquals(partitions, expectedPartitions);
   }
 

--- a/gobblin-core/src/test/java/gobblin/source/extractor/partition/PartitionerTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/partition/PartitionerTest.java
@@ -1,0 +1,392 @@
+package gobblin.source.extractor.partition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import org.joda.time.DateTime;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.source.extractor.extract.ExtractType;
+import gobblin.source.extractor.utils.Utils;
+import gobblin.source.extractor.watermark.WatermarkType;
+
+/**
+ * Unit tests for {@link PartitionerTest}
+ */
+public class PartitionerTest {
+  @Test
+  public void testGetPartitionList() {
+    List<Partition> expectedPartitions = new ArrayList<>();
+    SourceState sourceState = new SourceState();
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_IS_WATERMARK_OVERRIDE, true);
+
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+    long defaultValue = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;
+    expectedPartitions.add(new Partition(defaultValue, defaultValue));
+
+    // Watermark doesn't exist
+    Assert.assertEquals(partitioner.getPartitionList(-1), expectedPartitions);
+
+    // Set watermark
+    sourceState.setProp(ConfigurationKeys.EXTRACT_DELTA_FIELDS_KEY, "time");
+    // Set other properties
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_WATERMARK_TYPE, "hour");
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_EXTRACT_TYPE, "SNAPSHOT");
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_PARTITION_INTERVAL, "2");
+    sourceState.setProp(ConfigurationKeys.SOURCE_MAX_NUMBER_OF_PARTITIONS, "2");
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_IS_WATERMARK_OVERRIDE, true);
+
+    expectedPartitions.clear();
+    expectedPartitions.add(new Partition(defaultValue, Long.parseLong(TestPartitioner.currentTimeString)));
+    // No user specified watermarks
+    Assert.assertEquals(partitioner.getPartitionList(-1), expectedPartitions);
+
+    // Set user specified low and high watermarks
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE, "20170101002010");
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, "20170101122010");
+
+    expectedPartitions.clear();
+    expectedPartitions.add(new Partition(20170101000000L, 20170101060000L));
+    expectedPartitions.add(new Partition(20170101070000L, 20170101120000L, true));
+    List<Partition> partitions = partitioner.getPartitionList(-1);
+    Collections.sort(partitions, Partitioner.getAscendingComparator());
+    Assert.assertEquals(partitions, expectedPartitions);
+  }
+
+  /**
+   * Test getLowWatermark. Is watermark override: true.
+   */
+  @Test
+  public void testGetLowWatermarkOnUserOverride() {
+    String startValue = "20140101000000";
+    SourceState sourceState = new SourceState();
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_IS_WATERMARK_OVERRIDE, true);
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE, startValue);
+
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+    Assert.assertEquals(
+        partitioner.getLowWatermark(null, null, -1, 0),
+        Long.parseLong(startValue),
+        "Low watermark should be " + startValue);
+
+    // It works for full dump too
+    sourceState.removeProp(ConfigurationKeys.SOURCE_QUERYBASED_IS_WATERMARK_OVERRIDE);
+    sourceState.setProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY, true);
+    Assert.assertEquals(
+        partitioner.getLowWatermark(null, null, -1, 0),
+        Long.parseLong(startValue),
+        "Low watermark should be " + startValue);
+
+    // Should return ConfigurationKeys.DEFAULT_WATERMARK_VALUE if no SOURCE_QUERYBASED_START_VALUE is specified
+    sourceState.removeProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE);
+    Assert.assertEquals(
+        partitioner.getLowWatermark(null, null, -1, 0),
+        ConfigurationKeys.DEFAULT_WATERMARK_VALUE,
+        "Low watermark should be " + ConfigurationKeys.DEFAULT_WATERMARK_VALUE);
+  }
+
+
+  /**
+   * Test getLowWatermark. Extract type: Snapshot.
+   */
+  @Test
+  public void testGetLowWatermarkOnSnapshotExtract() {
+    SourceState sourceState = new SourceState();
+    String startValue = "20140101000000";
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE, startValue);
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+
+    ExtractType extractType = ExtractType.SNAPSHOT;
+    int delta = 1;
+
+    // No previous watermark
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, null, ConfigurationKeys.DEFAULT_WATERMARK_VALUE, delta),
+        Long.parseLong(startValue),
+        "Low watermark should be " + startValue);
+
+    // With previous watermark
+    long previousWatermark = 20140101000050L;
+    long expected = previousWatermark + delta;
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.SIMPLE, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.TIMESTAMP, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+
+    // With SOURCE_QUERYBASED_LOW_WATERMARK_BACKUP_SECS
+    int backupSecs = 10;
+    expected = previousWatermark + delta - backupSecs;
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_LOW_WATERMARK_BACKUP_SECS, backupSecs);
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.SIMPLE, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.TIMESTAMP, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+  }
+
+  /**
+   * Test getLowWatermark. Extract type: Append.
+   */
+  @Test
+  public void testGetLowWatermarkOnAppendExtract() {
+    SourceState sourceState = new SourceState();
+    String startValue = "20140101000000";
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_START_VALUE, startValue);
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+
+    ExtractType extractType = ExtractType.APPEND_DAILY;
+    int delta = 1;
+
+    // No previous watermark
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, null, ConfigurationKeys.DEFAULT_WATERMARK_VALUE, delta),
+        Long.parseLong(startValue),
+        "Low watermark should be " + startValue);
+
+    // With previous watermark
+    long previousWatermark = 20140101000050L;
+    long expected = previousWatermark + delta;
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.SIMPLE, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.TIMESTAMP, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+
+    // The result has nothing to do with SOURCE_QUERYBASED_LOW_WATERMARK_BACKUP_SECS
+    int backupSecs = 10;
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_LOW_WATERMARK_BACKUP_SECS, backupSecs);
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.SIMPLE, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getLowWatermark(extractType, WatermarkType.TIMESTAMP, previousWatermark, delta),
+        expected,
+        "Low watermark should be " + expected);
+  }
+
+  /**
+   * Test getHighWatermark. Is watermark override: true.
+   */
+  @Test
+  public void testGetHighWatermarkOnUserOverride() {
+    String endValue = "20140101000000";
+    SourceState sourceState = new SourceState();
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_IS_WATERMARK_OVERRIDE, true);
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, endValue);
+
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(null, null),
+        Long.parseLong(endValue),
+        "High watermark should be " + endValue);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        true,
+        "Should mark as user specified high watermark");
+
+    partitioner.reset();
+
+    // Should return current time if no SOURCE_QUERYBASED_END_VALUE is specified
+    sourceState.removeProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE);
+    long expected = Long.parseLong(TestPartitioner.currentTimeString);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(null, null),
+        expected,
+        "High watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        false,
+        "Should not mark as user specified high watermark");
+  }
+
+  /**
+   * Test getHighWatermark. Extract type: Snapshot.
+   */
+  @Test
+  public void testGetHighWatermarkOnSnapshotExtract() {
+    String endValue = "20140101000000";
+    SourceState sourceState = new SourceState();
+    // It won't use SOURCE_QUERYBASED_END_VALUE when extract is full
+    sourceState.setProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY, true);
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, endValue);
+
+    ExtractType extractType = ExtractType.SNAPSHOT;
+
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, WatermarkType.SIMPLE),
+        ConfigurationKeys.DEFAULT_WATERMARK_VALUE,
+        "High watermark should be " + ConfigurationKeys.DEFAULT_WATERMARK_VALUE);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        false,
+        "Should not mark as user specified high watermark");
+
+    long expected = Long.parseLong(TestPartitioner.currentTimeString);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, WatermarkType.TIMESTAMP),
+        expected,
+        "High watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        false,
+        "Should not mark as user specified high watermark");
+  }
+
+  /**
+   * Test getHighWatermark. Extract type: Append.
+   */
+  @Test
+  public void testGetHighWatermarkOnAppendExtract() {
+    String endValue = "20140101000000";
+    SourceState sourceState = new SourceState();
+    sourceState.setProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY, true);
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_END_VALUE, endValue);
+
+    ExtractType extractType = ExtractType.APPEND_DAILY;
+
+    TestPartitioner partitioner = new TestPartitioner(sourceState);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, null),
+        Long.parseLong(endValue),
+        "High watermark should be " + endValue);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        true,
+        "Should mark as user specified high watermark");
+
+    partitioner.reset();
+
+    // Test non-full-dump cases below
+    sourceState.removeProp(ConfigurationKeys.EXTRACT_IS_FULL_KEY);
+
+    // No limit type
+    Assert.assertEquals(
+        partitioner.getHighWatermark(ExtractType.APPEND_BATCH, null),
+        ConfigurationKeys.DEFAULT_WATERMARK_VALUE,
+        "High watermark should be " + ConfigurationKeys.DEFAULT_WATERMARK_VALUE);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        false,
+        "Should not mark as user specified high watermark");
+
+    // No limit delta
+    long expected = Long.parseLong(TestPartitioner.currentTimeString);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, null),
+        expected,
+        "High watermark should be " + expected);
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        false,
+        "Should not mark as user specified high watermark");
+
+    // CURRENTDATE - 1
+    String maxLimit = "CURRENTDATE-1";
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT, maxLimit);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, null),
+        20161231235959L,
+        "High watermark should be 20161231235959");
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        true,
+        "Should not mark as user specified high watermark");
+
+    partitioner.reset();
+
+    // CURRENTHOUR - 1
+    maxLimit = "CURRENTHOUR-1";
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT, maxLimit);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, null),
+        20161231235959L,
+        "High watermark should be 20161231235959");
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        true,
+        "Should not mark as user specified high watermark");
+
+    partitioner.reset();
+
+    // CURRENTMINUTE - 1
+    maxLimit = "CURRENTMINUTE-1";
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT, maxLimit);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, null),
+        20161231235959L,
+        "High watermark should be 20161231235959");
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        true,
+        "Should not mark as user specified high watermark");
+
+    partitioner.reset();
+
+    // CURRENTSECOND - 1
+    maxLimit = "CURRENTSECOND-1";
+    sourceState.setProp(ConfigurationKeys.SOURCE_QUERYBASED_APPEND_MAX_WATERMARK_LIMIT, maxLimit);
+    Assert.assertEquals(
+        partitioner.getHighWatermark(extractType, null),
+        20161231235959L,
+        "High watermark should be 20161231235959");
+
+    Assert.assertEquals(
+        partitioner.getUserSpecifiedHighWatermark(),
+        true,
+        "Should not mark as user specified high watermark");
+  }
+
+  private class TestPartitioner extends Partitioner {
+    static final String currentTimeString = "20170101000000";
+
+    private DateTime currentTime;
+    TestPartitioner(SourceState state) {
+      super(state);
+      currentTime = Utils.toDateTime(currentTimeString, "yyyyMMddHHmmss", ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE);
+    }
+
+    boolean getUserSpecifiedHighWatermark() {
+      return hasUserSpecifiedHighWatermark;
+    }
+
+    @Override
+    public DateTime getCurrentTime(String timeZone) {
+      return currentTime;
+    }
+
+    void reset() {
+      hasUserSpecifiedHighWatermark = false;
+    }
+  }
+
+}


### PR DESCRIPTION
As between the time when data query was created and that was executed, there might be some new data generated in the source. Removing the upper bounds will help us grab the new data. 