### PR TITLE
Fixing bug in gobblin.configuration.State

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/State.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/State.java
@@ -78,7 +78,10 @@ public class State implements WritableShim {
   public State(State otherState) {
     this.commonProperties = otherState.getCommonProperties();
     this.specProperties = new Properties();
-    this.specProperties.putAll(otherState.getSpecProperties());
+    this.specProperties.putAll(otherState.getProperties());
+    for (Object key : this.commonProperties.keySet()) {
+      this.specProperties.remove(key);
+    }
   }
 
   /**


### PR DESCRIPTION
A State can have properties other than commonProperties and specProperties. 

For example WorkUnitState extends State. Hence WorkUnitState does contain commonProperties and specProperties. A WorkUnitState also contains WorkUnit(extends State). Hence a WorkUnitState contains properties other commonProperties and specProperties in the form of Properties belonging to a WorkUnit.

I encountered this error when workUnitState is passed as a parameter to the State constructor leading to loss of few properties.