### PR TITLE
Fix the multithreading bug in TimestampWatermark

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/partition/Partitioner.java
@@ -232,7 +232,7 @@ public class Partitioner {
    * @param diff the amount of difference
    * @return the adjusted watermark value
    */
-  synchronized private static long adjustWatermark(String baseWatermark, WatermarkType watermarkType, int diff) {
+  private static long adjustWatermark(String baseWatermark, WatermarkType watermarkType, int diff) {
     SimpleDateFormat watermarkTimeParser = new SimpleDateFormat(WATERMARKTIMEFORMAT);
     Date date;
     long result = ConfigurationKeys.DEFAULT_WATERMARK_VALUE;

--- a/gobblin-core/src/main/java/gobblin/source/extractor/watermark/DateWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/watermark/DateWatermark.java
@@ -32,6 +32,7 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Ints;
+
 import gobblin.source.extractor.extract.QueryBasedExtractor;
 
 
@@ -41,8 +42,7 @@ public class DateWatermark implements Watermark {
   private static final String INPUTFORMAT = "yyyyMMddHHmmss";
   // output format of date water mark example: 20140301
   private static final String OUTPUTFORMAT = "yyyyMMdd";
-  private static final SimpleDateFormat INPUTFORMATPARSER = new SimpleDateFormat(INPUTFORMAT);
-
+  private final SimpleDateFormat inputFormatParser;
   private static final int deltaForNextWatermark = 24 * 60 * 60;
   private String watermarkColumn;
   private String watermarkFormat;
@@ -50,6 +50,7 @@ public class DateWatermark implements Watermark {
   public DateWatermark(String watermarkColumn, String watermarkFormat) {
     this.watermarkColumn = watermarkColumn;
     this.watermarkFormat = watermarkFormat;
+    inputFormatParser = new SimpleDateFormat(INPUTFORMAT);
   }
 
   @Override
@@ -91,11 +92,11 @@ public class DateWatermark implements Watermark {
     long lwm;
     long hwm;
     while (startTime.getTime() <= endTime.getTime()) {
-      lwm = Long.parseLong(INPUTFORMATPARSER.format(startTime));
+      lwm = Long.parseLong(inputFormatParser.format(startTime));
       calendar.setTime(startTime);
       calendar.add(Calendar.DATE, interval - 1);
       nextTime = calendar.getTime();
-      hwm = Long.parseLong(INPUTFORMATPARSER.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
+      hwm = Long.parseLong(inputFormatParser.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
       intervalMap.put(lwm, hwm);
       LOG.debug("Partition - low:" + lwm + "; high:" + hwm);
       calendar.add(Calendar.SECOND, deltaForNextWatermark);

--- a/gobblin-core/src/main/java/gobblin/source/extractor/watermark/HourWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/watermark/HourWatermark.java
@@ -18,6 +18,7 @@
 package gobblin.source.extractor.watermark;
 
 import gobblin.source.extractor.extract.QueryBasedExtractor;
+
 import java.math.RoundingMode;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
@@ -41,14 +42,14 @@ public class HourWatermark implements Watermark {
   // output format of hour water mark example: 2014030105
   private static final String OUTPUTFORMAT = "yyyyMMddHH";
   private static final int deltaForNextWatermark = 60 * 60;
-  private static final SimpleDateFormat INPUTFORMATPARSER = new SimpleDateFormat(INPUTFORMAT);
-
+  private final SimpleDateFormat inputFormatParser;
   private String watermarkColumn;
   private String watermarkFormat;
 
   public HourWatermark(String watermarkColumn, String watermarkFormat) {
     this.watermarkColumn = watermarkColumn;
     this.watermarkFormat = watermarkFormat;
+    inputFormatParser = new SimpleDateFormat(INPUTFORMAT);
   }
 
   @Override
@@ -65,8 +66,8 @@ public class HourWatermark implements Watermark {
   synchronized public HashMap<Long, Long> getIntervals(long lowWatermarkValue, long highWatermarkValue,
       long partitionIntervalInHours, int maxIntervals) {
     Preconditions.checkArgument(maxIntervals > 0, "Invalid value for maxIntervals, positive value expected.");
-    Preconditions.checkArgument(partitionIntervalInHours > 0,
-        "Invalid value for partitionInterval, should be at least 1.");
+    Preconditions
+        .checkArgument(partitionIntervalInHours > 0, "Invalid value for partitionInterval, should be at least 1.");
     HashMap<Long, Long> intervalMap = Maps.newHashMap();
 
     if (lowWatermarkValue > highWatermarkValue) {
@@ -90,11 +91,11 @@ public class HourWatermark implements Watermark {
     long lwm;
     long hwm;
     while (startTime.getTime() <= endTime.getTime()) {
-      lwm = Long.parseLong(INPUTFORMATPARSER.format(startTime));
+      lwm = Long.parseLong(inputFormatParser.format(startTime));
       calendar.setTime(startTime);
       calendar.add(Calendar.HOUR, interval - 1);
       nextTime = calendar.getTime();
-      hwm = Long.parseLong(INPUTFORMATPARSER.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
+      hwm = Long.parseLong(inputFormatParser.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
       intervalMap.put(lwm, hwm);
       LOG.debug("Partition - low:" + lwm + "; high:" + hwm);
       calendar.add(Calendar.SECOND, deltaForNextWatermark);

--- a/gobblin-core/src/main/java/gobblin/source/extractor/watermark/TimestampWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/watermark/TimestampWatermark.java
@@ -30,6 +30,7 @@ import org.slf4j.LoggerFactory;
 import com.google.common.base.Preconditions;
 import com.google.common.math.DoubleMath;
 import com.google.common.primitives.Ints;
+
 import gobblin.source.extractor.extract.QueryBasedExtractor;
 
 
@@ -37,9 +38,7 @@ public class TimestampWatermark implements Watermark {
   private static final Logger LOG = LoggerFactory.getLogger(TimestampWatermark.class);
   // default water mark format(input format) example: 20140301050505
   private static final String INPUTFORMAT = "yyyyMMddHHmmss";
-  private final SimpleDateFormat _inputFormatParser;
-
-
+  private final SimpleDateFormat inputFormatParser;
   private static final int deltaForNextWatermark = 1;
   private String watermarkColumn;
   private String watermarkFormat;
@@ -47,13 +46,13 @@ public class TimestampWatermark implements Watermark {
   public TimestampWatermark(String watermarkColumn, String watermarkFormat) {
     this.watermarkColumn = watermarkColumn;
     this.watermarkFormat = watermarkFormat;
-    _inputFormatParser = new SimpleDateFormat(INPUTFORMAT);
+    inputFormatParser = new SimpleDateFormat(INPUTFORMAT);
   }
 
   @Override
   public String getWatermarkCondition(QueryBasedExtractor<?, ?> extractor, long watermarkValue, String operator) {
-    return extractor.getTimestampPredicateCondition(this.watermarkColumn, watermarkValue, this.watermarkFormat,
-        operator);
+    return extractor
+        .getTimestampPredicateCondition(this.watermarkColumn, watermarkValue, this.watermarkFormat, operator);
   }
 
   @Override
@@ -64,8 +63,8 @@ public class TimestampWatermark implements Watermark {
   @Override
   synchronized public HashMap<Long, Long> getIntervals(long lowWatermarkValue, long highWatermarkValue,
       long partitionInterval, int maxIntervals) {
-    Preconditions.checkArgument(partitionInterval >= 1,
-        "Invalid value for partitionInterval, value should be at least 1.");
+    Preconditions
+        .checkArgument(partitionInterval >= 1, "Invalid value for partitionInterval, value should be at least 1.");
     Preconditions.checkArgument(maxIntervals > 0, "Invalid value for maxIntervals, positive value expected.");
 
     HashMap<Long, Long> intervalMap = new HashMap<>();
@@ -93,11 +92,11 @@ public class TimestampWatermark implements Watermark {
     long lwm;
     long hwm;
     while (startTime.getTime() <= endTime.getTime()) {
-      lwm = Long.parseLong(_inputFormatParser.format(startTime));
+      lwm = Long.parseLong(inputFormatParser.format(startTime));
       calendar.setTime(startTime);
       calendar.add(Calendar.HOUR, (int) interval);
       nextTime = calendar.getTime();
-      hwm = Long.parseLong(_inputFormatParser.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
+      hwm = Long.parseLong(inputFormatParser.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
       intervalMap.put(lwm, hwm);
       LOG.debug("Partition - low:" + lwm + "; high:" + hwm);
       calendar.add(Calendar.SECOND, deltaForNextWatermark);

--- a/gobblin-core/src/main/java/gobblin/source/extractor/watermark/TimestampWatermark.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/watermark/TimestampWatermark.java
@@ -37,7 +37,8 @@ public class TimestampWatermark implements Watermark {
   private static final Logger LOG = LoggerFactory.getLogger(TimestampWatermark.class);
   // default water mark format(input format) example: 20140301050505
   private static final String INPUTFORMAT = "yyyyMMddHHmmss";
-  private static final SimpleDateFormat INPUTFORMATPARSER = new SimpleDateFormat(INPUTFORMAT);
+  private final SimpleDateFormat _inputFormatParser;
+
 
   private static final int deltaForNextWatermark = 1;
   private String watermarkColumn;
@@ -46,6 +47,7 @@ public class TimestampWatermark implements Watermark {
   public TimestampWatermark(String watermarkColumn, String watermarkFormat) {
     this.watermarkColumn = watermarkColumn;
     this.watermarkFormat = watermarkFormat;
+    _inputFormatParser = new SimpleDateFormat(INPUTFORMAT);
   }
 
   @Override
@@ -91,11 +93,11 @@ public class TimestampWatermark implements Watermark {
     long lwm;
     long hwm;
     while (startTime.getTime() <= endTime.getTime()) {
-      lwm = Long.parseLong(INPUTFORMATPARSER.format(startTime));
+      lwm = Long.parseLong(_inputFormatParser.format(startTime));
       calendar.setTime(startTime);
       calendar.add(Calendar.HOUR, (int) interval);
       nextTime = calendar.getTime();
-      hwm = Long.parseLong(INPUTFORMATPARSER.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
+      hwm = Long.parseLong(_inputFormatParser.format(nextTime.getTime() <= endTime.getTime() ? nextTime : endTime));
       intervalMap.put(lwm, hwm);
       LOG.debug("Partition - low:" + lwm + "; high:" + hwm);
       calendar.add(Calendar.SECOND, deltaForNextWatermark);


### PR DESCRIPTION
Fix the bug that the shared object SimpleDateFormat will cause issues in multi-threads. The scenario is that when all pull jobs start at the same time, the partition calculation for all jobs will be messed up.
