### PR TITLE
Added property with scheduler service startup timeout

### DIFF
--- a/conf/gobblin-standalone-v2.properties
+++ b/conf/gobblin-standalone-v2.properties
@@ -62,4 +62,8 @@ task.status.reportintervalinms=5000
 # Unit in milliseconds, configurable.
 jobconf.monitor.interval=30000
 
+# Startup timeout of JobScheduler. You may want to make it larger while using built-in Quartz scheduler in clustered
+# mode. (seconds)
+jobscheduler.startup.timeout=1
+
 task.maxretries=0

--- a/conf/gobblin-standalone.properties
+++ b/conf/gobblin-standalone.properties
@@ -66,3 +66,7 @@ task.status.reportintervalinms=5000
 # Unit in milliseconds, configurable.
 jobconf.monitor.interval=30000
 
+# Startup timeout of JobScheduler. You may want to make it larger while using built-in Quartz scheduler in clustered
+# mode. (seconds)
+jobscheduler.startup.timeout=1
+

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -94,6 +94,9 @@ public class ConfigurationKeys {
   // Note this only applies to jobs scheduled by the built-in Quartz-based job scheduler.
   public static final String SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY = "scheduler.wait.for.job.completion";
   public static final String DEFAULT_SCHEDULER_WAIT_FOR_JOB_COMPLETION = Boolean.TRUE.toString();
+  // Timeout for starting a scheduler, in seconds. Useful when you are using quartz in clustered mode
+  public static final String JOB_SCHEDULER_STARTUP_TIMEOUT_KEY = "jobscheduler.startup.timeout";
+  public static final long DEFAULT_JOB_SCHEDULER_STARTUP_TIMEOUT = 1L;
 
 
   /**

--- a/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
+++ b/gobblin-docs/user-guide/Configuration-Properties-Glossary.md
@@ -174,6 +174,13 @@ Controls how often Gobblin checks the jobconf.dir for new configuration files, o
 300000
 ###### Required
 No
+#### jobscheduler.startup.timeout
+###### Description
+Value in seconds after which Scheduler will be considered as not running. Consider increasing the value when you use Quartz scheduler in clustered mode.
+###### Default value
+1
+###### Required
+No
 ## CliMRJobLauncher Properties <a name="CliMRJobLauncher-Properties"></a>
 There are no configuration parameters specific to CliMRJobLauncher. This class is used to launch Gobblin jobs on Hadoop from the command line, the jobs are not scheduled. Common properties are set using the `--sysconfig` option when launching jobs via the command line. For more information on how to set the configuration parameters for jobs launched through the command line, check out the [Deployment](Gobblin-Deployment) page.  
 ## AzkabanJobLauncher Properties <a name="AzkabanJobLauncher-Properties"></a>

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -169,7 +169,7 @@ public class JobScheduler extends AbstractIdleService {
     LOG.info("Starting the job scheduler");
 
     try {
-      this.scheduler.awaitRunning(Long.valueOf(
+      this.scheduler.awaitRunning(Long.parseLong(
               this.properties.getProperty(ConfigurationKeys.JOB_SCHEDULER_STARTUP_TIMEOUT_KEY,
                       Long.toString(ConfigurationKeys.DEFAULT_JOB_SCHEDULER_STARTUP_TIMEOUT))),
               TimeUnit.SECONDS);

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -169,9 +169,12 @@ public class JobScheduler extends AbstractIdleService {
     LOG.info("Starting the job scheduler");
 
     try {
-      this.scheduler.awaitRunning(1, TimeUnit.SECONDS);
+      this.scheduler.awaitRunning(Long.valueOf(
+              this.properties.getProperty(ConfigurationKeys.JOB_SCHEDULER_STARTUP_TIMEOUT_KEY,
+                      Long.toString(ConfigurationKeys.DEFAULT_JOB_SCHEDULER_STARTUP_TIMEOUT))),
+              TimeUnit.SECONDS);
     } catch (TimeoutException | IllegalStateException exc) {
-      throw new IllegalStateException("Scheduler service is not running.");
+      throw new IllegalStateException("Scheduler service is not running.", exc);
     }
 
     // Note: This should not be mandatory, gobblin-cluster modes have their own job configuration managers


### PR DESCRIPTION
Hello,

I'm trying to run Gobblin in standalone cluster mode on our dev environment. I don't want to use Azkaban or Oozie as a scheduler, so I configured Quartz in cluster mode with MySQL backend. Because of not so good performance of mysql cluster on dev environment or physical distance between current mysql master and Gobblin installation, I've encountered `TimeoutException`s during job scheduler startup on Gobblin master. After diving in the code, I've noticed that in `startUp` method of `JobScheduler` there is such a piece of code: `this.scheduler.awaitRunning(1, TimeUnit.SECONDS);`. That was not enough to establish the connection by Quartz which produces  stacktrace below:

```
Exception in thread "GobblinHelixJobScheduler STARTING" java.lang.IllegalStateException: Scheduler service is not running.
	at gobblin.scheduler.JobScheduler.startUp(JobScheduler.java:178)
	at gobblin.cluster.GobblinHelixJobScheduler.startUp(GobblinHelixJobScheduler.java:82)
	at com.google.common.util.concurrent.AbstractIdleService$2$1.run(AbstractIdleService.java:54)
	at com.google.common.util.concurrent.Callables$3.run(Callables.java:93)
	at java.lang.Thread.run(Thread.java:745)
Caused by: java.util.concurrent.TimeoutException: Timed out waiting for  [STARTING] to reach the RUNNING state. Current state: STARTING
	at com.google.common.util.concurrent.AbstractService.awaitRunning(AbstractService.java:295)
	at com.google.common.util.concurrent.AbstractIdleService.awaitRunning(AbstractIdleService.java:184)
	at gobblin.scheduler.JobScheduler.startUp(JobScheduler.java:176)
	... 4 more
```

Introducing new property: `jobscheduler.startup.timeout` with default value of `1` was the simplest solution that fixes the issue. Please let me know if it meets your standards :)