### PR TITLE
Added retention to gobblin-compliance

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/hive/HiveDataset.java
@@ -124,8 +124,6 @@ public class HiveDataset implements PrioritizedCopyableDataset {
         Optional.fromNullable(this.table.getDataLocation());
 
     this.tableIdentifier = this.table.getDbName() + "." + this.table.getTableName();
-    log.info("Created Hive dataset for table " + this.tableIdentifier);
-
     this.datasetNamePattern = Optional.fromNullable(ConfigUtils.getString(datasetConfig, DATASET_NAME_PATTERN_KEY, null));
     this.dbAndTable = new DbAndTable(table.getDbName(), table.getTableName());
     if (this.datasetNamePattern.isPresent()) {

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/ComplianceConfigurationKeys.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/ComplianceConfigurationKeys.java
@@ -32,7 +32,7 @@ public class ComplianceConfigurationKeys {
   public static final String COMPLIANCE_DATASET_WHITELIST = COMPLIANCE_PREFIX + ".dataset.whitelist";
   public static final String PARTITION_NAME = COMPLIANCE_PREFIX + ".partition.name";
   public static final int TIME_STAMP_LENGTH = 13;
-  public static final String DBNAME_SEPARATOR = "@";
+  public static final String DBNAME_SEPARATOR = "__";
 
   public static final String MAX_CONCURRENT_DATASETS = COMPLIANCE_PREFIX + ".max.concurrent.datasets";
   public static final String DEFAULT_MAX_CONCURRENT_DATASETS = "100";

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/DatasetDescriptor.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/DatasetDescriptor.java
@@ -55,7 +55,7 @@ public abstract class DatasetDescriptor {
 
   protected void checkValidJsonStr(String jsonStr) {
     try {
-      new JsonParser().parse(this.descriptor);
+      new JsonParser().parse(jsonStr);
     } catch (JsonParseException e) {
       log.warn("Not a valid JSON String : " + jsonStr);
       Throwables.propagate(e);

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePartitionVersionFinder.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HivePartitionVersionFinder.java
@@ -17,14 +17,27 @@
 package gobblin.compliance;
 
 import java.io.IOException;
+import java.security.PrivilegedExceptionAction;
+import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+import org.apache.hadoop.security.UserGroupInformation;
 
-import lombok.AllArgsConstructor;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
 
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.compliance.purger.HivePurgerQueryTemplate;
+import gobblin.compliance.retention.HivePartitionRetentionVersion;
+import gobblin.compliance.utils.ProxyUtils;
 import gobblin.configuration.State;
+import gobblin.data.management.copy.hive.HiveDataset;
+import gobblin.data.management.copy.hive.HiveDatasetFinder;
 import gobblin.dataset.Dataset;
 
 
@@ -33,18 +46,117 @@ import gobblin.dataset.Dataset;
  *
  * @author adsharma
  */
-@AllArgsConstructor
-public abstract class HivePartitionVersionFinder implements gobblin.data.management.version.finder.VersionFinder<HivePartitionVersion> {
+@Slf4j
+public class HivePartitionVersionFinder implements gobblin.data.management.version.finder.VersionFinder<HivePartitionVersion> {
   protected final FileSystem fs;
   protected final State state;
   protected List<String> patterns;
+  private Optional<String> owner = Optional.absent();
+  private List<HivePartitionVersion> versions = new ArrayList<>();
+
+  public HivePartitionVersionFinder(FileSystem fs, State state, List<String> patterns) {
+    this.fs = fs;
+    this.state = new State(state);
+    this.patterns = patterns;
+  }
 
   @Override
   public Class<HivePartitionVersion> versionClass() {
     return HivePartitionVersion.class;
   }
 
+  /**
+   * Will find all the versions of the {@link HivePartitionDataset}.
+   *
+   * For a dataset with table name table1, corresponding versions table will be
+   * table1_backup_timestamp or table1_staging_timestamp or table1_trash_timestamp
+   *
+   * Based on pattern, a type of version will be selected eg. backup or trash or staging
+   *
+   * If a Hive version's table contain no Partitions, it will be dropped.
+   */
   @Override
-  public abstract Collection<HivePartitionVersion> findDatasetVersions(Dataset dataset)
-      throws IOException;
+  public Collection<HivePartitionVersion> findDatasetVersions(Dataset dataset)
+      throws IOException {
+    List<HivePartitionVersion> versions = new ArrayList<>();
+    if (!(dataset instanceof HivePartitionDataset)) {
+      return versions;
+    }
+    HivePartitionDataset hivePartitionDataset = (HivePartitionDataset) dataset;
+    this.owner = hivePartitionDataset.getOwner();
+    Preconditions.checkArgument(!this.patterns.isEmpty(),
+        "No patterns to find versions for the dataset " + dataset.datasetURN());
+
+    versions
+        .addAll(findVersions(hivePartitionDataset.getName(), hivePartitionDataset.datasetURN()));
+    return versions;
+  }
+
+  private List<HivePartitionVersion> findVersions(String name, String urn)
+      throws IOException {
+    State state = new State(this.state);
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.HIVE_VERSIONS_WHITELIST),
+        "Missing required property " + ComplianceConfigurationKeys.HIVE_VERSIONS_WHITELIST);
+
+    state.setProp(ComplianceConfigurationKeys.HIVE_DATASET_WHITELIST,
+        this.state.getProp(ComplianceConfigurationKeys.HIVE_VERSIONS_WHITELIST));
+    setVersions(name, state);
+    log.info("Found " + this.versions.size() + " versions for the dataset " + urn);
+    return this.versions;
+  }
+
+  private void addPartitionsToVersions(List<HivePartitionVersion> versions, String name, HiveDataset hiveDataset,
+      List<Partition> partitions)
+      throws IOException {
+    if (partitions.isEmpty()) {
+      if (Boolean.parseBoolean(this.state.getProp(ComplianceConfigurationKeys.SHOULD_DROP_EMPTY_TABLES,
+          ComplianceConfigurationKeys.DEFAULT_SHOULD_DROP_EMPTY_TABLES))) {
+        executeDropTableQuery(hiveDataset);
+      }
+      return;
+    }
+    for (Partition partition : partitions) {
+      if (partition.getName().equalsIgnoreCase(name)) {
+        versions.add(new HivePartitionRetentionVersion(partition));
+      }
+    }
+  }
+
+  private void executeDropTableQuery(HiveDataset hiveDataset)
+      throws IOException {
+    String dbName = hiveDataset.getTable().getDbName();
+    String tableName = hiveDataset.getTable().getTableName();
+    Optional<String> datasetOwner = Optional.fromNullable(hiveDataset.getTable().getOwner());
+    try (HiveProxyQueryExecutor hiveProxyQueryExecutor = ProxyUtils
+        .getQueryExecutor(new State(this.state), datasetOwner)) {
+      hiveProxyQueryExecutor.executeQuery(HivePurgerQueryTemplate.getDropTableQuery(dbName, tableName), datasetOwner);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private void setVersions(final String name, final State state)
+      throws IOException {
+    try {
+      UserGroupInformation loginUser = UserGroupInformation.getLoginUser();
+      loginUser.doAs(new PrivilegedExceptionAction<Void>() {
+        @Override
+        public Void run()
+            throws IOException {
+          HiveDatasetFinder finder = new HiveDatasetFinder(fs, state.getProperties());
+          for (HiveDataset hiveDataset : finder.findDatasets()) {
+            List<Partition> partitions = hiveDataset.getPartitionsFromDataset();
+            for (String pattern : patterns) {
+              if (hiveDataset.getTable().getTableName().contains(pattern)) {
+                addPartitionsToVersions(versions, name, hiveDataset, partitions);
+              }
+            }
+          }
+          return null;
+        }
+      });
+    } catch (InterruptedException | IOException e) {
+      throw new IOException(e);
+    }
+  }
 }

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HiveProxyQueryExecutor.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/HiveProxyQueryExecutor.java
@@ -153,7 +153,7 @@ public class HiveProxyQueryExecutor implements QueryExecutor, Closeable {
     Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.HIVE_JDBC_URL), "Missing required property " + ComplianceConfigurationKeys.HIVE_JDBC_URL);
     String url = this.state.getProp(ComplianceConfigurationKeys.HIVE_JDBC_URL);
     if (proxyUser.isPresent()) {
-      url = url + ComplianceConfigurationKeys.HIVE_SERVER2_PROXY_USER + proxyUser;
+      url = url + ComplianceConfigurationKeys.HIVE_SERVER2_PROXY_USER + proxyUser.get();
     }
     return (HiveConnection) DriverManager.getConnection(url);
   }

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/purger/PurgeableHivePartitionDataset.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/purger/PurgeableHivePartitionDataset.java
@@ -18,9 +18,7 @@ package gobblin.compliance.purger;
 
 import java.io.IOException;
 import java.sql.SQLException;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/CleanableHivePartitionDataset.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/CleanableHivePartitionDataset.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.base.Preconditions;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.compliance.ComplianceConfigurationKeys;
+import gobblin.compliance.HivePartitionDataset;
+import gobblin.compliance.HivePartitionVersion;
+import gobblin.compliance.HivePartitionVersionFinder;
+import gobblin.compliance.HivePartitionVersionPolicy;
+import gobblin.configuration.State;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.retention.version.VersionCleaner;
+import gobblin.util.reflection.GobblinConstructorUtils;
+
+
+/**
+ * This class is a Cleanable representation of {@link HivePartitionDataset}.
+ * This class implements the clean method which will be called for each dataset
+ *
+ * @author adsharma
+ */
+@Slf4j
+public class CleanableHivePartitionDataset extends HivePartitionDataset implements CleanableDataset {
+  private FileSystem fs;
+  private State state;
+
+  public CleanableHivePartitionDataset(Partition partition, FileSystem fs, State state) {
+    super(partition);
+    this.fs = fs;
+    this.state = new State(state);
+  }
+
+  public CleanableHivePartitionDataset(HivePartitionDataset hivePartitionDataset, FileSystem fs, State state) {
+    super(hivePartitionDataset);
+    this.fs = fs;
+    this.state = new State(state);
+  }
+
+  @Override
+  public Path datasetRoot() {
+    return this.getLocation();
+  }
+
+  /**
+   * This method uses {@link HivePartitionVersionFinder} to list out versions
+   * corresponding to this dataset. It will then filter out versions using {@link HivePartitionVersionPolicy}.
+   *
+   * For each version there will be a corresponding {@link VersionCleaner} which will clean the version.
+   */
+  @Override
+  public void clean()
+      throws IOException {
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.RETENTION_VERSION_FINDER_CLASS_KEY),
+        "Missing required property " + ComplianceConfigurationKeys.RETENTION_VERSION_FINDER_CLASS_KEY);
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.RETENTION_SELECTION_POLICY_CLASS_KEY),
+        "Missing required property " + ComplianceConfigurationKeys.RETENTION_SELECTION_POLICY_CLASS_KEY);
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.RETENTION_VERSION_CLEANER_CLASS_KEY),
+        "Missing required property " + ComplianceConfigurationKeys.RETENTION_VERSION_CLEANER_CLASS_KEY);
+
+    List<String> patterns = new ArrayList<>();
+    patterns.add(getCompleteTableName(this) + ComplianceConfigurationKeys.BACKUP);
+    patterns.add(getCompleteTableName(this) + ComplianceConfigurationKeys.STAGING);
+    patterns.add(getCompleteTableName(this) + ComplianceConfigurationKeys.TRASH);
+
+    HivePartitionVersionFinder versionFinder = GobblinConstructorUtils
+        .invokeConstructor(HivePartitionVersionFinder.class,
+            this.state.getProp(ComplianceConfigurationKeys.RETENTION_VERSION_FINDER_CLASS_KEY), this.fs, this.state,
+            patterns);
+
+    List<HivePartitionVersion> versions = new ArrayList<>(versionFinder.findDatasetVersions(this));
+    HivePartitionVersionPolicy versionPolicy = GobblinConstructorUtils
+        .invokeConstructor(HivePartitionVersionPolicy.class,
+            this.state.getProp(ComplianceConfigurationKeys.RETENTION_SELECTION_POLICY_CLASS_KEY), this.state, this);
+
+    List<HivePartitionVersion> deletableVersions = new ArrayList<>(versionPolicy.selectedList(versions));
+    List<String> nonDeletableVersionLocations = getNonDeletableVersionLocations(versions, deletableVersions);
+
+    for (HivePartitionVersion hivePartitionDatasetVersion : deletableVersions) {
+      try {
+        VersionCleaner versionCleaner = GobblinConstructorUtils
+            .invokeConstructor(HivePartitionVersionRetentionRunner.class,
+                this.state.getProp(ComplianceConfigurationKeys.RETENTION_VERSION_CLEANER_CLASS_KEY), this,
+                hivePartitionDatasetVersion, nonDeletableVersionLocations, this.state);
+        versionCleaner.clean();
+      } catch (Exception e) {
+        log.warn("Caught exception trying to clean version " + hivePartitionDatasetVersion.datasetURN() + "\n" + e
+            .getMessage());
+      }
+    }
+  }
+
+  private List<String> getNonDeletableVersionLocations(List<HivePartitionVersion> versions,
+      List<HivePartitionVersion> deletableVersions) {
+    List<String> nonDeletableVersionLocations = new ArrayList<>();
+    for (HivePartitionVersion version : versions) {
+      if (!deletableVersions.contains(version)) {
+        nonDeletableVersionLocations.add(version.getLocation().toString());
+      }
+    }
+    nonDeletableVersionLocations.add(this.getLocation().toString());
+    return nonDeletableVersionLocations;
+  }
+
+  public String getCompleteTableName(HivePartitionDataset dataset) {
+    return StringUtils
+        .join(Arrays.asList(dataset.getDbName(), dataset.getTableName()), ComplianceConfigurationKeys.DBNAME_SEPARATOR);
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/CleanableHivePartitionDatasetFinder.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/CleanableHivePartitionDatasetFinder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+
+import gobblin.compliance.HivePartitionDataset;
+import gobblin.compliance.HivePartitionFinder;
+import gobblin.configuration.State;
+import gobblin.util.WriterUtils;
+
+
+/**
+ * A dataset finder class to find all the {@link CleanableHivePartitionDataset} based on the whitelist.
+ *
+ * @author adsharma
+ */
+public class CleanableHivePartitionDatasetFinder extends HivePartitionFinder {
+  protected FileSystem fs;
+
+  public CleanableHivePartitionDatasetFinder(State state)
+      throws IOException {
+    this(WriterUtils.getWriterFs(new State(state)), state);
+  }
+
+  public CleanableHivePartitionDatasetFinder(FileSystem fs, State state)
+      throws IOException {
+    super(state);
+    this.fs = fs;
+  }
+
+  /**
+   * Will find all datasets according to whitelist, except the backup and staging tables.
+   */
+  public List<HivePartitionDataset> findDatasets()
+      throws IOException {
+    List<HivePartitionDataset> list = new ArrayList<>();
+    for (HivePartitionDataset hivePartitionDataset : super.findDatasets()) {
+      CleanableHivePartitionDataset dataset =
+          new CleanableHivePartitionDataset(hivePartitionDataset, this.fs, this.state);
+      list.add(dataset);
+    }
+    return list;
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/ComplianceRetentionJob.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/ComplianceRetentionJob.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Properties;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CountDownLatch;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+import org.apache.thrift.TException;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Throwables;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.util.concurrent.FutureCallback;
+import com.google.common.util.concurrent.Futures;
+import com.google.common.util.concurrent.ListenableFuture;
+
+import javax.annotation.Nullable;
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.compliance.ComplianceEvents;
+import gobblin.compliance.ComplianceJob;
+import gobblin.compliance.utils.ProxyUtils;
+import gobblin.configuration.State;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.dataset.Dataset;
+import gobblin.dataset.DatasetsFinder;
+import gobblin.util.ExecutorsUtils;
+import gobblin.util.reflection.GobblinConstructorUtils;
+
+import static gobblin.compliance.ComplianceConfigurationKeys.GOBBLIN_COMPLIANCE_DATASET_FINDER_CLASS;
+
+
+/**
+ * A compliance job for compliance retention requirements.
+ */
+@Slf4j
+public class ComplianceRetentionJob extends ComplianceJob {
+  public ComplianceRetentionJob(Properties properties) {
+    super(properties);
+    initDatasetFinder(properties);
+    try {
+      ProxyUtils.cancelTokens(new State(properties));
+    } catch (InterruptedException | TException | IOException e) {
+      Throwables.propagate(e);
+    }
+  }
+
+  public void initDatasetFinder(Properties properties) {
+    Preconditions.checkArgument(properties.containsKey(GOBBLIN_COMPLIANCE_DATASET_FINDER_CLASS),
+        "Missing required propety " + GOBBLIN_COMPLIANCE_DATASET_FINDER_CLASS);
+    String finderClass = properties.getProperty(GOBBLIN_COMPLIANCE_DATASET_FINDER_CLASS);
+    this.finder = GobblinConstructorUtils.invokeConstructor(DatasetsFinder.class, finderClass, new State(properties));
+  }
+
+  public void run()
+      throws IOException {
+    Preconditions.checkNotNull(this.finder, "Dataset finder class is not set");
+    List<Dataset> datasets = this.finder.findDatasets();
+    this.finishCleanSignal = Optional.of(new CountDownLatch(datasets.size()));
+    for (final Dataset dataset : datasets) {
+      ListenableFuture<Void> future = this.service.submit(new Callable<Void>() {
+        @Override
+        public Void call()
+            throws Exception {
+          if (dataset instanceof CleanableDataset) {
+            ((CleanableDataset) dataset).clean();
+          } else {
+            log.warn(
+                "Not an instance of " + CleanableDataset.class + " Dataset won't be cleaned " + dataset.datasetURN());
+          }
+          return null;
+        }
+      });
+      Futures.addCallback(future, new FutureCallback<Void>() {
+        @Override
+        public void onSuccess(@Nullable Void result) {
+          ComplianceRetentionJob.this.finishCleanSignal.get().countDown();
+          log.info("Successfully cleaned: " + dataset.datasetURN());
+        }
+
+        @Override
+        public void onFailure(Throwable t) {
+          ComplianceRetentionJob.this.finishCleanSignal.get().countDown();
+          log.warn("Exception caught when cleaning " + dataset.datasetURN() + ".", t);
+          ComplianceRetentionJob.this.throwables.add(t);
+          ComplianceRetentionJob.this.eventSubmitter.submit(ComplianceEvents.Retention.FAILED_EVENT_NAME, ImmutableMap
+              .of(ComplianceEvents.FAILURE_CONTEXT_METADATA_KEY, ExceptionUtils.getFullStackTrace(t),
+                  ComplianceEvents.DATASET_URN_METADATA_KEY, dataset.datasetURN()));
+        }
+      });
+    }
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    try {
+      if (this.finishCleanSignal.isPresent()) {
+        this.finishCleanSignal.get().await();
+      }
+      if (!this.throwables.isEmpty()) {
+        for (Throwable t : this.throwables) {
+          log.error("Failed clean due to ", t);
+        }
+        throw new RuntimeException("Retention failed for one or more datasets");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Not all datasets finish retention", e);
+    } finally {
+      ExecutorsUtils.shutdownExecutorService(this.service, Optional.of(log));
+      this.closer.close();
+    }
+  }
+
+  /**
+   * Generates retention metrics for the instrumentation of this class.
+   */
+  @Override
+  protected void regenerateMetrics() {
+    // TODO
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionRetentionVersion.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionRetentionVersion.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import org.apache.hadoop.hive.ql.metadata.Partition;
+
+import com.google.common.base.Preconditions;
+
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
+
+import gobblin.compliance.ComplianceConfigurationKeys;
+import gobblin.compliance.HivePartitionVersion;
+
+
+/**
+ * A version class corresponding to the {@link CleanableHivePartitionDataset}
+ *
+ * @author adsharma
+ */
+@SuppressWarnings
+public class HivePartitionRetentionVersion extends HivePartitionVersion {
+
+  public HivePartitionRetentionVersion(Partition version) {
+    super(version);
+  }
+
+  @Override
+  public int compareTo(HivePartitionVersion version) {
+    long thisAge = getAgeInMilliSeconds(this);
+    long otherAge = getAgeInMilliSeconds((HivePartitionRetentionVersion) version);
+    return Long.compare(thisAge, otherAge);
+  }
+
+  public boolean equals(Object obj) {
+    if (obj == null) {
+      return false;
+    }
+    if (obj instanceof HivePartitionVersion) {
+      return compareTo((HivePartitionVersion) obj) == 0;
+    }
+    return false;
+  }
+
+  public long getAgeInMilliSeconds(HivePartitionRetentionVersion version) {
+    Preconditions.checkArgument(getTimeStamp(version).length() == ComplianceConfigurationKeys.TIME_STAMP_LENGTH,
+        "Invalid time stamp for dataset : " + version.datasetURN() + " time stamp is :" + getTimeStamp(version));
+    return System.currentTimeMillis() - Long.parseLong(getTimeStamp(version));
+  }
+
+  public Long getAgeInMilliSeconds() {
+    return getAgeInMilliSeconds(this);
+  }
+
+  public static String getTimeStamp(HivePartitionRetentionVersion version) {
+    return version.getTableName().substring(version.getTableName().lastIndexOf("_") + 1);
+  }
+
+  public String getTimeStamp() {
+    return getTimeStamp(this);
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionCleaner.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionCleaner.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.List;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.base.Optional;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.compliance.ComplianceConfigurationKeys;
+import gobblin.compliance.HiveProxyQueryExecutor;
+import gobblin.compliance.purger.HivePurgerQueryTemplate;
+import gobblin.compliance.utils.PartitionUtils;
+import gobblin.compliance.utils.ProxyUtils;
+import gobblin.configuration.State;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.util.HadoopUtils;
+
+
+/**
+ * A version cleaner for the {@link HivePartitionRetentionVersion}.
+ *
+ * A version will be considered as clean only if it's metadata no longer exists in the db and the data
+ * it was pointing to no longer exists.
+ *
+ * @author adsharma
+ */
+@Slf4j
+public class HivePartitionVersionRetentionCleaner extends HivePartitionVersionRetentionRunner {
+  private FileSystem fs;
+  private boolean simulate;
+  private Optional<String> versionOwner = Optional.absent();
+
+  public HivePartitionVersionRetentionCleaner(CleanableDataset dataset, DatasetVersion version,
+      List<String> nonDeletableVersionLocations, State state) {
+    super(dataset, version, nonDeletableVersionLocations, state);
+    this.versionOwner = ((HivePartitionRetentionVersion) this.datasetVersion).getOwner();
+    this.simulate = this.state.getPropAsBoolean(ComplianceConfigurationKeys.COMPLIANCE_JOB_SIMULATE,
+        ComplianceConfigurationKeys.DEFAULT_COMPLIANCE_JOB_SIMULATE);
+  }
+
+  /**
+   * If simulate is set to true, this will simply return.
+   * If version is pointing to an empty location, drop the partition and close the jdbc connection.
+   * If version is pointing to the same location as of the dataset, then drop the partition and close the jdbc connection.
+   * If version is pointing to the non deletable version locations, then drop the partition and close the jdbc connection.
+   * Otherwise delete the data underneath, drop the partition and close the jdbc connection.
+   */
+  @Override
+  public void clean()
+      throws IOException {
+    Path versionLocation = ((HivePartitionRetentionVersion) this.datasetVersion).getLocation();
+    Path datasetLocation = ((CleanableHivePartitionDataset) this.cleanableDataset).getLocation();
+    String completeName = ((HivePartitionRetentionVersion) this.datasetVersion).datasetURN();
+
+    State state = new State(this.state);
+    this.fs = ProxyUtils.getOwnerFs(state, this.versionOwner);
+
+    try (HiveProxyQueryExecutor queryExecutor = ProxyUtils.getQueryExecutor(state, this.versionOwner)) {
+      log.info("Trying to clean version " + completeName);
+      if (this.simulate) {
+        log.info("Simulate is set to true. Won't delete the partition " + completeName);
+        return;
+      }
+      if (!this.fs.exists(versionLocation)) {
+        log.info("Data versionLocation doesn't exist. Metadata will be dropped for the version  " + completeName);
+      } else if (datasetLocation.toString().equalsIgnoreCase(versionLocation.toString())) {
+        log.info(
+            "Dataset location is same as version location. Won't delete the data but metadata will be dropped for the version "
+                + completeName);
+      } else if (this.nonDeletableVersionLocations.contains(versionLocation.toString())) {
+        log.info(
+            "This version corresponds to the non deletable version. Won't delete the data but metadata will be dropped for the version "
+                + completeName);
+      } else if (HadoopUtils.hasContent(this.fs, versionLocation)) {
+        log.info("Deleting data from the version " + completeName);
+        this.fs.delete(versionLocation, true);
+      }
+      executeDropVersionQueries(queryExecutor);
+    }
+  }
+
+  // These methods are not implemented by this class
+  @Override
+  public void preCleanAction() {
+
+  }
+
+  @Override
+  public void postCleanAction() {
+
+  }
+
+  private void executeDropVersionQueries(HiveProxyQueryExecutor queryExecutor)
+      throws IOException {
+    String dbName = ((HivePartitionRetentionVersion) this.datasetVersion).getDbName();
+    String tableName = ((HivePartitionRetentionVersion) this.datasetVersion).getTableName();
+    String partitionSpec =
+        PartitionUtils.getPartitionSpecString(((HivePartitionRetentionVersion) this.datasetVersion).getSpec());
+    try {
+      queryExecutor.executeQuery(HivePurgerQueryTemplate.getUseDbQuery(dbName), this.versionOwner);
+      queryExecutor
+          .executeQuery(HivePurgerQueryTemplate.getDropPartitionQuery(tableName, partitionSpec), this.versionOwner);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionCleaner.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionCleaner.java
@@ -79,10 +79,6 @@ public class HivePartitionVersionRetentionCleaner extends HivePartitionVersionRe
 
     try (HiveProxyQueryExecutor queryExecutor = ProxyUtils.getQueryExecutor(state, this.versionOwner)) {
       log.info("Trying to clean version " + completeName);
-      if (this.simulate) {
-        log.info("Simulate is set to true. Won't delete the partition " + completeName);
-        return;
-      }
       if (!this.fs.exists(versionLocation)) {
         log.info("Data versionLocation doesn't exist. Metadata will be dropped for the version  " + completeName);
       } else if (datasetLocation.toString().equalsIgnoreCase(versionLocation.toString())) {
@@ -94,6 +90,10 @@ public class HivePartitionVersionRetentionCleaner extends HivePartitionVersionRe
             "This version corresponds to the non deletable version. Won't delete the data but metadata will be dropped for the version "
                 + completeName);
       } else if (HadoopUtils.hasContent(this.fs, versionLocation)) {
+        if (this.simulate) {
+          log.info("Simulate is set to true. Won't delete the partition " + completeName);
+          return;
+        }
         log.info("Deleting data from the version " + completeName);
         this.fs.delete(versionLocation, true);
       }

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionCleanerPolicy.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionCleanerPolicy.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import com.google.common.base.Preconditions;
+import gobblin.compliance.ComplianceConfigurationKeys;
+import gobblin.compliance.HivePartitionDataset;
+import gobblin.compliance.HivePartitionVersion;
+import gobblin.compliance.HivePartitionVersionPolicy;
+import gobblin.configuration.State;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A retention version policy for the {@link HivePartitionRetentionVersion}.
+ *
+ * @author adsharma
+ */
+@Slf4j
+public class HivePartitionVersionRetentionCleanerPolicy extends HivePartitionVersionPolicy {
+  /**
+   * Maximum number of backups to be retained.
+   */
+  private int backupRetentionVersions;
+  /**
+   * Maximum age for a retained backup.
+   */
+  private int backupRetentionDays;
+  /**
+   * Maximum age for a retained trash partition.
+   */
+  private int trashRetentionDays;
+
+  public HivePartitionVersionRetentionCleanerPolicy(State state, HivePartitionDataset dataset) {
+    super(state, dataset);
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.CLEANER_BACKUP_RETENTION_VERSIONS),
+        "Missing required property " + ComplianceConfigurationKeys.CLEANER_BACKUP_RETENTION_VERSIONS);
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.CLEANER_BACKUP_RETENTION_DAYS),
+        "Missing required property " + ComplianceConfigurationKeys.CLEANER_BACKUP_RETENTION_DAYS);
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.CLEANER_TRASH_RETENTION_DAYS),
+        "Missing required property " + ComplianceConfigurationKeys.CLEANER_TRASH_RETENTION_DAYS);
+    this.backupRetentionVersions =
+        this.state.getPropAsInt(ComplianceConfigurationKeys.CLEANER_BACKUP_RETENTION_VERSIONS);
+    this.backupRetentionDays = this.state.getPropAsInt(ComplianceConfigurationKeys.CLEANER_BACKUP_RETENTION_DAYS);
+    this.trashRetentionDays = this.state.getPropAsInt(ComplianceConfigurationKeys.CLEANER_TRASH_RETENTION_DAYS);
+  }
+
+  @Override
+  public boolean shouldSelect(HivePartitionVersion version) {
+    // not implemented by this class
+    return false;
+  }
+
+  @Override
+  public List<HivePartitionVersion> selectedList(List<HivePartitionVersion> versions) {
+    if (versions.isEmpty()) {
+      return versions;
+    }
+    List<HivePartitionRetentionVersion> backupVersions = new ArrayList<>();
+    List<HivePartitionRetentionVersion> trashVersions = new ArrayList<>();
+    List<HivePartitionVersion> selectedVersions = new ArrayList<>();
+    for (HivePartitionVersion version : versions) {
+      String prefix = this.dataset.getDbName() + ComplianceConfigurationKeys.DBNAME_SEPARATOR;
+      if (!version.getTableName().startsWith(prefix)) {
+        continue;
+      }
+      if (version.getTableName().contains(ComplianceConfigurationKeys.BACKUP)) {
+        backupVersions.add((HivePartitionRetentionVersion) version);
+      }
+      if (version.getTableName().contains(ComplianceConfigurationKeys.TRASH)) {
+        trashVersions.add((HivePartitionRetentionVersion) version);
+      }
+    }
+
+    for (HivePartitionRetentionVersion version : trashVersions) {
+      long ageInDays = TimeUnit.MILLISECONDS.toDays(version.getAgeInMilliSeconds());
+      if (ageInDays >= this.trashRetentionDays) {
+        selectedVersions.add(version);
+      }
+    }
+
+    if (backupVersions.isEmpty()) {
+      return selectedVersions;
+    }
+    Collections.sort(backupVersions);
+    selectedVersions.addAll(backupVersions.subList(this.backupRetentionVersions, versions.size()));
+    if (this.backupRetentionVersions == 0) {
+      return selectedVersions;
+    }
+
+    for (HivePartitionRetentionVersion version : backupVersions.subList(0, this.backupRetentionVersions)) {
+      long ageInDays = TimeUnit.MILLISECONDS.toDays(version.getAgeInMilliSeconds());
+      if (ageInDays >= this.backupRetentionDays) {
+        selectedVersions.add(version);
+      }
+    }
+    return selectedVersions;
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionReaper.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionReaper.java
@@ -93,10 +93,6 @@ public class HivePartitionVersionRetentionReaper extends HivePartitionVersionRet
         .getQueryExecutor(state, this.versionOwner, this.backUpOwner)) {
 
       Path newVersionLocation = getNewVersionLocation();
-      if (this.simulate) {
-        log.info("Simulate is set to true. Won't move the version " + completeName);
-        return;
-      }
 
       if (!this.versionOwnerFs.exists(versionLocation)) {
         log.info("Data versionLocation doesn't exist. Metadata will be dropped for the version  " + completeName);
@@ -104,6 +100,9 @@ public class HivePartitionVersionRetentionReaper extends HivePartitionVersionRet
         log.info(
             "Dataset location is same as version location. Won't delete the data but metadata will be dropped for the version "
                 + completeName);
+      } else if (this.simulate) {
+        log.info("Simulate is set to true. Won't move the version " + completeName);
+        return;
       } else if (completeName.contains(ComplianceConfigurationKeys.STAGING)) {
         log.info("Deleting data from version " + completeName);
         this.versionOwnerFs.delete(versionLocation, true);

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionReaper.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionReaper.java
@@ -1,0 +1,193 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.io.IOException;
+import java.sql.SQLException;
+import java.util.Arrays;
+import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsAction;
+import org.apache.hadoop.fs.permission.FsPermission;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.compliance.ComplianceConfigurationKeys;
+import gobblin.compliance.HivePartitionVersion;
+import gobblin.compliance.HiveProxyQueryExecutor;
+import gobblin.compliance.purger.HivePurgerQueryTemplate;
+import gobblin.compliance.utils.PartitionUtils;
+import gobblin.compliance.utils.ProxyUtils;
+import gobblin.configuration.State;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.version.DatasetVersion;
+import gobblin.util.HadoopUtils;
+
+import static gobblin.compliance.purger.HivePurgerQueryTemplate.getDropPartitionQuery;
+import static gobblin.compliance.purger.HivePurgerQueryTemplate.getUseDbQuery;
+
+
+/**
+ * Class to move/clean backups/staging partitions.
+ *
+ * @author adsharma
+ */
+@Slf4j
+public class HivePartitionVersionRetentionReaper extends HivePartitionVersionRetentionRunner {
+  private FileSystem versionOwnerFs;
+
+  private boolean simulate;
+  private Optional<String> versionOwner = Optional.absent();
+  private Optional<String> backUpOwner = Optional.absent();
+
+  public HivePartitionVersionRetentionReaper(CleanableDataset dataset, DatasetVersion version,
+      List<String> nonDeletableVersionLocations, State state) {
+    super(dataset, version, nonDeletableVersionLocations, state);
+    this.versionOwner = ((HivePartitionVersion) this.datasetVersion).getOwner();
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.BACKUP_OWNER),
+        "Missing required property " + ComplianceConfigurationKeys.BACKUP_OWNER);
+    this.backUpOwner = Optional.fromNullable(this.state.getProp(ComplianceConfigurationKeys.BACKUP_OWNER));
+    this.simulate = this.state.getPropAsBoolean(ComplianceConfigurationKeys.COMPLIANCE_JOB_SIMULATE,
+        ComplianceConfigurationKeys.DEFAULT_COMPLIANCE_JOB_SIMULATE);
+  }
+
+  /**
+   * If simulate is set to true, will simply return.
+   * If a version is pointing to a non-existing location, then drop the partition and close the jdbc connection.
+   * If a version is pointing to the same location as of the dataset, then drop the partition and close the jdbc connection.
+   * If a version is staging, it's data will be deleted and metadata is dropped.
+   * IF a versions is backup, it's data will be moved to a backup dir, current metadata will be dropped and it will
+   * be registered in the backup db.
+   */
+  @Override
+  public void clean()
+      throws IOException {
+    Path versionLocation = ((HivePartitionRetentionVersion) this.datasetVersion).getLocation();
+    Path datasetLocation = ((CleanableHivePartitionDataset) this.cleanableDataset).getLocation();
+    String completeName = ((HivePartitionRetentionVersion) this.datasetVersion).datasetURN();
+    State state = new State(this.state);
+
+    this.versionOwnerFs = ProxyUtils.getOwnerFs(state, this.versionOwner);
+
+    try (HiveProxyQueryExecutor queryExecutor = ProxyUtils
+        .getQueryExecutor(state, this.versionOwner, this.backUpOwner)) {
+
+      Path newVersionLocation = getNewVersionLocation();
+      if (this.simulate) {
+        log.info("Simulate is set to true. Won't move the version " + completeName);
+        return;
+      }
+
+      if (!this.versionOwnerFs.exists(versionLocation)) {
+        log.info("Data versionLocation doesn't exist. Metadata will be dropped for the version  " + completeName);
+      } else if (datasetLocation.toString().equalsIgnoreCase(versionLocation.toString())) {
+        log.info(
+            "Dataset location is same as version location. Won't delete the data but metadata will be dropped for the version "
+                + completeName);
+      } else if (completeName.contains(ComplianceConfigurationKeys.STAGING)) {
+        log.info("Deleting data from version " + completeName);
+        this.versionOwnerFs.delete(versionLocation, true);
+      } else if (completeName.contains(ComplianceConfigurationKeys.BACKUP)) {
+        executeAlterQueries(queryExecutor);
+        log.info("Creating new dir " + newVersionLocation.getParent().toString());
+        this.versionOwnerFs.mkdirs(newVersionLocation.getParent());
+        log.info("Moving data from " + versionLocation + " to " + newVersionLocation);
+        this.versionOwnerFs.rename(versionLocation, newVersionLocation);
+        FsPermission permission = new FsPermission(FsAction.ALL, FsAction.ALL, FsAction.NONE);
+        HadoopUtils
+            .setPermissions(newVersionLocation.getParent(), this.versionOwner, this.backUpOwner, this.versionOwnerFs,
+                permission);
+      }
+      executeDropVersionQueries(queryExecutor);
+    }
+  }
+
+  // These methods are not implemented by this class
+  @Override
+  public void preCleanAction() {
+
+  }
+
+  @Override
+  public void postCleanAction() {
+
+  }
+
+  private void executeAlterQueries(HiveProxyQueryExecutor queryExecutor)
+      throws IOException {
+    HivePartitionRetentionVersion version = (HivePartitionRetentionVersion) this.datasetVersion;
+    String partitionSpecString = PartitionUtils.getPartitionSpecString(version.getSpec());
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.BACKUP_DB),
+        "Missing required property " + ComplianceConfigurationKeys.BACKUP_DB);
+    String backUpDb = this.state.getProp(ComplianceConfigurationKeys.BACKUP_DB);
+    String backUpTableName = getCompleteTableName(version);
+    try {
+      queryExecutor.executeQuery(HivePurgerQueryTemplate.getUseDbQuery(backUpDb), this.backUpOwner);
+      queryExecutor.executeQuery(HivePurgerQueryTemplate
+          .getCreateTableQuery(backUpDb + "." + backUpTableName, version.getDbName(), version.getTableName(),
+              getBackUpTableLocation(version)), this.backUpOwner);
+      queryExecutor.executeQuery(HivePurgerQueryTemplate.getAddPartitionQuery(backUpTableName, partitionSpecString),
+          this.backUpOwner);
+      queryExecutor.executeQuery(HivePurgerQueryTemplate
+              .getAlterTableLocationQuery(backUpTableName, partitionSpecString, getNewVersionLocation().toString()),
+          this.backUpOwner);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private void executeDropVersionQueries(HiveProxyQueryExecutor queryExecutor)
+      throws IOException {
+    HivePartitionRetentionVersion version = (HivePartitionRetentionVersion) this.datasetVersion;
+    String partitionSpec = PartitionUtils.getPartitionSpecString(version.getSpec());
+    try {
+      queryExecutor.executeQuery(getUseDbQuery(version.getDbName()), this.versionOwner);
+      queryExecutor.executeQuery(getDropPartitionQuery(version.getTableName(), partitionSpec), this.versionOwner);
+    } catch (SQLException e) {
+      throw new IOException(e);
+    }
+  }
+
+  private String getVersionTimeStamp() {
+    return ((HivePartitionRetentionVersion) this.datasetVersion).getTimeStamp();
+  }
+
+  private String getCompleteTableName(HivePartitionVersion version) {
+    return version.getTableName();
+  }
+
+  private String getBackUpTableLocation(HivePartitionVersion version) {
+    Preconditions.checkArgument(this.state.contains(ComplianceConfigurationKeys.BACKUP_DIR),
+        "Missing required property " + ComplianceConfigurationKeys.BACKUP_DIR);
+    return StringUtils
+        .join(Arrays.asList(this.state.getProp(ComplianceConfigurationKeys.BACKUP_DIR), getCompleteTableName(version)),
+            '/');
+  }
+
+  private Path getNewVersionLocation() {
+    HivePartitionVersion version = (HivePartitionRetentionVersion) this.datasetVersion;
+    String backUpTableLocation = getBackUpTableLocation(version);
+    return new Path(
+        StringUtils.join(Arrays.asList(backUpTableLocation, getVersionTimeStamp(), version.getName()), '/'));
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionReaperPolicy.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionReaperPolicy.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Preconditions;
+
+import gobblin.compliance.ComplianceConfigurationKeys;
+import gobblin.compliance.HivePartitionDataset;
+import gobblin.compliance.HivePartitionVersion;
+import gobblin.compliance.HivePartitionVersionPolicy;
+import gobblin.configuration.State;
+
+
+public class HivePartitionVersionRetentionReaperPolicy extends HivePartitionVersionPolicy {
+  /**
+   * Number of days after which a {@link HivePartitionVersion} will be either moved to
+   * backup or deleted.
+   */
+  private int retentionDays;
+
+  public HivePartitionVersionRetentionReaperPolicy(State state, HivePartitionDataset dataset) {
+    super(state, dataset);
+    Preconditions.checkArgument(state.contains(ComplianceConfigurationKeys.REAPER_RETENTION_DAYS),
+        "Missing required property " + ComplianceConfigurationKeys.REAPER_RETENTION_DAYS);
+    this.retentionDays = state.getPropAsInt(ComplianceConfigurationKeys.REAPER_RETENTION_DAYS);
+  }
+
+  @Override
+  public boolean shouldSelect(HivePartitionVersion version) {
+    HivePartitionRetentionVersion partitionVersion = (HivePartitionRetentionVersion) version;
+    long ageInDays = TimeUnit.MILLISECONDS.toDays(partitionVersion.getAgeInMilliSeconds());
+    return ageInDays >= this.retentionDays;
+  }
+
+  @Override
+  public List<HivePartitionVersion> selectedList(List<HivePartitionVersion> versions) {
+    if (versions.isEmpty()) {
+      return versions;
+    }
+
+    Preconditions.checkArgument(versions.get(0) instanceof HivePartitionRetentionVersion);
+    List<HivePartitionVersion> selectedVersions = new ArrayList<>();
+    Collections.sort(versions);
+    for (HivePartitionVersion version : versions) {
+      if (shouldSelect(version)) {
+        selectedVersions.add(version);
+      }
+    }
+    return selectedVersions;
+  }
+}

--- a/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionRunner.java
+++ b/gobblin-modules/gobblin-compliance/src/main/java/gobblin/compliance/retention/HivePartitionVersionRetentionRunner.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.compliance.retention;
+
+import java.util.List;
+
+import gobblin.configuration.State;
+import gobblin.data.management.retention.dataset.CleanableDataset;
+import gobblin.data.management.retention.version.VersionCleaner;
+import gobblin.data.management.version.DatasetVersion;
+
+
+/**
+ * An abstract class for handling retention of {@link HivePartitionRetentionVersion}
+ *
+ * @author adsharma
+ */
+public abstract class HivePartitionVersionRetentionRunner extends VersionCleaner {
+  protected List<String> nonDeletableVersionLocations;
+  protected State state;
+
+  public HivePartitionVersionRetentionRunner(CleanableDataset dataset, DatasetVersion version,
+      List<String> nonDeletableVersionLocations, State state) {
+    super(version, dataset);
+    this.state = new State(state);
+    this.nonDeletableVersionLocations = nonDeletableVersionLocations;
+  }
+}


### PR DESCRIPTION
Work flow of Retetention:
1) ComplianceRetentionJob.run() is called by by the ComplianceAzkabanJob.
2) ComplianceRetentionJob will find all the HivePartitionDataset(s) for which retention needs to run. Note that here HivePartitionDataset refers to the original hive partitions not the backups/staging partitions.
3) For each HivePartitionDataset, HivePartitionVersionFinder will find associated versions. Here versions refer to a backup/staging partition corresponding to an original partition.
4) A HivePartitionVersionPolicy will be called to shortlist the versions which needs to deleted/moved. All the backups are moved to a backup directory after 2 days so that inflight queries won't get affected.
5) On each shortlisted version, a cleaner/reaper will run. Cleaner for deletion of backups. Reaper for deletion of staging and moving of backups to backup directory.