### PR TITLE
Update constructor of FlowConfigClient and FlowStatusClient

### DIFF
--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/gobblin/service/FlowConfigClient.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/gobblin/service/FlowConfigClient.java
@@ -68,6 +68,19 @@ public class FlowConfigClient implements Closeable {
   }
 
   /**
+   * Construct a {@link FlowConfigClient} to communicate with http flow config server at URI serverUri
+   * @param restClient restClient to send restli request
+   */
+  public FlowConfigClient(RestClient restClient) {
+    LOG.debug("FlowConfigClient with restClient " + restClient);
+
+    _httpClientFactory = Optional.absent();
+    _restClient = Optional.of(restClient);
+
+    _flowconfigsRequestBuilders = new FlowconfigsRequestBuilders();
+  }
+
+  /**
    * Create a flow configuration
    * @param flowConfig flow configuration attributes
    * @throws RemoteInvocationException

--- a/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/gobblin/service/FlowStatusClient.java
+++ b/gobblin-restli/gobblin-flow-config-service/gobblin-flow-config-service-client/src/main/java/gobblin/service/FlowStatusClient.java
@@ -63,6 +63,19 @@ public class FlowStatusClient implements Closeable {
   }
 
   /**
+   * Construct a {@link FlowStatusClient} to communicate with http flow status server at URI serverUri
+   * @param restClient restClient to send restli request
+   */
+  public FlowStatusClient(RestClient restClient) {
+    LOG.debug("FlowConfigClient with restClient " + restClient);
+
+    _httpClientFactory = Optional.absent();
+    _restClient = Optional.of(restClient);
+
+    _flowstatusesRequestBuilders = new FlowstatusesRequestBuilders();
+  }
+
+  /**
    * Get a flow status
    * @param flowStatusId identifier of flow status to get
    * @return a {@link FlowStatus} with the flow status


### PR DESCRIPTION
To integrate with dependency framework like Spring, add constructor that can inject RestClient from framework