### PR TITLE
Fix distcp from CLI hang

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/copy/writer/FileAwareInputStreamDataWriter.java
@@ -89,7 +89,6 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   protected final FileSystem fs;
   protected final Path stagingDir;
   protected final Path outputDir;
-  protected final Closer closer = Closer.create();
   private final Map<String, Object> encryptionConfig;
   protected CopyableDatasetMetadata copyableDatasetMetadata;
   protected final RecoveryHelper recoveryHelper;
@@ -341,12 +340,6 @@ public class FileAwareInputStreamDataWriter extends InstrumentedDataWriter<FileA
   public long bytesWritten()
       throws IOException {
     return this.bytesWritten.get();
-  }
-
-  @Override
-  public void close()
-      throws IOException {
-    this.closer.close();
   }
 
   /**


### PR DESCRIPTION
@ibuenros 

`bin/gobblin run distcp foo bar` was hanging on exit whenever any file was actually copied. The root cause was that `FSAwareInputDataStreamWriter` overrode `close()` without calling the superclass method -- this caused the metric updater thread from `InstrumentedDataWriterBase` to hang around forever because it was never shutdown.

This fix is correct, but I'm not sure if we should also be started the metric writer thread as a daemon thread vs one that can hang the process -- thoughts?

- Remove shadowed closer variable since the superclass defines one already
- Remove overridden close() method - it wasn't calling super.close()
which was causing bugs, and is now irrelevant since the parent close
will close resources properly