### PR TITLE
Enable KafKaSource to accpet table type and namespace configuration

### DIFF
--- a/gobblin-utility/src/main/java/gobblin/util/ImmutableProperties.java
+++ b/gobblin-utility/src/main/java/gobblin/util/ImmutableProperties.java
@@ -27,13 +27,36 @@ import lombok.experimental.Delegate;
 /**
  * Immutable wrapper for {@link Properties}.
  */
-
 public class ImmutableProperties extends Properties {
   @Delegate
   private final Map<Object, Object> props;
 
   public ImmutableProperties(Properties props) {
     this.props = Collections.unmodifiableMap(props);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    ImmutableProperties that = (ImmutableProperties) o;
+
+    return props != null ? props.equals(that.props) : that.props == null;
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + (props != null ? props.hashCode() : 0);
+    return result;
   }
 
   /**


### PR DESCRIPTION
- Accept configured table type and namespace instead of fixed values
- Add configuration key `gobblin.kafka.extract.allowTableTypeAndNamspaceCustomization` to turn on the changes, avoid breaking existing jobs