### PR TITLE
Bug fixes for avro2orc

### DIFF
--- a/gobblin-modules/gobblin-azkaban/src/main/java/gobblin/data/management/conversion/hive/validation/ValidationJob.java
+++ b/gobblin-modules/gobblin-azkaban/src/main/java/gobblin/data/management/conversion/hive/validation/ValidationJob.java
@@ -16,6 +16,7 @@
  */
 package gobblin.data.management.conversion.hive.validation;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.sql.ResultSet;
@@ -348,7 +349,7 @@ public class ValidationJob extends AbstractJob {
               log.debug(String.format("Not validating partition: %s as updateTime: %s is not in range of max look back: %s " + "and skip recent than: %s",
                   sourcePartition.getCompleteName(), updateTime, this.maxLookBackTime, this.skipRecentThanTime));
             }
-          } catch (UpdateNotFoundException e) {
+          } catch (UncheckedExecutionException e) {
             log.warn(String.format("Not validating partition: %s as update time was not found. %s", sourcePartition.getCompleteName(), e.getMessage()));
           }
         }


### PR DESCRIPTION
1) Changed UpdateNotFoundException to UncheckedExecutionException in ValidationJob
    UpdateNotFoundException extends RuntimeException. All the RuntimeExceptions are wrapped as   UncheckedExecutionException by com.google.common.cache.LocalCache. Hence the job fails whenever UpdateNotFoundException is thrown which defeats the purpose of catching it.

2) Replacing LinkedHashMap for storing evolved HiveColumns. This correponds to the issue https://github.com/linkedin/gobblin/issues/1672

3) Adding the property to skip setting group for the destination dataset same as source. This is needed because if the owner is not a part of the group (there are various reasons why such a thing can happen at the first place), then the task will fail.
