### PR TITLE
Batch level metadata support

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -308,6 +308,9 @@ public class ConfigurationKeys {
   public static final String SIMPLE_WRITER_DELIMITER = "simple.writer.delimiter";
   public static final String SIMPLE_WRITER_PREPEND_SIZE = "simple.writer.prepend.size";
 
+  // Internal use only - used to send metadata to publisher
+  public static final String WRITER_METADATA_KEY = WRITER_PREFIX + "._internal.metadata";
+
   /**
    * Writer configuration properties used internally.
    */
@@ -349,8 +352,18 @@ public class ConfigurationKeys {
   public static final String DATA_PUBLISHER_PREFIX = "data.publisher";
 
   /**
+   * Metadata configuration
+   *
+   * PUBLISH_WRITER_METADATA_KEY: Whether or not to publish writer-generated metadata
+   * PUBLISH_WRITER_METADATA_MERGER_NAME_KEY: Class to use to merge writer-generated metadata.
+   */
+  public static final String DATA_PUBLISH_WRITER_METADATA_KEY = DATA_PUBLISHER_PREFIX + ".metadata.publish.writer";
+  public static final String DATA_PUBLISH_WRITER_METADATA_MERGER_NAME_KEY = DATA_PUBLISHER_PREFIX + ".metadata.publish.writer.merger.class";
+
+  /**
    * Metadata configuration properties used internally
    */
+  public static final String DATA_PUBLISH_WRITER_METADATA_MERGER_NAME_DEFAULT = "gobblin.metadata.types.GlobalMetadataJsonMerger";
   public static final String DATA_PUBLISHER_METADATA_OUTPUT_DIR =  DATA_PUBLISHER_PREFIX + ".metadata.output.dir";
   //Metadata String in the configuration file
   public static final String DATA_PUBLISHER_METADATA_STR = DATA_PUBLISHER_PREFIX + ".metadata.string";

--- a/gobblin-api/src/main/java/gobblin/metadata/MetadataMerger.java
+++ b/gobblin-api/src/main/java/gobblin/metadata/MetadataMerger.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.metadata;
+
+/**
+ * Interface for an object that can merge metadata from several work units together.
+ * @param <T> Type of the metadata record that will be merged
+ */
+public interface MetadataMerger<T> {
+  /**
+   * Process a metadata record, merging it with all previously processed records.
+   * @param metadata Record to process
+   */
+  void update(T metadata);
+
+  /**
+   * Get a metadata record that is a representation of all records passed into update().
+   */
+  T getMergedMetadata();
+}

--- a/gobblin-core/src/main/java/gobblin/metadata/types/GlobalMetadata.java
+++ b/gobblin-core/src/main/java/gobblin/metadata/types/GlobalMetadata.java
@@ -1,0 +1,266 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.metadata.types;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import org.codehaus.jackson.JsonEncoding;
+import org.codehaus.jackson.JsonGenerator;
+import org.codehaus.jackson.annotate.JsonProperty;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.util.json.JsonUtils;
+
+
+/**
+ * Represents metadata for a pipeline. There are two 'levels' of metadata - one that is global to an entire
+ * dataset, and one that is applicable to each file present in a dataset.
+ */
+@Slf4j
+public class GlobalMetadata {
+  @JsonProperty("dataset")
+  private final Map<String, Object> datasetLevel;
+
+  @JsonProperty("file")
+  private final Map<String, Map<String, Object>> fileLevel;
+
+  private final static String DATASET_URN_KEY = "Dataset-URN";
+  private final static String TRANSFER_ENCODING_KEY = "Transfer-Encoding";
+
+  /**
+   * Create a new, empty, metadata descriptor.
+   */
+  public GlobalMetadata() {
+    datasetLevel = new ConcurrentHashMap<>();
+    fileLevel = new ConcurrentHashMap<>();
+  }
+
+  /**
+   * Create a new GlobalMetadata object from its serialized representation.
+   * @throws IOException If the JSON string cannot be parsed.
+   */
+  public static GlobalMetadata fromJson(String json)
+      throws IOException {
+    return JsonUtils.getDefaultObjectMapper().readValue(json, GlobalMetadata.class);
+  }
+
+  /**
+   * Merge another GlobalMetadata object into this one. All keys from 'other' will be placed into
+   * this object, replacing any already existing keys.
+   * @param other Metadata object to add
+   */
+  public void addAll(GlobalMetadata other) {
+    datasetLevel.putAll(other.datasetLevel);
+    for (Map.Entry<String, Map<String, Object>> e : other.fileLevel.entrySet()) {
+      Map<String, Object> val = new ConcurrentHashMap<>();
+      val.putAll(e.getValue());
+      fileLevel.put(e.getKey(), val);
+    }
+  }
+
+  /**
+   * Merge default settings into this object. Logic is very similar to addAll(), but Transfer-Encoding gets
+   * special treatment; the 'default' transfer-encoding settings are appended to any transfer-encoding
+   * already set (vs simply overwriting them).
+   */
+  public static GlobalMetadata metadataMergedWithDefaults(GlobalMetadata orig, GlobalMetadata defaults) {
+    GlobalMetadata newMd = new GlobalMetadata();
+    newMd.addAll(orig);
+
+    List<String> defaultTransferEncoding = defaults.getTransferEncoding();
+    List<String> myEncoding = orig.getTransferEncoding();
+
+    if (defaultTransferEncoding != null) {
+      if (myEncoding == null) {
+        newMd.setDatasetMetadata(TRANSFER_ENCODING_KEY, defaultTransferEncoding);
+      } else {
+        List<String> combinedEncoding = new ArrayList<>();
+        combinedEncoding.addAll(myEncoding);
+        combinedEncoding.addAll(defaultTransferEncoding);
+
+        newMd.setDatasetMetadata(TRANSFER_ENCODING_KEY, combinedEncoding);
+      }
+    }
+
+    for (Map.Entry<String, Object> entry : defaults.datasetLevel.entrySet()) {
+      if (!newMd.datasetLevel.containsKey(entry.getKey())) {
+        newMd.datasetLevel.put(entry.getKey(), entry.getValue());
+      }
+    }
+
+    return newMd;
+  }
+
+  /**
+   * Serialize as a UTF8 encoded JSON string.
+   */
+  public byte[] toJsonUtf8() {
+    try {
+      ByteArrayOutputStream bOs = new ByteArrayOutputStream(512);
+
+      try (JsonGenerator generator = JsonUtils.getDefaultJacksonFactory().createJsonGenerator(bOs, JsonEncoding.UTF8)
+          .setCodec(JsonUtils.getDefaultObjectMapper())) {
+        toJsonUtf8(generator);
+      }
+
+      return bOs.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException("Unexpected IOException serializing to ByteArray", e);
+    }
+  }
+
+  /**
+   * Serialize as a String
+   */
+  public String toJson()
+      throws IOException {
+    StringWriter writer = new StringWriter();
+    try (JsonGenerator generator = JsonUtils.getDefaultJacksonFactory().createJsonGenerator(writer)
+        .setCodec(JsonUtils.getDefaultObjectMapper())) {
+      toJsonUtf8(generator);
+    }
+
+    return writer.toString();
+  }
+
+  /**
+   * Write this object out to an existing JSON stream
+   */
+  protected void toJsonUtf8(JsonGenerator generator)
+      throws IOException {
+    generator.writeStartObject();
+
+    generator.writeObjectField("dataset", datasetLevel);
+    generator.writeObjectFieldStart("file");
+    for (Map.Entry<String, Map<String, Object>> entry : fileLevel.entrySet()) {
+      generator.writeObjectField(entry.getKey(), entry.getValue());
+    }
+    generator.writeEndObject();
+    generator.writeEndObject();
+    generator.flush();
+  }
+
+  // Dataset-level metadata
+
+  /**
+   * Convenience method to retrieve the Dataset-URN dataset-level property.
+   */
+  public String getDatasetUrn() {
+    return (String) datasetLevel.get(DATASET_URN_KEY);
+  }
+
+  /**
+   * Convenience method to set the Dataset-URN property.
+   */
+  public void setDatasetUrn(String urn) {
+    setDatasetMetadata(DATASET_URN_KEY, urn);
+  }
+
+  /**
+   * Get an arbitrary dataset-level metadata key
+   */
+  public Object getDatasetMetadata(String key) {
+    return datasetLevel.get(key);
+  }
+
+  /**
+   * Set an arbitrary dataset-level metadata key
+   */
+  public void setDatasetMetadata(String key, Object val) {
+    datasetLevel.put(key, val);
+  }
+
+  /**
+   * Convenience method to retrieve the transfer-encodings that have been applied to the dataset
+   */
+  @SuppressWarnings("unchecked")
+  public List<String> getTransferEncoding() {
+    return (List<String>) getDatasetMetadata(TRANSFER_ENCODING_KEY);
+  }
+
+  /**
+   * Convenience method to add a new transfer-encoding to a dataset
+   */
+  public synchronized void addTransferEncoding(String encoding) {
+    List<String> encodings = getTransferEncoding();
+    if (encodings == null) {
+      encodings = new ArrayList<>();
+    }
+
+    encodings.add(encoding);
+
+    setDatasetMetadata(TRANSFER_ENCODING_KEY, encodings);
+  }
+
+  // File-level  metadata
+
+  /**
+   * Get an arbitrary file-level metadata key
+   */
+  public Object getFileMetadata(String file, String key) {
+    Map<String, Object> fileKeys = fileLevel.get(file);
+    if (fileKeys == null) {
+      return null;
+    }
+
+    return fileKeys.get(key);
+  }
+
+  /**
+   * Set an arbitrary file-level metadata key
+   */
+  public void setFileMetadata(String file, String key, Object val) {
+    Map<String, Object> fileKeys = fileLevel.get(file);
+    if (fileKeys == null) {
+      fileKeys = new ConcurrentHashMap<>();
+      fileLevel.put(file, fileKeys);
+    }
+
+    fileKeys.put(key, val);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    GlobalMetadata that = (GlobalMetadata) o;
+
+    if (!datasetLevel.equals(that.datasetLevel)) {
+      return false;
+    }
+    return fileLevel.equals(that.fileLevel);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = datasetLevel.hashCode();
+    result = 31 * result + fileLevel.hashCode();
+    return result;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/metadata/types/GlobalMetadataJsonMerger.java
+++ b/gobblin-core/src/main/java/gobblin/metadata/types/GlobalMetadataJsonMerger.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.metadata.types;
+
+import java.io.IOException;
+
+import gobblin.metadata.MetadataMerger;
+
+
+/**
+ * Merges a set of GlobalMetadata objects that have been serialized as JSON together to
+ * create a final output.
+ */
+public class GlobalMetadataJsonMerger implements MetadataMerger<String> {
+  private GlobalMetadata mergedMetadata;
+
+  public GlobalMetadataJsonMerger() {
+    mergedMetadata = new GlobalMetadata();
+  }
+
+  @Override
+  public void update(String metadata) {
+    try {
+      GlobalMetadata parsedMetadata = GlobalMetadata.fromJson(metadata);
+      mergedMetadata.addAll(parsedMetadata);
+    } catch (IOException e) {
+      throw new IllegalArgumentException("Error parsing metadata", e);
+    }
+  }
+
+  @Override
+  public String getMergedMetadata() {
+    try {
+      return mergedMetadata.toJson();
+    } catch (IOException e) {
+      throw new AssertionError("Unexpected IOException serializing to JSON", e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/BaseDataPublisher.java
@@ -19,13 +19,16 @@ package gobblin.publisher;
 
 import java.io.IOException;
 import java.net.URI;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
-import gobblin.util.HadoopUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -42,12 +45,15 @@ import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 
+import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
-import gobblin.configuration.ConfigurationKeys;
+import gobblin.metadata.MetadataMerger;
 import gobblin.util.ForkOperatorUtils;
+import gobblin.util.HadoopUtils;
 import gobblin.util.ParallelRunner;
 import gobblin.util.WriterUtils;
+import gobblin.util.reflection.GobblinConstructorUtils;
 
 
 /**
@@ -85,8 +91,10 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   protected final int parallelRunnerThreads;
   protected final Map<String, ParallelRunner> parallelRunners = Maps.newHashMap();
   protected final Set<Path> publisherOutputDirs = Sets.newHashSet();
+  protected final List<MetadataMerger<String>> metadataMergers;
 
-  public BaseDataPublisher(State state) throws IOException {
+  public BaseDataPublisher(State state)
+      throws IOException {
     super(state);
     this.closer = Closer.create();
     Configuration conf = new Configuration();
@@ -103,6 +111,7 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
     this.metaDataWriterFileSystemByBranches = Lists.newArrayListWithCapacity(this.numBranches);
     this.publisherFinalDirOwnerGroupsByBranches = Lists.newArrayListWithCapacity(this.numBranches);
     this.permissions = Lists.newArrayListWithCapacity(this.numBranches);
+    this.metadataMergers = mergersForEachBranch();
 
     // Get a FileSystem instance for each branch
     for (int i = 0; i < this.numBranches; i++) {
@@ -111,8 +120,9 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
           ConfigurationKeys.LOCAL_FS_URI));
       this.writerFileSystemByBranches.add(FileSystem.get(writerUri, conf));
 
-      URI publisherUri = URI.create(this.getState().getProp(ForkOperatorUtils.getPropertyNameForBranch(
-          ConfigurationKeys.DATA_PUBLISHER_FILE_SYSTEM_URI, this.numBranches, i), writerUri.toString()));
+      URI publisherUri = URI.create(this.getState().getProp(ForkOperatorUtils
+              .getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISHER_FILE_SYSTEM_URI, this.numBranches, i),
+          writerUri.toString()));
       this.publisherFileSystemByBranches.add(FileSystem.get(publisherUri, conf));
       this.metaDataWriterFileSystemByBranches.add(FileSystem.get(publisherUri, conf));
 
@@ -133,13 +143,61 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
     this.parallelRunnerCloser = Closer.create();
   }
 
+  // Build the list of metadataMergers for each branch. Return null if none are configured at all
+  private List<MetadataMerger<String>> mergersForEachBranch() {
+    List<MetadataMerger<String>> metadataMergers = new ArrayList<>();
+    boolean mergersConfigured = false;
+
+    for (int i = 0; i < numBranches; i++) {
+      if (shouldPublishMetadataForBranch(i)) {
+        metadataMergers.add(buildPublisherForBranch(i));
+        mergersConfigured = true;
+      } else {
+        metadataMergers.add(null);
+      }
+    }
+
+    return mergersConfigured ? metadataMergers : null;
+  }
+
+  private MetadataMerger<String> buildPublisherForBranch(int branchId) {
+    String keyName = ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_MERGER_NAME_KEY,
+        this.numBranches, branchId);
+    String className = this.getState().getProp(keyName, ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_MERGER_NAME_DEFAULT);
+
+    try {
+      Class<?> mdClass = Class.forName(className);
+
+      // If the merger understands properties, use that constructor; otherwise use the default
+      // parameter-less ctor
+      @SuppressWarnings("uncheeked")
+      Object merger = GobblinConstructorUtils.invokeFirstConstructor(mdClass, Collections.<Object>singletonList(
+          this.getState().getProperties()), Collections.<Object>emptyList());
+
+      try {
+        @SuppressWarnings("unchecked")
+        MetadataMerger<String> casted = (MetadataMerger<String>)merger;
+
+        return casted;
+      } catch (ClassCastException e) {
+        throw new IllegalArgumentException(className + " does not implement the MetadataMerger interface", e);
+      }
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("Specified metadata merger class " + className + " not found!", e);
+    } catch (ReflectiveOperationException e) {
+      throw new IllegalArgumentException("Error building merger class " + className, e);
+    }
+  }
+
   @Override
-  public void initialize() throws IOException {
+  public void initialize()
+      throws IOException {
     // Nothing needs to be done since the constructor already initializes the publisher.
   }
 
   @Override
-  public void close() throws IOException {
+  public void close()
+      throws IOException {
     try {
       for (Path path : this.publisherOutputDirs) {
         this.state.appendToSetProp(ConfigurationKeys.PUBLISHER_DIRS, path.toString());
@@ -150,7 +208,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   }
 
   @Override
-  public void publishData(WorkUnitState state) throws IOException {
+  public void publishData(WorkUnitState state)
+      throws IOException {
     for (int branchId = 0; branchId < this.numBranches; branchId++) {
       publishSingleTaskData(state, branchId);
     }
@@ -161,12 +220,14 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
    * This method publishes output data for a single task based on the given {@link WorkUnitState}.
    * Output data from other tasks won't be published even if they are in the same folder.
    */
-  private void publishSingleTaskData(WorkUnitState state, int branchId) throws IOException {
+  private void publishSingleTaskData(WorkUnitState state, int branchId)
+      throws IOException {
     publishData(state, branchId, true, new HashSet<Path>());
   }
 
   @Override
-  public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
+  public void publishData(Collection<? extends WorkUnitState> states)
+      throws IOException {
 
     // We need a Set to collect unique writer output paths as multiple tasks may belong to the same extract. Tasks that
     // belong to the same Extract will by default have the same output directory
@@ -198,7 +259,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   }
 
   protected void publishData(WorkUnitState state, int branchId, boolean publishSingleTaskData,
-      Set<Path> writerOutputPathsMoved) throws IOException {
+      Set<Path> writerOutputPathsMoved)
+      throws IOException {
     // Get a ParallelRunner instance for moving files in parallel
     ParallelRunner parallelRunner = this.getParallelRunner(this.writerFileSystemByBranches.get(branchId));
 
@@ -215,7 +277,6 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
     Path publisherOutputDir = getPublisherOutputDir(state, branchId);
 
     if (publishSingleTaskData) {
-
       // Create final output directory
       WriterUtils.mkdirsWithRecursivePermission(this.publisherFileSystemByBranches.get(branchId), publisherOutputDir,
           this.permissions.get(branchId));
@@ -270,7 +331,8 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   }
 
   protected void addSingleTaskWriterOutputToExistingDir(Path writerOutputDir, Path publisherOutputDir,
-      WorkUnitState workUnitState, int branchId, ParallelRunner parallelRunner) throws IOException {
+      WorkUnitState workUnitState, int branchId, ParallelRunner parallelRunner)
+      throws IOException {
     String outputFilePropName = ForkOperatorUtils
         .getPropertyNameForBranch(ConfigurationKeys.WRITER_FINAL_OUTPUT_FILE_PATHS, this.numBranches, branchId);
 
@@ -297,20 +359,18 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
   }
 
   protected void addWriterOutputToExistingDir(Path writerOutputDir, Path publisherOutputDir,
-      WorkUnitState workUnitState, int branchId, ParallelRunner parallelRunner) throws IOException {
-    boolean preserveFileName = workUnitState.getPropAsBoolean(ForkOperatorUtils.getPropertyNameForBranch(
-        ConfigurationKeys.SOURCE_FILEBASED_PRESERVE_FILE_NAME, this.numBranches, branchId), false);
-
+      WorkUnitState workUnitState, int branchId, ParallelRunner parallelRunner)
+      throws IOException {
+    boolean preserveFileName = workUnitState.getPropAsBoolean(ForkOperatorUtils
+            .getPropertyNameForBranch(ConfigurationKeys.SOURCE_FILEBASED_PRESERVE_FILE_NAME, this.numBranches, branchId),
+        false);
     // Go through each file in writerOutputDir and move it into publisherOutputDir
     for (FileStatus status : this.writerFileSystemByBranches.get(branchId).listStatus(writerOutputDir)) {
 
       // Preserve the file name if configured, use specified name otherwise
-      Path finalOutputPath =
-          preserveFileName
-              ? new Path(publisherOutputDir,
-                  workUnitState.getProp(ForkOperatorUtils.getPropertyNameForBranch(
-                      ConfigurationKeys.DATA_PUBLISHER_FINAL_NAME, this.numBranches, branchId)))
-              : new Path(publisherOutputDir, status.getPath().getName());
+      Path finalOutputPath = preserveFileName ? new Path(publisherOutputDir, workUnitState.getProp(ForkOperatorUtils
+          .getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISHER_FINAL_NAME, this.numBranches, branchId)))
+          : new Path(publisherOutputDir, status.getPath().getName());
 
       movePath(parallelRunner, workUnitState, status.getPath(), finalOutputPath, branchId);
     }
@@ -325,73 +385,177 @@ public class BaseDataPublisher extends SingleTaskDataPublisher {
         this.publisherFinalDirOwnerGroupsByBranches.get(branchId));
   }
 
-  protected Collection<Path> recordPublisherOutputDirs(Path src, Path dst, int branchId) throws IOException {
+  protected Collection<Path> recordPublisherOutputDirs(Path src, Path dst, int branchId)
+      throws IOException {
 
     // Getting file status from src rather than dst, because at this time dst doesn't yet exist.
     // If src is a dir, add dst to the set of paths. Otherwise, add dst's parent.
     if (this.writerFileSystemByBranches.get(branchId).getFileStatus(src).isDirectory()) {
-      return ImmutableList.<Path> of(dst);
+      return ImmutableList.<Path>of(dst);
     }
-    return ImmutableList.<Path> of(dst.getParent());
+    return ImmutableList.<Path>of(dst.getParent());
   }
 
   private ParallelRunner getParallelRunner(FileSystem fs) {
     String uri = fs.getUri().toString();
     if (!this.parallelRunners.containsKey(uri)) {
-      this.parallelRunners.put(uri,
-          this.parallelRunnerCloser.register(new ParallelRunner(this.parallelRunnerThreads, fs)));
+      this.parallelRunners
+          .put(uri, this.parallelRunnerCloser.register(new ParallelRunner(this.parallelRunnerThreads, fs)));
     }
     return this.parallelRunners.get(uri);
   }
 
+  /**
+   * Merge all of the metadata output from each work-unit and publish the merged record.
+   * @param states States from all tasks
+   * @throws IOException If there is an error publishing the file
+   */
   @Override
-  public void publishMetadata(Collection<? extends WorkUnitState> states) throws IOException {
-        for (WorkUnitState workUnitState : states) {
+  public void publishMetadata(Collection<? extends WorkUnitState> states)
+      throws IOException {
+    if (metadataMergers != null) {
+      mergeAndPublishMetadata(states);
+    } else {
+      for (WorkUnitState workUnitState : states) {
         publishMetadata(workUnitState);
+      }
     }
   }
 
-  @Override
-  public void publishMetadata(WorkUnitState state) throws IOException {
-    String metadataValue = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_STR);
-    if (metadataValue == null) {
-      //Nothing to write
-      return;
-    }
-
-    if (state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR) == null) {
-      LOG.error("Missing metadata output directory path : "  + ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR
-                + " in the config");
-      return;
-    }
-
-    //Write for each branch
-    for (int branchId = 0; branchId < this.numBranches; branchId++) {
-      FileSystem fs = this.metaDataWriterFileSystemByBranches.get(branchId);
-
-      String filePrefix = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE);
-      String fileName = ForkOperatorUtils.getPropertyNameForBranch(filePrefix, this.numBranches, branchId);
-      String metaDataOutputDirStr = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR);
-
-      Path metaDataOutputPath = new Path(metaDataOutputDirStr);
-      try {
-        if (!fs.exists(metaDataOutputPath)) {
-          WriterUtils.mkdirsWithRecursivePermission(fs, metaDataOutputPath, this.permissions.get(branchId));
+  private void mergeAndPublishMetadata(Collection<? extends WorkUnitState> states)
+      throws IOException {
+    // There should be one merged metadata file per branch; first merge all of the pieces together
+    for (WorkUnitState workUnitState : states) {
+      for (int branchId = 0; branchId < numBranches; branchId++) {
+        String md = getIntermediateMetadataFromState(workUnitState, branchId);
+        if (md != null) {
+          metadataMergers.get(branchId).update(md);
         }
-
-        Path metaFilepath = new Path(metaDataOutputDirStr, fileName);
-
-        //Delete the file if metadata already exists
-        if (fs.exists(metaFilepath)) {
-          HadoopUtils.deletePath(fs, metaFilepath, false);
-        }
-
-        try (FSDataOutputStream outputStream = this.closer.register(fs.create(metaFilepath))) {
-          outputStream.write(metadataValue.getBytes("UTF-8"));
-        }
-      } catch (IOException e) {
-        LOG.error("metadata file is not generated: " + e, e);
       }
     }
+
+    // Now, pick an arbitrary WorkUnitState and publish its metadata. We assume that publisher config settings
+    // are the same across all workunits so it doesn't really matter which workUnit we call publishMetadata() for.
+    WorkUnitState anyState = states.iterator().next();
+    publishMetadata(anyState);
+  }
+
+  /**
+   * Publish metadata for each branch. We expect the metadata to be of String format and
+   * populated in either the WRITER_MERGED_METADATA_KEY state or the WRITER_METADATA_KEY configuration key.
+   */
+  @Override
+  public void publishMetadata(WorkUnitState state)
+      throws IOException {
+
+    // For each branch - retrieve metadata and metadata output directory from task state; then publish
+    for (int branchId = 0; branchId < this.numBranches; branchId++) {
+      String metadataValue = getMergedMetadataForState(state, branchId);
+      if (metadataValue == null) {
+        //Nothing to write
+        continue;
+      }
+
+      try {
+        Path metadataOutputPath = getMetadataOutputFileForBranch(state, branchId);
+        if (metadataOutputPath == null) {
+          LOG.info("Metadata output path not set for branch " + String.valueOf(branchId) + ", not publishing.");
+          continue;
+        }
+
+        FileSystem fs = this.metaDataWriterFileSystemByBranches.get(branchId);
+
+        if (!fs.exists(metadataOutputPath.getParent())) {
+          WriterUtils.mkdirsWithRecursivePermission(fs, metadataOutputPath, this.permissions.get(branchId));
+        }
+
+        //Delete the file if metadata already exists
+        if (fs.exists(metadataOutputPath)) {
+          HadoopUtils.deletePath(fs, metadataOutputPath, false);
+        }
+        LOG.info("Writing metadata for branch " + String.valueOf(branchId) + " to " + metadataOutputPath.toString());
+        try (FSDataOutputStream outputStream = fs.create(metadataOutputPath)) {
+          outputStream.write(metadataValue.getBytes(StandardCharsets.UTF_8));
+        }
+      } catch (IOException e) {
+        LOG.error("Metadata file is not generated: " + e, e);
+      }
+    }
+  }
+
+  private Path getMetadataOutputFileForBranch(WorkUnitState state, int branchId) {
+    // Note: This doesn't follow the pattern elsewhere in Gobblin where we have branch specific config
+    // parameters! Leaving this way for backwards compatibility.
+    String filePrefix = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE);
+    String fileName = ForkOperatorUtils.getPropertyNameForBranch(filePrefix, this.numBranches, branchId);
+    String metaDataOutputDirStr = getMetadataOutputPathFromState(state, branchId);
+
+    if (filePrefix == null || metaDataOutputDirStr == null || fileName == null) {
+      return null;
+    }
+    return new Path(metaDataOutputDirStr, fileName);
+  }
+
+  private String getMetadataOutputPathFromState(WorkUnitState state, int branchId) {
+    String outputDir = state.getProp(ForkOperatorUtils
+        .getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR, this.numBranches, branchId));
+
+    // An older version of this code did not get a branch specific PUBLISHER_METADATA_OUTPUT_DIR so fallback
+    // for compatibility's sake
+    if (outputDir == null && this.numBranches > 1) {
+      outputDir = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR);
+      if (outputDir != null) {
+        LOG.warn("Branches are configured for this job but a per branch metadata output directory was not set;"
+            + " is this intended?");
+      }
+    }
+
+    // Just write out to the regular output path if a metadata specific path hasn't been provided
+    if (outputDir == null) {
+      String publisherOutputDir = getPublisherOutputDir(state, branchId).toString();
+      LOG.info("Missing metadata output directory path : " + ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR
+          + " in the config; assuming outputPath " + publisherOutputDir);
+      return publisherOutputDir;
+    }
+
+    return outputDir;
+  }
+
+  /*
+   * Retrieve intermediate metadata (eg the metadata stored by each writer) for a given state and branch id.
+   */
+  private String getIntermediateMetadataFromState(WorkUnitState state, int branchId) {
+    return state.getProp(
+        ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_METADATA_KEY, this.numBranches, branchId));
+  }
+
+  /*
+   * Get the merged metadata given a workunit state and branch id. This method assumes
+   * all intermediate metadata has already been passed to the MetadataMerger.
+   *
+   * If metadata mergers are not configured, instead return the metadata from job config that was
+   * passed in by the user.
+   */
+  private String getMergedMetadataForState(WorkUnitState state, int branchId) {
+    String mergedMd = null;
+
+    if (metadataMergers != null && metadataMergers.get(branchId) != null) {
+      mergedMd = metadataMergers.get(branchId).getMergedMetadata();
+      if (mergedMd == null) {
+        LOG.warn("Metadata merger for branch {} returned null - bug in merger?", branchId);
+      }
+    }
+
+    if (mergedMd == null) {
+      mergedMd = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_STR);
+    }
+
+    return mergedMd;
+  }
+
+  private boolean shouldPublishMetadataForBranch(int branchId) {
+    String keyName = ForkOperatorUtils
+        .getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY, this.numBranches, branchId);
+    return this.getState().getPropAsBoolean(keyName, false);
   }
 }

--- a/gobblin-core/src/test/java/gobblin/metadata/types/GlobalMetadataTest.java
+++ b/gobblin-core/src/test/java/gobblin/metadata/types/GlobalMetadataTest.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.metadata.types;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Iterator;
+import java.util.List;
+
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableList;
+
+
+public class GlobalMetadataTest {
+  @Test
+  public void testMerge() {
+    GlobalMetadata m = new GlobalMetadata();
+    m.setFileMetadata("file1", "key1", "val1");
+    m.addTransferEncoding("gzip");
+
+    GlobalMetadata m2 = new GlobalMetadata();
+    m2.setFileMetadata("file2", "key1", "val2");
+    m2.addTransferEncoding("gzip");
+
+    GlobalMetadata merged = new GlobalMetadata();
+    merged.addAll(m);
+    merged.addAll(m2);
+
+    Assert.assertEquals(merged.getFileMetadata("file1", "key1"), "val1");
+    Assert.assertEquals(merged.getFileMetadata("file2", "key1"), "val2");
+    List<String> mergedEncoding = merged.getTransferEncoding();
+    Assert.assertEquals(mergedEncoding.size(), 1);
+    Assert.assertEquals(mergedEncoding.get(0), "gzip");
+  }
+
+  @Test
+  public void testToJson() throws IOException {
+    GlobalMetadata m = new GlobalMetadata();
+    m.addTransferEncoding("foo");
+    m.addTransferEncoding("bar");
+
+    byte[] utf8 = m.toJsonUtf8();
+    String parsed = new String(utf8, StandardCharsets.UTF_8);
+
+    JsonNode root = new ObjectMapper().readTree(parsed);
+    Assert.assertTrue(root.isObject());
+    Iterator<JsonNode> children = root.getElements();
+    int numChildren = 0;
+    while (children.hasNext()) {
+      children.next();
+      numChildren++;
+    }
+
+    Assert.assertEquals(numChildren, 2, "expected only 3 child nodes - file, dataset, record");
+    Assert.assertEquals(root.get("file").size(), 0, "expected no children in file node");
+
+    JsonNode transferEncoding = root.get("dataset").get("Transfer-Encoding");
+    Assert.assertEquals(transferEncoding.size(), m.getTransferEncoding().size());
+    for (int i = 0; i < m.getTransferEncoding().size(); i++) {
+      Assert.assertEquals(transferEncoding.get(i).getTextValue(), m.getTransferEncoding().get(i));
+    }
+  }
+
+  @Test
+  public void testFromJson() throws IOException {
+    String serialized = "{\"dataset\":{\"Transfer-Encoding\":[\"gzip\",\"aes_rotating\"]},\"file\":{\"part.task_hello-world_1488584636479_1.json.gzip.aes_rotating\":{\"exists\":\"true\"}}}";
+    GlobalMetadata md = GlobalMetadata.fromJson(serialized);
+
+    List<String> transferEncoding = md.getTransferEncoding();
+    Assert.assertEquals(transferEncoding, ImmutableList.of("gzip", "aes_rotating"));
+
+    Assert.assertEquals(md.getFileMetadata("part.task_hello-world_1488584636479_1.json.gzip.aes_rotating", "exists"), "true");
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/publisher/BaseDataPublisherTest.java
+++ b/gobblin-core/src/test/java/gobblin/publisher/BaseDataPublisherTest.java
@@ -1,0 +1,248 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.publisher;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.metadata.MetadataMerger;
+import gobblin.util.ForkOperatorUtils;
+
+
+/**
+ * Tests for BaseDataPublisher
+ */
+public class BaseDataPublisherTest {
+  /**
+   * Test DATA_PUBLISHER_METADATA_STR: a user should be able to put an arbitrary metadata string in job configuration
+   * and have that written out.
+   */
+  @Test
+  public void testMetadataStrOneBranch()
+      throws IOException {
+    State s = buildDefaultState(1);
+
+    WorkUnitState wuState = new WorkUnitState();
+    wuState.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_STR, "foobar");
+    addStateToWorkunit(s, wuState);
+
+    BaseDataPublisher publisher = new BaseDataPublisher(s);
+    publisher.publishMetadata(wuState);
+
+    try (InputStream mdStream = new FileInputStream(openMetadataFile(s, 1, 0))) {
+      String mdBytes = IOUtils.toString(mdStream, StandardCharsets.UTF_8);
+      Assert.assertEquals(mdBytes, "foobar", "Expected to read back metadata from string");
+    }
+  }
+
+  /**
+   * Test that DATA_PUBLISHER_METADATA_STR functionality works across multiple branches.
+   */
+  @Test
+  public void testMetadataStrMultipleWorkUnitsAndBranches()
+      throws IOException {
+    final int numBranches = 3;
+    State s = buildDefaultState(numBranches);
+
+    List<WorkUnitState> workUnits = new ArrayList<>();
+    for (int i = 0; i < numBranches; i++) {
+      WorkUnitState wuState = new WorkUnitState();
+      wuState.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_STR, "foobar");
+      addStateToWorkunit(s, wuState);
+      workUnits.add(wuState);
+    }
+
+    BaseDataPublisher publisher = new BaseDataPublisher(s);
+    publisher.publishMetadata(workUnits);
+
+    for (int branch = 0; branch < numBranches; branch++) {
+      try (InputStream mdStream = new FileInputStream(openMetadataFile(s, numBranches, branch))) {
+        String mdBytes = IOUtils.toString(mdStream, StandardCharsets.UTF_8);
+        Assert.assertEquals(mdBytes, "foobar", "Expected to read back metadata from string");
+      }
+    }
+  }
+
+  /**
+   * Test that an exception is properly thrown if we configure a merger that doesn't actually implement
+   * MetadataMerger
+   */
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testBogusMetadataMerger()
+      throws IOException {
+    State s = buildDefaultState(1);
+    s.setProp(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY, "true");
+    s.setProp(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_MERGER_NAME_KEY, "java.lang.String");
+    s.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_STR, "foobar");
+    WorkUnitState wuState = new WorkUnitState();
+    addStateToWorkunit(s, wuState);
+
+    BaseDataPublisher publisher = new BaseDataPublisher(s);
+    publisher.publishMetadata(Collections.singletonList(wuState));
+  }
+
+  /**
+   * This test is testing several things at once:
+   *  1. That a merger is called properly for all workunits in a brach
+   *  2. That different mergers can be instantiated per branch
+   */
+  @Test
+  public void testMergedMetadata()
+      throws IOException {
+    final int numBranches = 2;
+    final int numWorkUnits = 10;
+
+    State s = buildDefaultState(numBranches);
+
+    for (int i = 0; i < numBranches; i++) {
+      String mdKeyName = ForkOperatorUtils
+          .getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY, numBranches, i);
+      String mdMergerKeyName = ForkOperatorUtils
+          .getPropertyNameForBranch(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_MERGER_NAME_KEY, numBranches, i);
+
+      s.setProp(mdKeyName, "true");
+      s.setProp(mdMergerKeyName,
+          (i % 2) == 0 ? TestAdditionMerger.class.getName() : TestMultiplicationMerger.class.getName());
+    }
+
+    // For each branch, metadata is (branchId+1*workUnitNumber+1) - adding 1 so we don't ever multiply by 0
+    List<WorkUnitState> workUnits = new ArrayList<>();
+    for (int workUnitId = 0; workUnitId < numWorkUnits; workUnitId++) {
+      WorkUnitState wuState = new WorkUnitState();
+      addStateToWorkunit(s, wuState);
+
+      for (int branchId = 0; branchId < numBranches; branchId++) {
+        String mdForBranchName =
+            ForkOperatorUtils.getPropertyNameForBranch(ConfigurationKeys.WRITER_METADATA_KEY, numBranches, branchId);
+        wuState.setProp(mdForBranchName, String.valueOf((branchId + 1) * (workUnitId + 1)));
+      }
+
+      workUnits.add(wuState);
+    }
+
+    BaseDataPublisher publisher = new BaseDataPublisher(s);
+    publisher.publishMetadata(workUnits);
+
+    for (int branch = 0; branch < numBranches; branch++) {
+      int expectedSum = (branch % 2 == 0) ? 0 : 1;
+      for (int i = 0; i < numWorkUnits; i++) {
+        if (branch % 2 == 0) {
+          expectedSum += (branch + 1) * (i + 1);
+        } else {
+          expectedSum *= (branch + 1) * (i + 1);
+        }
+      }
+
+      try (InputStream mdStream = new FileInputStream(openMetadataFile(s, numBranches, branch))) {
+        String mdBytes = IOUtils.toString(mdStream, StandardCharsets.UTF_8);
+        Assert.assertEquals(mdBytes, String.valueOf(expectedSum), "Expected to read back correctly merged metadata from string");
+      }
+    }
+  }
+
+  @Test
+  public void testNoOutputWhenDisabled()
+      throws IOException {
+    State s = buildDefaultState(1);
+
+    WorkUnitState wuState = new WorkUnitState();
+    addStateToWorkunit(s, wuState);
+
+    wuState.setProp(ConfigurationKeys.WRITER_METADATA_KEY, "abcdefg");
+
+    BaseDataPublisher publisher = new BaseDataPublisher(s);
+    publisher.publishMetadata(Collections.singletonList(wuState));
+
+    File mdFile = openMetadataFile(s, 1, 0);
+    Assert.assertFalse(mdFile.exists(), "Internal metadata from writer should not be written out if no merger is set in config");
+  }
+
+  public static class TestAdditionMerger implements MetadataMerger<String> {
+    private int sum = 0;
+
+    @Override
+    public void update(String metadata) {
+      sum += Integer.valueOf(metadata);
+    }
+
+    @Override
+    public String getMergedMetadata() {
+      return String.valueOf(sum);
+    }
+  }
+
+  public static class TestMultiplicationMerger implements MetadataMerger<String> {
+    private int product = 1;
+
+    public TestMultiplicationMerger(Properties config) {
+      // testing ctor call
+    }
+
+    @Override
+    public void update(String metadata) {
+      product *= Integer.valueOf(metadata);
+    }
+
+    @Override
+    public String getMergedMetadata() {
+      return String.valueOf(product);
+    }
+  }
+
+  private void addStateToWorkunit(State s, WorkUnitState wuState) {
+    for (Map.Entry<Object, Object> prop : s.getProperties().entrySet()) {
+      wuState.setProp((String) prop.getKey(), prop.getValue());
+    }
+  }
+
+  private File openMetadataFile(State state, int numBranches, int branchId) {
+    String dir = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR);
+    String fileName = state.getProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE);
+    if (numBranches > 1) {
+      fileName += "." + String.valueOf(branchId);
+    }
+    return new File(dir, fileName);
+  }
+
+  private State buildDefaultState(int numBranches)
+      throws IOException {
+    State state = new State();
+
+    state.setProp(ConfigurationKeys.FORK_BRANCHES_KEY, numBranches);
+    File tmpLocation = File.createTempFile("metadata", "");
+    tmpLocation.delete();
+    state.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR, tmpLocation.getParent());
+    state.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE, tmpLocation.getName());
+
+    return state;
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/SimpleDataWriterTest.java
@@ -39,10 +39,13 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import com.google.common.collect.ImmutableList;
+
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.crypto.EncryptionConfigParser;
 import gobblin.crypto.InsecureShiftCodec;
+import gobblin.metadata.types.GlobalMetadata;
 
 
 /**
@@ -289,6 +292,10 @@ public class SimpleDataWriterTest {
 
     byte[] contents = IOUtils.toByteArray(uncompressedFile);
     Assert.assertEquals(contents, toWrite, "expected to decode same contents");
+
+    String serializedMetadata = properties.getProp(ConfigurationKeys.WRITER_METADATA_KEY);
+    GlobalMetadata md = GlobalMetadata.fromJson(serializedMetadata);
+    Assert.assertEquals(md.getTransferEncoding(), ImmutableList.of("gzip", "encrypted_insecure_shift"));
  }
 
   /**

--- a/gobblin-utility/src/main/java/gobblin/util/json/JsonUtils.java
+++ b/gobblin-utility/src/main/java/gobblin/util/json/JsonUtils.java
@@ -1,0 +1,43 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.util.json;
+
+import org.codehaus.jackson.JsonFactory;
+import org.codehaus.jackson.map.ObjectMapper;
+
+
+/**
+ * JSON related utilities
+ */
+public class JsonUtils {
+  private static final JsonFactory jacksonFactory = new JsonFactory();
+  private static final ObjectMapper jacksonObjectMapper = new ObjectMapper();
+
+  /**
+   * Get a Jackson JsonFactory configured with standard settings. The JsonFactory is thread-safe.
+   */
+  public static JsonFactory getDefaultJacksonFactory() {
+    return jacksonFactory;
+  }
+
+  /**
+   * Get a Jackson ObjectMapper configured with standard settings. The ObjectMapper is thread-safe.
+   */
+  public static ObjectMapper getDefaultObjectMapper() {
+    return jacksonObjectMapper;
+  }
+}


### PR DESCRIPTION
- Each writer keeps track of some GlobalMetadata (which for now is only TransferEncoding).
- BaseDataPublisher merges all of these metadata objects together using the GlobalMetadataMerger, and writes the merged data out to disk if the appropriate config is set
- Add a JsonUtil class to hold Jackson objects so we aren't constructing them all over the place. This will also let us hang config settings off there if we figure out there are good defaults to set.

To follow in future PRs:
 - Support to set GlobalMetadata from config/an arbitrary retriever
 - Allow sources + converters to optionally set global metadata
 - Per-record metadata