### PR TITLE
Throttling server refuses extremely large requests, can provide fewer…

### DIFF
--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-api/src/main/pegasus/gobblin/restli/throttling/PermitAllocation.pdsc
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-api/src/main/pegasus/gobblin/restli/throttling/PermitAllocation.pdsc
@@ -5,6 +5,7 @@
   "doc": "Used by gobblin-throttling-service to allocate permits to a client.",
   "fields": [
     {"name": "permits", "type": "long", "doc": "Number of permits allocated. This may be 0 if no permits are allocated, or the number of requested permits."},
-    {"name": "expiration", "type": "long", "doc": "Expiration time in Unix timestamp of the allocated permits."}
+    {"name": "expiration", "type": "long", "doc": "Expiration time in Unix timestamp of the allocated permits."},
+    {"name": "minRetryDelayMillis", "type": "long", "doc": "Client should not try to acquire permits before this delay has passed.", "optional" : true}
   ]
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-api/src/main/pegasus/gobblin/restli/throttling/PermitRequest.pdsc
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-api/src/main/pegasus/gobblin/restli/throttling/PermitRequest.pdsc
@@ -6,6 +6,7 @@
   "fields": [
     {"name": "resource", "type": "string", "doc": "Resource for which permits are needed."},
     {"name": "permits", "type": "long", "doc": "Number of permits needed."},
+    {"name": "minPermits", "type": "long", "doc": "Minimum number of useful permits.", "optional" : true},
     {"name": "requestorIdentifier", "type": "string", "doc" : "Identifier of the service requesting the permits."}
   ]
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-api/src/main/snapshot/gobblin.restli.throttling.permits.snapshot.json
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-api/src/main/snapshot/gobblin.restli.throttling.permits.snapshot.json
@@ -12,6 +12,11 @@
       "name" : "expiration",
       "type" : "long",
       "doc" : "Expiration time in Unix timestamp of the allocated permits."
+    }, {
+      "name" : "minRetryDelayMillis",
+      "type" : "long",
+      "doc" : "Client should not try to acquire permits before this delay has passed.",
+      "optional" : true
     } ]
   }, {
     "type" : "record",
@@ -26,6 +31,11 @@
       "name" : "permits",
       "type" : "long",
       "doc" : "Number of permits needed."
+    }, {
+      "name" : "minPermits",
+      "type" : "long",
+      "doc" : "Minimum number of useful permits.",
+      "optional" : true
     }, {
       "name" : "requestorIdentifier",
       "type" : "string",

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/restli/throttling/RestliServiceBasedLimiterTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/restli/throttling/RestliServiceBasedLimiterTest.java
@@ -42,13 +42,13 @@ public class RestliServiceBasedLimiterTest {
 
   @Test
   public void test() throws Exception {
-    SharedLimiterFactory factory = new SharedLimiterFactory();
+    ThrottlingPolicyFactory factory = new ThrottlingPolicyFactory();
     SharedLimiterKey res1key = new SharedLimiterKey("res1");
 
     Map<String, String> configMap = ImmutableMap.<String, String>builder()
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, SharedLimiterFactory.LIMITER_CLASS_KEY),
-            CountBasedLimiter.FACTORY_ALIAS)
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, CountBasedLimiter.Factory.COUNT_KEY), "100")
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, ThrottlingPolicyFactory.POLICY_KEY),
+            CountBasedPolicy.FACTORY_ALIAS)
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, CountBasedPolicy.COUNT_KEY), "100")
         .build();
 
     Injector injector = ThrottlingGuiceServletConfig.getInjector(ConfigFactory.parseMap(configMap));

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/restli/throttling/ThrottlingClientTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/restli/throttling/ThrottlingClientTest.java
@@ -53,14 +53,14 @@ public class ThrottlingClientTest {
   @Test
   public void test() throws Exception {
 
-    SharedLimiterFactory factory = new SharedLimiterFactory();
+    ThrottlingPolicyFactory factory = new ThrottlingPolicyFactory();
     SharedLimiterKey res1key = new SharedLimiterKey("res1");
 
     Map<String, String> configMap = ImmutableMap.<String, String>builder()
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, SharedLimiterFactory.LIMITER_CLASS_KEY),
-            CountBasedLimiter.FACTORY_ALIAS)
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, CountBasedLimiter.Factory.COUNT_KEY), "50")
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, null, null, SharedLimiterFactory.FAIL_ON_UNKNOWN_RESOURCE_ID),
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, ThrottlingPolicyFactory.POLICY_KEY),
+            CountBasedPolicy.FACTORY_ALIAS)
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, CountBasedPolicy.COUNT_KEY), "50")
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, null, null, ThrottlingPolicyFactory.FAIL_ON_UNKNOWN_RESOURCE_ID),
             "true")
         .build();
 

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/CountBasedPolicy.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/CountBasedPolicy.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.restli.common.HttpStatus;
+import com.linkedin.restli.server.RestLiServiceException;
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.util.limiter.CountBasedLimiter;
+
+
+/**
+ * A count based {@link ThrottlingPolicy} used for testing. Not recommended as an actual policy.
+ */
+public class CountBasedPolicy implements ThrottlingPolicy {
+
+  public static final String COUNT_KEY = "count";
+  public static final String FACTORY_ALIAS = "countForTesting";
+
+  @Alias(FACTORY_ALIAS)
+  public static class Factory implements ThrottlingPolicyFactory.SpecificPolicyFactory {
+    @Override
+    public ThrottlingPolicy createPolicy(SharedResourcesBroker<SimpleScopeType> broker, Config config) {
+      Preconditions.checkArgument(config.hasPath(COUNT_KEY), "Missing key " + COUNT_KEY);
+      return new CountBasedPolicy(config.getLong(COUNT_KEY));
+    }
+  }
+
+  private final CountBasedLimiter limiter;
+
+  public CountBasedPolicy(long count) {
+    this.limiter = new CountBasedLimiter(count);
+  }
+
+  @Override
+  public PermitAllocation computePermitAllocation(PermitRequest request) {
+    long permits = request.getPermits();
+    long allocated = 0;
+
+    try {
+      if (limiter.acquirePermits(permits) != null) {
+        allocated = permits;
+      } else {
+        throw new RestLiServiceException(HttpStatus.S_403_FORBIDDEN, "Not enough permits.");
+      }
+    } catch (InterruptedException ie) {
+      // return no permits
+    }
+
+    PermitAllocation allocation = new PermitAllocation();
+    allocation.setPermits(allocated);
+    allocation.setExpiration(Long.MAX_VALUE);
+    if (allocated <= 0) {
+      allocation.setMinRetryDelayMillis(60000);
+    }
+    return allocation;
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/DynamicTokenBucket.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/DynamicTokenBucket.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * A wrapper around a {@link TokenBucket} that returns different number of tokens following an internal heuristic.
+ *
+ * The heuristic is as follows:
+ * * The calling process specifies an ideal and minimum number of token it requires, as well as a timeout.
+ * * If there is a large number of tokens stored (i.e. underutilization), this class may return more than the requested
+ *   ideal number of tokens (up to 1/2 of the stored tokens). This reduces unnecessary slowdown when there is no
+ *   contention.
+ * * The object has a short ideal timeout for fulfilling the full request ({@link #fullRequestTimeout}). If it can fulfill
+ *   the full request within that timeout, it will.
+ * * If the full request cannot be satisfied within the timeout, the object will try to satisfy smaller requests up to
+ *   the minimum number of tokens requested, increasing the timeout up to the caller specified timeout.
+ */
+class DynamicTokenBucket {
+
+  private final TokenBucket tokenBucket;
+  private final long fullRequestTimeout;
+
+  /**
+   * @param qps the average qps desired.
+   * @param fullRequestTimeoutMillis max time to fully satisfy a token request. This is generally a small timeout, on the
+   *                                 order of the network latency (e.g. ~100 ms).
+   * @param maxBucketSizeMillis maximum number of unused tokens that can be stored during under-utilization time, in
+   *                            milliseconds. The actual tokens stored will be 1000 * qps * maxBucketSizeMillis.
+   */
+  DynamicTokenBucket(long qps, long fullRequestTimeoutMillis, long maxBucketSizeMillis) {
+    this.tokenBucket = new TokenBucket(qps, maxBucketSizeMillis);
+    this.fullRequestTimeout = fullRequestTimeoutMillis;
+  }
+
+  /**
+   * Request tokens.
+   * @param requestedPermits the ideal number of tokens to acquire.
+   * @param minPermits the minimum number of tokens useful for the calling process. If this many tokens cannot be acquired,
+   *                   the method will return 0 instead,
+   * @param timeoutMillis the maximum wait the calling process is willing to wait for tokens.
+   * @return the number of allocated tokens.
+   */
+  public long getPermits(long requestedPermits, long minPermits, long timeoutMillis) {
+
+    try {
+      long storedTokens = this.tokenBucket.getStoredTokens();
+
+      long eagerTokens = storedTokens / 2;
+      if (eagerTokens > requestedPermits && this.tokenBucket.getTokens(eagerTokens, 0, TimeUnit.MILLISECONDS)) {
+        return eagerTokens;
+      }
+
+      long actualTimeout = Math.min(this.fullRequestTimeout, timeoutMillis);
+      while (requestedPermits >= minPermits) {
+        if (this.tokenBucket.getTokens(requestedPermits, actualTimeout, TimeUnit.MILLISECONDS)) {
+          return requestedPermits;
+        }
+        requestedPermits /= 2;
+        actualTimeout = Math.min(2 * actualTimeout + 1, timeoutMillis);
+      }
+
+      if (this.tokenBucket.getTokens(minPermits, timeoutMillis, TimeUnit.MILLISECONDS)) {
+        return minPermits;
+      }
+    } catch (InterruptedException ie) {
+      // Fallback to returning 0
+    }
+
+    return 0;
+  }
+
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/NoopPolicy.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/NoopPolicy.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.annotation.Alpha;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.SharedResourcesBroker;
+
+
+/**
+ * A {@link ThrottlingPolicy} that does no throttling and eagerly returns a large amount of permits.
+ */
+@Alpha
+public class NoopPolicy implements ThrottlingPolicy {
+
+  public static final String FACTORY_ALIAS = "noop";
+
+  @Alias(FACTORY_ALIAS)
+  public static class Factory implements ThrottlingPolicyFactory.SpecificPolicyFactory {
+    @Override
+    public ThrottlingPolicy createPolicy(SharedResourcesBroker<SimpleScopeType> broker, Config config) {
+      return new NoopPolicy();
+    }
+  }
+
+  @Override
+  public PermitAllocation computePermitAllocation(PermitRequest request) {
+
+    PermitAllocation allocation = new PermitAllocation();
+    // For overflow safety, don't return max long
+    allocation.setPermits(Math.max(Long.MAX_VALUE / 100, request.getPermits()));
+    allocation.setExpiration(Long.MAX_VALUE);
+
+    return allocation;
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/QPSPolicy.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/QPSPolicy.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import com.google.common.base.Preconditions;
+import com.linkedin.data.template.GetMode;
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.annotation.Alpha;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.SharedResourcesBroker;
+
+
+/**
+ * A {@link ThrottlingPolicy} based on a QPS (queries per second). It internally uses a {@link DynamicTokenBucket}.
+ */
+@Alpha
+public class QPSPolicy implements ThrottlingPolicy {
+
+  public static final String FACTORY_ALIAS = "qps";
+
+  /**
+   * The qps the policy should enforce.
+   */
+  public static final String QPS = "qps";
+  /**
+   * The time the policy should spend trying to satisfy the full permit request.
+   */
+  public static final String FULL_REQUEST_TIMEOUT_MILLIS = "fullRequestTimeoutMillis";
+  public static final long DEFAULT_FULL_REQUEST_TIMEOUT = 50;
+  /**
+   * Maximum number of tokens (in milliseconds) that can be accumulated when underutilized.
+   */
+  public static final String MAX_BUCKET_SIZE_MILLIS = "maxBucketSizeMillis";
+  public static final long DEFAULT_MAX_BUCKET_SIZE = 10000;
+
+  private final DynamicTokenBucket tokenBucket;
+
+  @Alias(FACTORY_ALIAS)
+  public static class Factory implements ThrottlingPolicyFactory.SpecificPolicyFactory {
+    @Override
+    public ThrottlingPolicy createPolicy(SharedResourcesBroker<SimpleScopeType> broker, Config config) {
+      return new QPSPolicy(config);
+    }
+  }
+
+  public QPSPolicy(Config config) {
+    Preconditions.checkArgument(config.hasPath(QPS), "QPS required.");
+
+    long qps = config.getLong(QPS);
+    long fullRequestTimeoutMillis = config.hasPath(FULL_REQUEST_TIMEOUT_MILLIS)
+        ? config.getLong(FULL_REQUEST_TIMEOUT_MILLIS) : DEFAULT_FULL_REQUEST_TIMEOUT;
+    long maxBucketSizeMillis = config.hasPath(MAX_BUCKET_SIZE_MILLIS)
+        ? config.getLong(MAX_BUCKET_SIZE_MILLIS) : DEFAULT_MAX_BUCKET_SIZE;
+    this.tokenBucket = new DynamicTokenBucket(qps, fullRequestTimeoutMillis, maxBucketSizeMillis);
+  }
+
+  @Override
+  public PermitAllocation computePermitAllocation(PermitRequest request) {
+    long permitsRequested = request.getPermits();
+    Long minPermits = request.getMinPermits(GetMode.NULL);
+    if (minPermits == null) {
+      minPermits = permitsRequested;
+    }
+
+    long permitsGranted = this.tokenBucket.getPermits(permitsRequested, minPermits, LimiterServerResource.TIMEOUT_MILLIS);
+
+    PermitAllocation allocation = new PermitAllocation();
+    allocation.setPermits(permitsGranted);
+    allocation.setExpiration(Long.MAX_VALUE);
+    if (permitsGranted <= 0) {
+      allocation.setMinRetryDelayMillis(LimiterServerResource.TIMEOUT_MILLIS);
+    }
+    return allocation;
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/ThrottlingPolicy.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/ThrottlingPolicy.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+/**
+ * A throttling policy.
+ */
+public interface ThrottlingPolicy {
+  /**
+   * Comput the {@link PermitAllocation} for the given {@link PermitRequest}.
+   */
+  PermitAllocation computePermitAllocation(PermitRequest request);
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/ThrottlingPolicyFactory.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/ThrottlingPolicyFactory.java
@@ -1,0 +1,82 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import com.typesafe.config.Config;
+
+import gobblin.broker.ResourceInstance;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.ConfigView;
+import gobblin.broker.iface.NotConfiguredException;
+import gobblin.broker.iface.ScopedConfigView;
+import gobblin.broker.iface.SharedResourceFactory;
+import gobblin.broker.iface.SharedResourceFactoryResponse;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.util.ClassAliasResolver;
+import gobblin.util.limiter.broker.SharedLimiterKey;
+
+
+/**
+ * A {@link SharedResourceFactory} to create {@link ThrottlingPolicy}s.
+ */
+public class ThrottlingPolicyFactory implements SharedResourceFactory<ThrottlingPolicy, SharedLimiterKey, SimpleScopeType> {
+
+  public static final String NAME = "throttlingPolicy";
+
+  public static final String POLICY_KEY = "policy";
+  public static final String FAIL_ON_UNKNOWN_RESOURCE_ID = "faiOnUnknownResourceId";
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public SharedResourceFactoryResponse<ThrottlingPolicy> createResource(SharedResourcesBroker<SimpleScopeType> broker,
+      ScopedConfigView<SimpleScopeType, SharedLimiterKey> configView) throws NotConfiguredException {
+
+    Config config = configView.getConfig();
+
+    if (!config.hasPath(POLICY_KEY)) {
+      if (config.hasPath(FAIL_ON_UNKNOWN_RESOURCE_ID) && config.getBoolean(FAIL_ON_UNKNOWN_RESOURCE_ID)) {
+        throw new NotConfiguredException("Missing key " + POLICY_KEY);
+      } else {
+        return new ResourceInstance<ThrottlingPolicy>(new NoopPolicy());
+      }
+    }
+    ClassAliasResolver<SpecificPolicyFactory> resolver = new ClassAliasResolver<>(SpecificPolicyFactory.class);
+
+    try {
+      SpecificPolicyFactory factory = resolver.resolveClass(config.getString(POLICY_KEY)).newInstance();
+      return new ResourceInstance<>(factory.createPolicy(broker, config));
+    } catch (ReflectiveOperationException roe) {
+      throw new RuntimeException(roe);
+    }
+  }
+
+  @Override
+  public SimpleScopeType getAutoScope(SharedResourcesBroker<SimpleScopeType> broker,
+      ConfigView<SimpleScopeType, SharedLimiterKey> config) {
+    return SimpleScopeType.GLOBAL;
+  }
+
+  public interface SpecificPolicyFactory {
+    ThrottlingPolicy createPolicy(SharedResourcesBroker<SimpleScopeType> broker, Config config);
+  }
+
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/TokenBucket.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/TokenBucket.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import java.util.concurrent.TimeUnit;
+
+import com.google.common.base.Preconditions;
+
+
+/**
+ * An implementation of Token Bucket (https://en.wikipedia.org/wiki/Token_bucket).
+ *
+ * This class is intended to limit the rate at which tokens are used to a given QPS. It can store tokens for future usage.
+ */
+public class TokenBucket {
+
+  private double tokensPerMilli;
+  private double maxBucketSizeInTokens;
+
+  private volatile long nextTokenAvailableMillis;
+  private volatile double tokensStored;
+
+  public TokenBucket(long qps, long maxBucketSizeInMillis) {
+    this.nextTokenAvailableMillis = System.currentTimeMillis();
+    resetQPS(qps, maxBucketSizeInMillis);
+  }
+
+  public void resetQPS(long qps, long maxBucketSizeInMillis) {
+    Preconditions.checkArgument(qps > 0, "QPS must be positive.");
+    Preconditions.checkArgument(maxBucketSizeInMillis >= 0, "Max bucket size must be non-negative.");
+
+    long now = System.currentTimeMillis();
+    synchronized (this) {
+      updateTokensStored(now);
+      if (this.nextTokenAvailableMillis > now) {
+        this.tokensStored -= (this.nextTokenAvailableMillis - now) * this.tokensPerMilli;
+      }
+      this.tokensPerMilli = (double) qps / 1000;
+      this.maxBucketSizeInTokens = this.tokensPerMilli * maxBucketSizeInMillis;
+    }
+  }
+
+  /**
+   * Attempt to get the specified amount of tokens within the specified timeout. If the tokens cannot be retrieved in the
+   * specified timeout, the call will return false immediately, otherwise, the call will block until the tokens are available.
+   *
+   * @return true if the tokens are granted.
+   * @throws InterruptedException
+   */
+  public boolean getTokens(long tokens, long timeout, TimeUnit timeoutUnit) throws InterruptedException {
+    long timeoutMillis = timeoutUnit.toMillis(timeout);
+    long wait;
+    synchronized (this) {
+      wait = tryReserveTokens(tokens, timeoutMillis);
+    }
+
+    if (wait < 0) {
+      return false;
+    }
+    if (wait == 0) {
+      return true;
+    }
+
+    Thread.sleep(wait);
+    return true;
+  }
+
+  /**
+   * Get the current number of stored tokens. Note this is a snapshot of the object, and there is no guarantee that those
+   * tokens will be available at any point in the future.
+   */
+  public long getStoredTokens() {
+    synchronized (this) {
+      updateTokensStored(System.currentTimeMillis());
+    }
+    return (long) this.tokensStored;
+  }
+
+  /**
+   * Note: this method should only be called while holding the class lock. For performance, the lock is not explicitly
+   * acquired.
+   *
+   * @return the wait until the tokens are available or negative if they can't be acquired in the give timeout.
+   */
+  private long tryReserveTokens(long tokens, long maxWaitMillis) {
+    long now = System.currentTimeMillis();
+    long waitUntilNextTokenAvailable = Math.max(0, this.nextTokenAvailableMillis - now);
+
+    updateTokensStored(now);
+    if (tokens <= this.tokensStored) {
+      this.tokensStored -= tokens;
+      return waitUntilNextTokenAvailable;
+    }
+
+    double additionalNeededTokens = tokens - this.tokensStored;
+    // casting to long will round towards 0
+    long additionalWaitForEnoughTokens = (long) (additionalNeededTokens / this.tokensPerMilli) + 1;
+    long totalWait = waitUntilNextTokenAvailable + additionalWaitForEnoughTokens;
+    if (totalWait > maxWaitMillis) {
+      return -1;
+    }
+    this.tokensStored = this.tokensPerMilli * additionalWaitForEnoughTokens - additionalNeededTokens;
+    this.nextTokenAvailableMillis = this.nextTokenAvailableMillis + additionalWaitForEnoughTokens;
+    return totalWait;
+  }
+
+  /**
+   * Note: this method should only be called while holding the class lock. For performance, the lock is not explicitly
+   * acquired.
+   */
+  private void updateTokensStored(long now) {
+    if (now <= this.nextTokenAvailableMillis) {
+      return;
+    }
+    long millisUnaccounted = now - this.nextTokenAvailableMillis;
+    double newTokens = millisUnaccounted * this.tokensPerMilli;
+    this.nextTokenAvailableMillis = now;
+    this.tokensStored = Math.min(this.tokensStored + newTokens, Math.max(this.tokensStored, this.maxBucketSizeInTokens));
+  }
+
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/test/java/gobblin/restli/throttling/DynamicTokenBucketTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/test/java/gobblin/restli/throttling/DynamicTokenBucketTest.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class DynamicTokenBucketTest {
+
+  @Test
+  public void test() throws Exception {
+    int qps = 10;
+    DynamicTokenBucket limiter = new DynamicTokenBucket(qps, 10, 0);
+
+    // Requesting 10 seconds worth of permits with 1 second timeout fails
+    Assert.assertEquals(limiter.getPermits(10 * qps, 10 * qps, 1000), 0);
+    // Requesting 0.2 seconds worth of permits with 300 millis timeout succeeds
+    long permits = qps / 5;
+    Assert.assertEquals(limiter.getPermits(permits, permits, 300), permits);
+    // Requesting 1 seconds worth of permits, with min of 0.1 seconds, and with 200 millis timeout will return at least
+    // min permits
+    permits = qps;
+    Assert.assertTrue(limiter.getPermits(permits, qps / 10, 200) >= qps / 10);
+  }
+
+  @Test
+  public void testEagerGrantingIfUnderused() throws Exception {
+    int qps = 100;
+    DynamicTokenBucket limiter = new DynamicTokenBucket(qps, 10, 100);
+
+    Thread.sleep(100); // fill bucket
+    // Grant 4 permits even though only 1 requested
+    Assert.assertTrue(limiter.getPermits(1, 0, 100) > 4);
+  }
+
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/test/java/gobblin/restli/throttling/LimiterServerResourceTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/test/java/gobblin/restli/throttling/LimiterServerResourceTest.java
@@ -52,24 +52,24 @@ public class LimiterServerResourceTest {
     request.setResource("myResource");
     PermitAllocation allocation = limiterServer.get(new ComplexResourceKey<>(request, new EmptyRecord()));
 
-    Assert.assertEquals(allocation.getPermits(), new Long(10));
+    Assert.assertTrue(allocation.getPermits() >= 10);
 
   }
 
   @Test
   public void testLimitedRequests() {
 
-    SharedLimiterFactory factory = new SharedLimiterFactory();
+    ThrottlingPolicyFactory factory = new ThrottlingPolicyFactory();
     SharedLimiterKey res1key = new SharedLimiterKey("res1");
     SharedLimiterKey res2key = new SharedLimiterKey("res2");
 
     Map<String, String> configMap = ImmutableMap.<String, String>builder()
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, SharedLimiterFactory.LIMITER_CLASS_KEY),
-            CountBasedLimiter.FACTORY_ALIAS)
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, CountBasedLimiter.Factory.COUNT_KEY), "100")
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res2key, null, SharedLimiterFactory.LIMITER_CLASS_KEY),
-            CountBasedLimiter.FACTORY_ALIAS)
-        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res2key, null, CountBasedLimiter.Factory.COUNT_KEY), "50")
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, ThrottlingPolicyFactory.POLICY_KEY),
+            CountBasedPolicy.FACTORY_ALIAS)
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, CountBasedPolicy.COUNT_KEY), "100")
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res2key, null, ThrottlingPolicyFactory.POLICY_KEY),
+            CountBasedPolicy.FACTORY_ALIAS)
+        .put(BrokerConfigurationKeyGenerator.generateKey(factory, res2key, null, CountBasedPolicy.COUNT_KEY), "50")
         .build();
 
     Injector injector = ThrottlingGuiceServletConfig.getInjector(ConfigFactory.parseMap(configMap));
@@ -114,7 +114,7 @@ public class LimiterServerResourceTest {
     }
 
     // No limit
-    Assert.assertEquals(limiterServer.get(new ComplexResourceKey<>(res3request, new EmptyRecord())).getPermits(), res3request.getPermits());
+    Assert.assertTrue(limiterServer.get(new ComplexResourceKey<>(res3request, new EmptyRecord())).getPermits() >= res3request.getPermits());
   }
 
   @Test

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/test/java/gobblin/restli/throttling/TokenBucketTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/test/java/gobblin/restli/throttling/TokenBucketTest.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.restli.throttling;
+
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import lombok.AllArgsConstructor;
+
+
+public class TokenBucketTest {
+
+  @Test
+  public void testSmallQps() throws Exception {
+    testForQps(100);
+  }
+
+  @Test
+  public void testLargeQps() throws Exception {
+    testForQps((long) 1e10);
+  }
+
+  @Test
+  public void testTimeout() throws Exception {
+    TokenBucket tokenBucket = new TokenBucket(100, 0);
+
+    // If it cannot satisfy the request within the timeout, return false immediately
+    Assert.assertFalse(tokenBucket.getTokens(100, 1, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(tokenBucket.getTokens(100, 10, TimeUnit.MILLISECONDS));
+    Assert.assertFalse(tokenBucket.getTokens(100, 100, TimeUnit.MILLISECONDS));
+    Assert.assertTrue(tokenBucket.getTokens(10, 101, TimeUnit.MILLISECONDS));
+
+    // Can use stored tokens to satisfy request
+    tokenBucket = new TokenBucket(100, 100);
+    Thread.sleep(200); // fill up bucket
+    Assert.assertTrue(tokenBucket.getTokens(20, 101, TimeUnit.MILLISECONDS));
+  }
+
+  private void testForQps(long qps) throws Exception {
+    ExecutorService executorService = Executors.newFixedThreadPool(10);
+
+    TokenBucket tokenBucket = new TokenBucket(qps, 1000);
+
+    List<Future<Boolean>> futures = Lists.newArrayList();
+
+    long permitsPerRequest = qps / 10;
+
+    long start = System.currentTimeMillis();
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+    futures.add(executorService.submit(new MyRunnable(tokenBucket, permitsPerRequest, 1000)));
+
+    for (Future<Boolean> future : futures) {
+      Assert.assertTrue(future.get());
+    }
+    long end = System.currentTimeMillis();
+
+    double averageRate = 1000 * (double) (permitsPerRequest * futures.size()) / (end - start);
+
+    Assert.assertTrue(Math.abs(averageRate - qps) / qps < 0.2, "Average rate: " + averageRate + " expected: 100");
+  }
+
+  @AllArgsConstructor
+  public static class MyRunnable implements Callable<Boolean> {
+    private final TokenBucket tokenBucket;
+    private final long tokens;
+    private final long timeoutMillis;
+
+    @Override
+    public Boolean call() {
+      try {
+        return this.tokenBucket.getTokens(this.tokens, this.timeoutMillis, TimeUnit.MILLISECONDS);
+      } catch (InterruptedException ie) {
+        throw new RuntimeException(ie);
+      }
+    }
+  }
+}


### PR DESCRIPTION
… than requested permits.

This PR improves the throttling server:
* Previously, large requests would just block for a long time, eventually timing out on the client. This is obviously not useful.
* Introduced a few heuristics to the server:
** If a request cannot be satisfied within timeout, return immediately.
** If a request has a minimum useful permits lower than the ideal requested permits, and the ideal requested permits cannot be satisfied quickly, try to return a lower number of permits.
** If the throttler is under-utilized, e.g. there are a lot of stored permits, then it may return more permits than requested.
* Since Guava `RateLimiter` does not allow extension or fine control, implemented a custom `TokenBucket` algorithm.
* No longer use straight `Limiter`s in the server, as the needs are different than in a client. Instead, use `ThrottlingPolicies` (which may or may not wrap a `Limiter`).
* Throttling client sends an ideal and minimum number of requested permits.