### PR TITLE
Add runtime table properties(e.g. Kafka topic) into Hive Registration

### DIFF
--- a/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
@@ -17,8 +17,6 @@
 
 package gobblin.publisher;
 
-import com.google.common.base.Splitter;
-import gobblin.hive.metastore.HiveMetaStoreUtils;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
@@ -33,6 +31,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.fs.Path;
 
 import com.google.common.base.Optional;
+import com.google.common.base.Splitter;
 import com.google.common.collect.Sets;
 import com.google.common.io.Closer;
 
@@ -43,6 +42,7 @@ import gobblin.hive.HiveRegProps;
 import gobblin.hive.HiveRegister;
 import gobblin.hive.policy.HiveRegistrationPolicy;
 import gobblin.hive.policy.HiveRegistrationPolicyBase;
+import gobblin.hive.metastore.HiveMetaStoreUtils;
 import gobblin.hive.spec.HiveSpec;
 import gobblin.util.ExecutorsUtils;
 
@@ -103,7 +103,7 @@ public class HiveRegistrationPublisher extends DataPublisher {
     // runtime.props are comma-separated props collected in runtime.
     Set<String> pathsToRegisterFromSingleState = Sets.newHashSet() ;
     for (State state:states) {
-      State taskSpecificState = super.state;
+      State taskSpecificState = state;
       if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {
 
         // Upstream data attribute is specified, need to inject these info into superState as runtimeTableProps.

--- a/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
+++ b/gobblin-core/src/main/java/gobblin/publisher/HiveRegistrationPublisher.java
@@ -17,6 +17,8 @@
 
 package gobblin.publisher;
 
+import com.google.common.base.Splitter;
+import gobblin.hive.metastore.HiveMetaStoreUtils;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Set;
@@ -63,6 +65,7 @@ import lombok.extern.slf4j.Slf4j;
 public class HiveRegistrationPublisher extends DataPublisher {
 
   private static final String DATA_PUBLISH_TIME = HiveRegistrationPublisher.class.getName() + ".lastDataPublishTime";
+  private static final Splitter LIST_SPLITTER_COMMA = Splitter.on(",").trimResults().omitEmptyStrings();
   private final Closer closer = Closer.create();
   private final HiveRegister hiveRegister;
   private final ExecutorService hivePolicyExecutor;
@@ -92,23 +95,45 @@ public class HiveRegistrationPublisher extends DataPublisher {
     CompletionService<Collection<HiveSpec>> completionService =
         new ExecutorCompletionService<>(this.hivePolicyExecutor);
 
-    //addRuntimeHiveRegistrationProperties(super.state);
-    final HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(super.state);
+    // Each state in states is task-level State, while superState is the Job-level State.
+    // Using both State objects to distinguish each HiveRegistrationPolicy so that
+    // they can carry task-level information to pass into Hive Partition and its corresponding Hive Table.
 
-    Set<String> pathsToRegister = getUniquePathsToRegister(states);
-    log.info("Number of paths to be registered in Hive: " + pathsToRegister.size());
-    for (final String path : pathsToRegister) {
-      completionService.submit(new Callable<Collection<HiveSpec>>() {
+    // Here all runtime task-level props are injected into superstate which installed in each Policy Object.
+    // runtime.props are comma-separated props collected in runtime.
+    Set<String> pathsToRegisterFromSingleState = Sets.newHashSet() ;
+    for (State state:states) {
+      State taskSpecificState = super.state;
+      if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {
 
-        @Override
-        public Collection<HiveSpec> call() throws Exception {
-          return policy.getHiveSpecs(new Path(path));
+        // Upstream data attribute is specified, need to inject these info into superState as runtimeTableProps.
+        if (this.hiveRegister.getProps().getUpstreamDataAttrName().isPresent()) {
+          for (String attrName:
+              LIST_SPLITTER_COMMA.splitToList(this.hiveRegister.getProps().getUpstreamDataAttrName().get())){
+            if (state.contains(attrName)) {
+              taskSpecificState.appendToListProp(HiveMetaStoreUtils.RUNTIME_PROPS,
+                    attrName + ":" + state.getProp(attrName));
+            }
+          }
         }
-      });
 
+        final HiveRegistrationPolicy policy = HiveRegistrationPolicyBase.getPolicy(taskSpecificState);
+        for ( final String path : state.getPropAsList(ConfigurationKeys.PUBLISHER_DIRS) ) {
+          if (pathsToRegisterFromSingleState.contains(path)){
+            continue;
+          }
+          pathsToRegisterFromSingleState.add(path);
+          completionService.submit(new Callable<Collection<HiveSpec>>() {
+            @Override
+            public Collection<HiveSpec> call() throws Exception {
+              return policy.getHiveSpecs(new Path(path));
+            }
+          });
+        }
+      }
+      else continue;
     }
-
-    for (int i = 0; i < pathsToRegister.size(); i++) {
+    for (int i = 0; i < pathsToRegisterFromSingleState.size(); i++) {
       try {
         for (HiveSpec spec : completionService.take().get()) {
           this.hiveRegister.register(spec);
@@ -118,17 +143,7 @@ public class HiveRegistrationPublisher extends DataPublisher {
         throw new IOException(e);
       }
     }
-    log.info("Finished generating all HiveSpecs");
-  }
-
-  private static Set<String> getUniquePathsToRegister(Collection<? extends WorkUnitState> states) {
-    Set<String> paths = Sets.newHashSet();
-    for (State state : states) {
-      if (state.contains(ConfigurationKeys.PUBLISHER_DIRS)) {
-        paths.addAll(state.getPropAsList(ConfigurationKeys.PUBLISHER_DIRS));
-      }
-    }
-    return paths;
+    log.info("Finished registering all HiveSpecs");
   }
 
   @Override

--- a/gobblin-docs/user-guide/Hive-Registration.md
+++ b/gobblin-docs/user-guide/Hive-Registration.md
@@ -55,21 +55,24 @@ If you are running a Gobblin compaction job: add [`HiveRegistrationCompactorList
 
 | Property Name  | Semantics  |
 |---|---|
-| `hive.registration.policy` | class name which implements `HiveRegistrationPolicy` |
-| `hive.row.format` | either `AVRO`, or the class name which implements `HiveSerDeManager`|
+| `hive.registration.policy` | Class name which implements `HiveRegistrationPolicy` |
+| `hive.row.format` | Either `AVRO`, or the class name which implements `HiveSerDeManager`|
 | `hive.database.name` | Hive database name |
 | `hive.database.regex` | Hive database regex |
 | `hive.database.name.prefix` | Hive database name prefix |
 | `hive.database.name.suffix` | Hive database name suffix |
-| `additional.hive.database.names` | additional Hive database names |
+| `additional.hive.database.names` | Additional Hive database names |
 | `hive.table.name` | Hive table name |
 | `hive.table.regex` | Hive table regex |
 | `hive.table.name.prefix` | Hive table name prefix |
 | `hive.table.name.suffix` | Hive table name suffix |
-| `additional.hive.table.names` | additional Hive table names |
-| `hive.register.threads` | thread pool size used for Hive registration |
-| `hive.db.root.dir` | the root dir of Hive db |
-| `hive.table.partition.props` | table/partition properties |
-| `hive.storage.props` | storage descriptor properties |
+| `additional.hive.table.names` | Additional Hive table names |
+| `hive.register.threads` | Thread pool size used for Hive registration |
+| `hive.db.root.dir` | The root dir of Hive db |
+| `hive.table.partition.props` | Table/partition properties |
+| `hive.storage.props` | Storage descriptor properties |
 | `hive.serde.props` | SerDe properties |
-| `hive.registration.fs.uri` | file system URI for Hive registration |
+| `hive.registration.fs.uri` | File system URI for Hive registration |
+| `hive.upstream.data.attr.names` | Attributes to describe upstream data source as Hive Metadata |
+
+

--- a/gobblin-hive-registration/src/test/java/gobblin/hive/policy/HiveRegistrationPolicyBaseTest.java
+++ b/gobblin-hive-registration/src/test/java/gobblin/hive/policy/HiveRegistrationPolicyBaseTest.java
@@ -101,7 +101,6 @@ public class HiveRegistrationPolicyBaseTest {
     examine(spec, "db2", "tbl5");
   }
 
-
   private static void examine(HiveSpec spec, String dbName, String tableName) {
     Assert.assertEquals(spec.getClass(), SimpleHiveSpec.class);
     Assert.assertEquals(spec.getTable().getDbName(), dbName);


### PR DESCRIPTION
Adding upstream data src(specifically "topic.name" for kafka data in this PR, temporarily) info into registered hive table, as one of the table properties.

@ibuenros @htran1  Could you help review ? Thanks. 