### PR TITLE
Added fail-fast option to CopyableDatasetRequestor (disabled by default)

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
@@ -57,6 +57,8 @@ public class CopyConfiguration {
   public static final String BINPACKING_MAX_PER_BUCKET_PREFIX = COPY_PREFIX + ".binPacking.maxPerBucket";
   public static final String BUFFER_SIZE = COPY_PREFIX + ".bufferSize";
 
+  public static final String ABORT_ON_SINGLE_DATASET_FAILURE = COPY_PREFIX + ".abortOnSingleDatasetFailure";
+
   /**
    * User supplied directory where files should be published. This value is identical for all datasets in the distcp job.
    */
@@ -76,12 +78,15 @@ public class CopyConfiguration {
 
   private final Config config;
 
+  private final boolean abortOnSingleDatasetFailure;
+
   public static class CopyConfigurationBuilder {
 
     private PreserveAttributes preserve;
     private Optional<String> targetGroup;
     private CopyContext copyContext;
     private Path publishDir;
+    private boolean abortOnSingleDatasetFailure;
 
     public CopyConfigurationBuilder(FileSystem targetFs, Properties properties) {
 
@@ -114,6 +119,11 @@ public class CopyConfiguration {
         this.prioritizer = Optional.absent();
       }
       this.maxToCopy = CopyResourcePool.fromConfig(ConfigUtils.getConfigOrEmpty(this.config, MAX_COPY_PREFIX));
+
+      this.abortOnSingleDatasetFailure = false;
+      if (this.config.hasPath(ABORT_ON_SINGLE_DATASET_FAILURE)) {
+        this.abortOnSingleDatasetFailure = this.config.getBoolean(ABORT_ON_SINGLE_DATASET_FAILURE);
+      }
     }
   }
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/CopyConfiguration.java
@@ -86,7 +86,6 @@ public class CopyConfiguration {
     private Optional<String> targetGroup;
     private CopyContext copyContext;
     private Path publishDir;
-    private boolean abortOnSingleDatasetFailure;
 
     public CopyConfigurationBuilder(FileSystem targetFs, Properties properties) {
 

--- a/gobblin-data-management/src/main/java/gobblin/data/management/partition/CopyableDatasetRequestor.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/partition/CopyableDatasetRequestor.java
@@ -53,9 +53,6 @@ import lombok.extern.slf4j.Slf4j;
 @AllArgsConstructor
 @Getter
 public class CopyableDatasetRequestor implements PushDownRequestor<FileSet<CopyEntity>> {
-  private final static String CONF_PREFIX = CopyConfiguration.COPY_PREFIX + "." + CopyableDatasetRequestor.class.getSimpleName();
-  private final static String FAIL_FAST = CONF_PREFIX + ".failFast";
-
   @AllArgsConstructor
   public static class Factory implements Function<CopyableDatasetBase, CopyableDatasetRequestor> {
     private final FileSystem targetFs;
@@ -89,8 +86,7 @@ public class CopyableDatasetRequestor implements PushDownRequestor<FileSet<CopyE
     try {
       return injectRequestor(this.dataset.getFileSetIterator(this.targetFs, this.copyConfiguration));
     } catch (Throwable exc) {
-      if (copyConfiguration.getConfig().hasPath(FAIL_FAST)
-          && copyConfiguration.getConfig().getBoolean(FAIL_FAST)) {
+      if (copyConfiguration.isAbortOnSingleDatasetFailure()) {
         throw new RuntimeException(String.format("Could not get FileSets for dataset %s", this.dataset.datasetURN()), exc);
       }
       log.error(String.format("Could not get FileSets for dataset %s. Skipping.", this.dataset.datasetURN()), exc);


### PR DESCRIPTION
Currently when there's failure getting dataset in CopyableDatasetRequestor, it logs the error and continue to perform distcp and makes job status success overall. 
This change will have user to choose to make the job fail fast so that failure from CopyableDatasetRequestor will make the job fail immediately.

- Integration test passed.

job property snippet:
gobblin.copy.CopyableDatasetRequestor.failFast=true
