### PR TITLE
Enable partitioning based on source info + partitioned metadata writes

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -214,6 +214,7 @@ public class ConfigurationKeys {
   public static final String WORK_UNIT_WORKING_STATE_KEY = "workunit.working.state";
   public static final String WORK_UNIT_STATE_RUNTIME_HIGH_WATER_MARK = "workunit.state.runtime.high.water.mark";
   public static final String WORK_UNIT_STATE_ACTUAL_HIGH_WATER_MARK_KEY = "workunit.state.actual.high.water.mark";
+  public static final String WORK_UNIT_DATE_PARTITION_KEY = "workunit.source.date.partition";
 
   /**
    * Watermark interval related configuration properties.
@@ -313,6 +314,7 @@ public class ConfigurationKeys {
 
   // Internal use only - used to send metadata to publisher
   public static final String WRITER_METADATA_KEY = WRITER_PREFIX + "._internal.metadata";
+  public static final String WRITER_PARTITION_PATH_KEY = WRITER_PREFIX + "._internal.partition.path";
 
   /**
    * Writer configuration properties used internally.

--- a/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
+++ b/gobblin-api/src/main/java/gobblin/publisher/DataPublisher.java
@@ -62,8 +62,13 @@ public abstract class DataPublisher implements Closeable {
    * @throws IOException if there is a problem with publishing the metadata or the data.
    */
   public void publish(Collection<? extends WorkUnitState> states) throws IOException {
-    publishMetadata(states);
-    publishData(states);
+    if (shouldPublishMetadataFirst()) {
+      publishMetadata(states);
+      publishData(states);
+    } else {
+      publishData(states);
+      publishMetadata(states);
+    }
   }
 
   public State getState() {
@@ -93,5 +98,13 @@ public abstract class DataPublisher implements Closeable {
    */
   public boolean isThreadSafe() {
     return this.getClass() == DataPublisher.class;
+  }
+
+  /**
+   * Generally metadata should be published before the data it represents, but this allows subclasses to override
+   * if they are dependent on data getting published first.
+   */
+  protected boolean shouldPublishMetadataFirst() {
+    return true;
   }
 }

--- a/gobblin-core/src/main/java/gobblin/source/DatePartitionedAvroFileSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/DatePartitionedAvroFileSource.java
@@ -62,57 +62,57 @@ import gobblin.source.workunit.WorkUnit;
 /**
  * Implementation of {@link gobblin.source.Source} that reads over date-partitioned Avro data.
  * This source can be regarded as the reader equivalent of {@link TimeBasedAvroWriterPartitioner}.
- * 
+ *
  * <p>
  * The class will iterate through all the data folders given by the base directory
- * {@link ConfigurationKeys#SOURCE_FILEBASED_DATA_DIRECTORY} and the partitioning type 
+ * {@link ConfigurationKeys#SOURCE_FILEBASED_DATA_DIRECTORY} and the partitioning type
  * {@link #DATE_PARTITIONED_SOURCE_PARTITION_PATTERN} or {@link #DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY}
- * 
+ *
  * <p>
  * For example, if the base directory is set to /my/data/ and daily partitioning is used, then it is assumed that
- * /my/data/daily/[year]/[month]/[day] is present. It will iterate through all the data under these folders starting 
- * from the date specified by {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until either 
- * {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data 
+ * /my/data/daily/[year]/[month]/[day] is present. It will iterate through all the data under these folders starting
+ * from the date specified by {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} until either
+ * {@link #DATE_PARTITIONED_SOURCE_MAX_FILES_PER_JOB} files have been processed, or until there is no more data
  * to process. For example, if {@link #DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE} is set to 2015/01/01, then the job
  * will read from the folder /my/data/daily/2015/01/02/, /my/data/daily/2015/01/03/, /my/data/2015/01/04/ etc.
  * When partitions contain pre/suffixes in the form of /my/data/prefix/[year]/[month]/[day]/suffix, one can refer to
  * them via the {@link #DATE_PARTITIONED_SOURCE_PARTITION_PREFIX} and {@link #DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX}
  * properties.
  * </p>
- * 
+ *
  * </p>
- * 
+ *
  * The class will only process data in Avro format.
  */
 public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, GenericRecord> {
-  
+
   // Configuration parameters
   private static final String DATE_PARTITIONED_SOURCE_PREFIX = "date.partitioned.source";
-  
+
   private static final String DATE_PARTITIONED_SOURCE_PARTITION_PREFIX =
       DATE_PARTITIONED_SOURCE_PREFIX + ".partition.prefix";
-  
+
   private static final String DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX =
       DATE_PARTITIONED_SOURCE_PREFIX + ".partition.suffix";
-  
+
   static final String DATE_PARTITIONED_SOURCE_PARTITION_PATTERN =
       DATE_PARTITIONED_SOURCE_PREFIX + ".partition.pattern";
-  
+
   private static final String DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY =
       DATE_PARTITIONED_SOURCE_PREFIX + ".partition.granularity";
   private static final DatePartitionType DEFAULT_DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY =
       DatePartitionType.HOUR;
-  
+
   /**
-  * A String of the format defined by {@link #DATE_PARTITIONED_SOURCE_PARTITION_PATTERN} or 
-  * {@link #DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY}. For example for yyyy/MM/dd the 
-  * 2015/01/01 corresponds to January 1st, 2015. The job will start reading data from this point in time. 
+  * A String of the format defined by {@link #DATE_PARTITIONED_SOURCE_PARTITION_PATTERN} or
+  * {@link #DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY}. For example for yyyy/MM/dd the
+  * 2015/01/01 corresponds to January 1st, 2015. The job will start reading data from this point in time.
   * If this parameter is not specified the job will start reading data from
   * the beginning of Unix time.
   */
   private static final String DATE_PARTITIONED_SOURCE_MIN_WATERMARK_VALUE =
       DATE_PARTITIONED_SOURCE_PREFIX + ".min.watermark.value";
-  
+
   /**
   * The maximum number of files that this job should process.
   */
@@ -162,7 +162,7 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
   private String sourcePartitionSuffix;
   private DateTimeFormatter partitionPatternFormatter;
   private DurationFieldType incrementalUnit;
-  
+
   /**
    * Gobblin calls the {@link Source#getWorkunits(SourceState)} method after creating a {@link Source} object with a
    * blank constructor, so any custom initialization of the object needs to be done here.
@@ -170,9 +170,9 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
   protected void init(SourceState state) {
     DateTimeZone.setDefault(DateTimeZone
         .forID(state.getProp(ConfigurationKeys.SOURCE_TIMEZONE, ConfigurationKeys.DEFAULT_SOURCE_TIMEZONE)));
-    
+
     initDatePartition(state);
-    
+
     try {
       initFileSystemHelper(state);
     } catch (FileBasedHelperException e) {
@@ -199,20 +199,20 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
     this.fileCount = 0;
 
     this.sourceDir = new Path(state.getProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY));
-    
+
     this.sourcePartitionPrefix = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_PREFIX, StringUtils.EMPTY);
-    
+
     this.sourcePartitionSuffix = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_SUFFIX, StringUtils.EMPTY);
-    
+
   }
-  
+
   private void initDatePartition(State state) {
     initDatePartitionFromPattern(state);
     if (this.partitionPatternFormatter == null) {
       initDatePartitionFromGranularity(state);
     }
   }
-  
+
   private void initDatePartitionFromPattern(State state) {
     String partitionPattern = null;
     try {
@@ -227,7 +227,7 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
       throw new IllegalArgumentException("Invalid source partition pattern: " + partitionPattern, e);
     }
   }
-  
+
   private void initDatePartitionFromGranularity(State state) {
     String granularityProp = state.getProp(DATE_PARTITIONED_SOURCE_PARTITION_GRANULARITY);
     DatePartitionType partitionType = null;
@@ -243,7 +243,7 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
     this.partitionPatternFormatter = DateTimeFormat.forPattern(partitionType.getDateTimePattern());
     this.incrementalUnit = partitionType.getDateTimeFieldType().getDurationType();
   }
-  
+
   @Override
   public void initFileSystemHelper(State state) throws FileBasedHelperException {
     this.fsHelper = new AvroFsHelper(state);
@@ -320,10 +320,10 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
     // Process all data from the lowWaterMark date until the maxFilesPerJob has been hit
     for (DateTime date = lowWaterMarkDate; !date.isAfter(currentDay) && this.fileCount < this.maxFilesPerJob; date =
         date.withFieldAdded(incrementalUnit, 1)) {
-       
+
       // Constructs the path folder - e.g. /my/data/prefix/2015/01/01/suffix
       Path sourcePath = constructSourcePath(date);
-      
+
       try {
         if (this.fs.exists(sourcePath)) {
 
@@ -365,12 +365,25 @@ public class DatePartitionedAvroFileSource extends FileBasedSource<Schema, Gener
   }
 
   private Path constructSourcePath(DateTime date) {
-    return new Path(this.sourceDir, this.sourcePartitionPrefix + Path.SEPARATOR
-        + this.partitionPatternFormatter.print(date) + Path.SEPARATOR + this.sourcePartitionSuffix);
+    StringBuilder pathBuilder = new StringBuilder();
+
+    if (!this.sourcePartitionPrefix.isEmpty()) {
+      pathBuilder.append(this.sourcePartitionPrefix);
+      pathBuilder.append(Path.SEPARATOR);
+    }
+
+    pathBuilder.append(this.partitionPatternFormatter.print(date));
+
+    if (!this.sourcePartitionSuffix.isEmpty()) {
+      pathBuilder.append(Path.SEPARATOR);
+      pathBuilder.append(this.sourcePartitionSuffix);
+    }
+
+    return new Path(this.sourceDir, pathBuilder.toString());
   }
-  
+
   /**
-   * Gets the LWM for this job runs. The new LWM is the HWM of the previous run + 1 unit (day,hour,minute..etc). 
+   * Gets the LWM for this job runs. The new LWM is the HWM of the previous run + 1 unit (day,hour,minute..etc).
    * If there was no previous execution then it is set to the given lowWaterMark + 1 unit.
    */
   private long getLowWaterMark(Iterable<WorkUnitState> previousStates, String lowWaterMark) {

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -145,6 +145,11 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Spec
     for (StreamCodec c : getEncoders()) {
       this.defaultMetadata.addTransferEncoding(c.getTag());
     }
+
+    String partitionPath = builder.getPartitionPath(properties);
+    if (builder.getPartitionPath(properties) != null) {
+      properties.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + builder.getWriterId(), partitionPath);
+    }
   }
 
   /**

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriterBuilder.java
@@ -81,15 +81,22 @@ public abstract class FsDataWriterBuilder<S, D> extends PartitionAwareDataWriter
     return properties.getProp(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY, StringUtils.EMPTY);
   }
 
-  protected String getPartitionedFileName(State properties, String originalFileName) {
-    boolean includePartitionerFieldNames = properties.getPropAsBoolean(
-        ForkOperatorUtils.getPropertyNameForBranch(WRITER_INCLUDE_PARTITION_IN_FILE_NAMES, this.branches, this.branch),
-        false);
-    boolean removePathSeparators = properties.getPropAsBoolean(ForkOperatorUtils
-        .getPropertyNameForBranch(WRITER_REPLACE_PATH_SEPARATORS_IN_PARTITIONS, this.branches, this.branch), false);
+  protected String getPartitionPath(State properties) {
+    if (this.partition.isPresent()) {
+      boolean includePartitionerFieldNames = properties.getPropAsBoolean(ForkOperatorUtils
+          .getPropertyNameForBranch(WRITER_INCLUDE_PARTITION_IN_FILE_NAMES, this.branches, this.branch), false);
+      boolean removePathSeparators = properties.getPropAsBoolean(ForkOperatorUtils
+          .getPropertyNameForBranch(WRITER_REPLACE_PATH_SEPARATORS_IN_PARTITIONS, this.branches, this.branch), false);
 
+      return AvroUtils.serializeAsPath(this.partition.get(), includePartitionerFieldNames, removePathSeparators).toString();
+    } else {
+      return null;
+    }
+  }
+
+  protected String getPartitionedFileName(State properties, String originalFileName) {
     return new Path(
-        AvroUtils.serializeAsPath(this.partition.get(), includePartitionerFieldNames, removePathSeparators).toString(),
+        getPartitionPath(properties),
         originalFileName).toString();
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/partitioner/WorkUnitStateWriterPartitioner.java
+++ b/gobblin-core/src/main/java/gobblin/writer/partitioner/WorkUnitStateWriterPartitioner.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.writer.partitioner;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+
+
+/**
+ * A #{@link TimeBasedWriterPartitioner} that partitions an incoming set of records based purely
+ * on WorkUnitState.
+ */
+public class WorkUnitStateWriterPartitioner extends TimeBasedWriterPartitioner<Object> {
+  private final long timestamp;
+
+  public WorkUnitStateWriterPartitioner(State state, int numBranches, int branches) {
+    super(state, numBranches, branches);
+    this.timestamp = calculateTimestamp(state);
+  }
+
+  @Override
+  public long getRecordTimestamp(Object record) {
+    return timestamp;
+  }
+
+  private long calculateTimestamp(State state) {
+    long timestamp = state.getPropAsLong(ConfigurationKeys.WORK_UNIT_DATE_PARTITION_KEY, -1L);
+    if (timestamp == -1L) {
+      throw new IllegalArgumentException(
+          "WORK_UNIT_DATE_PARTITION_KEY not present in WorkUnitState; is source an instance of DatePartitionedAvroFileSource?");
+    }
+
+    return timestamp;
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/source/extractor/DatePartitionedAvroFileExtractorTest.java
+++ b/gobblin-core/src/test/java/gobblin/source/extractor/DatePartitionedAvroFileExtractorTest.java
@@ -65,11 +65,11 @@ public class DatePartitionedAvroFileExtractorTest {
 
   private static final String PREFIX = "minutes";
   private static final String SUFFIX = "test";
-  private static final String SOURCE_ENTITY = "testsource"; 
-  
+  private static final String SOURCE_ENTITY = "testsource";
+
   private static final String DATE_PATTERN = "yyyy/MM/dd/HH_mm";
   private static final int RECORD_SIZE = 4;
-  
+
   private static final String AVRO_SCHEMA =
     "{" +
       "\"type\" : \"record\"," +
@@ -93,9 +93,9 @@ public class DatePartitionedAvroFileExtractorTest {
 
   @BeforeClass
   public void setUp() throws IOException {
-    
+
     this.schema = new Schema.Parser().parse(AVRO_SCHEMA);
-    
+
     //set up datetime objects
     DateTime now = new DateTime(TZ).minusHours(2);
     this.startDateTime =
@@ -128,7 +128,7 @@ public class DatePartitionedAvroFileExtractorTest {
         .withWriterId("writer-1")
         .withSchema(this.schema)
         .withBranches(1).forBranch(0);
-    
+
     this.writer = new PartitionedDataWriter<Schema, GenericRecord>(builder, state);
 
     GenericRecordBuilder genericRecordBuilder = new GenericRecordBuilder(this.schema);
@@ -165,6 +165,35 @@ public class DatePartitionedAvroFileExtractorTest {
     List<WorkUnit> workunits = source.getWorkunits(state);
 
     Assert.assertEquals(workunits.size(), 4);
+    verifyWorkUnits(workunits);
+  }
+
+  @Test
+  public void testWorksNoPrefix() throws IOException, DataRecordException {
+    DatePartitionedAvroFileSource source = new DatePartitionedAvroFileSource();
+
+    SourceState state = new SourceState();
+    state.setProp(ConfigurationKeys.SOURCE_FILEBASED_FS_URI, ConfigurationKeys.LOCAL_FS_URI);
+    state.setProp(ConfigurationKeys.EXTRACT_NAMESPACE_NAME_KEY, SOURCE_ENTITY);
+    state.setProp(ConfigurationKeys.SOURCE_FILEBASED_DATA_DIRECTORY, OUTPUT_DIR + Path.SEPARATOR + SOURCE_ENTITY + Path.SEPARATOR + PREFIX);
+    state.setProp(ConfigurationKeys.SOURCE_ENTITY, SOURCE_ENTITY);
+    state.setProp(ConfigurationKeys.SOURCE_MAX_NUMBER_OF_PARTITIONS, 2);
+
+    state.setProp("date.partitioned.source.partition.pattern", DATE_PATTERN);
+    state.setProp("date.partitioned.source.min.watermark.value", DateTimeFormat.forPattern(DATE_PATTERN).print(
+        this.startDateTime.minusMinutes(1)));
+    state.setProp(ConfigurationKeys.EXTRACT_TABLE_TYPE_KEY, TableType.SNAPSHOT_ONLY);
+    state.setProp("date.partitioned.source.partition.suffix", SUFFIX);
+
+    //Read data partitioned by minutes, i.e each workunit is assigned records under the same YYYY/MM/dd/HH_mm directory
+    List<WorkUnit> workunits = source.getWorkunits(state);
+
+    Assert.assertEquals(workunits.size(), 4);
+    verifyWorkUnits(workunits);
+  }
+
+  private void verifyWorkUnits(List<WorkUnit> workunits)
+      throws IOException, DataRecordException {
     for (int i = 0; i < RECORD_SIZE; i++) {
       WorkUnit workUnit = ((MultiWorkUnit) workunits.get(i)).getWorkUnits().get(0);
       WorkUnitState wuState = new WorkUnitState(workunits.get(i), new State());


### PR DESCRIPTION
@ibuenros @shirshanka 

- Fix an issue in DatePartitionedAvroFileSource where the code would not
resolve paths properly if the prefix config property was empty
- Enhance the AvroFileSource to send along the partition it extracted
in WorkUnitState
- Create a WorkUnitStateWriterPartitioner that will partition an
incoming record solely based on WorkUnitState
- Update writers to set any partition paths they use in an internal
PARTITION_PATH_KEY
- Update BaseDataPublisher to collect partition information and publish
metadata files in each partition directory if the metadata output
directory is not specifically configured somewhere else.
- Update BaseDataPublisher to publish metadata _after_ publishing data.
If this isn't done - and partitions are enabled - then the code that
publishes all of the data files ends up publishing them as
subdirectories into the partition path. (Eg you get
/out/2017-01-01/2017-01-01/data.json).