### PR TITLE
Set a 10s timeout on YARN connection failures for unit tests

### DIFF
--- a/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
+++ b/gobblin-yarn/src/test/java/gobblin/yarn/GobblinYarnAppLauncherTest.java
@@ -110,6 +110,7 @@ public class GobblinYarnAppLauncherTest implements HelixMessageTestBase {
     setEnv("JAVA_HOME", javaHome);
 
     final YarnConfiguration clusterConf = new YarnConfiguration();
+    clusterConf.set("yarn.resourcemanager.connect.max-wait.ms", "10000");
 
     MiniYARNCluster miniYARNCluster = this.closer.register(new MiniYARNCluster("TestCluster", 1, 1, 1));
     miniYARNCluster.init(clusterConf);


### PR DESCRIPTION
@htran1 

I pretty consistently get failures in the yarn unit tests on my Linux machine. I know the problem is some sort of DNS/host resolution issue - the MiniYARNCluster is only listening on 127.0.0.1, but the unit test is trying to connect to my external IP address, but don't know if there's an obvious fix.

That said... this change makes the test fail in 10s instead of the default 15 minute setting (https://hadoop.apache.org/docs/r2.6.2/hadoop-yarn/hadoop-yarn-common/yarn-default.xml) which has made my life easier. :)
