### PR TITLE
Can run custom tasks in Gobblin.

### DIFF
--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/event/EventSubmitter.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/event/EventSubmitter.java
@@ -52,7 +52,7 @@ public class EventSubmitter {
     private final String namespace;
 
     public Builder(MetricContext metricContext, String namespace) {
-      this(Optional.of(metricContext), namespace);
+      this(Optional.fromNullable(metricContext), namespace);
     }
 
     public Builder(Optional<MetricContext> metricContext, String namespace) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -17,13 +17,6 @@
 
 package gobblin.runtime;
 
-import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
-import gobblin.broker.gobblin_scopes.TaskScopeInstance;
-import gobblin.broker.iface.SharedResourcesBroker;
-import gobblin.runtime.task.TaskIFace;
-import gobblin.runtime.task.TaskUtils;
-import gobblin.runtime.task.TaskFactory;
-import gobblin.runtime.task.TaskIFaceWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -33,7 +26,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
-import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,6 +35,9 @@ import com.google.common.collect.Iterators;
 import com.google.common.collect.Lists;
 
 import gobblin.annotation.Alpha;
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import gobblin.broker.gobblin_scopes.TaskScopeInstance;
+import gobblin.broker.iface.SharedResourcesBroker;
 import gobblin.broker.iface.SubscopedBrokerBuilder;
 import gobblin.commit.CommitStep;
 import gobblin.configuration.ConfigurationKeys;
@@ -50,6 +45,9 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.metastore.StateStore;
 import gobblin.metrics.event.EventSubmitter;
 import gobblin.metrics.event.JobEvent;
+import gobblin.runtime.task.TaskFactory;
+import gobblin.runtime.task.TaskIFaceWrapper;
+import gobblin.runtime.task.TaskUtils;
 import gobblin.runtime.util.JobMetrics;
 import gobblin.source.workunit.WorkUnit;
 import gobblin.util.Either;

--- a/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/GobblinMultiTaskAttempt.java
@@ -20,6 +20,10 @@ package gobblin.runtime;
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.gobblin_scopes.TaskScopeInstance;
 import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.runtime.task.TaskIFace;
+import gobblin.runtime.task.TaskUtils;
+import gobblin.runtime.task.TaskFactory;
+import gobblin.runtime.task.TaskIFaceWrapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
@@ -29,6 +33,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 
+import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -294,8 +299,7 @@ public class GobblinMultiTaskAttempt {
         workUnitState.setProp(ConfigurationKeys.TASK_ATTEMPT_ID_KEY, this.containerIdOptional.get());
       }
       // Create a new task from the work unit and submit the task to run
-      Task task = new Task(new TaskContext(workUnitState), this.taskStateTracker, this.taskExecutor,
-                           Optional.of(countDownLatch));
+      Task task = createTaskRunnable(workUnitState, countDownLatch);
       this.taskStateTracker.registerNewTask(task);
       tasks.add(task);
       this.taskExecutor.execute(task);
@@ -305,6 +309,17 @@ public class GobblinMultiTaskAttempt {
         .submit(JobEvent.TASKS_SUBMITTED, "tasksCount", Integer.toString(workUnits.size()));
 
     return tasks;
+  }
+
+  private Task createTaskRunnable(WorkUnitState workUnitState, CountDownLatch countDownLatch) {
+    Optional<TaskFactory> taskFactoryOpt = TaskUtils.getTaskFactory(workUnitState);
+    if (taskFactoryOpt.isPresent()) {
+      return new TaskIFaceWrapper(taskFactoryOpt.get().createTask(new TaskContext(workUnitState)), new TaskContext(workUnitState),
+          countDownLatch, this.taskStateTracker);
+    } else {
+      return new Task(new TaskContext(workUnitState), this.taskStateTracker, this.taskExecutor,
+          Optional.of(countDownLatch));
+    }
   }
 
   public void runAndOptionallyCommitTaskAttempt(CommitPolicy multiTaskAttemptCommitPolicy)
@@ -347,7 +362,6 @@ public class GobblinMultiTaskAttempt {
    * @param taskStateTracker a {@link TaskStateTracker} for task state tracking
    * @param taskExecutor a {@link TaskExecutor} for task execution
    * @param taskStateStore a {@link StateStore} for storing {@link TaskState}s
-   * @param logger a {@link Logger} for logging
    * @param multiTaskAttemptCommitPolicy {@link GobblinMultiTaskAttempt.CommitPolicy} for committing {@link GobblinMultiTaskAttempt}
    * @throws IOException if there's something wrong with any IO operations
    * @throws InterruptedException if the task execution gets cancelled

--- a/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/JobContext.java
@@ -403,6 +403,8 @@ public class JobContext implements Closeable {
           }).iterator(), numCommitThreads, ExecutorsUtils.newThreadFactory(Optional.of(this.logger), Optional.of("Commit-thread-%d")))
           .executeAndGetResults();
 
+      IteratorExecutor.logFailures(result, LOG, 10);
+
       if (!IteratorExecutor.verifyAllSuccessful(result)) {
         this.jobState.setState(JobState.RunningState.FAILED);
         throw new IOException("Failed to commit dataset state for some dataset(s) of job " + this.jobId);

--- a/gobblin-runtime/src/main/java/gobblin/runtime/SafeDatasetCommit.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/SafeDatasetCommit.java
@@ -107,7 +107,8 @@ final class SafeDatasetCommit implements Callable<Void> {
                 taskFactory.createDataPublisher(this.datasetState);
             if (this.isMultithreaded && !publisher.isThreadSafe()) {
               log.warn(String.format(
-                  "Gobblin is set up to parallelize publishing, however the publisher %s is not thread-safe. " + "Falling back to serial publishing.", publisher.getClass().getName()));
+                  "Gobblin is set up to parallelize publishing, however the publisher %s is not thread-safe. "
+                      + "Falling back to serial publishing.", publisher.getClass().getName()));
               safeCommitDataset(entry.getValue(), publisher);
             } else {
               commitDataset(entry.getValue(), publisher);
@@ -124,12 +125,10 @@ final class SafeDatasetCommit implements Callable<Void> {
       log.error(String.format("Failed to instantiate data publisher for dataset %s of job %s.", this.datasetUrn,
               this.jobContext.getJobId()), roe);
       throw new RuntimeException(roe);
-    } catch (IOException ioe) {
+    } catch (Throwable throwable) {
       log.error(String.format("Failed to commit dataset state for dataset %s of job %s", this.datasetUrn,
-          this.jobContext.getJobId()), ioe);
-      throw new RuntimeException(ioe);
-    } catch (Throwable t) {
-      log.error("Error", t);
+          this.jobContext.getJobId()), throwable);
+      throw new RuntimeException(throwable);
     } finally {
       try {
         finalizeDatasetState(datasetState, datasetUrn);
@@ -185,7 +184,7 @@ final class SafeDatasetCommit implements Callable<Void> {
     private final TaskFactory taskFactory;
 
     public boolean equals(Object other) {
-      if (other instanceof TaskFactoryWrapper) {
+      if (canEqual(other)) {
         if (this.taskFactory == null) {
           return ((TaskFactoryWrapper) other).taskFactory == null;
         }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -80,6 +80,8 @@ import gobblin.writer.MultiWriterWatermarkManager;
 import gobblin.writer.WatermarkManager;
 import gobblin.writer.WatermarkStorage;
 
+import lombok.NoArgsConstructor;
+
 
 /**
  * A physical unit of execution for a Gobblin {@link gobblin.source.workunit.WorkUnit}.
@@ -109,6 +111,7 @@ import gobblin.writer.WatermarkStorage;
  *
  * @author Yinan Li
  */
+@NoArgsConstructor(force = true)
 public class Task implements TaskIFace {
 
   private static final Logger LOG = LoggerFactory.getLogger(Task.class);
@@ -142,29 +145,6 @@ public class Task implements TaskIFace {
 
   private final AtomicBoolean shutdownRequested;
   private final CountDownLatch shutdownLatch;
-
-  public Task() {
-    this.taskContext = null;
-    this.taskState = null;
-    this.jobId = null;
-    this.taskId = null;
-    this.taskStateTracker = null;
-    this.taskExecutor = null;
-    this.countDownLatch = null;
-    this.closer = null;
-    this.extractor = null;
-    this.converter = null;
-    this.rowChecker = null;
-    this.taskMode = null;
-    this.recordsPulled = null;
-    this.lastRecordPulledTimestampMillis = 0;
-    this.shutdownRequested = null;
-    this.shutdownLatch = null;
-    this.watermarkingStrategy = null;
-    this.watermarkManager = null;
-    this.watermarkTracker = null;
-    this.watermarkStorage = null;
-  }
 
   /**
    * Instantiate a new {@link Task}.

--- a/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/Task.java
@@ -17,6 +17,8 @@
 
 package gobblin.runtime;
 
+import gobblin.configuration.State;
+import gobblin.runtime.task.TaskIFace;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -107,7 +109,7 @@ import gobblin.writer.WatermarkStorage;
  *
  * @author Yinan Li
  */
-public class Task implements Runnable {
+public class Task implements TaskIFace {
 
   private static final Logger LOG = LoggerFactory.getLogger(Task.class);
 
@@ -140,6 +142,29 @@ public class Task implements Runnable {
 
   private final AtomicBoolean shutdownRequested;
   private final CountDownLatch shutdownLatch;
+
+  public Task() {
+    this.taskContext = null;
+    this.taskState = null;
+    this.jobId = null;
+    this.taskId = null;
+    this.taskStateTracker = null;
+    this.taskExecutor = null;
+    this.countDownLatch = null;
+    this.closer = null;
+    this.extractor = null;
+    this.converter = null;
+    this.rowChecker = null;
+    this.taskMode = null;
+    this.recordsPulled = null;
+    this.lastRecordPulledTimestampMillis = 0;
+    this.shutdownRequested = null;
+    this.shutdownLatch = null;
+    this.watermarkingStrategy = null;
+    this.watermarkManager = null;
+    this.watermarkTracker = null;
+    this.watermarkStorage = null;
+  }
 
   /**
    * Instantiate a new {@link Task}.
@@ -551,6 +576,21 @@ public class Task implements Runnable {
    */
   public TaskState getTaskState() {
     return this.taskState;
+  }
+
+  @Override
+  public State getPersistentState() {
+    return getTaskState();
+  }
+
+  @Override
+  public State getExecutionMetadata() {
+    return getTaskState();
+  }
+
+  @Override
+  public WorkUnitState.WorkingState getWorkingState() {
+    return getTaskState().getWorkingState();
   }
 
   /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/BaseAbstractTask.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/BaseAbstractTask.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime.task;
+
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.metrics.MetricContext;
+import gobblin.runtime.TaskContext;
+import gobblin.runtime.util.TaskMetrics;
+
+
+/**
+ * A base implementation of {@link TaskIFace}.
+ */
+public abstract class BaseAbstractTask implements TaskIFace {
+
+  protected WorkUnitState.WorkingState workingState = WorkUnitState.WorkingState.PENDING;
+  protected MetricContext metricContext;
+
+  public BaseAbstractTask(TaskContext taskContext) {
+    this.metricContext = TaskMetrics.get(taskContext.getTaskState()).getMetricContext();
+  }
+
+  /**
+   * Overriding methods should call super at the end.
+   */
+  @Override
+  public void run() {
+    this.workingState = WorkUnitState.WorkingState.SUCCESSFUL;
+  }
+
+  /**
+   * Overriding methods should call super at the end.
+   */
+  @Override
+  public void commit() {
+    this.workingState = WorkUnitState.WorkingState.SUCCESSFUL;
+  }
+
+  @Override
+  public State getPersistentState() {
+    return new State();
+  }
+
+  @Override
+  public State getExecutionMetadata() {
+    return new State();
+  }
+
+  @Override
+  public WorkUnitState.WorkingState getWorkingState() {
+    return this.workingState;
+  }
+
+  @Override
+  public void shutdown() {
+    if (getWorkingState() == WorkUnitState.WorkingState.PENDING || getWorkingState() == WorkUnitState.WorkingState.RUNNING) {
+      this.workingState = WorkUnitState.WorkingState.CANCELLED;
+    }
+  }
+
+  @Override
+  public boolean awaitShutdown(long timeoutMillis) {
+    return true;
+  }
+
+  @Override
+  public String getProgress() {
+    return getWorkingState().toString();
+  }
+
+  @Override
+  public boolean isSpeculativeExecutionSafe() {
+    return false;
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskFactory.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskFactory.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime.task;
+
+import gobblin.publisher.DataPublisher;
+import gobblin.runtime.JobState;
+
+import gobblin.runtime.TaskContext;
+
+
+/**
+ * Builds {@link TaskIFace} and {@link DataPublisher}s for a Gobblin execution.
+ */
+public interface TaskFactory {
+
+  /**
+   * Builds a {@link TaskIFace} for the input {@link TaskContext}.
+   */
+  TaskIFace createTask(TaskContext taskContext);
+
+  /**
+   * Build a {@link DataPublisher} for the input {@link gobblin.runtime.JobState.DatasetState}.
+   */
+  DataPublisher createDataPublisher(JobState.DatasetState datasetState);
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskIFace.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskIFace.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime.task;
+
+import gobblin.annotation.Alpha;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+
+
+/**
+ * The interface that a task to be run in Gobblin should implement.
+ */
+@Alpha
+public interface TaskIFace extends Runnable {
+
+  /**
+   * Execute the bulk of the work for this task. Due to possible speculative execution, all operations in this method
+   * should be attempt-isolated.
+   */
+  void run();
+
+  /**
+   * Commit the data to the job staging location. This method is guaranteed to be called only once per task, even if
+   * a task is attempted in multiple containers.
+   */
+  void commit();
+
+  /**
+   * @return The persistent state for this task. This is the state that will be available in the next Gobblin execution.
+   */
+  State getPersistentState();
+
+  /**
+   * @return The metadata corresponding to this task execution. This metadata will be available to the publisher and may
+   *         be viewable by the user, but may not be stored for the next Gobblin execution.
+   */
+  State getExecutionMetadata();
+
+  /**
+   * @return The current working state of the task.
+   */
+  WorkUnitState.WorkingState getWorkingState();
+
+  /**
+   * Prematurely shutdown the task.
+   */
+  void shutdown();
+
+  /**
+   * Block until the task finishes shutting down. This method is guaranteed to only be called after {@link #shutdown()}
+   * is called.
+   * @param timeoutMillis The method should return after this many millis regardless of the shutdown of the task.
+   * @return true if the task shut down correctly.
+   * @throws InterruptedException
+   */
+  boolean awaitShutdown(long timeoutMillis) throws InterruptedException;
+
+  /**
+   * @return a string describing the progress of this task.
+   */
+  String getProgress();
+
+  /**
+   * @return true if the {@link #run()} method is safe to be executed in various executors at the same time.
+   */
+  boolean isSpeculativeExecutionSafe();
+
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskIFaceWrapper.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskIFaceWrapper.java
@@ -17,8 +17,12 @@
 
 package gobblin.runtime.task;
 
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
 import com.google.common.base.Optional;
 import com.google.common.collect.Lists;
+
 import gobblin.configuration.State;
 import gobblin.configuration.WorkUnitState;
 import gobblin.runtime.Task;
@@ -26,9 +30,6 @@ import gobblin.runtime.TaskContext;
 import gobblin.runtime.TaskState;
 import gobblin.runtime.TaskStateTracker;
 import gobblin.runtime.fork.Fork;
-
-import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 
 /**

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskIFaceWrapper.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskIFaceWrapper.java
@@ -1,0 +1,169 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime.task;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.runtime.Task;
+import gobblin.runtime.TaskContext;
+import gobblin.runtime.TaskState;
+import gobblin.runtime.TaskStateTracker;
+import gobblin.runtime.fork.Fork;
+
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+
+
+/**
+ * An extension of {@link Task} that wraps a generic {@link TaskIFace} for backwards compatibility.
+ */
+public class TaskIFaceWrapper extends Task {
+
+  private final TaskIFace underlyingTask;
+  private final TaskContext taskContext;
+  private final String jobId;
+  private final String taskId;
+  private final CountDownLatch countDownLatch;
+  private final TaskStateTracker taskStateTracker;
+  private int retryCount = 0;
+
+  public TaskIFaceWrapper(TaskIFace underlyingTask, TaskContext taskContext, CountDownLatch countDownLatch,
+      TaskStateTracker taskStateTracker) {
+    super();
+    this.underlyingTask = underlyingTask;
+    this.taskContext = taskContext;
+    this.jobId = taskContext.getTaskState().getJobId();
+    this.taskId = taskContext.getTaskState().getTaskId();
+    this.countDownLatch = countDownLatch;
+    this.taskStateTracker = taskStateTracker;
+  }
+
+  @Override
+  public boolean awaitShutdown(long timeoutInMillis) throws InterruptedException {
+    return this.underlyingTask.awaitShutdown(timeoutInMillis);
+  }
+
+  @Override
+  public void shutdown() {
+    this.underlyingTask.shutdown();
+  }
+
+  @Override
+  public String getProgress() {
+    return this.underlyingTask.getProgress();
+  }
+
+  @Override
+  public void run() {
+    this.underlyingTask.run();
+    this.taskStateTracker.onTaskRunCompletion(this);
+  }
+
+  @Override
+  public String getJobId() {
+    return this.jobId;
+  }
+
+  @Override
+  public String getTaskId() {
+    return this.taskId;
+  }
+
+  @Override
+  public TaskContext getTaskContext() {
+    return this.taskContext;
+  }
+
+  @Override
+  public TaskState getTaskState() {
+    TaskState taskState = this.taskContext.getTaskState();
+    taskState.setTaskId(getTaskId());
+    taskState.setJobId(getJobId());
+    taskState.setWorkingState(getWorkingState());
+    taskState.addAll(getExecutionMetadata());
+    taskState.addAll(getPersistentState());
+    return taskState;
+  }
+
+  @Override
+  public State getPersistentState() {
+    return this.underlyingTask.getPersistentState();
+  }
+
+  @Override
+  public State getExecutionMetadata() {
+    return this.underlyingTask.getExecutionMetadata();
+  }
+
+  @Override
+  public WorkUnitState.WorkingState getWorkingState() {
+    return this.underlyingTask.getWorkingState();
+  }
+
+  @Override
+  public List<Optional<Fork>> getForks() {
+    return Lists.newArrayList();
+  }
+
+  @Override
+  public void updateRecordMetrics() {
+  }
+
+  @Override
+  public void updateByteMetrics() {
+  }
+
+  @Override
+  public void incrementRetryCount() {
+    this.retryCount++;
+  }
+
+  @Override
+  public int getRetryCount() {
+    return this.retryCount;
+  }
+
+  @Override
+  public void markTaskCompletion() {
+    if (this.countDownLatch != null) {
+      this.countDownLatch.countDown();
+    }
+  }
+
+  @Override
+  public String toString() {
+    return this.underlyingTask.toString();
+  }
+
+  @Override
+  public void commit() {
+    this.underlyingTask.commit();
+    this.taskStateTracker.onTaskCommitCompletion(this);
+  }
+
+  @Override
+  protected void submitTaskCommittedEvent() {
+  }
+
+  @Override
+  public boolean isSpeculativeExecutionSafe() {
+    return this.underlyingTask.isSpeculativeExecutionSafe();
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskUtils.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/TaskUtils.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime.task;
+
+import com.google.common.base.Optional;
+import gobblin.configuration.State;
+
+
+/**
+ * Task utilities.
+ */
+public class TaskUtils {
+
+  private static final String TASK_FACTORY_CLASS = "gobblin.runtime.taskFactoryClass";
+
+  /**
+   * Parse the {@link TaskFactory} in the state if one is defined.
+   */
+  public static Optional<TaskFactory> getTaskFactory(State state) {
+    try {
+      if (state.contains(TASK_FACTORY_CLASS)) {
+        return Optional.of((TaskFactory) Class.forName(state.getProp(TASK_FACTORY_CLASS)).newInstance());
+      } else {
+        return Optional.absent();
+      }
+    } catch (ReflectiveOperationException roe) {
+      throw new RuntimeException("Could not create task factory.", roe);
+    }
+  }
+
+  /**
+   * Define the {@link TaskFactory} that should be used to run this task.
+   */
+  public static void setTaskFactoryClass(State state, Class<? extends TaskFactory> klazz) {
+    state.setProp(TASK_FACTORY_CLASS, klazz.getName());
+  }
+
+}

--- a/gobblin-runtime/src/main/resources/embedded/embedded.conf
+++ b/gobblin-runtime/src/main/resources/embedded/embedded.conf
@@ -21,6 +21,8 @@
 
 GOBBLIN_WORK_DIR=/tmp/gobblin/work_dir
 
+job.name=EmbeddedGobblin
+
 # Thread pool settings for the task executor
 taskexecutor.threadpool.size=2
 taskretry.threadpool.coresize=1

--- a/gobblin-runtime/src/test/java/gobblin/task/CustomTaskTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/task/CustomTaskTest.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.task;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Queues;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
+import com.google.common.eventbus.EventBus;
+import com.google.common.eventbus.Subscribe;
+import com.google.common.io.Files;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.SourceState;
+import gobblin.configuration.State;
+import gobblin.configuration.WorkUnitState;
+import gobblin.publisher.DataPublisher;
+import gobblin.publisher.NoopPublisher;
+import gobblin.runtime.JobState;
+import gobblin.runtime.TaskContext;
+import gobblin.runtime.TaskState;
+import gobblin.runtime.api.JobExecutionResult;
+import gobblin.runtime.embedded.EmbeddedGobblin;
+import gobblin.runtime.task.BaseAbstractTask;
+import gobblin.runtime.task.TaskFactory;
+import gobblin.runtime.task.TaskIFace;
+import gobblin.runtime.task.TaskUtils;
+import gobblin.source.Source;
+import gobblin.source.extractor.Extractor;
+import gobblin.source.workunit.WorkUnit;
+import gobblin.writer.test.TestingEventBuses;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.Set;
+import java.util.UUID;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class CustomTaskTest {
+
+  @Test
+  public void testCustomTask() throws Exception {
+
+    String eventBusId = UUID.randomUUID().toString();
+    MyListener listener = new MyListener();
+
+    EventBus eventBus = TestingEventBuses.getEventBus(eventBusId);
+    eventBus.register(listener);
+
+    JobExecutionResult result =
+        new EmbeddedGobblin("testJob").setConfiguration(ConfigurationKeys.SOURCE_CLASS_KEY, MySource.class.getName())
+        .setConfiguration(MySource.NUM_TASKS_KEY, "10").setConfiguration(MyFactory.EVENTBUS_ID_KEY, eventBusId)
+        .run();
+
+    Assert.assertTrue(result.isSuccessful());
+
+    SetMultimap<String, Integer> seenEvents = HashMultimap.create();
+    Set<Integer> expected = Sets.newHashSet(0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+
+    for (Event event : listener.events) {
+      seenEvents.put(event.getType(), event.getId());
+    }
+
+    Assert.assertEquals(seenEvents.get("run"), expected);
+    Assert.assertEquals(seenEvents.get("commit"), expected);
+    Assert.assertEquals(seenEvents.get("publish"), expected);
+  }
+
+  @Test
+  public void testStatePersistence() throws Exception {
+    File stateStore = Files.createTempDir();
+    stateStore.deleteOnExit();
+
+    String eventBusId = UUID.randomUUID().toString();
+    MyListener listener = new MyListener();
+
+    EventBus eventBus = TestingEventBuses.getEventBus(eventBusId);
+    eventBus.register(listener);
+
+    EmbeddedGobblin embeddedGobblin = new EmbeddedGobblin("testJob")
+        .setConfiguration(MyFactory.EVENTBUS_ID_KEY, eventBusId)
+        .setConfiguration(ConfigurationKeys.SOURCE_CLASS_KEY, MySource.class.getName())
+        .setConfiguration(MySource.NUM_TASKS_KEY, "2")
+        .setConfiguration(ConfigurationKeys.STATE_STORE_ENABLED, Boolean.toString(true))
+        .setConfiguration(ConfigurationKeys.STATE_STORE_ROOT_DIR_KEY, stateStore.getAbsolutePath());
+
+    JobExecutionResult result = embeddedGobblin.run();
+    Assert.assertTrue(result.isSuccessful());
+
+    SetMultimap<String, Integer> seenEvents = HashMultimap.create();
+    for (Event event : listener.events) {
+      seenEvents.put(event.getType(), event.getId());
+    }
+    Assert.assertEquals(seenEvents.get("previousState").size(), 0);
+
+    result = embeddedGobblin.run();
+    Assert.assertTrue(result.isSuccessful());
+
+    seenEvents = HashMultimap.create();
+    for (Event event : listener.events) {
+      seenEvents.put(event.getType(), event.getId());
+    }
+
+    Assert.assertEquals(seenEvents.get("previousState"), Sets.newHashSet(0, 1));
+
+  }
+
+  public static class MyListener {
+    private final Queue<Event> events = Queues.newArrayDeque();
+
+    @Subscribe
+    public void listen(Event event) {
+      this.events.add(event);
+    }
+  }
+
+  public static class MySource implements Source<String, String> {
+    public static final String NUM_TASKS_KEY = "num.tasks";
+
+    @Override
+    public List<WorkUnit> getWorkunits(SourceState state) {
+      int numTasks = state.getPropAsInt(NUM_TASKS_KEY);
+      String eventBusId = state.getProp(MyFactory.EVENTBUS_ID_KEY);
+      EventBus eventBus = TestingEventBuses.getEventBus(eventBusId);
+
+      Map<String, SourceState> previousStates = state.getPreviousDatasetStatesByUrns();
+      for (Map.Entry<String, SourceState> entry : previousStates.entrySet()) {
+        JobState.DatasetState datasetState = (JobState.DatasetState) entry.getValue();
+        for (TaskState taskState : datasetState.getTaskStates()) {
+          if (taskState.contains(MyTask.PERSISTENT_STATE) && eventBus != null) {
+            eventBus.post(new Event("previousState", taskState.getPropAsInt(MyTask.PERSISTENT_STATE)));
+          }
+        }
+      }
+
+      List<WorkUnit> workUnits = Lists.newArrayList();
+      for (int i = 0; i < numTasks; i++) {
+        WorkUnit workUnit = new WorkUnit();
+        TaskUtils.setTaskFactoryClass(workUnit, MyFactory.class);
+        workUnit.setProp(MyFactory.EVENTBUS_ID_KEY, eventBusId);
+        workUnit.setProp(MyFactory.TASK_ID_KEY, i);
+        workUnits.add(workUnit);
+      }
+      return workUnits;
+    }
+
+    @Override
+    public Extractor<String, String> getExtractor(WorkUnitState state) throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void shutdown(SourceState state) {
+      // Do nothing
+    }
+  }
+
+  @Data
+  @EqualsAndHashCode(callSuper = false)
+  public static class MyTask extends BaseAbstractTask {
+    public static final String PERSISTENT_STATE = "persistent.state";
+    public static final String EXECUTION_METADATA = "execution.metadata";
+
+    private final String taskId;
+    private final EventBus eventBus;
+
+    public MyTask(TaskContext taskContext, String taskId, EventBus eventBus) {
+      super(taskContext);
+      this.taskId = taskId;
+      this.eventBus = eventBus;
+    }
+
+    @Override
+    public void run() {
+      if (this.eventBus != null) {
+        this.eventBus.post(new Event("run", Integer.parseInt(this.taskId)));
+      }
+      super.run();
+    }
+
+    @Override
+    public void commit() {
+      if (this.eventBus != null) {
+        this.eventBus.post(new Event("commit", Integer.parseInt(this.taskId)));
+      }
+      super.commit();
+    }
+
+    @Override
+    public State getPersistentState() {
+      State state = super.getPersistentState();
+      state.setProp(PERSISTENT_STATE, this.taskId);
+      return state;
+    }
+
+    @Override
+    public State getExecutionMetadata() {
+      State state = super.getExecutionMetadata();
+      state.setProp(EXECUTION_METADATA, this.taskId);
+      return state;
+    }
+  }
+
+  public static class MyPublisher extends NoopPublisher {
+    private final EventBus eventBus;
+
+    public MyPublisher(State state, EventBus eventBus) {
+      super(state);
+      this.eventBus = eventBus;
+    }
+
+    @Override
+    public void publishData(Collection<? extends WorkUnitState> states) throws IOException {
+      for (WorkUnitState state : states) {
+        String taskId = state.getProp(MyFactory.TASK_ID_KEY);
+        Assert.assertEquals(state.getProp(MyTask.EXECUTION_METADATA), taskId);
+        Assert.assertEquals(state.getProp(MyTask.PERSISTENT_STATE), taskId);
+        if (this.eventBus != null) {
+          this.eventBus.post(new Event("publish", Integer.parseInt(state.getProp(MyFactory.TASK_ID_KEY))));
+        }
+      }
+      super.publishData(states);
+    }
+  }
+
+  public static class MyFactory implements TaskFactory {
+    public static final String TASK_ID_KEY = "MyFactory.task.id";
+    public static final String EVENTBUS_ID_KEY = "eventbus.id";
+
+    @Override
+    public TaskIFace createTask(TaskContext taskContext) {
+      String taskId = taskContext.getTaskState().getProp(TASK_ID_KEY);
+      EventBus eventBus = null;
+      if (taskContext.getTaskState().contains(EVENTBUS_ID_KEY)) {
+        String eventbusId = taskContext.getTaskState().getProp(EVENTBUS_ID_KEY);
+        eventBus = TestingEventBuses.getEventBus(eventbusId);
+      }
+      return new MyTask(taskContext, taskId, eventBus);
+    }
+
+    @Override
+    public DataPublisher createDataPublisher(JobState.DatasetState datasetState) {
+      EventBus eventBus = null;
+      if (datasetState.getTaskStates().get(0).contains(EVENTBUS_ID_KEY)) {
+        eventBus = TestingEventBuses.getEventBus(datasetState.getTaskStates().get(0).getProp(EVENTBUS_ID_KEY));
+      }
+      return new MyPublisher(datasetState, eventBus);
+    }
+  }
+
+  @Data
+  public static class Event {
+    private final String type;
+    private final int id;
+  }
+
+}


### PR DESCRIPTION
This PR allows running custom tasks in Gobblin. 

To use custom tasks, implement a `TaskFactory` and use `TaskUtils.setTaskFactoryClass(WorkUnitState, Class<? extends TaskFactory>` in the `Source`. Tasks need to implement `TaskIFace`.