### PR TITLE
Fixes to InstrumentedFileSystem on MR jobs and BatchedPermitsContainer.

### DIFF
--- a/gobblin-core-base/src/main/java/gobblin/instrumented/converter/InstrumentedConverterBase.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/converter/InstrumentedConverterBase.java
@@ -95,7 +95,7 @@ abstract class InstrumentedConverterBase<SI, SO, DI, DO> extends Converter<SI, S
       this.recordsOutMeter = Optional.of(this.metricContext.meter(MetricNames.ConverterMetrics.RECORDS_OUT_METER));
       this.recordsExceptionMeter = Optional.of(
           this.metricContext.meter(MetricNames.ConverterMetrics.RECORDS_FAILED_METER));
-      this.converterTimer = Optional.of(this.metricContext.timer(MetricNames.ConverterMetrics.CONVERT_TIMER));
+      this.converterTimer = Optional.<Timer>of(this.metricContext.timer(MetricNames.ConverterMetrics.CONVERT_TIMER));
     }
   }
 

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/extractor/InstrumentedExtractorBase.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/extractor/InstrumentedExtractorBase.java
@@ -94,7 +94,7 @@ public abstract class InstrumentedExtractorBase<S, D>
       this.readRecordsMeter = Optional.of(this.metricContext.meter(MetricNames.ExtractorMetrics.RECORDS_READ_METER));
       this.dataRecordExceptionsMeter =
           Optional.of(this.metricContext.meter(MetricNames.ExtractorMetrics.RECORDS_FAILED_METER));
-      this.extractorTimer = Optional.of(this.metricContext.timer(MetricNames.ExtractorMetrics.EXTRACT_TIMER));
+      this.extractorTimer = Optional.<Timer>of(this.metricContext.timer(MetricNames.ExtractorMetrics.EXTRACT_TIMER));
     } else {
       this.readRecordsMeter = Optional.absent();
       this.dataRecordExceptionsMeter = Optional.absent();

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/fork/InstrumentedForkOperatorBase.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/fork/InstrumentedForkOperatorBase.java
@@ -98,7 +98,7 @@ abstract class InstrumentedForkOperatorBase<S, D> implements Instrumentable, For
     if (isInstrumentationEnabled()) {
       this.inputMeter = Optional.of(this.metricContext.meter(MetricNames.ForkOperatorMetrics.RECORDS_IN_METER));
       this.outputForks = Optional.of(this.metricContext.meter(MetricNames.ForkOperatorMetrics.FORKS_OUT_METER));
-      this.forkOperatorTimer = Optional.of(this.metricContext.timer(MetricNames.ForkOperatorMetrics.FORK_TIMER));
+      this.forkOperatorTimer = Optional.<Timer>of(this.metricContext.timer(MetricNames.ForkOperatorMetrics.FORK_TIMER));
     } else {
       this.inputMeter = Optional.absent();
       this.outputForks = Optional.absent();

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/qualitychecker/InstrumentedRowLevelPolicyBase.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/qualitychecker/InstrumentedRowLevelPolicyBase.java
@@ -92,7 +92,7 @@ abstract class InstrumentedRowLevelPolicyBase extends RowLevelPolicy implements 
           this.metricContext.meter(MetricNames.RowLevelPolicyMetrics.RECORDS_PASSED_METER));
       this.failedRecordsMeter = Optional.of(
           this.metricContext.meter(MetricNames.RowLevelPolicyMetrics.RECORDS_FAILED_METER));
-      this.policyTimer = Optional.of(
+      this.policyTimer = Optional.<Timer>of(
           this.metricContext.timer(MetricNames.RowLevelPolicyMetrics.CHECK_TIMER));
     } else {
       this.recordsMeter = Optional.absent();

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterBase.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterBase.java
@@ -113,7 +113,7 @@ abstract class InstrumentedDataWriterBase<D> implements DataWriter<D>, Instrumen
       this.failedWritesMeter = Optional.of(this.metricContext.meter(MetricNames.DataWriterMetrics.FAILED_WRITES_METER));
       setRecordsWrittenMeter(isInstrumentationEnabled());
       setBytesWrittenMeter(isInstrumentationEnabled());
-      this.dataWriterTimer = Optional.of(this.metricContext.timer(MetricNames.DataWriterMetrics.WRITE_TIMER));
+      this.dataWriterTimer = Optional.<Timer>of(this.metricContext.timer(MetricNames.DataWriterMetrics.WRITE_TIMER));
     } else {
       this.recordsInMeter = Optional.absent();
       this.successfulWritesMeter = Optional.absent();

--- a/gobblin-core-base/src/main/java/gobblin/writer/AsyncWriterManager.java
+++ b/gobblin-core-base/src/main/java/gobblin/writer/AsyncWriterManager.java
@@ -209,7 +209,7 @@ public class AsyncWriterManager<D> implements WatermarkAwareWriter<D>, DataWrite
     this.bytesWritten = this.metricContext.meter(MetricNames.DataWriterMetrics.BYTES_WRITTEN_METER);
 
     if (isInstrumentationEnabled()) {
-      this.dataWriterTimer = Optional.of(this.metricContext.timer(MetricNames.DataWriterMetrics.WRITE_TIMER));
+      this.dataWriterTimer = Optional.<Timer>of(this.metricContext.timer(MetricNames.DataWriterMetrics.WRITE_TIMER));
     } else {
       this.dataWriterTimer = Optional.absent();
     }

--- a/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
@@ -72,7 +72,7 @@ public class ThrottleWriter<D> implements DataWriter<D>, FinalState, Retriable {
 
     this.limiter = new RateBasedLimiter(computeRateLimit(state));
     if (GobblinMetrics.isEnabled(state)) {
-      throttledTimer = Optional.of(Instrumented.getMetricContext(state, getClass()).timer(WRITES_THROTTLED_TIMER));
+      throttledTimer = Optional.<Timer>of(Instrumented.getMetricContext(state, getClass()).timer(WRITES_THROTTLED_TIMER));
     } else {
       throttledTimer = Optional.absent();
     }

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/MetricContext.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/MetricContext.java
@@ -379,7 +379,7 @@ public class MetricContext extends MetricRegistry implements ReportableContext, 
    * This is equivalent to {@link #contextAwareTimer(String)}.
    */
   @Override
-  public Timer timer(String name) {
+  public ContextAwareTimer timer(String name) {
     return contextAwareTimer(name);
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -121,6 +121,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
   private final Job job;
   private final Path mrJobDir;
   private final Path jarsDir;
+  /** A location to store jars that should not be shared between different jobs. */
+  private final Path unsharedJarsDir;
   private final Path jobInputPath;
   private final Path jobOutputPath;
 
@@ -165,8 +167,9 @@ public class MRJobLauncher extends AbstractJobLauncher {
       LOG.warn("Job working directory already exists for job " + this.jobContext.getJobName());
       this.fs.delete(this.mrJobDir, true);
     }
+    this.unsharedJarsDir = new Path(this.mrJobDir, JARS_DIR_NAME);
     this.jarsDir = this.jobProps.containsKey(ConfigurationKeys.MR_JARS_DIR) ? new Path(
-        this.jobProps.getProperty(ConfigurationKeys.MR_JARS_DIR)) : new Path(this.mrJobDir, JARS_DIR_NAME);
+        this.jobProps.getProperty(ConfigurationKeys.MR_JARS_DIR)) : this.unsharedJarsDir;
     this.fs.mkdirs(this.mrJobDir);
 
     this.jobInputPath = new Path(this.mrJobDir, INPUT_DIR_NAME);
@@ -388,8 +391,10 @@ public class MRJobLauncher extends AbstractJobLauncher {
       Path srcJarFile = new Path(jarFile);
       FileStatus[] fileStatusList = lfs.globStatus(srcJarFile);
       for (FileStatus status : fileStatusList) {
+        // SNAPSHOT jars should not be shared, as different jobs may be using different versions of it
+        Path baseDir = status.getPath().getName().contains("SNAPSHOT") ? this.unsharedJarsDir : jarFileDir;
         // DistributedCache requires absolute path, so we need to use makeQualified.
-        Path destJarFile = new Path(this.fs.makeQualified(jarFileDir), status.getPath().getName());
+        Path destJarFile = new Path(this.fs.makeQualified(baseDir), status.getPath().getName());
         if (!this.fs.exists(destJarFile)) {
           // Copy the jar file from local file system to HDFS
           this.fs.copyFromLocalFile(status.getPath(), destJarFile);

--- a/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerFactory.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerFactory.java
@@ -134,7 +134,9 @@ public class SharedResourcesBrokerFactory {
 
     if (ConfigUtils.getBoolean(config, LOAD_HADOOP_CONFIGURATION, true)) {
       Map<String, String> hadoopConfMap = Maps.newHashMap();
-      addBrokerKeys(hadoopConfMap, new Configuration());
+      Configuration hadoopConf = new Configuration();
+      hadoopConf.addResource("gobblin-site.xml");
+      addBrokerKeys(hadoopConfMap, hadoopConf);
       config = config.withFallback(ConfigFactory.parseMap(hadoopConfMap));
     }
 


### PR DESCRIPTION
This PR does the following:

* Add an `onClose` trigger for `FileSystemInstrumentations`. Metrics instrumentation writes out a report on this trigger. This required updating the return type of `MetricContext.timer`.
* Fix `BatchedPermitsRequester` to correctly handle multiple batches with the same expiration.
* A few small fixes.