### PR TITLE
Forks: Making primitive types copyable by default, tests and bug fixes

### DIFF
--- a/gobblin-api/build.gradle
+++ b/gobblin-api/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     compile externalDependency.typesafeConfig
 
     testCompile externalDependency.testng
+    testCompile externalDependency.mockito
     testCompile externalDependency.log4j
 }
 

--- a/gobblin-api/src/main/java/gobblin/fork/CopyHelper.java
+++ b/gobblin-api/src/main/java/gobblin/fork/CopyHelper.java
@@ -26,7 +26,7 @@ package gobblin.fork;
 public class CopyHelper {
 
   /**
-   * Check if an object is copyable using the {@link #copy(Object)} method.
+   * Check if an object is copyable using the {@link #copy(Object, int)} method.
    * @param thing: the object that needs to be copied
    * @return: true if {@link CopyHelper} can copy this thing, false otherwise
    */
@@ -55,28 +55,38 @@ public class CopyHelper {
   }
 
   /**
-   * Copy this object if possible.
+   * Copy this object if needed.
    * @param thing: this object that needs to be copied
-   * @return: a copied instance
-   * @throws CopyNotSupportedException if thing cannot be copied
+   * @param instance: the number of instances of this object already copied
+   * @return: a possibly copied instance
+   * @throws CopyNotSupportedException if thing needs to be copied but cannot be
    */
-  public static Object copy(Object thing) throws CopyNotSupportedException {
-    if (!isCopyable(thing)) {
-      throw new CopyNotSupportedException(thing.getClass().getName() + " cannot be copied. See Copyable");
-    }
-    if (thing instanceof Copyable) {
-      return ((Copyable) thing).copy();
-    }
+  public static Object copy(Object thing, int instance) throws CopyNotSupportedException {
+    // First copy is special, we only copy if the thing is an instance of Copyable
+    if (instance == 0) {
+      if (thing instanceof Copyable) {
+        return ((Copyable) thing).copy();
+      } else {
+        return thing;
+      }
+    } else {
 
-    // Support for a few primitive types out of the box
-    if (thing instanceof byte[]) {
-      byte[] copy = new byte[((byte[]) thing).length];
-      System.arraycopy(thing, 0, copy, 0, ((byte[]) thing).length);
-      return copy;
-    }
+      if (!isCopyable(thing)) {
+        throw new CopyNotSupportedException(thing.getClass().getName() + " cannot be copied. See Copyable");
+      }
+      if (thing instanceof Copyable) {
+        return ((Copyable) thing).copy();
+      }
+      // Support for a few primitive types out of the box
+      if (thing instanceof byte[]) {
+        byte[] copy = new byte[((byte[]) thing).length];
+        System.arraycopy(thing, 0, copy, 0, ((byte[]) thing).length);
+        return copy;
+      }
 
-    // Assume that everything other type is immutable, not checking this again
-    return thing;
+      // Assume that everything other type is immutable, not checking this again
+      return thing;
+    }
   }
 
 }

--- a/gobblin-api/src/main/java/gobblin/fork/CopyHelper.java
+++ b/gobblin-api/src/main/java/gobblin/fork/CopyHelper.java
@@ -26,17 +26,15 @@ package gobblin.fork;
 public class CopyHelper {
 
   /**
-   *
+   * Check if an object is copyable using the {@link #copy(Object)} method.
    * @param thing: the object that needs to be copied
-   * @return: true if CopyHelper can copy this thing, false otherwise
+   * @return: true if {@link CopyHelper} can copy this thing, false otherwise
    */
   public static boolean isCopyable(Object thing) {
     if (
         (thing instanceof Copyable)
-        || (thing instanceof byte[])
-        || (thing instanceof String)
-        || (thing instanceof Integer)
-        || (thing instanceof Long)
+            || (thing instanceof byte[])
+            || (isImmutableType(thing))
         ) {
       return true;
     }
@@ -44,7 +42,20 @@ public class CopyHelper {
   }
 
   /**
-   *
+   * Contains a collection of supported immutable types for copying.
+   * Only keep the types that are worth supporting as record types.
+   * @param thing: an Object being checked
+   * @return true if supported immutable type, false otherwise
+   */
+  private static boolean isImmutableType(Object thing) {
+    return ((thing == null)
+        || (thing instanceof String)
+        || (thing instanceof Integer)
+        || (thing instanceof Long));
+  }
+
+  /**
+   * Copy this object if possible.
    * @param thing: this object that needs to be copied
    * @return: a copied instance
    * @throws CopyNotSupportedException if thing cannot be copied
@@ -64,13 +75,8 @@ public class CopyHelper {
       return copy;
     }
 
-    if (thing instanceof String
-        || thing instanceof Integer
-        || thing instanceof Long) {
-      // These are immutable so don't need to copy
-      return thing;
-    }
-    throw new CopyNotSupportedException(thing.getClass().getName() + " cannot be copied.");
+    // Assume that everything other type is immutable, not checking this again
+    return thing;
   }
 
 }

--- a/gobblin-api/src/main/java/gobblin/fork/CopyHelper.java
+++ b/gobblin-api/src/main/java/gobblin/fork/CopyHelper.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package gobblin.fork;
+
+/**
+ * A helper class to copy things that may or may not be {@link Copyable}.
+ * Supports implementations for common primitive types.
+ */
+public class CopyHelper {
+
+  /**
+   *
+   * @param thing: the object that needs to be copied
+   * @return: true if CopyHelper can copy this thing, false otherwise
+   */
+  public static boolean isCopyable(Object thing) {
+    if (
+        (thing instanceof Copyable)
+        || (thing instanceof byte[])
+        || (thing instanceof String)
+        || (thing instanceof Integer)
+        || (thing instanceof Long)
+        ) {
+      return true;
+    }
+    return false;
+  }
+
+  /**
+   *
+   * @param thing: this object that needs to be copied
+   * @return: a copied instance
+   * @throws CopyNotSupportedException if thing cannot be copied
+   */
+  public static Object copy(Object thing) throws CopyNotSupportedException {
+    if (!isCopyable(thing)) {
+      throw new CopyNotSupportedException(thing.getClass().getName() + " cannot be copied. See Copyable");
+    }
+    if (thing instanceof Copyable) {
+      return ((Copyable) thing).copy();
+    }
+
+    // Support for a few primitive types out of the box
+    if (thing instanceof byte[]) {
+      byte[] copy = new byte[((byte[]) thing).length];
+      System.arraycopy(thing, 0, copy, 0, ((byte[]) thing).length);
+      return copy;
+    }
+
+    if (thing instanceof String
+        || thing instanceof Integer
+        || thing instanceof Long) {
+      // These are immutable so don't need to copy
+      return thing;
+    }
+    throw new CopyNotSupportedException(thing.getClass().getName() + " cannot be copied.");
+  }
+
+}

--- a/gobblin-api/src/main/java/gobblin/writer/DataWriterBuilder.java
+++ b/gobblin-api/src/main/java/gobblin/writer/DataWriterBuilder.java
@@ -20,6 +20,7 @@ package gobblin.writer;
 import java.io.IOException;
 
 import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
 
 
 /**
@@ -31,6 +32,7 @@ import lombok.Getter;
  * @author Yinan Li
  */
 @Getter
+@Slf4j
 public abstract class DataWriterBuilder<S, D> {
 
   protected Destination destination;
@@ -49,6 +51,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> writeTo(Destination destination) {
     this.destination = destination;
+    log.debug("For destination: {}", destination);
     return this;
   }
 
@@ -60,6 +63,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> writeInFormat(WriterOutputFormat format) {
     this.format = format;
+    log.debug("writeInFormat : {}", this.format);
     return this;
   }
 
@@ -71,6 +75,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> withWriterId(String writerId) {
     this.writerId = writerId;
+    log.debug("withWriterId : {}", this.writerId);
     return this;
   }
 
@@ -82,6 +87,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> withSchema(S schema) {
     this.schema = schema;
+    log.debug("withSchema : {}", this.schema);
     return this;
   }
 
@@ -93,6 +99,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> withBranches(int branches) {
     this.branches = branches;
+    log.debug("With branches: {}", this.branches);
     return this;
   }
 
@@ -104,6 +111,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> forBranch(int branch) {
     this.branch = branch;
+    log.debug("For branch: {}", this.branch);
     return this;
   }
 
@@ -113,6 +121,7 @@ public abstract class DataWriterBuilder<S, D> {
    */
   public DataWriterBuilder<S, D> withAttemptId(String attemptId) {
     this.writerAttemptId = attemptId;
+    log.debug("With writerAttemptId: {}", this.writerAttemptId);
     return this;
   }
 

--- a/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
+++ b/gobblin-api/src/main/java/gobblin/writer/WriterOutputFormat.java
@@ -31,6 +31,7 @@ public enum WriterOutputFormat {
   JSON("json"),
   ORC("orc"),
   CSV("csv"),
+  TXT("txt"),
   OTHER(StringUtils.EMPTY);
 
   /**

--- a/gobblin-api/src/test/java/gobblin/fork/CopyHelperTest.java
+++ b/gobblin-api/src/test/java/gobblin/fork/CopyHelperTest.java
@@ -19,9 +19,11 @@
 
 package gobblin.fork;
 
+import java.io.ByteArrayInputStream;
 import java.util.Random;
 
 import org.testng.Assert;
+import org.testng.annotations.ExpectedExceptions;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -61,32 +63,34 @@ public class CopyHelperTest {
   }
 
   @Test
-  public void testInteger()
+  public void testImmutables()
       throws CopyNotSupportedException {
+
+    Object nullObject = null;
 
     Integer integer = RANDOM.nextInt(200);
 
-    Assert.assertTrue(CopyHelper.isCopyable(integer));
-
-    Integer copiedInteger = (Integer) CopyHelper.copy(integer);
-    Assert.assertEquals(copiedInteger, integer, "Copied integer value should be the same");
-
-  }
-
-  @Test
-  public void testString()
-      throws CopyNotSupportedException {
-
-    int length = RANDOM.nextInt(200);
-    byte[] bytes = new byte[length];
+    byte[] bytes = new byte[integer];
     RANDOM.nextBytes(bytes);
 
     String string = new String(bytes);
-    Assert.assertTrue(CopyHelper.isCopyable(string));
 
-    String copiedString = (String) CopyHelper.copy(string);
-    Assert.assertEquals(copiedString, string, "Copied string value should be the same");
+    Long longNum = RANDOM.nextLong();
+
+    Object[] immutables = new Object[]{nullObject, integer, string, longNum};
+
+    for (Object immutable : immutables) {
+      Assert.assertTrue(CopyHelper.isCopyable(immutable));
+      Object copiedObject = CopyHelper.copy(immutable);
+      Assert.assertEquals(copiedObject, immutable);
+    }
   }
 
+  @Test(expectedExceptions = CopyNotSupportedException.class)
+  public void testUnsupportedTypes()
+      throws CopyNotSupportedException {
+    Object foobar = mock(ByteArrayInputStream.class);
+    CopyHelper.copy(foobar);
+  }
 
 }

--- a/gobblin-api/src/test/java/gobblin/fork/CopyHelperTest.java
+++ b/gobblin-api/src/test/java/gobblin/fork/CopyHelperTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package gobblin.fork;
+
+import java.util.Random;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@Test
+public class CopyHelperTest {
+
+  private static final Random RANDOM = new Random();
+
+  @Test
+  public void testCopyable()
+      throws CopyNotSupportedException {
+
+    Copyable c = mock(Copyable.class);
+    Assert.assertTrue(CopyHelper.isCopyable(c));
+
+    Object copy = new Object();
+    when(c.copy()).thenReturn(copy);
+    Assert.assertEquals(CopyHelper.copy(c), copy);
+
+  }
+
+  @Test
+  public void testByteArray()
+      throws CopyNotSupportedException {
+
+    int length = RANDOM.nextInt(200);
+    byte[] bytes = new byte[length];
+    RANDOM.nextBytes(bytes);
+
+    Assert.assertTrue(CopyHelper.isCopyable(bytes));
+
+    byte[] copiedBytes = (byte[]) CopyHelper.copy(bytes);
+    Assert.assertTrue(copiedBytes != bytes, "Copied bytes reference should be different");
+    Assert.assertEquals(copiedBytes, bytes, "Copied bytes value should be the same");
+  }
+
+  @Test
+  public void testInteger()
+      throws CopyNotSupportedException {
+
+    Integer integer = RANDOM.nextInt(200);
+
+    Assert.assertTrue(CopyHelper.isCopyable(integer));
+
+    Integer copiedInteger = (Integer) CopyHelper.copy(integer);
+    Assert.assertEquals(copiedInteger, integer, "Copied integer value should be the same");
+
+  }
+
+  @Test
+  public void testString()
+      throws CopyNotSupportedException {
+
+    int length = RANDOM.nextInt(200);
+    byte[] bytes = new byte[length];
+    RANDOM.nextBytes(bytes);
+
+    String string = new String(bytes);
+    Assert.assertTrue(CopyHelper.isCopyable(string));
+
+    String copiedString = (String) CopyHelper.copy(string);
+    Assert.assertEquals(copiedString, string, "Copied string value should be the same");
+  }
+
+
+}

--- a/gobblin-core-base/src/main/java/gobblin/writer/PartitionAwareDataWriterBuilder.java
+++ b/gobblin-core-base/src/main/java/gobblin/writer/PartitionAwareDataWriterBuilder.java
@@ -22,6 +22,8 @@ import org.apache.avro.generic.GenericRecord;
 
 import com.google.common.base.Optional;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.writer.partitioner.WriterPartitioner;
 
 
@@ -48,6 +50,7 @@ import gobblin.writer.partitioner.WriterPartitioner;
  *   * Different partitions should generate non-colliding writers.
  * </p>
  */
+@Slf4j
 public abstract class PartitionAwareDataWriterBuilder<S, D> extends DataWriterBuilder<S, D> {
 
   protected Optional<GenericRecord> partition = Optional.absent();
@@ -59,6 +62,7 @@ public abstract class PartitionAwareDataWriterBuilder<S, D> extends DataWriterBu
    */
   public PartitionAwareDataWriterBuilder<S, D> forPartition(GenericRecord partition) {
     this.partition = Optional.fromNullable(partition);
+    log.debug("For partition {}", this.partition);
     return this;
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
@@ -302,8 +302,8 @@ public class TaskContext {
    * @return a {@link DataWriterBuilder}
    */
   public DataWriterBuilder getDataWriterBuilder(int branches, int index) {
-    log.debug("TaskState properties = {}", this.taskState.getProperties());
-    String writerBuilderPropertyName = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUILDER_CLASS, branches, index);
+    String writerBuilderPropertyName = ForkOperatorUtils
+        .getPropertyNameForBranch(ConfigurationKeys.WRITER_BUILDER_CLASS, branches, index);
     log.debug("Using property {} to get a writer builder for branches:{}, index:{}", writerBuilderPropertyName,
         branches, index);
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
@@ -174,9 +174,12 @@ public class TaskContext {
     String writerOutputFormatValue = this.taskState.getProp(
         ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY, branches, index),
         WriterOutputFormat.OTHER.name());
+    log.debug("Found writer output format value = {}", writerOutputFormatValue);
 
-    return Enums.getIfPresent(WriterOutputFormat.class, writerOutputFormatValue.toUpperCase())
+    WriterOutputFormat wof = Enums.getIfPresent(WriterOutputFormat.class, writerOutputFormatValue.toUpperCase())
         .or(WriterOutputFormat.OTHER);
+    log.debug("Returning writer output format = {}", wof);
+    return wof;
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskContext.java
@@ -25,6 +25,8 @@ import com.google.common.base.Enums;
 import com.google.common.base.Splitter;
 import com.google.common.collect.Lists;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.WorkUnitState;
 import gobblin.converter.Converter;
@@ -58,6 +60,7 @@ import gobblin.writer.WriterOutputFormat;
  *
  * @author Yinan Li
  */
+@Slf4j
 public class TaskContext {
 
   private final TaskState taskState;
@@ -299,9 +302,18 @@ public class TaskContext {
    * @return a {@link DataWriterBuilder}
    */
   public DataWriterBuilder getDataWriterBuilder(int branches, int index) {
-    String dataWriterBuilderClassName = this.taskState.getProp(
-        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUILDER_CLASS, branches, index),
-        ConfigurationKeys.DEFAULT_WRITER_BUILDER_CLASS);
+    log.debug("TaskState properties = {}", this.taskState.getProperties());
+    String writerBuilderPropertyName = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_BUILDER_CLASS, branches, index);
+    log.debug("Using property {} to get a writer builder for branches:{}, index:{}", writerBuilderPropertyName,
+        branches, index);
+
+    String dataWriterBuilderClassName = this.taskState.getProp(writerBuilderPropertyName, null);
+    if (dataWriterBuilderClassName == null) {
+      dataWriterBuilderClassName = ConfigurationKeys.DEFAULT_WRITER_BUILDER_CLASS;
+      log.info("No configured writer builder found, using {} as the default builder", dataWriterBuilderClassName);
+    } else {
+      log.info("Found configured writer builder as {}", dataWriterBuilderClassName);
+    }
     try {
       return DataWriterBuilder.class.cast(Class.forName(dataWriterBuilderClassName).newInstance());
     } catch (ClassNotFoundException cnfe) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/local/LocalJobLauncher.java
@@ -31,6 +31,8 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 import com.google.common.util.concurrent.ServiceManager;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.SharedResourcesBroker;
 import gobblin.metrics.Tag;
@@ -53,6 +55,7 @@ import gobblin.util.JobLauncherUtils;
  *
  * @author Yinan Li
  */
+@Slf4j
 public class LocalJobLauncher extends AbstractJobLauncher {
 
   private static final Logger LOG = LoggerFactory.getLogger(LocalJobLauncher.class);
@@ -72,6 +75,7 @@ public class LocalJobLauncher extends AbstractJobLauncher {
 
   public LocalJobLauncher(Properties jobProps, SharedResourcesBroker<GobblinScopeTypes> instanceBroker) throws Exception {
     super(jobProps, ImmutableList.<Tag<?>> of(), instanceBroker);
+    log.debug("Local job launched with properties: {}", jobProps);
 
     TimingEvent jobLocalSetupTimer = this.eventSubmitter.getTimingEvent(TimingEvent.RunJobTimings.JOB_LOCAL_SETUP);
 

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/PathAlterationListenerAdaptorForMonitor.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/PathAlterationListenerAdaptorForMonitor.java
@@ -25,12 +25,10 @@ import org.apache.commons.configuration.ConfigurationException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.Path;
-import org.slf4j.LoggerFactory;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.common.collect.Maps;
-
-import lombok.extern.slf4j.Slf4j;
 
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.runtime.JobException;

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/PathAlterationListenerAdaptorForMonitor.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/PathAlterationListenerAdaptorForMonitor.java
@@ -30,6 +30,8 @@ import org.slf4j.Logger;
 
 import com.google.common.collect.Maps;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.runtime.JobException;
 import gobblin.runtime.listeners.EmailNotificationJobListener;
@@ -74,6 +76,7 @@ public class PathAlterationListenerAdaptorForMonitor extends PathAlterationListe
     try {
       Properties jobProps =
           SchedulerUtils.loadGenericJobConfig(this.jobScheduler.properties, path, jobConfigFileDirPath);
+      LOG.debug("Loaded job properties: {}", jobProps);
       switch (action) {
         case SCHEDULE:
           boolean runOnce = Boolean.valueOf(jobProps.getProperty(ConfigurationKeys.JOB_RUN_ONCE_KEY, "false"));
@@ -148,7 +151,7 @@ public class PathAlterationListenerAdaptorForMonitor extends PathAlterationListe
       } catch (IOException e) {
         e.printStackTrace();
       }
-      LOG.info("Detected cration to common properties file" + path.toString());
+      LOG.info("Detected creation of common properties file" + path.toString());
       // New .properties file founded with some new attributes, reschedule jobs.
       loadNewCommonConfigAndHandleNewJob(path, JobScheduler.Action.RESCHEDULE);
       return;
@@ -189,7 +192,7 @@ public class PathAlterationListenerAdaptorForMonitor extends PathAlterationListe
   public void onFileDelete(Path path) {
     String fileExtension = path.getName().substring(path.getName().lastIndexOf('.') + 1);
     if (fileExtension.equalsIgnoreCase(SchedulerUtils.JOB_PROPS_FILE_EXTENSION)) {
-      LOG.info("Detected deletion to common properties file " + path.toString());
+      LOG.info("Detected deletion of common properties file " + path.toString());
       // For JobProps, deletion in local folder means inheritance from ancestor folder and reschedule.
       loadNewCommonConfigAndHandleNewJob(path, JobScheduler.Action.RESCHEDULE);
       return;
@@ -200,7 +203,7 @@ public class PathAlterationListenerAdaptorForMonitor extends PathAlterationListe
       return;
     }
 
-    LOG.info("Detected deletion to job configuration file " + path.toString());
+    LOG.info("Detected deletion of job configuration file " + path.toString());
     // As for normal job file, deletion means unschedule
     unscheduleJobAtPath(path);
   }

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/SchedulerDaemon.java
@@ -23,6 +23,8 @@ import java.util.UUID;
 import org.apache.commons.configuration.ConfigurationConverter;
 import org.apache.commons.configuration.PropertiesConfiguration;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.runtime.app.ServiceBasedAppLauncher;
 import gobblin.util.PropertiesUtils;
 
@@ -32,6 +34,7 @@ import gobblin.util.PropertiesUtils;
  *
  * @author Yinan Li
  */
+@Slf4j
 public class SchedulerDaemon extends ServiceBasedAppLauncher {
 
   private SchedulerDaemon(Properties defaultProperties, Properties customProperties) throws Exception {
@@ -66,6 +69,8 @@ public class SchedulerDaemon extends ServiceBasedAppLauncher {
       customProperties.putAll(ConfigurationConverter.getProperties(new PropertiesConfiguration(args[1])));
     }
 
+    log.debug("Scheduler Daemon::main starting with defaultProperties: {}, customProperties: {}", defaultProperties,
+        customProperties);
     // Start the scheduler daemon
     new SchedulerDaemon(defaultProperties, customProperties).start();
   }

--- a/gobblin-runtime/src/test/java/gobblin/runtime/TaskTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/TaskTest.java
@@ -25,7 +25,13 @@ import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Properties;
+import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -33,24 +39,46 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import lombok.extern.slf4j.Slf4j;
 
 import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
+import gobblin.fork.ForkOperator;
 import gobblin.fork.IdentityForkOperator;
 import gobblin.publisher.TaskPublisher;
+import gobblin.qualitychecker.row.RowLevelPolicyCheckResults;
+import gobblin.qualitychecker.row.RowLevelPolicyChecker;
 import gobblin.qualitychecker.task.TaskLevelPolicyCheckResults;
 import gobblin.qualitychecker.task.TaskLevelPolicyChecker;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.source.workunit.Extract;
 import gobblin.source.workunit.WorkUnit;
+import gobblin.util.ConfigUtils;
+import gobblin.writer.DataWriter;
+import gobblin.writer.DataWriterBuilder;
 
 
 /**
  * Integration tests for {@link Task}.
  */
 @Test
+@Slf4j
 public class TaskTest {
+
+  TaskState getEmptyTestTaskState(String taskId) {
+    // Create a TaskState
+    TaskState taskState = new TaskState(new WorkUnitState(WorkUnit.create(
+        new Extract(Extract.TableType.SNAPSHOT_ONLY, this.getClass().getName(), this.getClass().getSimpleName()))));
+    taskState.setProp(ConfigurationKeys.METRICS_ENABLED_KEY, Boolean.toString(false));
+    taskState.setTaskId(taskId);
+    taskState.setJobId("1234");
+    return taskState;
+  }
 
   /**
    * Check if a {@link WorkUnitState.WorkingState} of a {@link Task} is set properly after a {@link Task} fails once,
@@ -59,11 +87,7 @@ public class TaskTest {
   @Test
   public void testRetryTask() throws Exception {
     // Create a TaskState
-    TaskState taskState = new TaskState(new WorkUnitState(WorkUnit.create(
-        new Extract(Extract.TableType.SNAPSHOT_ONLY, this.getClass().getName(), this.getClass().getSimpleName()))));
-    taskState.setProp(ConfigurationKeys.METRICS_ENABLED_KEY, Boolean.toString(false));
-    taskState.setTaskId("testRetryTaskId");
-
+    TaskState taskState = getEmptyTestTaskState("testRetryTaskId");
     // Create a mock TaskContext
     TaskContext mockTaskContext = mock(TaskContext.class);
     when(mockTaskContext.getExtractor()).thenReturn(new FailOnceExtractor());
@@ -98,6 +122,169 @@ public class TaskTest {
     task.run();
     task.commit();
     Assert.assertEquals(task.getTaskState().getWorkingState(), WorkUnitState.WorkingState.SUCCESSFUL);
+  }
+
+  private TaskContext getMockTaskContext(TaskState taskState, Extractor mockExtractor,
+      ArrayList<ArrayList<Object>> writerCollectors, ForkOperator mockForkOperator)
+      throws Exception {
+
+    int numForks = writerCollectors.size();
+
+    // Create a mock RowLevelPolicyChecker
+    RowLevelPolicyChecker mockRowLevelPolicyChecker = mock(RowLevelPolicyChecker.class);
+    when(mockRowLevelPolicyChecker.executePolicies(any(Object.class), any(RowLevelPolicyCheckResults.class)))
+        .thenReturn(true);
+    when(mockRowLevelPolicyChecker.getFinalState()).thenReturn(new State());
+
+    // Create a mock TaskPublisher
+    TaskPublisher mockTaskPublisher = mock(TaskPublisher.class);
+    when(mockTaskPublisher.canPublish()).thenReturn(TaskPublisher.PublisherState.SUCCESS);
+
+    // Create a mock TaskContext
+    TaskContext mockTaskContext = mock(TaskContext.class);
+    when(mockTaskContext.getExtractor()).thenReturn(mockExtractor);
+    when(mockTaskContext.getRawSourceExtractor()).thenReturn(mockExtractor);
+    when(mockTaskContext.getForkOperator()).thenReturn(mockForkOperator);
+    when(mockTaskContext.getTaskState()).thenReturn(taskState);
+    when(mockTaskContext.getTaskPublisher(any(TaskState.class), any(TaskLevelPolicyCheckResults.class)))
+        .thenReturn(mockTaskPublisher);
+    when(mockTaskContext.getRowLevelPolicyChecker()).thenReturn(mockRowLevelPolicyChecker);
+    when(mockTaskContext.getRowLevelPolicyChecker(anyInt())).thenReturn(mockRowLevelPolicyChecker);
+    when(mockTaskContext.getTaskLevelPolicyChecker(any(TaskState.class), anyInt())).thenReturn(mock(TaskLevelPolicyChecker.class));
+    for (int i =0; i < numForks; ++i) {
+      when(mockTaskContext.getDataWriterBuilder(numForks, i)).thenReturn(new RecordCollectingWriterBuilder(writerCollectors.get(i)));
+    }
+    return mockTaskContext;
+  }
+
+  /**
+   * Test that forks work correctly when the operator picks one outgoing fork
+   */
+  @Test
+  public void testForkCorrectnessRoundRobin()
+      throws Exception {
+    // Create a TaskState
+    TaskState taskState = getEmptyTestTaskState("testForkTaskId");
+    int numRecords = 9;
+    int numForks = 3;
+    ForkOperator mockForkOperator = new RoundRobinForkOperator(numForks);
+
+
+    // The following code depends on exact multiples
+    Assert.assertTrue(numRecords % numForks == 0);
+
+    ArrayList<ArrayList<Object>> recordCollectors = runTaskAndGetResults(taskState, numRecords, numForks, mockForkOperator);
+
+    // Check that we got the right records in the collectors
+    int recordsPerFork = numRecords/numForks;
+    for (int forkNumber=0; forkNumber < numForks; ++ forkNumber) {
+      ArrayList<Object> forkRecords = recordCollectors.get(forkNumber);
+      Assert.assertTrue(forkRecords.size() == recordsPerFork);
+      for (int j=0; j < recordsPerFork; ++j) {
+        Object forkRecord = forkRecords.get(j);
+        Assert.assertEquals((String) forkRecord, "" + (j * recordsPerFork + forkNumber));
+      }
+    }
+  }
+
+  /**
+   * Test that forks work correctly when the operator picks all outgoing forks
+   */
+  @Test
+  public void testForkCorrectnessIdentity()
+      throws Exception {
+    // Create a TaskState
+    TaskState taskState = getEmptyTestTaskState("testForkTaskId");
+    int numRecords = 100;
+    int numForks = 5;
+
+    // Identity Fork Operator looks for number of forks in work unit state.
+    taskState.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, "" + numForks);
+    ForkOperator mockForkOperator = new IdentityForkOperator();
+
+    ArrayList<ArrayList<Object>> recordCollectors = runTaskAndGetResults(taskState, numRecords, numForks, mockForkOperator);
+
+    // Check that we got the right records in the collectors
+    int recordsPerFork = numRecords;
+    for (int forkNumber=0; forkNumber < numForks; ++ forkNumber) {
+      ArrayList<Object> forkRecords = recordCollectors.get(forkNumber);
+      Assert.assertTrue(forkRecords.size() == recordsPerFork);
+      for (int j=0; j < recordsPerFork; ++j) {
+        Object forkRecord = forkRecords.get(j);
+        Assert.assertEquals((String) forkRecord, "" + j);
+      }
+    }
+  }
+
+
+  /**
+   * Test that forks work correctly when the operator picks a subset of outgoing forks
+   */
+  @Test
+  public void testForkCorrectnessSubset()
+      throws Exception {
+    // Create a TaskState
+    TaskState taskState = getEmptyTestTaskState("testForkTaskId");
+    int numRecords = 20;
+    int numForks = 5;
+    int subset = 2;
+
+    ForkOperator mockForkOperator = new SubsetForkOperator(numForks, subset);
+
+    ArrayList<ArrayList<Object>> recordCollectors = runTaskAndGetResults(taskState, numRecords, numForks, mockForkOperator);
+
+    log.info("Records collected: {}", recordCollectors);
+    // Check that we got the right records in the collectors
+    int totalRecordsExpected = numRecords * subset;
+    int totalRecordsFound = 0;
+    HashMap<String, ArrayList<Integer>> recordsMap = new HashMap<>();
+    for (int forkNumber=0; forkNumber < numForks; ++ forkNumber) {
+      ArrayList<Object> forkRecords = recordCollectors.get(forkNumber);
+      for (Object forkRecord: forkRecords) {
+        String recordAsString = (String) forkRecord;
+        totalRecordsFound++;
+        if (recordsMap.containsKey(recordAsString)) {
+          recordsMap.get(recordAsString).add(forkNumber);
+        } else {
+          ArrayList<Integer> forksFound = new ArrayList<>();
+          forksFound.add(forkNumber);
+          recordsMap.put(recordAsString, forksFound);
+        }
+      }
+    }
+    Assert.assertEquals(totalRecordsFound, totalRecordsExpected, "Total records");
+    for (Map.Entry<String, ArrayList<Integer>> recordForks: recordsMap.entrySet()) {
+      Assert.assertEquals(recordForks.getValue().size(), subset);
+    }
+
+  }
+
+
+
+  private ArrayList<ArrayList<Object>> runTaskAndGetResults(TaskState taskState, int numRecords, int numForks,
+      ForkOperator mockForkOperator)
+      throws Exception {
+    ArrayList<ArrayList<Object>> recordCollectors = new ArrayList<>(numForks);
+    for (int i=0; i < numForks; ++i) {
+      recordCollectors.add(new ArrayList<Object>());
+    }
+
+    TaskContext mockTaskContext = getMockTaskContext(taskState,
+        new StringExtractor(numRecords), recordCollectors, mockForkOperator);
+
+    // Create a mock TaskStateTracker
+    TaskStateTracker mockTaskStateTracker = mock(TaskStateTracker.class);
+
+    // Create a TaskExecutor - a real TaskExecutor must be created so a Fork is run in a separate thread
+    TaskExecutor taskExecutor = new TaskExecutor(new Properties());
+
+    // Create the Task
+    Task task = new Task(mockTaskContext, mockTaskStateTracker, taskExecutor, Optional.<CountDownLatch>absent());
+
+    // Run and commit
+    task.run();
+    task.commit();
+    return recordCollectors;
   }
 
   /**
@@ -135,6 +322,211 @@ public class TaskTest {
     @Override
     public void close() throws IOException {
       // Do nothing
+    }
+  }
+
+
+  private static class StringExtractor implements Extractor<Object, String> {
+
+    private final int _numRecords;
+    private int _currentRecord;
+    public StringExtractor(int numRecords) {
+      _numRecords = numRecords;
+      _currentRecord = -1;
+    }
+
+    @Override
+    public Object getSchema()
+        throws IOException {
+      return "";
+    }
+
+    @Override
+    public String readRecord(@Deprecated String reuse)
+        throws DataRecordException, IOException {
+      if (_currentRecord < _numRecords-1) {
+        _currentRecord++;
+        return "" + _currentRecord;
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public long getExpectedRecordCount() {
+      return _numRecords;
+    }
+
+    @Override
+    public long getHighWatermark() {
+      return -1;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+
+    }
+  }
+
+  private static class RoundRobinForkOperator implements ForkOperator<Object, Object> {
+
+    private final int _numForks;
+    private final Boolean[] _forkedSchemas;
+    private final Boolean[] _forkedRecords;
+    private int _lastForkTaken;
+
+    public RoundRobinForkOperator(int numForks) {
+      _numForks = numForks;
+      _forkedSchemas = new Boolean[_numForks];
+      _forkedRecords = new Boolean[_numForks];
+      _lastForkTaken = _numForks-1;
+      for (int i=0; i < _numForks; ++i) {
+        _forkedSchemas[i] = Boolean.TRUE;
+        _forkedRecords[i] = Boolean.FALSE;
+      }
+    }
+
+    @Override
+    public void init(WorkUnitState workUnitState)
+        throws Exception {
+    }
+
+    @Override
+    public int getBranches(WorkUnitState workUnitState) {
+      return _numForks;
+    }
+
+    @Override
+    public List<Boolean> forkSchema(WorkUnitState workUnitState, Object input) {
+      return Arrays.asList(_forkedSchemas);
+    }
+
+    @Override
+    public List<Boolean> forkDataRecord(WorkUnitState workUnitState, Object input) {
+      _forkedRecords[_lastForkTaken] = Boolean.FALSE;
+      _lastForkTaken = (_lastForkTaken+1)%_numForks;
+      _forkedRecords[_lastForkTaken] = Boolean.TRUE;
+      return Arrays.asList(_forkedRecords);
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+
+    }
+  }
+
+  private static class SubsetForkOperator implements ForkOperator<Object, Object> {
+
+    private final int _numForks;
+    private final int _subsetSize;
+    private final Boolean[] _forkedSchemas;
+    private final Boolean[] _forkedRecords;
+    private final Random _random;
+
+    public SubsetForkOperator(int numForks, int subsetSize) {
+      Preconditions.checkArgument(subsetSize >=0 && subsetSize <= numForks,
+          "Subset size should be in range [0, numForks]");
+      _numForks = numForks;
+      _subsetSize = subsetSize;
+      _forkedSchemas = new Boolean[_numForks];
+      _forkedRecords = new Boolean[_numForks];
+      _random = new Random();
+      for (int i=0; i < _numForks; ++i) {
+        _forkedSchemas[i] = Boolean.TRUE;
+        _forkedRecords[i] = Boolean.FALSE;
+      }
+    }
+
+    @Override
+    public void init(WorkUnitState workUnitState)
+        throws Exception {
+    }
+
+    @Override
+    public int getBranches(WorkUnitState workUnitState) {
+      return _numForks;
+    }
+
+    @Override
+    public List<Boolean> forkSchema(WorkUnitState workUnitState, Object input) {
+      return Arrays.asList(_forkedSchemas);
+    }
+
+    @Override
+    public List<Boolean> forkDataRecord(WorkUnitState workUnitState, Object input) {
+
+      for (int i=0; i < _numForks; ++i) {
+        _forkedRecords[i] = Boolean.FALSE;
+      }
+
+      // Really lazy way of getting a random subset, not intended for production use
+      int chosenRecords = 0;
+      while (chosenRecords != _subsetSize) {
+        int index = _random.nextInt(_numForks);
+        if (!_forkedRecords[index]) {
+          _forkedRecords[index] = Boolean.TRUE;
+          chosenRecords++;
+        }
+      }
+      return Arrays.asList(_forkedRecords);
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+
+    }
+  }
+
+  private class RecordCollectingWriterBuilder extends DataWriterBuilder {
+    private final ArrayList<Object> _recordSink;
+
+    public RecordCollectingWriterBuilder(ArrayList<Object> objects) {
+      super();
+      _recordSink = objects;
+    }
+
+    @Override
+    public DataWriter build()
+        throws IOException {
+      return new DataWriter() {
+        @Override
+        public void write(Object record)
+            throws IOException {
+          _recordSink.add(record);
+        }
+
+        @Override
+        public void commit()
+            throws IOException {
+
+        }
+
+        @Override
+        public void cleanup()
+            throws IOException {
+
+        }
+
+        @Override
+        public long recordsWritten() {
+          return _recordSink.size();
+        }
+
+        @Override
+        public long bytesWritten()
+            throws IOException {
+          return -1;
+        }
+
+        @Override
+        public void close()
+            throws IOException {
+
+        }
+      };
     }
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ConfigUtils.java
@@ -221,8 +221,12 @@ public class ConfigUtils {
   }
 
   public static String desanitizeKey(String propKey) {
-    return propKey.endsWith(STRIP_SUFFIX) ?
+    propKey =  propKey.endsWith(STRIP_SUFFIX) ?
         propKey.substring(0, propKey.length() - STRIP_SUFFIX.length()) : propKey;
+
+    // Also strip quotes that can get introduced by TypeSafe.Config
+    propKey = propKey.replace("\"", "");
+    return propKey;
   }
 
 

--- a/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/ConfigUtilsTest.java
@@ -180,6 +180,25 @@ public class ConfigUtilsTest {
     Assert.assertEquals(props.getProperty("a.key3"), "true");
   }
 
+  /**
+   * Test that you can go from properties to Config and back without changing.
+   * Specifically tests prefixed paths and numeric key-parts.
+   */
+  @Test
+  public void testPropertiesToConfigAndBack() {
+    Properties props = new Properties();
+
+    props.setProperty("writer.staging.dir", "foobar");
+    props.setProperty("writer.staging.dir.0", "foobar-0");
+
+    Config config = ConfigUtils.propertiesToConfig(props);
+
+    Properties configProps = ConfigUtils.configToProperties(config);
+
+    Assert.assertEquals(configProps, props);
+  }
+
+
   @Test
   public void testFindFullPrefixKeys() {
     Properties props = new Properties();


### PR DESCRIPTION
Currently, record types must implement Copyable to participate in fork-based pipelines. 
This PR relaxes this requirement by adding support for byte[] and immutable types like String etc. 

There are a few notable un-filed issues that were discovered that this PR also fixes. 
a) Fork specific config (typically prefixed by numerical branch ids e.g. writer.staging.dir.0) were being mangled due to transformation from Properties -> TypeSafe Config -> Properties. TypeSafe Config surrounds numeric looking tokens with quotes, leading to these config keys looking like writer.staging.dir."0" in TaskState. This PR works around this by stripping all quotes from keys in the Properties bag when transiting through ConfigUtils::configToProperties

b) #1596 inadvertently introduced a bug in Task.java where forked records weren't being sent into the correct fork.


