### PR TITLE
Catching UncheckedExecutionException in HiveSource

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/source/HiveSource.java
@@ -16,6 +16,7 @@
  */
 package gobblin.data.management.conversion.hive.source;
 
+import com.google.common.util.concurrent.UncheckedExecutionException;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
@@ -328,10 +329,13 @@ public class HiveSource implements Source {
               sourcePartition.getCompleteName(), updateTime, lowWatermark.getValue()));
         }
       } catch (UpdateNotFoundException e) {
-        log.error(String.format("Not Creating workunit for %s as update time was not found. %s",
+        log.error(String.format("Not creating workunit for %s as update time was not found. %s",
             sourcePartition.getCompleteName(), e.getMessage()));
       } catch (SchemaNotFoundException e) {
-        log.error(String.format("Not Creating workunit for %s as schema was not found. %s",
+        log.error(String.format("Not creating workunit for %s as schema was not found. %s",
+            sourcePartition.getCompleteName(), e.getMessage()));
+      } catch (UncheckedExecutionException e) {
+        log.error(String.format("Not creating workunit for %s because an unchecked exception occurred. %s",
             sourcePartition.getCompleteName(), e.getMessage()));
       }
     }


### PR DESCRIPTION
During creation of WorkUnits in HiveSource, failure to create a single WorkUnit shouldn't lead to failure of Job.
Some exceptions in this case (eg. UpdateNotFoundException) are often wrapped as UncheckedExecutionException leading to failure of Job.