### PR TITLE
Throttle underlying input streams.

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DecryptConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DecryptConverter.java
@@ -55,11 +55,11 @@ public class DecryptConverter extends DistcpConverter {
   }
 
   @Override
-  public Function<FSDataInputStream, FSDataInputStream> inputStreamTransformation() {
-    return new Function<FSDataInputStream, FSDataInputStream>() {
+  public Function<InputStream, InputStream> inputStreamTransformation() {
+    return new Function<InputStream, InputStream>() {
       @Nullable
       @Override
-      public FSDataInputStream apply(FSDataInputStream input) {
+      public InputStream apply(InputStream input) {
         try {
           return GPGFileDecrypter.decryptFile(input, DecryptConverter.this.passphrase);
         } catch (IOException exception) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DistcpConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/DistcpConverter.java
@@ -17,10 +17,9 @@
 
 package gobblin.data.management.copy.converter;
 
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
-
-import org.apache.hadoop.fs.FSDataInputStream;
 
 import com.google.common.base.Function;
 
@@ -46,9 +45,9 @@ public abstract class DistcpConverter extends Converter<String, String, FileAwar
   }
 
   /**
-   * @return A {@link Function} that transforms the {@link FSDataInputStream} in the {@link FileAwareInputStream}.
+   * @return A {@link Function} that transforms the {@link InputStream} in the {@link FileAwareInputStream}.
    */
-  public abstract Function<FSDataInputStream, FSDataInputStream> inputStreamTransformation();
+  public abstract Function<InputStream, InputStream> inputStreamTransformation();
 
   /**
    * @return A list of extensions that should be removed from the output file name, which will be applied in order.
@@ -76,7 +75,7 @@ public abstract class DistcpConverter extends Converter<String, String, FileAwar
   }
 
   /**
-   * Applies the transformation in {@link #inputStreamTransformation} to the {@link FSDataInputStream} in the
+   * Applies the transformation in {@link #inputStreamTransformation} to the {@link InputStream} in the
    * {@link FileAwareInputStream}.
    */
   @Override
@@ -85,7 +84,7 @@ public abstract class DistcpConverter extends Converter<String, String, FileAwar
 
     modifyExtensionAtDestination(fileAwareInputStream.getFile());
     try {
-      FSDataInputStream newInputStream = inputStreamTransformation().apply(fileAwareInputStream.getInputStream());
+      InputStream newInputStream = inputStreamTransformation().apply(fileAwareInputStream.getInputStream());
       return new SingleRecordIterable<>(new FileAwareInputStream(fileAwareInputStream.getFile(), newInputStream));
     } catch (RuntimeException re) {
       throw new DataConversionException(re);

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/UnGzipConverter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/converter/UnGzipConverter.java
@@ -45,9 +45,9 @@ public class UnGzipConverter extends DistcpConverter {
   private static final String GZ_EXTENSION = ".gz";
   private static final String TGZ_EXTENSION = ".tgz";
 
-  @Override public Function<FSDataInputStream, FSDataInputStream> inputStreamTransformation() {
-    return new Function<FSDataInputStream, FSDataInputStream>() {
-      @Nullable @Override public FSDataInputStream apply(FSDataInputStream input) {
+  @Override public Function<InputStream, InputStream> inputStreamTransformation() {
+    return new Function<InputStream, InputStream>() {
+      @Nullable @Override public InputStream apply(InputStream input) {
         try {
           return StreamUtils.convertStream(new GZIPInputStream(input));
         } catch (IOException ioe) {

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/extractor/FileAwareInputStreamExtractor.java
@@ -23,6 +23,7 @@ import gobblin.data.management.copy.FileAwareInputStream;
 import gobblin.source.extractor.DataRecordException;
 import gobblin.source.extractor.Extractor;
 import gobblin.util.HadoopUtils;
+import gobblin.util.io.MeteredInputStream;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -79,7 +80,8 @@ public class FileAwareInputStreamExtractor implements Extractor<String, FileAwar
           this.state == null ? HadoopUtils.newConfiguration() : HadoopUtils.getConfFromState(this.state);
       FileSystem fsFromFile = this.file.getOrigin().getPath().getFileSystem(conf);
       this.recordRead = true;
-      return new FileAwareInputStream(this.file, fsFromFile.open(this.file.getFileStatus().getPath()));
+      return new FileAwareInputStream(this.file,
+          MeteredInputStream.builder().in(fsFromFile.open(this.file.getFileStatus().getPath())).build());
     }
     return null;
   }

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/TarArchiveInputStreamDataWriter.java
@@ -61,7 +61,7 @@ public class TarArchiveInputStreamDataWriter extends FileAwareInputStreamDataWri
    * @see gobblin.data.management.copy.writer.FileAwareInputStreamDataWriter#write(gobblin.data.management.copy.FileAwareInputStream)
    */
   @Override
-  public void writeImpl(FSDataInputStream inputStream, Path writeAt, CopyableFile copyableFile) throws IOException {
+  public void writeImpl(InputStream inputStream, Path writeAt, CopyableFile copyableFile) throws IOException {
     this.closer.register(inputStream);
 
     TarArchiveInputStream tarIn = new TarArchiveInputStream(inputStream);

--- a/gobblin-utility/src/main/java/gobblin/broker/DefaultBrokerCache.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/DefaultBrokerCache.java
@@ -106,7 +106,7 @@ class DefaultBrokerCache<S extends ScopeType<S>> {
     Object obj = this.sharedResourceCache.get(fullKey, new Callable<Object>() {
       @Override
       public Object call() throws Exception {
-        return factory.createResource(broker, broker.getConfigView(scope.getType(), key, factory.getName()));
+        return factory.createResource(broker.getScopedView(scope.getType()), broker.getConfigView(scope.getType(), key, factory.getName()));
       }
     });
     if (obj instanceof ResourceCoordinate) {

--- a/gobblin-utility/src/main/java/gobblin/broker/EmptyKey.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/EmptyKey.java
@@ -15,16 +15,17 @@
  * limitations under the License.
  */
 
-package java.io;
+package gobblin.broker;
 
-public class FilterStreamUnpacker {
+import gobblin.broker.iface.SharedResourceKey;
 
-  public static InputStream unpackFilterInputStream(FilterInputStream is) {
-    return is.in;
+
+/**
+ * A dummy {@link SharedResourceKey}.
+ */
+public final class EmptyKey implements SharedResourceKey {
+  @Override
+  public String toConfigurationKey() {
+    return null;
   }
-
-  public static OutputStream unpackFilterOutputStream(FilterOutputStream os) {
-    return os.out;
-  }
-
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/NonExtendableBrokerView.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/NonExtendableBrokerView.java
@@ -15,26 +15,27 @@
  * limitations under the License.
  */
 
-package gobblin.data.management.copy;
+package gobblin.broker;
 
-import java.io.InputStream;
+import java.util.List;
+import java.util.Map;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
+import gobblin.broker.iface.ScopeInstance;
+import gobblin.broker.iface.ScopeType;
+
 
 /**
- * A wrapper to {@link InputStream} that represents an entity to be copied. The enclosed {@link CopyableFile} instance
- * contains file Metadata like permission, destination path etc. required by the writers and converters.
+ * A view of a {@link SharedResourcesBrokerImpl} at a higher scope than the leaf scope. This is used only to pass into
+ * factories, and it does not allow creating subscoped brokers.
  */
-@AllArgsConstructor
-@Getter
-public class FileAwareInputStream {
-
-  private CopyableFile file;
-  private InputStream inputStream;
+class NonExtendableBrokerView<S extends ScopeType<S>> extends SharedResourcesBrokerImpl<S> {
+  public NonExtendableBrokerView(DefaultBrokerCache<S> brokerCache, ScopeWrapper<S> selfScope,
+      List<ScopedConfig<S>> scopedConfigs, Map<S, ScopeWrapper<S>> ancestorScopesByType) {
+    super(brokerCache, selfScope, scopedConfigs, ancestorScopesByType);
+  }
 
   @Override
-  public String toString() {
-    return this.file.toString();
+  public SubscopedBrokerBuilder newSubscopedBuilder(ScopeInstance<S> subscope) {
+    throw new UnsupportedOperationException();
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerImpl.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerImpl.java
@@ -25,6 +25,7 @@ import java.util.Queue;
 import java.util.concurrent.ExecutionException;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Predicate;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -40,6 +41,7 @@ import gobblin.broker.iface.SharedResourceKey;
 import gobblin.broker.iface.SharedResourcesBroker;
 import gobblin.util.ConfigUtils;
 
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.NotThreadSafe;
 import lombok.Data;
 
@@ -118,6 +120,16 @@ public class SharedResourcesBrokerImpl<S extends ScopeType<S>> implements Shared
     }
 
     return new KeyedScopedConfigViewImpl<>(scope, key, factoryName, config);
+  }
+
+  NonExtendableBrokerView<S> getScopedView(final S scope) throws NoSuchScopeException {
+    return new NonExtendableBrokerView<>(this.brokerCache, getWrappedScope(scope), this.scopedConfigs,
+        Maps.filterKeys(this.ancestorScopesByType, new Predicate<S>() {
+          @Override
+          public boolean apply(@Nullable S input) {
+            return SharedResourcesBrokerUtils.isScopeTypeAncestor(scope, input);
+          }
+        }));
   }
 
   ScopeWrapper<S> getWrappedScope(S scopeType) throws NoSuchScopeException {

--- a/gobblin-utility/src/main/java/gobblin/util/io/BatchedMeterDecorator.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/BatchedMeterDecorator.java
@@ -24,6 +24,9 @@ import gobblin.util.Decorator;
 import javax.annotation.concurrent.NotThreadSafe;
 
 
+/**
+ * A decorator to a {@link Meter} that batches updates for performance.
+ */
 @NotThreadSafe
 public class BatchedMeterDecorator implements Decorator {
 
@@ -58,6 +61,10 @@ public class BatchedMeterDecorator implements Decorator {
 
   @Override
   public Object getDecoratedObject() {
+    return this.underlying;
+  }
+
+  public Meter getUnderlyingMeter() {
     return this.underlying;
   }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/io/BatchedMeterDecorator.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/BatchedMeterDecorator.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import com.codahale.metrics.Meter;
+
+import gobblin.util.Decorator;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+
+@NotThreadSafe
+public class BatchedMeterDecorator implements Decorator {
+
+  private final Meter underlying;
+  private final int updateFrequency;
+  private int count;
+
+  public BatchedMeterDecorator(Meter underlying, int updateFrequency) {
+    this.underlying = underlying;
+    this.updateFrequency = updateFrequency;
+    this.count = 0;
+  }
+
+  public void mark() {
+    this.count++;
+    if (this.count > this.updateFrequency) {
+      updateUnderlying();
+    }
+  }
+
+  public void mark(long n) {
+    this.count += n;
+    if (this.count > this.updateFrequency) {
+      updateUnderlying();
+    }
+  }
+
+  private void updateUnderlying() {
+    this.underlying.mark(this.count);
+    this.count = 0;
+  }
+
+  @Override
+  public Object getDecoratedObject() {
+    return this.underlying;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/FilterStreamUnpacker.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/FilterStreamUnpacker.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.FilterInputStream;
+import java.io.FilterOutputStream;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.lang.reflect.Field;
+
+
+/**
+ * Contains utilities for getting uderlying streams to a filter stream.
+ */
+public class FilterStreamUnpacker {
+
+  /**
+   * Finds the underlying {@link InputStream} to a {@link FilterInputStream}. Note this is not always possible due
+   * to security restrictions of the JVM.
+   * @throws IllegalAccessException If security policies of the JVM prevent unpacking of the {@link FilterInputStream}.
+   */
+  public static InputStream unpackFilterInputStream(FilterInputStream is) throws IllegalAccessException {
+    try {
+      Field field = FilterInputStream.class.getDeclaredField("in");
+      field.setAccessible(true);
+      return (InputStream) field.get(is);
+    } catch (NoSuchFieldException nsfe) {
+      throw new RuntimeException(nsfe);
+    }
+  }
+
+  /**
+   * Finds the underlying {@link OutputStream} to a {@link FilterOutputStream}. Note this is not always possible due
+   * to security restrictions of the JVM.
+   * @throws IllegalAccessException If security policies of the JVM prevent unpacking of the {@link FilterOutputStream}.
+   */
+  public static OutputStream unpackFilterOutputStream(FilterOutputStream os) throws IllegalAccessException {
+    try {
+      Field field = FilterOutputStream.class.getDeclaredField("out");
+      field.setAccessible(true);
+      return (OutputStream) field.get(os);
+    } catch (NoSuchFieldException nsfe) {
+      throw new RuntimeException(nsfe);
+    }
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/MeteredInputStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/MeteredInputStream.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.FilterInputStream;
+import java.io.FilterStreamUnpacker;
+import java.io.IOException;
+import java.io.InputStream;
+
+import com.codahale.metrics.Meter;
+import com.google.common.base.Optional;
+
+import lombok.Getter;
+
+
+public class MeteredInputStream extends FilterInputStream {
+
+  public static Optional<MeteredInputStream> findWrappedMeteredInputStream(InputStream is) {
+    if (is instanceof FilterInputStream) {
+      Optional<MeteredInputStream> meteredInputStream =
+          findWrappedMeteredInputStream(FilterStreamUnpacker.unpackFilterInputStream((FilterInputStream) is));
+      if (meteredInputStream.isPresent()) {
+        return meteredInputStream;
+      }
+    }
+    if (is instanceof MeteredInputStream) {
+      return Optional.of((MeteredInputStream) is);
+    }
+    return Optional.absent();
+  }
+
+  @Getter
+  BatchedMeterDecorator meter;
+
+  public MeteredInputStream(InputStream in) {
+    this(in, null);
+  }
+
+  public MeteredInputStream(InputStream in, Meter meter) {
+    super(in);
+    this.meter = new BatchedMeterDecorator(meter == null ? new Meter() : meter, 1000);
+  }
+
+  @Override
+  public int read() throws IOException {
+    this.meter.mark();
+    return super.read();
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    int readBytes = super.read(b, off, len);
+    this.meter.mark(readBytes);
+    return readBytes;
+  }
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/MeteredOutputStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/MeteredOutputStream.java
@@ -18,48 +18,72 @@
 package gobblin.util.io;
 
 import java.io.FilterOutputStream;
-import java.io.FilterStreamUnpacker;
 import java.io.IOException;
 import java.io.OutputStream;
 
 import com.codahale.metrics.Meter;
 import com.google.common.base.Optional;
 
-import lombok.Getter;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
 
 
-public class MeteredOutputStream extends FilterOutputStream {
+/**
+ * A {@link FilterOutputStream} that counts the bytes read from the underlying {@link OutputStream}.
+ */
+@Slf4j
+public class MeteredOutputStream extends FilterOutputStream implements MeteredStream {
 
-  public static Optional<MeteredOutputStream> findWrappedMeteredOutputStream(OutputStream is) {
-    if (is instanceof FilterOutputStream) {
-      Optional<MeteredOutputStream> meteredOutputStream =
-          findWrappedMeteredOutputStream(FilterStreamUnpacker.unpackFilterOutputStream((FilterOutputStream) is));
-      if (meteredOutputStream.isPresent()) {
-        return meteredOutputStream;
+  /**
+   * Find the lowest {@link MeteredOutputStream} in a chain of {@link FilterOutputStream}s.
+   */
+  public static Optional<MeteredOutputStream> findWrappedMeteredOutputStream(OutputStream os) {
+    if (os instanceof FilterOutputStream) {
+      try {
+        Optional<MeteredOutputStream> meteredOutputStream =
+            findWrappedMeteredOutputStream(FilterStreamUnpacker.unpackFilterOutputStream((FilterOutputStream) os));
+        if (meteredOutputStream.isPresent()) {
+          return meteredOutputStream;
+        }
+      } catch (IllegalAccessException iae) {
+        log.warn("Cannot unpack input stream due to SecurityManager.", iae);
+        // Do nothing, we can't unpack the FilterInputStream due to security restrictions
       }
     }
-    if (is instanceof MeteredOutputStream) {
-      return Optional.of((MeteredOutputStream) is);
+    if (os instanceof MeteredOutputStream) {
+      return Optional.of((MeteredOutputStream) os);
     }
     return Optional.absent();
   }
 
-  @Getter
   BatchedMeterDecorator meter;
 
-  public MeteredOutputStream(OutputStream out) {
-    this(out, null);
-  }
-
-  public MeteredOutputStream(OutputStream out, Meter meter) {
+  /**
+   * Builds a {@link MeteredOutputStream}.
+   * @param out The {@link OutputStream} to measure.
+   * @param meter A {@link Meter} to use for measuring the {@link OutputStream}. If null, a new {@link Meter} will be created.
+   * @param updateFrequency For performance, {@link MeteredInputStream} will batch {@link Meter} updates to this many bytes.
+   */
+  @Builder
+  public MeteredOutputStream(OutputStream out, Meter meter, int updateFrequency) {
     super(out);
-    this.meter = new BatchedMeterDecorator(meter == null ? new Meter() : meter, 1000);
+    this.meter = new BatchedMeterDecorator(meter == null ? new Meter() : meter, updateFrequency > 0 ? updateFrequency : 1000);
   }
 
   @Override
   public void write(int b) throws IOException {
     this.meter.mark();
-    out.write(b);
+    this.out.write(b);
   }
 
+  @Override
+  public void write(byte[] b, int off, int len) throws IOException {
+    this.meter.mark(len);
+    this.out.write(b, off, len);
+  }
+
+  @Override
+  public Meter getBytesProcessedMeter() {
+    return this.meter.getUnderlyingMeter();
+  }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/io/MeteredOutputStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/MeteredOutputStream.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.FilterOutputStream;
+import java.io.FilterStreamUnpacker;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import com.codahale.metrics.Meter;
+import com.google.common.base.Optional;
+
+import lombok.Getter;
+
+
+public class MeteredOutputStream extends FilterOutputStream {
+
+  public static Optional<MeteredOutputStream> findWrappedMeteredOutputStream(OutputStream is) {
+    if (is instanceof FilterOutputStream) {
+      Optional<MeteredOutputStream> meteredOutputStream =
+          findWrappedMeteredOutputStream(FilterStreamUnpacker.unpackFilterOutputStream((FilterOutputStream) is));
+      if (meteredOutputStream.isPresent()) {
+        return meteredOutputStream;
+      }
+    }
+    if (is instanceof MeteredOutputStream) {
+      return Optional.of((MeteredOutputStream) is);
+    }
+    return Optional.absent();
+  }
+
+  @Getter
+  BatchedMeterDecorator meter;
+
+  public MeteredOutputStream(OutputStream out) {
+    this(out, null);
+  }
+
+  public MeteredOutputStream(OutputStream out, Meter meter) {
+    super(out);
+    this.meter = new BatchedMeterDecorator(meter == null ? new Meter() : meter, 1000);
+  }
+
+  @Override
+  public void write(int b) throws IOException {
+    this.meter.mark();
+    out.write(b);
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/MeteredStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/MeteredStream.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import com.codahale.metrics.Meter;
+
+
+public interface MeteredStream {
+  Meter getMeter();
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/MeteredStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/MeteredStream.java
@@ -20,6 +20,12 @@ package gobblin.util.io;
 import com.codahale.metrics.Meter;
 
 
+/**
+ * A {@link java.io.InputStream} or {@link java.io.OutputStream} that measures bytes processed.
+ */
 public interface MeteredStream {
-  Meter getMeter();
+  /**
+   * @return The {@link Meter} measuring the bytes processed.
+   */
+  Meter getBytesProcessedMeter();
 }

--- a/gobblin-utility/src/main/java/gobblin/util/io/StreamCopier.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/StreamCopier.java
@@ -46,9 +46,6 @@ public class StreamCopier {
   private final WritableByteChannel outputChannel;
   private int bufferSize = DEFAULT_BUFFER_SIZE;
   private Meter copySpeedMeter;
-  private Limiter bytesTransferredLimiter;
-  private MeteredStream inputMeter;
-  private MeteredStream outputMeter;
 
   private boolean closeChannelsOnComplete = false;
   private volatile boolean copied = false;
@@ -75,15 +72,6 @@ public class StreamCopier {
    */
   public StreamCopier withCopySpeedMeter(Meter copySpeedMeter) {
     this.copySpeedMeter = copySpeedMeter;
-    return this;
-  }
-
-  /**
-   * Set a {@link Limiter} to throttle the bytes transferred. Before filling the buffer, the copier will request
-   * as many permits as bytes fit in the buffer.
-   */
-  public StreamCopier withBytesTransferedLimiter(Limiter limiter) {
-    this.bytesTransferredLimiter = limiter;
     return this;
   }
 
@@ -140,15 +128,7 @@ public class StreamCopier {
   }
 
   private long fillBufferFromInputChannel(ByteBuffer buffer) throws IOException {
-    try (Closeable permit = this.bytesTransferredLimiter == null ? NOOP_CLOSEABLE :
-        this.bytesTransferredLimiter.acquirePermits(this.bufferSize)) {
-      if (permit == null) {
-        throw new NotEnoughPermitsException();
-      }
-      return this.inputChannel.read(buffer);
-    } catch (InterruptedException ie) {
-      throw new IOException("Stream copier was interrupted!", ie);
-    }
+    return this.inputChannel.read(buffer);
   }
 
   /**

--- a/gobblin-utility/src/main/java/gobblin/util/io/StreamCopier.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/StreamCopier.java
@@ -47,6 +47,9 @@ public class StreamCopier {
   private int bufferSize = DEFAULT_BUFFER_SIZE;
   private Meter copySpeedMeter;
   private Limiter bytesTransferredLimiter;
+  private MeteredStream inputMeter;
+  private MeteredStream outputMeter;
+
   private boolean closeChannelsOnComplete = false;
   private volatile boolean copied = false;
 

--- a/gobblin-utility/src/main/java/gobblin/util/io/StreamThrottler.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/StreamThrottler.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.InputStream;
+import java.net.URI;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+
+import gobblin.broker.EmptyKey;
+import gobblin.broker.ResourceInstance;
+import gobblin.broker.iface.ConfigView;
+import gobblin.broker.iface.NotConfiguredException;
+import gobblin.broker.iface.ScopeType;
+import gobblin.broker.iface.ScopedConfigView;
+import gobblin.broker.iface.SharedResourceFactory;
+import gobblin.broker.iface.SharedResourceFactoryResponse;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.util.limiter.Limiter;
+import gobblin.util.limiter.MultiLimiter;
+import gobblin.util.limiter.NoopLimiter;
+import gobblin.util.limiter.broker.SharedLimiterFactory;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A class used to throttle {@link InputStream}s.
+ * @param <S>
+ */
+@Slf4j
+@AllArgsConstructor
+public class StreamThrottler<S extends ScopeType<S>> {
+
+  /**
+   * A {@link SharedResourceFactory} that creates {@link StreamThrottler}.
+   */
+  public static class Factory<S extends ScopeType<S>> implements SharedResourceFactory<StreamThrottler<S>, EmptyKey, S> {
+    public static final String NAME = "streamThrottler";
+
+    @Override
+    public String getName() {
+      return NAME;
+    }
+
+    @Override
+    public SharedResourceFactoryResponse<StreamThrottler<S>> createResource(SharedResourcesBroker<S> broker,
+        ScopedConfigView<S, EmptyKey> config) throws NotConfiguredException {
+      return new ResourceInstance<>(new StreamThrottler<>(broker));
+    }
+
+    @Override
+    public S getAutoScope(SharedResourcesBroker<S> broker, ConfigView<S, EmptyKey> config) {
+      return broker.selfScope().getType();
+    }
+  }
+
+  private final SharedResourcesBroker<S> broker;
+
+  /**
+   * Throttles an {@link InputStream} if throttling is configured.
+   * @param inputStream {@link InputStream} to throttle.
+   * @param sourceURI used for selecting the throttling policy.
+   * @param targetURI used for selecting the throttling policy.
+   */
+  @Builder(builderMethodName = "throttleInputStream", builderClassName = "InputStreamThrottler")
+  private ThrottledInputStream doThrottleInputStream(InputStream inputStream, URI sourceURI, URI targetURI) {
+    Preconditions.checkNotNull(inputStream, "InputStream cannot be null.");
+
+    Limiter limiter = new NoopLimiter();
+    if (sourceURI != null && targetURI != null) {
+      StreamCopierSharedLimiterKey key = new StreamCopierSharedLimiterKey(sourceURI, targetURI);
+      try {
+        limiter = new MultiLimiter(limiter, this.broker.getSharedResource(new SharedLimiterFactory<S>(),
+            key));
+      } catch (NotConfiguredException nce) {
+        log.warn("Could not create a Limiter for key " + key, nce);
+      }
+    } else {
+      log.info("Not throttling input stream because source or target URIs are not defined.");
+    }
+
+    Optional<MeteredInputStream> meteredStream = MeteredInputStream.findWrappedMeteredInputStream(inputStream);
+    if (!meteredStream.isPresent()) {
+      meteredStream = Optional.of(MeteredInputStream.builder().in(inputStream).build());
+      inputStream = meteredStream.get();
+    }
+
+    return new ThrottledInputStream(inputStream, limiter, meteredStream.get());
+  }
+
+}

--- a/gobblin-utility/src/main/java/gobblin/util/io/ThrottledInputStream.java
+++ b/gobblin-utility/src/main/java/gobblin/util/io/ThrottledInputStream.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.Closeable;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import gobblin.util.limiter.Limiter;
+
+import javax.annotation.concurrent.NotThreadSafe;
+
+
+/**
+ * A throttled {@link InputStream}.
+ */
+@NotThreadSafe
+public class ThrottledInputStream extends FilterInputStream {
+
+  private final Limiter limiter;
+  private final MeteredInputStream meter;
+
+  private long prevCount;
+
+  /**
+   * Builds a {@link ThrottledInputStream}.
+   *
+   * It is recommended to use a {@link StreamThrottler} for creation of {@link ThrottledInputStream}s.
+   *
+   * @param in {@link InputStream} to throttle.
+   * @param limiter {@link Limiter} to use for throttling.
+   * @param meter {@link MeteredInputStream} used to measure the {@link InputStream}. Note the {@link MeteredInputStream}
+   *                                        MUST be in the {@link FilterInputStream} chain of {@link #in}.
+   */
+  public ThrottledInputStream(InputStream in, Limiter limiter, MeteredInputStream meter) {
+    super(in);
+    this.limiter = limiter;
+    this.meter = meter;
+    // In case the meter was already used
+    this.prevCount = this.meter.getBytesProcessedMeter().getCount();
+  }
+
+  @Override
+  public int read() throws IOException {
+    blockUntilPermitsAvailable();
+    return this.in.read();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    blockUntilPermitsAvailable();
+    return this.in.read(b);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    blockUntilPermitsAvailable();
+    return this.in.read(b, off, len);
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    super.reset();
+    this.prevCount = this.meter.getBytesProcessedMeter().getCount();
+  }
+
+  private void blockUntilPermitsAvailable() {
+    try {
+      long currentCount = this.meter.getBytesProcessedMeter().getCount();
+      long permitsNeeded = currentCount - this.prevCount;
+      this.prevCount = currentCount;
+      Closeable permit = this.limiter.acquirePermits(permitsNeeded);
+      if (permit == null) {
+        throw new RuntimeException("Could not acquire permits.");
+      }
+    } catch (InterruptedException ie) {
+      throw new RuntimeException(ie);
+    }
+  }
+}

--- a/gobblin-utility/src/main/java/java/io/FilterStreamUnpacker.java
+++ b/gobblin-utility/src/main/java/java/io/FilterStreamUnpacker.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package java.io;
+
+public class FilterStreamUnpacker {
+
+  public static InputStream unpackFilterInputStream(FilterInputStream is) {
+    return is.in;
+  }
+
+  public static OutputStream unpackFilterOutputStream(FilterOutputStream os) {
+    return os.out;
+  }
+
+}

--- a/gobblin-utility/src/test/java/gobblin/util/io/MeteredInputStreamTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/io/MeteredInputStreamTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataInputStream;
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Meter;
+import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
+
+
+public class MeteredInputStreamTest {
+
+  @Test
+  public void test() throws Exception {
+    InputStream is = new ByteArrayInputStream("aabbccddee".getBytes(Charsets.UTF_8));
+
+    Meter meter = new Meter();
+    MeteredInputStream mis = MeteredInputStream.builder().in(is).meter(meter).updateFrequency(1).build();
+
+    InputStream skipped = new MyInputStream(mis);
+    DataInputStream dis = new DataInputStream(skipped);
+
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+
+    IOUtils.copy(dis, os);
+    String output = os.toString(Charsets.UTF_8.name());
+
+    Assert.assertEquals(output, "abcde");
+
+    Optional<MeteredInputStream> meteredOpt = MeteredInputStream.findWrappedMeteredInputStream(dis);
+    Assert.assertEquals(meteredOpt.get(), mis);
+    Assert.assertEquals(meteredOpt.get().getBytesProcessedMeter().getCount(), 10);
+  }
+
+  /**
+   * An input stream that skips every second byte
+   */
+  public static class MyInputStream extends FilterInputStream {
+    public MyInputStream(InputStream in) {
+      super(in);
+    }
+
+    @Override
+    public int read() throws IOException {
+      int bte = super.read();
+      if (bte == -1) {
+        return bte;
+      }
+      return super.read();
+    }
+
+    @Override
+    public int read(byte[] b, int off, int len) throws IOException {
+      for (int i = 0; i < len; i++) {
+        byte bte = (byte) read();
+        if (bte == -1) {
+          return i == 0 ? -1 : i;
+        }
+        b[off + i] = bte;
+      }
+      return len;
+    }
+  }
+
+}

--- a/gobblin-utility/src/test/java/gobblin/util/io/MeteredOutputStreamTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/io/MeteredOutputStreamTest.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.FilterOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.codahale.metrics.Meter;
+import com.google.common.base.Charsets;
+import com.google.common.base.Optional;
+
+
+public class MeteredOutputStreamTest {
+
+  @Test
+  public void test() throws Exception {
+
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    Meter meter = new Meter();
+    MeteredOutputStream mos = MeteredOutputStream.builder().out(outputStream).meter(meter).updateFrequency(1).build();
+
+    MyOutputStream duplicated = new MyOutputStream(mos);
+    DataOutputStream dos = new DataOutputStream(duplicated);
+
+    dos.write("abcde".getBytes(Charsets.UTF_8));
+
+    Assert.assertEquals(outputStream.toString(Charsets.UTF_8.name()), "aabbccddee");
+    Optional<MeteredOutputStream> meteredOutputStream = MeteredOutputStream.findWrappedMeteredOutputStream(dos);
+    Assert.assertEquals(meteredOutputStream.get(), mos);
+    Assert.assertEquals(meteredOutputStream.get().getBytesProcessedMeter().getCount(), 10);
+  }
+
+  /**
+   * An {@link OutputStream} that duplicates every byte.
+   */
+  private static class MyOutputStream extends FilterOutputStream {
+    public MyOutputStream(OutputStream out) {
+      super(out);
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      this.out.write(b);
+      this.out.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      for (int i = 0; i < len; i++) {
+        write(b[off + i]);
+      }
+    }
+  }
+
+}

--- a/gobblin-utility/src/test/java/gobblin/util/io/StreamCopierTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/io/StreamCopierTest.java
@@ -71,29 +71,4 @@ public class StreamCopierTest {
     Assert.assertEquals(meter.getCount(), testString.length());
   }
 
-  @Test
-  public void testLimiter() throws Exception {
-    String testString = "This is a string";
-
-    ByteArrayInputStream inputStream = new ByteArrayInputStream(testString.getBytes(Charsets.UTF_8));
-    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-    try {
-      new StreamCopier(inputStream, outputStream).withBufferSize(10)
-          .withBytesTransferedLimiter(new CountBasedLimiter(10))
-          .copy();
-      Assert.fail();
-    } catch (StreamCopier.NotEnoughPermitsException npe) {
-      // expected
-    }
-
-    inputStream.reset();
-    outputStream.reset();
-
-    new StreamCopier(inputStream, outputStream).withBufferSize(10)
-        .withBytesTransferedLimiter(new CountBasedLimiter(30))
-        .copy();
-    Assert.assertEquals(testString, new String(outputStream.toByteArray(), Charsets.UTF_8));
-  }
-
 }

--- a/gobblin-utility/src/test/java/gobblin/util/io/ThrottledInputStreamTest.java
+++ b/gobblin-utility/src/test/java/gobblin/util/io/ThrottledInputStreamTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.io;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+
+import org.apache.commons.io.IOUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Charsets;
+
+import gobblin.util.limiter.CountBasedLimiter;
+import gobblin.util.limiter.Limiter;
+
+
+public class ThrottledInputStreamTest {
+
+  @Test
+  public void test() throws Exception {
+    ByteArrayInputStream inputStream = new ByteArrayInputStream("abcde".getBytes(Charsets.UTF_8));
+    MeteredInputStream meteredInputStream = MeteredInputStream.builder().in(inputStream).updateFrequency(1).build();
+    Limiter limiter = new CountBasedLimiter(4);
+
+    InputStream throttled = new ThrottledInputStream(meteredInputStream, limiter, meteredInputStream);
+    try {
+      String output = IOUtils.toString(throttled, Charsets.UTF_8);
+      Assert.fail();
+    } catch (RuntimeException re) {
+      // Expected
+    }
+
+    meteredInputStream.reset();
+    limiter = new CountBasedLimiter(5);
+    throttled = new ThrottledInputStream(meteredInputStream, limiter, meteredInputStream);
+
+    Assert.assertEquals(IOUtils.toString(throttled, Charsets.UTF_8), "abcde");
+  }
+
+}


### PR DESCRIPTION
The main point of this PR is that we should throttle underlying streams instead of the streams that Gobblin replication sees. For example, if a replication flow does on-the-fly compression / decompression, we want to limit the bytes per second that are actually going through the network, not the output of compression / decompression.

Few changes:
* Introduce metered streams to measure bytes processed in an input/output stream.
* Introduce throttled input stream that is transparently throttled, and a `StreamThrottler` to create the throttled input streams.
* Added the concept of a BrokerView that allows a higher scoped immutable view of a broker. This is necessary for correct functionality of some factories.
* There is no reason replication should use `FSDataInputStream`, so changed to use `InputStream` (this is a backwards incompatible change, but it was overly restrictive).
