### PR TITLE
Refactor RestApiConnector and RestApiExtractor

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -481,6 +481,8 @@ public class ConfigurationKeys {
   public static final String SOURCE_CONN_PORT = SOURCE_CONN_PREFIX + "port";
   public static final int SOURCE_CONN_DEFAULT_PORT = 22;
   public static final String SOURCE_CONN_SID = SOURCE_CONN_PREFIX + "sid";
+  public static final String SOURCE_CONN_REFRESH_TOKEN = SOURCE_CONN_PREFIX + "refresh.token";
+
 
   /**
    * Source default configurations.

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiConnector.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiConnector.java
@@ -109,14 +109,7 @@ public abstract class RestApiConnector {
 
         JsonObject jsonRet = json.getAsJsonObject();
         log.info("jsonRet: " + jsonRet.toString());
-        if (!hasId(jsonRet)) {
-          throw new RestApiConnectionException("Failed on authentication with the following HTTP response received:"
-              + json.toString().length() + ", string value: " + json.toString());
-        }
-
-        this.instanceUrl = jsonRet.get("instance_url").getAsString();
-        this.accessToken = jsonRet.get("access_token").getAsString();
-        this.createdAt = System.currentTimeMillis();
+        parseAuthenticationResponse(jsonRet);
       }
     } catch (IOException e) {
       throw new RestApiConnectionException("Failed to get rest api connection; error - " + e.getMessage(), e);
@@ -195,7 +188,7 @@ public abstract class RestApiConnector {
     return output;
   }
 
-  private void addHeaders(HttpRequestBase httpRequest) {
+  protected void addHeaders(HttpRequestBase httpRequest) {
     if (this.accessToken != null) {
       httpRequest.addHeader("Authorization", "OAuth " + this.accessToken);
     }
@@ -253,4 +246,14 @@ public abstract class RestApiConnector {
    */
   public abstract HttpEntity getAuthentication() throws RestApiConnectionException;
 
+  protected void parseAuthenticationResponse(JsonObject jsonRet) throws RestApiConnectionException {
+    if (!hasId(jsonRet)) {
+      throw new RestApiConnectionException("Failed on authentication with the following HTTP response received:"
+          + jsonRet.toString());
+    }
+
+    this.instanceUrl = jsonRet.get("instance_url").getAsString();
+    this.accessToken = jsonRet.get("access_token").getAsString();
+    this.createdAt = System.currentTimeMillis();
+  }
 }

--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/restapi/RestApiExtractor.java
@@ -73,10 +73,11 @@ public abstract class RestApiExtractor extends QueryBasedExtractor<JsonArray, Js
 
   protected abstract RestApiConnector getConnector(WorkUnitState state);
 
-  protected void buildQuery(String inputQuery, String entity, JsonArray columnArray) {
+  protected String buildDataQuery(String inputQuery, String entity) {
+    String dataQuery = null;
     if (inputQuery == null && this.columnList.size() != 0) {
       // if input query is null, build the query from metadata
-      this.updatedQuery = "SELECT " + Joiner.on(",").join(this.columnList) + " FROM " + entity;
+      dataQuery = "SELECT " + Joiner.on(",").join(this.columnList) + " FROM " + entity;
     } else {
       // if input query is not null, build the query with intersection of columns from input query and columns from Metadata
       if (inputQuery != null) {
@@ -85,13 +86,14 @@ public abstract class RestApiExtractor extends QueryBasedExtractor<JsonArray, Js
         int columnsEndIndex = queryLowerCase.indexOf(" from ");
         if (columnsStartIndex > 0 && columnsEndIndex > 0) {
           String givenColumnList = inputQuery.substring(columnsStartIndex, columnsEndIndex);
-          this.updatedQuery = inputQuery.replace(givenColumnList, Joiner.on(",").join(this.columnList));
+          dataQuery = inputQuery.replace(givenColumnList, Joiner.on(",").join(this.columnList));
         } else {
-          this.updatedQuery = inputQuery;
+          dataQuery = inputQuery;
         }
       }
     }
-    log.info("Updated input query: " + this.updatedQuery);
+    log.info("Updated data query: " + dataQuery);
+    return dataQuery;
   }
 
   @Override
@@ -153,7 +155,7 @@ public abstract class RestApiExtractor extends QueryBasedExtractor<JsonArray, Js
         }
       }
 
-      buildQuery(inputQuery, entity, columnArray);
+      this.updatedQuery = buildDataQuery(inputQuery, entity);
       log.info("Schema:" + columnArray);
       this.setOutputSchema(columnArray);
     } catch (RuntimeException | RestApiConnectionException | RestApiProcessingException | IOException


### PR DESCRIPTION
To extend RestApiConnector and RestApiExtractor for other data source, some methods need to be able to override