### PR TITLE
Removing fork branch index, task id and job id form task metrics

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/TaskState.java
@@ -242,7 +242,9 @@ public class TaskState extends WorkUnitState {
    */
   public synchronized void updateRecordMetrics(long recordsWritten, int branchIndex) {
     TaskMetrics metrics = TaskMetrics.get(this);
-    String forkBranchId = ForkOperatorUtils.getForkId(this.taskId, branchIndex);
+    // chopping branch index from metric name
+    // String forkBranchId = ForkOperatorUtils.getForkId(this.taskId, branchIndex);
+    String forkBranchId = TaskMetrics.taskInstanceRemoved(this.taskId);
 
     Counter taskRecordCounter = metrics.getCounter(MetricGroup.TASK.name(), forkBranchId, RECORDS);
     long inc = recordsWritten - taskRecordCounter.getCount();
@@ -262,7 +264,7 @@ public class TaskState extends WorkUnitState {
    */
   public synchronized void updateByteMetrics(long bytesWritten, int branchIndex) {
     TaskMetrics metrics = TaskMetrics.get(this);
-    String forkBranchId = ForkOperatorUtils.getForkId(this.taskId, branchIndex);
+    String forkBranchId = TaskMetrics.taskInstanceRemoved(this.taskId);
 
     Counter taskByteCounter = metrics.getCounter(MetricGroup.TASK.name(), forkBranchId, BYTES);
     long inc = bytesWritten - taskByteCounter.getCount();

--- a/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/util/TaskMetrics.java
@@ -53,8 +53,7 @@ public class TaskMetrics extends GobblinMetrics {
   public static TaskMetrics get(final TaskState taskState) {
     return (TaskMetrics) GOBBLIN_METRICS_REGISTRY.getOrDefault(name(taskState), new Callable<GobblinMetrics>() {
       @Override
-      public GobblinMetrics call()
-          throws Exception {
+      public GobblinMetrics call() throws Exception {
         return new TaskMetrics(taskState);
       }
     });
@@ -85,5 +84,17 @@ public class TaskMetrics extends GobblinMetrics {
 
   private static MetricContext parentContextForTask(TaskState taskState) {
     return JobMetrics.get(taskState.getProp(ConfigurationKeys.JOB_NAME_KEY), taskState.getJobId()).getMetricContext();
+  }
+
+  public static String taskInstanceRemoved(String metricName) {
+    final String METRIC_SEPARATOR = "_";
+
+    String[] taskIdTokens = metricName.split(METRIC_SEPARATOR);
+    StringBuilder sb = new StringBuilder(taskIdTokens[0]);
+    // chopping taskId and jobId from metric name
+    for (int i = 1; i < taskIdTokens.length - 2; i++) {
+      sb.append(METRIC_SEPARATOR).append(taskIdTokens[i]);
+    }
+    return sb.toString();
   }
 }


### PR DESCRIPTION
This is a fix to avoid unnecessary memory consumption due to creation of separate Metric objects for every job/task.
I removed branch index, task id and job id form task metric name to avoid creating a new task metrics for every task/branch.
@abti @ibuenros 