### PR TITLE
Support shorten dataset state store name

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -75,6 +75,8 @@ public class ConfigurationKeys {
   public static final String STATE_STORE_DB_TABLE_KEY = "state.store.db.table";
   public static final String DEFAULT_STATE_STORE_DB_TABLE = "gobblin_job_state";
 
+  public static final String DATASETURN_STATESTORE_NAME_PARSER = "state.store.datasetUrnStateStoreNameParser";
+
   /**
    * Job scheduler configuration properties.
    */

--- a/gobblin-metastore/src/main/java/gobblin/metastore/nameParser/DatasetUrnStateStoreNameParser.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/nameParser/DatasetUrnStateStoreNameParser.java
@@ -15,29 +15,33 @@
  * limitations under the License.
  */
 
-package gobblin.metastore;
+package gobblin.metastore.nameParser;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Map;
 
-import com.typesafe.config.Config;
 
-import gobblin.configuration.State;
+/**
+ * Parses datasetUrns to dataset state store name. This is useful for systems that have limit on the length of the state
+ * store name.
+ */
+public interface DatasetUrnStateStoreNameParser {
 
-public interface DatasetStateStore<T extends State> extends StateStore<T> {
-  String DATASET_STATE_STORE_TABLE_SUFFIX = ".jst";
-  String CURRENT_DATASET_STATE_FILE_SUFFIX = "current";
+  /**
+   * Get state store name from the given datasetUrn.
+   */
+  String getStateStoreNameFromDatasetUrn(String datasetUrn)
+      throws IOException;
 
-  interface Factory {
-    <T extends State> DatasetStateStore<T> createStateStore(Config config);
-  }
+  /**
+   * Get datasetUrn from the given state store name.
+   */
+  String getDatasetUrnFromStateStoreName(String stateStoreName)
+      throws IOException;
 
-  public Map<String, T> getLatestDatasetStatesByUrns(String jobName) throws IOException;
-
-  public T getLatestDatasetState(String storeName, String datasetUrn) throws IOException;
-
-  public void persistDatasetState(String datasetUrn, T datasetState) throws IOException;
-
-  public void persistDatasetURNs(String storeName, Collection<String> datasetUrns) throws IOException;
+  /**
+   * Persist {@link Collection} of datasteUrns.
+   */
+  void persistDatasetUrns(Collection<String> datasetUrns)
+      throws IOException;
 }

--- a/gobblin-metastore/src/main/java/gobblin/metastore/nameParser/GuidDatasetUrnStateStoreNameParser.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/nameParser/GuidDatasetUrnStateStoreNameParser.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metastore.nameParser;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.Collection;
+
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Charsets;
+import com.google.common.collect.BiMap;
+import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Maps;
+import com.google.common.io.LineReader;
+
+import gobblin.util.guid.Guid;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+
+/**
+ * Implements {@link DatasetUrnStateStoreNameParser} using {@link Guid}.
+ */
+public class GuidDatasetUrnStateStoreNameParser implements DatasetUrnStateStoreNameParser {
+  private static final String TMP_SUFFIX = "_tmp";
+
+  private final FileSystem fs;
+  private Path versionIdentifier;
+
+  @AllArgsConstructor
+  public enum StateStoreNameVersion {
+    /**
+     * DatasetUrn is directly used as the state store name.
+     * This is the initial status when {@link GuidDatasetUrnStateStoreNameParser} is first enabled.
+     * It will be migrated to {@link StateStoreNameVersion#V1}.
+     */
+    V0(StringUtils.EMPTY),
+    /**
+     * DatasetUrn is hashed into shorten name.
+     */
+    V1("datasetUrnNameMapV1");
+
+    @Getter
+    private String datasetUrnNameMapFile;
+  }
+
+  private final StateStoreNameVersion version;
+  @VisibleForTesting
+  protected final BiMap<String, String> sanitizedNameToDatasetURNMap;
+
+  public GuidDatasetUrnStateStoreNameParser(FileSystem fs, Path jobStatestoreRootDir)
+      throws IOException {
+    this.fs = fs;
+    this.sanitizedNameToDatasetURNMap = Maps.synchronizedBiMap(HashBiMap.<String, String>create());
+    this.versionIdentifier = new Path(jobStatestoreRootDir, StateStoreNameVersion.V1.getDatasetUrnNameMapFile());
+    if (this.fs.exists(versionIdentifier)) {
+      this.version = StateStoreNameVersion.V1;
+      try (InputStream in = this.fs.open(versionIdentifier)) {
+        LineReader lineReader = new LineReader(new InputStreamReader(in, Charsets.UTF_8));
+        String shortenName = lineReader.readLine();
+        while (shortenName != null) {
+          String datasetUrn = lineReader.readLine();
+          this.sanitizedNameToDatasetURNMap.put(shortenName, datasetUrn);
+          shortenName = lineReader.readLine();
+        }
+      }
+    } else {
+      this.version = StateStoreNameVersion.V0;
+    }
+  }
+
+  /**
+   * Get datasetUrn for the given state store name.
+   * If the state store name can be found in {@link #sanitizedNameToDatasetURNMap}, the original datasetUrn will be returned.
+   * Otherwise, the state store name will be returned.
+   */
+  @Override
+  public String getDatasetUrnFromStateStoreName(String stateStoreName)
+      throws IOException {
+    if (version == StateStoreNameVersion.V0 || !this.sanitizedNameToDatasetURNMap.containsKey(stateStoreName)) {
+      return stateStoreName;
+    } else {
+      return this.sanitizedNameToDatasetURNMap.get(stateStoreName);
+    }
+  }
+
+  /**
+   * Merge the given {@link Collection} of datasetUrns with {@link #sanitizedNameToDatasetURNMap}, and write the results
+   * to the {@link Path} of {@link #versionIdentifier}, which is a text file.
+   */
+  @Override
+  public void persistDatasetUrns(Collection<String> datasetUrns)
+      throws IOException {
+    for (String datasetUrn : datasetUrns) {
+      String key = Guid.fromStrings(datasetUrn).toString();
+      if (!this.sanitizedNameToDatasetURNMap.containsKey(key)) {
+        this.sanitizedNameToDatasetURNMap.put(key, datasetUrn);
+      } else if (!this.sanitizedNameToDatasetURNMap.get(key).equals(datasetUrn)) {
+        // This should not happen for datasetUrns since Guid is SHA1 based...
+        throw new RuntimeException(
+            "Found a collision for " + datasetUrn + " with existing: " + this.sanitizedNameToDatasetURNMap.get(key));
+      }
+    }
+    Path tmpMapFile = new Path(this.versionIdentifier.getParent(), this.versionIdentifier.getName() + TMP_SUFFIX);
+    try (FSDataOutputStream fsout = this.fs.create(tmpMapFile)) {
+      for (String key : this.sanitizedNameToDatasetURNMap.keySet()) {
+        fsout.write(key.getBytes(Charsets.UTF_8));
+        fsout.writeByte('\n');
+        fsout.write(this.sanitizedNameToDatasetURNMap.get(key).getBytes(Charsets.UTF_8));
+        fsout.writeByte('\n');
+      }
+    }
+    // Back up the previous file first, and then rename the new file.
+    if (this.fs.exists(this.versionIdentifier) && !this.fs.rename(this.versionIdentifier,
+        new Path(this.versionIdentifier.getParent(),
+            this.versionIdentifier.getName() + "_" + System.currentTimeMillis()))) {
+      throw new IOException(
+          "Failed to back up existing datasetUrn to stateStore name mapping file: " + this.versionIdentifier);
+    }
+
+    if (!fs.rename(tmpMapFile, this.versionIdentifier)) {
+      throw new IOException("Failed to rename from " + tmpMapFile + " to " + this.versionIdentifier);
+    }
+  }
+
+  @Override
+  public String getStateStoreNameFromDatasetUrn(String datasetUrn)
+      throws IOException {
+    if (!this.sanitizedNameToDatasetURNMap.inverse().containsKey(datasetUrn)) {
+      String guid = Guid.fromStrings(datasetUrn).toString();
+      this.sanitizedNameToDatasetURNMap.put(guid, datasetUrn);
+    }
+    return this.sanitizedNameToDatasetURNMap.inverse().get(datasetUrn);
+  }
+}

--- a/gobblin-metastore/src/main/java/gobblin/metastore/nameParser/SimpleDatasetUrnStateStoreNameParser.java
+++ b/gobblin-metastore/src/main/java/gobblin/metastore/nameParser/SimpleDatasetUrnStateStoreNameParser.java
@@ -15,29 +15,31 @@
  * limitations under the License.
  */
 
-package gobblin.metastore;
+package gobblin.metastore.nameParser;
 
 import java.io.IOException;
 import java.util.Collection;
-import java.util.Map;
 
-import com.typesafe.config.Config;
 
-import gobblin.configuration.State;
-
-public interface DatasetStateStore<T extends State> extends StateStore<T> {
-  String DATASET_STATE_STORE_TABLE_SUFFIX = ".jst";
-  String CURRENT_DATASET_STATE_FILE_SUFFIX = "current";
-
-  interface Factory {
-    <T extends State> DatasetStateStore<T> createStateStore(Config config);
+/**
+ * Simple implementation of {@link DatasetUrnStateStoreNameParser}, in which datasetUrn is identical to dataset state store name.
+ */
+public class SimpleDatasetUrnStateStoreNameParser implements DatasetUrnStateStoreNameParser {
+  @Override
+  public String getStateStoreNameFromDatasetUrn(String datasetUrn)
+      throws IOException {
+    return datasetUrn;
   }
 
-  public Map<String, T> getLatestDatasetStatesByUrns(String jobName) throws IOException;
+  @Override
+  public String getDatasetUrnFromStateStoreName(String stateStoreName)
+      throws IOException {
+    return stateStoreName;
+  }
 
-  public T getLatestDatasetState(String storeName, String datasetUrn) throws IOException;
-
-  public void persistDatasetState(String datasetUrn, T datasetState) throws IOException;
-
-  public void persistDatasetURNs(String storeName, Collection<String> datasetUrns) throws IOException;
+  @Override
+  public void persistDatasetUrns(Collection<String> datasetUrns)
+      throws IOException {
+    //do nothing.
+  }
 }

--- a/gobblin-metastore/src/test/java/gobblin/metastore/nameParser/GuidDatasetUrnStateStoreNameParserTest.java
+++ b/gobblin-metastore/src/test/java/gobblin/metastore/nameParser/GuidDatasetUrnStateStoreNameParserTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metastore.nameParser;
+
+import java.io.IOException;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.testng.Assert;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.Lists;
+
+import gobblin.util.guid.Guid;
+
+
+/**
+ * Test for {@link GuidDatasetUrnStateStoreNameParser}.
+ */
+public class GuidDatasetUrnStateStoreNameParserTest {
+
+  Path jobStateRootDir;
+  FileSystem testFs;
+
+  @BeforeTest
+  public void setUp()
+      throws IOException {
+    this.jobStateRootDir = new Path("testStateStoreParser");
+    this.testFs = FileSystem.getLocal(new Configuration());
+  }
+
+  @Test
+  public void testPersistDatasetUrns()
+      throws IOException {
+    GuidDatasetUrnStateStoreNameParser parser =
+        new GuidDatasetUrnStateStoreNameParser(this.testFs, this.jobStateRootDir);
+    parser.persistDatasetUrns(Lists.newArrayList("dataset1", "dataset2"));
+    Assert.assertTrue(this.testFs.exists(new Path(jobStateRootDir,
+        GuidDatasetUrnStateStoreNameParser.StateStoreNameVersion.V1.getDatasetUrnNameMapFile())));
+  }
+
+  @Test(dependsOnMethods = {"testPersistDatasetUrns"})
+  public void testGetDatasetUrnFromStateStoreName()
+      throws IOException {
+    GuidDatasetUrnStateStoreNameParser parser =
+        new GuidDatasetUrnStateStoreNameParser(this.testFs, this.jobStateRootDir);
+    Assert.assertEquals(parser.sanitizedNameToDatasetURNMap.size(), 2);
+    Assert.assertTrue(parser.sanitizedNameToDatasetURNMap.inverse().containsKey("dataset1"));
+    Assert.assertTrue(parser.sanitizedNameToDatasetURNMap.inverse().containsKey("dataset2"));
+    Assert.assertEquals(parser.getStateStoreNameFromDatasetUrn("dataset1"), Guid.fromStrings("dataset1").toString());
+    Assert.assertEquals(parser.getStateStoreNameFromDatasetUrn("dataset2"), Guid.fromStrings("dataset2").toString());
+  }
+
+  @AfterTest
+  public void cleanUp()
+      throws IOException {
+    if (this.testFs.exists(this.jobStateRootDir)) {
+      this.testFs.delete(this.jobStateRootDir, true);
+    }
+  }
+}

--- a/gobblin-modules/gobblin-helix/src/main/java/gobblin/runtime/ZkDatasetStateStore.java
+++ b/gobblin-modules/gobblin-helix/src/main/java/gobblin/runtime/ZkDatasetStateStore.java
@@ -25,6 +25,7 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.DatasetStateStore;
 import gobblin.metastore.ZkStateStore;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -111,6 +112,12 @@ public class ZkDatasetStateStore extends ZkStateStore<JobState.DatasetState>
 
     put(jobName, tableName, datasetState);
     createAlias(jobName, tableName, getAliasName(datasetUrn));
+  }
+
+  @Override
+  public void persistDatasetURNs(String storeName, Collection<String> datasetUrns)
+      throws IOException {
+    // do nothing for now
   }
 
   private static String getAliasName(String datasetUrn) {

--- a/gobblin-runtime/src/main/java/gobblin/runtime/MysqlDatasetStateStore.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/MysqlDatasetStateStore.java
@@ -24,6 +24,7 @@ import gobblin.configuration.ConfigurationKeys;
 import gobblin.metastore.DatasetStateStore;
 import gobblin.metastore.MysqlStateStore;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import javax.sql.DataSource;
@@ -115,6 +116,12 @@ public class MysqlDatasetStateStore extends MysqlStateStore<JobState.DatasetStat
 
     put(jobName, tableName, datasetState);
     createAlias(jobName, tableName, getAliasName(datasetUrn));
+  }
+
+  @Override
+  public void persistDatasetURNs(String storeName, Collection<String> datasetUrns)
+      throws IOException {
+    //do nothing for now
   }
 
   private static String getAliasName(String datasetUrn) {


### PR DESCRIPTION
Created `DatasetUrnStateStoreNameParser` for providing the mapping between datasetUrn and state store name.
It currently has two implementations. The default: `SimpleDatasetUrnStateStoreNameParser` and SHA1 based guid: `GuidDatasetUrnStateStoreNameParser`.
`FsDatasetStateStore` has this feature enabled. It is backwards compatible.
Other `DatasetStateStore` can also have this feature. 
@htran1 or @ibuenros  can you take a look?
