### PR TITLE
Stress testing classes for throttling service.

### DIFF
--- a/gobblin-restli/client.gradle
+++ b/gobblin-restli/client.gradle
@@ -25,6 +25,13 @@ buildscript {
     }
   }
 
+  repositories {
+    jcenter()
+  }
+  dependencies {
+    classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.4'
+  }
+
 }
 
 apply plugin: 'pegasus'

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/RestliServiceBasedLimiter.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/RestliServiceBasedLimiter.java
@@ -18,7 +18,6 @@
 package gobblin.util.limiter;
 
 import com.codahale.metrics.Meter;
-import com.codahale.metrics.Timer;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Optional;
 import com.linkedin.restli.client.RestClient;
@@ -27,9 +26,7 @@ import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
 import gobblin.util.NoopCloseable;
 import java.io.Closeable;
-import java.io.IOException;
 
-import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 
@@ -91,6 +88,6 @@ public class RestliServiceBasedLimiter implements Limiter {
    */
   @VisibleForTesting
   public long getUnusedPermits() {
-    return this.bachedPermitsContainer.getPermitBatchContainer().getTotalPermits();
+    return this.bachedPermitsContainer.getPermitBatchContainer().getTotalAvailablePermits();
   }
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/FixedOperationsStressor.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/FixedOperationsStressor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.limiter.stressTest;
+
+import org.apache.hadoop.conf.Configuration;
+
+import gobblin.util.limiter.Limiter;
+
+
+/**
+ * A {@link Stressor} that performs a fixed number of permit requests to the {@link Limiter} without pausing.
+ */
+public class FixedOperationsStressor extends RandomDelayStartStressor {
+
+  public static final String OPS_TO_RUN = "fixedOperationsStressor.opsToRun";
+
+  public static final int DEFAULT_OPS_TARGET = 200;
+
+  private int opsTarget;
+
+  @Override
+  public void configure(Configuration configuration) {
+    super.configure(configuration);
+    this.opsTarget = configuration.getInt(OPS_TO_RUN, DEFAULT_OPS_TARGET);
+  }
+
+  @Override
+  public void doRun(Limiter limiter) throws InterruptedException {
+    int ops = 0;
+    while (ops < this.opsTarget) {
+      limiter.acquirePermits(1);
+      ops++;
+    }
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/MRStressTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/MRStressTest.java
@@ -1,0 +1,363 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.limiter.stressTest;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.io.DoubleWritable;
+import org.apache.hadoop.io.LongWritable;
+import org.apache.hadoop.io.NullWritable;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.io.Writable;
+import org.apache.hadoop.mapreduce.InputFormat;
+import org.apache.hadoop.mapreduce.InputSplit;
+import org.apache.hadoop.mapreduce.Job;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.MapContext;
+import org.apache.hadoop.mapreduce.Mapper;
+import org.apache.hadoop.mapreduce.RecordReader;
+import org.apache.hadoop.mapreduce.Reducer;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.joda.time.DateTime;
+import org.slf4j.Logger;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.broker.BrokerConfigurationKeyGenerator;
+import gobblin.broker.SharedResourcesBrokerFactory;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.NotConfiguredException;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.restli.SharedRestClientFactory;
+import gobblin.restli.SharedRestClientKey;
+import gobblin.util.ExecutorsUtils;
+import gobblin.util.limiter.Limiter;
+import gobblin.util.limiter.MultiLimiter;
+import gobblin.util.limiter.NoopLimiter;
+import gobblin.util.limiter.RateBasedLimiter;
+import gobblin.util.limiter.RestliLimiterFactory;
+import gobblin.util.limiter.broker.SharedLimiterKey;
+
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * An MR job to test the performance of throttling.
+ *
+ * Each mapper runs a {@link Stressor}, which uses an {@link AtomicLong} to record its progress, and a {@link Limiter}
+ * to throttle is progress. Different {@link Stressor}s might produce different usage patterns.
+ *
+ * The mappers emit a report every 15 seconds with the rate at which the {@link Stressor} is making progress (measured by
+ * the rate at which the {@link AtomicLong} increases).
+ *
+ * The reducer computes the aggregate rate at which all {@link Stressor}s make progress.
+ */
+@Slf4j
+public class MRStressTest {
+
+  public static final String USE_THROTTLING_SERVER = "stressTest.useThrottlingServer";
+  public static final String RESOURCE_ID = "stressTest.resourceLimited";
+  public static final String LOCALLY_ENFORCED_QPS = "stressTest.localQps";
+
+  public static final String NUM_MAPPERS = "stressTest.num.mappers";
+
+  public static String DEFAULT_MAPPERS = "10";
+
+  public static Option NUM_MAPPERS_OPT = new Option("mappers", true, "Num mappers");
+  public static Option THROTTLING_SERVER_URI = new Option("throttling", true, "Throttling server uri");
+  public static Option RESOURCE_ID_OPT = new Option("resource", true, "Resource id for throttling server");
+  public static Option LOCAL_QPS_OPT = new Option("localQps", true, "Locally enforced QPS");
+  public static Options OPTIONS = StressTestUtils.OPTIONS.addOption(NUM_MAPPERS_OPT).addOption(THROTTLING_SERVER_URI)
+      .addOption(RESOURCE_ID_OPT).addOption(LOCAL_QPS_OPT);
+
+  public static void main(String[] args) throws Exception {
+
+    CommandLine cli = StressTestUtils.parseCommandLine(OPTIONS, args);
+
+    Configuration configuration = new Configuration();
+    if (cli.hasOption(THROTTLING_SERVER_URI.getOpt())) {
+      configuration.setBoolean(USE_THROTTLING_SERVER, true);
+      String resourceLimited = cli.getOptionValue(RESOURCE_ID_OPT.getOpt(), "MRStressTest");
+      configuration .set(RESOURCE_ID, resourceLimited);
+      configuration .set(
+          BrokerConfigurationKeyGenerator.generateKey(new SharedRestClientFactory(),
+              new SharedRestClientKey(RestliLimiterFactory.RESTLI_SERVICE_NAME),
+              null, SharedRestClientFactory.SERVER_URI_KEY), cli.getOptionValue(THROTTLING_SERVER_URI.getOpt()));
+    }
+
+    if (cli.hasOption(LOCAL_QPS_OPT.getOpt())) {
+      configuration .set(LOCALLY_ENFORCED_QPS, cli.getOptionValue(LOCAL_QPS_OPT.getOpt()));
+    }
+
+    Job job = Job.getInstance(configuration, "ThrottlingStressTest");
+    job.getConfiguration().setBoolean("mapreduce.job.user.classpath.first", true);
+    job.getConfiguration().setBoolean("mapreduce.map.speculative", false);
+
+    job.getConfiguration().set(NUM_MAPPERS, cli.getOptionValue(NUM_MAPPERS_OPT.getOpt(), DEFAULT_MAPPERS));
+    StressTestUtils.populateConfigFromCli(job.getConfiguration(), cli);
+
+    job.setJarByClass(MRStressTest.class);
+    job.setMapperClass(StresserMapper.class);
+    job.setReducerClass(AggregatorReducer.class);
+    job.setInputFormatClass(MyInputFormat.class);
+
+    job.setOutputKeyClass(LongWritable.class);
+    job.setOutputValueClass(DoubleWritable.class);
+    FileOutputFormat.setOutputPath(job, new Path("/tmp/MRStressTest" + System.currentTimeMillis()));
+
+    System.exit(job.waitForCompletion(true) ? 0 : 1);
+  }
+
+  /**
+   * Instantiates a {@link Stressor} and runs it until it exits. It also sets up a {@link Recorder} that computes and
+   * records the rate at which the {@link AtomicLong} increases every 15 seconds.
+   */
+  public static class StresserMapper extends Mapper<Text, NullWritable, LongWritable, DoubleWritable> {
+    private SharedResourcesBroker<SimpleScopeType> broker;
+
+    @Override
+    protected void setup(Context context) throws IOException, InterruptedException {
+      Map<String, String> configMap = Maps.newHashMap();
+
+      SharedResourcesBrokerFactory.addBrokerKeys(configMap, context.getConfiguration());
+      this.broker = SharedResourcesBrokerFactory.createDefaultTopLevelBroker(ConfigFactory.parseMap(configMap),
+          SimpleScopeType.GLOBAL.defaultScopeInstance());
+
+      super.setup(context);
+    }
+
+    @Override
+    protected void map(Text key, NullWritable value, Context context) throws IOException, InterruptedException {
+      try {
+        Configuration configuration = context.getConfiguration();
+
+        Stressor stressor = context.getConfiguration().getClass(StressTestUtils.STRESSOR_CLASS,
+            StressTestUtils.DEFAULT_STRESSOR_CLASS, Stressor.class).newInstance();
+        stressor.configure(context.getConfiguration());
+
+        RateComputingLimiterContainer limiterContainer = new RateComputingLimiterContainer();
+        Limiter limiter = limiterContainer.decorateLimiter(createLimiter(configuration, this.broker));
+
+        ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+        ScheduledFuture<?> future = executor.scheduleAtFixedRate(new Recorder(limiterContainer, context, true),
+            0, 15, TimeUnit.SECONDS);
+
+        limiter.start();
+        stressor.run(limiter);
+        limiter.stop();
+
+        future.cancel(false);
+        ExecutorsUtils.shutdownExecutorService(executor, Optional.<Logger>absent(), 10, TimeUnit.SECONDS);
+      } catch (ReflectiveOperationException roe) {
+        throw new IOException(roe);
+      }
+    }
+  }
+
+  /**
+   * Simply adds up the rates for each key.
+   */
+  public static class AggregatorReducer extends Reducer<LongWritable, DoubleWritable, LongWritable, Text> {
+    @Override
+    protected void reduce(LongWritable key, Iterable<DoubleWritable> values, Context context)
+        throws IOException, InterruptedException {
+      double totalRate = 0;
+      int activeMappers = 0;
+      for (DoubleWritable value : values) {
+        totalRate += value.get();
+        activeMappers++;
+      }
+      context.write(key, new Text(String.format("%f\t%d", totalRate, activeMappers)));
+    }
+  }
+
+  /**
+   * Input format that just generates {@link #NUM_MAPPERS} dummy splits.
+   */
+  public static class MyInputFormat extends InputFormat<Text, NullWritable> {
+    @Override
+    public List<InputSplit> getSplits(JobContext context) throws IOException, InterruptedException {
+      int numMappers = context.getConfiguration().getInt(NUM_MAPPERS, 1);
+
+      List<InputSplit> splits = Lists.newArrayList();
+      for (int i = 0; i < numMappers; i++) {
+        splits.add(new MySplit());
+      }
+
+      return splits;
+    }
+
+    @Override
+    public RecordReader<Text, NullWritable> createRecordReader(InputSplit split, TaskAttemptContext context)
+        throws IOException, InterruptedException {
+      return new MyRecordReader((MySplit) split);
+    }
+  }
+
+  /**
+   * A dummy {@link InputSplit}.
+   */
+  @Data
+  public static class MySplit extends InputSplit implements Writable {
+
+    @Override
+    public long getLength() throws IOException, InterruptedException {
+      return 1;
+    }
+
+    @Override
+    public String[] getLocations() throws IOException, InterruptedException {
+      return new String[0];
+    }
+
+    @Override
+    public void write(DataOutput out) throws IOException {
+      Text.writeString(out, "split");
+    }
+
+    @Override
+    public void readFields(DataInput in) throws IOException {
+      Text.readString(in);
+    }
+  }
+
+  /**
+   * A dummy {@link RecordReader} that emits a single key-value.
+   */
+  @RequiredArgsConstructor
+  public static class MyRecordReader extends RecordReader<Text, NullWritable> {
+    private final MySplit split;
+    boolean keyValueAvailable = true;
+
+    @Override
+    public void initialize(InputSplit split, TaskAttemptContext context) throws IOException, InterruptedException {
+    }
+
+    @Override
+    public boolean nextKeyValue() throws IOException, InterruptedException {
+      if (!this.keyValueAvailable) {
+        return false;
+      }
+      this.keyValueAvailable = false;
+      return true;
+    }
+
+    @Override
+    public Text getCurrentKey() throws IOException, InterruptedException {
+      return new Text("split");
+    }
+
+    @Override
+    public NullWritable getCurrentValue() throws IOException, InterruptedException {
+      return NullWritable.get();
+    }
+
+    @Override
+    public float getProgress() throws IOException, InterruptedException {
+      return 0;
+    }
+
+    @Override
+    public void close() throws IOException {
+
+    }
+  }
+
+  /**
+   * A {@link Runnable} that computes the average rate at which the input {@link AtomicLong} increases and emits it to the
+   * mapper collector.
+   */
+  @RequiredArgsConstructor
+  private static class Recorder implements Runnable {
+    private final RateComputingLimiterContainer limiter;
+    private final MapContext<Text, NullWritable, LongWritable, DoubleWritable> context;
+    private final boolean relativeKey;
+    private int runs = -1;
+
+    @Override
+    public void run() {
+      DescriptiveStatistics stats = this.limiter.getRateStatsSinceLastReport();
+      long now = System.currentTimeMillis();
+      this.runs++;
+
+      if (stats != null) {
+        long key;
+        if (this.relativeKey) {
+          key = 15 * this.runs;
+        } else {
+          DateTime nowTime = new DateTime(now).withMillisOfSecond(0);
+          DateTime rounded = nowTime.withSecondOfMinute(15 * (nowTime.getSecondOfMinute() / 15));
+          key = rounded.getMillis() / 1000;
+        }
+
+
+        try {
+          this.context.write(new LongWritable(key), new DoubleWritable(stats.getSum()));
+        } catch (IOException | InterruptedException ioe) {
+          log.error("Error: ", ioe);
+        }
+      }
+
+    }
+  }
+
+  static Limiter createLimiter(Configuration configuration, SharedResourcesBroker<SimpleScopeType> broker) {
+    try {
+      Limiter limiter = new NoopLimiter();
+
+      long localQps = configuration.getLong(LOCALLY_ENFORCED_QPS, 0);
+      if (localQps > 0) {
+        log.info("Setting up local qps " + localQps);
+        limiter = new MultiLimiter(limiter, new RateBasedLimiter(localQps));
+      }
+
+      if (configuration.getBoolean(USE_THROTTLING_SERVER, false)) {
+        log.info("Setting up remote throttling.");
+        String resourceId = configuration.get(RESOURCE_ID);
+        Limiter globalLimiter =
+            broker.getSharedResource(new RestliLimiterFactory<SimpleScopeType>(), new SharedLimiterKey(resourceId));
+        limiter = new MultiLimiter(limiter, globalLimiter);
+      }
+      return limiter;
+    } catch (NotConfiguredException nce) {
+      throw new RuntimeException(nce);
+    }
+  }
+
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/MRStressTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/MRStressTest.java
@@ -97,13 +97,13 @@ public class MRStressTest {
 
   public static final String NUM_MAPPERS = "stressTest.num.mappers";
 
-  public static String DEFAULT_MAPPERS = "10";
+  public static final String DEFAULT_MAPPERS = "10";
 
-  public static Option NUM_MAPPERS_OPT = new Option("mappers", true, "Num mappers");
-  public static Option THROTTLING_SERVER_URI = new Option("throttling", true, "Throttling server uri");
-  public static Option RESOURCE_ID_OPT = new Option("resource", true, "Resource id for throttling server");
-  public static Option LOCAL_QPS_OPT = new Option("localQps", true, "Locally enforced QPS");
-  public static Options OPTIONS = StressTestUtils.OPTIONS.addOption(NUM_MAPPERS_OPT).addOption(THROTTLING_SERVER_URI)
+  public static final Option NUM_MAPPERS_OPT = new Option("mappers", true, "Num mappers");
+  public static final Option THROTTLING_SERVER_URI = new Option("throttling", true, "Throttling server uri");
+  public static final Option RESOURCE_ID_OPT = new Option("resource", true, "Resource id for throttling server");
+  public static final Option LOCAL_QPS_OPT = new Option("localQps", true, "Locally enforced QPS");
+  public static final Options OPTIONS = StressTestUtils.OPTIONS.addOption(NUM_MAPPERS_OPT).addOption(THROTTLING_SERVER_URI)
       .addOption(RESOURCE_ID_OPT).addOption(LOCAL_QPS_OPT);
 
   public static void main(String[] args) throws Exception {
@@ -114,8 +114,8 @@ public class MRStressTest {
     if (cli.hasOption(THROTTLING_SERVER_URI.getOpt())) {
       configuration.setBoolean(USE_THROTTLING_SERVER, true);
       String resourceLimited = cli.getOptionValue(RESOURCE_ID_OPT.getOpt(), "MRStressTest");
-      configuration .set(RESOURCE_ID, resourceLimited);
-      configuration .set(
+      configuration.set(RESOURCE_ID, resourceLimited);
+      configuration.set(
           BrokerConfigurationKeyGenerator.generateKey(new SharedRestClientFactory(),
               new SharedRestClientKey(RestliLimiterFactory.RESTLI_SERVICE_NAME),
               null, SharedRestClientFactory.SERVER_URI_KEY), cli.getOptionValue(THROTTLING_SERVER_URI.getOpt()));

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/RandomDelayStartStressor.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/RandomDelayStartStressor.java
@@ -15,20 +15,34 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.github.johnrengelman.shadow'
+package gobblin.util.limiter.stressTest;
 
-shadowJar {
-  zip64 true
-  dependencies {
-    exclude(dependency {
-      it.moduleGroup.startsWith("org.apache.hadoop") || it.moduleGroup.startsWith("org.apache.hive")
-    })
+import java.util.Random;
+
+import org.apache.hadoop.conf.Configuration;
+
+import gobblin.util.limiter.Limiter;
+
+
+/**
+ * A {@link Stressor} that sleeps for a random delay between 0 and 30 seconds before starting.
+ */
+public abstract class RandomDelayStartStressor implements Stressor {
+
+  @Override
+  public void configure(Configuration configuration) {
+
   }
-  mergeServiceFiles()
-}
 
-dependencies {
-  compile project(":gobblin-runtime")
-  compile project(":gobblin-restli:gobblin-restli-utils")
-  compile project(':gobblin-utility')
+  @Override
+  public void run(Limiter limiter) throws InterruptedException {
+    long delayStartSeconds = new Random().nextInt(30);
+    Thread.sleep(delayStartSeconds * 1000);
+    doRun(limiter);
+  }
+
+  /**
+   * Run the actual logic in the {@link Stressor}.
+   */
+  public abstract void doRun(Limiter limiter) throws InterruptedException;
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/RandomRuntimeStressor.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/RandomRuntimeStressor.java
@@ -15,20 +15,35 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.github.johnrengelman.shadow'
+package gobblin.util.limiter.stressTest;
 
-shadowJar {
-  zip64 true
-  dependencies {
-    exclude(dependency {
-      it.moduleGroup.startsWith("org.apache.hadoop") || it.moduleGroup.startsWith("org.apache.hive")
-    })
+import java.util.Random;
+
+import org.apache.hadoop.conf.Configuration;
+
+import gobblin.util.limiter.Limiter;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A {@link Stressor} that repeatedly requests 1 permits from {@link Limiter} for a random number of seconds between
+ * 1 and 181.
+ */
+@Slf4j
+public class RandomRuntimeStressor extends RandomDelayStartStressor {
+
+  @Override
+  public void configure(Configuration configuration) {
+    // Do nothing
   }
-  mergeServiceFiles()
-}
 
-dependencies {
-  compile project(":gobblin-runtime")
-  compile project(":gobblin-restli:gobblin-restli-utils")
-  compile project(':gobblin-utility')
+  @Override
+  public void doRun(Limiter limiter) throws InterruptedException {
+    long runForSeconds = new Random().nextInt(180) + 1;
+    long endTime = System.currentTimeMillis() + runForSeconds * 1000;
+    while (System.currentTimeMillis() < endTime) {
+      limiter.acquirePermits(1);
+    }
+  }
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/RateComputingLimiterContainer.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/RateComputingLimiterContainer.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.limiter.stressTest;
+
+import java.io.Closeable;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+
+import com.google.common.base.Function;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+
+import gobblin.util.Decorator;
+import gobblin.util.limiter.Limiter;
+import gobblin.util.limiter.RestliServiceBasedLimiter;
+
+import javax.annotation.Nullable;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Used to compute statistics on a set of {@link Limiter}s used in a throttling service stress test.
+ */
+@Slf4j
+@RequiredArgsConstructor
+public class RateComputingLimiterContainer {
+  private final List<AtomicLong> subLimiterPermitCounts = Lists.newArrayList();
+  private final Queue<Long> unusedPermitsCounts = new LinkedList<>();
+
+  private Map<String, Long> lastReportTimes = Maps.newHashMap();
+
+  /**
+   * Decorate a {@link Limiter} to measure its permit rate for statistics computation.
+   */
+  public Limiter decorateLimiter(Limiter limiter) {
+    AtomicLong localCount = new AtomicLong();
+    return new RateComputingLimiterDecorator(limiter, localCount);
+  }
+
+  /**
+   * A {@link Limiter} decorator that records all permits granted.
+   */
+  @RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+  public class RateComputingLimiterDecorator implements Limiter, Decorator {
+
+    private final Limiter underlying;
+    private final AtomicLong localPermitCount;
+
+    @Override
+    public Object getDecoratedObject() {
+      return this.underlying;
+    }
+
+    @Override
+    public void start() {
+      this.underlying.start();
+      RateComputingLimiterContainer.this.subLimiterPermitCounts.add(this.localPermitCount);
+    }
+
+    @Override
+    public Closeable acquirePermits(long permits) throws InterruptedException {
+      Closeable closeable = this.underlying.acquirePermits(permits);
+      this.localPermitCount.addAndGet(permits);
+      return closeable;
+    }
+
+    @Override
+    public void stop() {
+      this.underlying.stop();
+      if (this.underlying instanceof RestliServiceBasedLimiter) {
+        RestliServiceBasedLimiter restliLimiter = (RestliServiceBasedLimiter) this.underlying;
+        RateComputingLimiterContainer.this.unusedPermitsCounts.add(restliLimiter.getUnusedPermits());
+        log.info("Unused permits: " + restliLimiter.getUnusedPermits());
+      }
+      RateComputingLimiterContainer.this.subLimiterPermitCounts.remove(this.localPermitCount);
+    }
+  }
+
+  /**
+   * Get a {@link DescriptiveStatistics} object with the rate of permit granting for all {@link Limiter}s decorated
+   * with this {@link RateComputingLimiterContainer}.
+   */
+  public @Nullable DescriptiveStatistics getRateStatsSinceLastReport() {
+    return getNormalizedStatistics("seenQPS", Lists.transform(this.subLimiterPermitCounts, new Function<AtomicLong, Double>() {
+      @Override
+      public Double apply(AtomicLong atomicLong) {
+        return (double) atomicLong.getAndSet(0);
+      }
+    }));
+  }
+
+  public @Nullable DescriptiveStatistics getUnusedPermitsSinceLastReport() {
+    DescriptiveStatistics stats = getNormalizedStatistics("unusedPermits", this.unusedPermitsCounts);
+    this.unusedPermitsCounts.clear();
+    return stats;
+  }
+
+  private @Nullable DescriptiveStatistics getNormalizedStatistics(String key, Collection<? extends Number> values) {
+    long now = System.currentTimeMillis();
+
+    long deltaTime = 0;
+    if (this.lastReportTimes.containsKey(key)) {
+      deltaTime = now - this.lastReportTimes.get(key);
+    }
+    this.lastReportTimes.put(key, now);
+
+    if (deltaTime == 0) {
+      return null;
+    }
+
+    double[] normalizedValues = new double[values.size()];
+    int i = 0;
+    for (Number value : values) {
+      normalizedValues[i++] = 1000 * value.doubleValue() / deltaTime;
+    }
+
+    return new DescriptiveStatistics(normalizedValues);
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/StressTestUtils.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/StressTestUtils.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.limiter.stressTest;
+
+import java.util.List;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.CommandLineParser;
+import org.apache.commons.cli.DefaultParser;
+import org.apache.commons.cli.HelpFormatter;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.cli.ParseException;
+import org.apache.hadoop.conf.Configuration;
+
+import com.google.common.base.Splitter;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Utilities for throttling service stress tests.
+ */
+@Slf4j
+public class StressTestUtils {
+
+  public static Option HELP_OPT = new Option("h", "Print help");
+  public static Option CONFIG_OPT = new Option("conf", true, "Set configuration for the stressor.");
+  public static Option STRESSOR_OPT = new Option("stressor", true, "Stressor class.");
+
+  public static final String STRESSOR_CLASS = "stressTest.stressor.class";
+  public static final Class<? extends Stressor> DEFAULT_STRESSOR_CLASS = FixedOperationsStressor.class;
+
+  public static Options OPTIONS = new Options().addOption(HELP_OPT).addOption(CONFIG_OPT);
+
+  /**
+   * Parse command line.
+   */
+  public static CommandLine parseCommandLine(Options options, String[] args) throws ParseException {
+    CommandLineParser parser = new DefaultParser();
+    CommandLine cli = parser.parse(options, args);
+
+    if (cli.hasOption(StressTestUtils.HELP_OPT.getOpt())) {
+      HelpFormatter formatter = new HelpFormatter();
+      formatter.printHelp( MRStressTest.class.getSimpleName(), OPTIONS);
+      System.exit(0);
+    }
+
+    return cli;
+  }
+
+  /**
+   * Add configurations provided with {@link #CONFIG_OPT} to {@link Configuration}.
+   */
+  public static void populateConfigFromCli(Configuration configuration, CommandLine cli) {
+    String stressorClass = cli.getOptionValue(STRESSOR_OPT.getOpt(), DEFAULT_STRESSOR_CLASS.getName());
+    configuration.set(STRESSOR_CLASS, stressorClass);
+
+    if (cli.hasOption(CONFIG_OPT.getOpt())) {
+      for (String arg : cli.getOptionValues(CONFIG_OPT.getOpt())) {
+        List<String> tokens = Splitter.on(":").limit(2).splitToList(arg);
+        if (tokens.size() < 2) {
+          throw new IllegalArgumentException("Configurations must be of the form <key>:<value>");
+        }
+        configuration.set(tokens.get(0), tokens.get(1));
+      }
+    }
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/StressTestUtils.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/StressTestUtils.java
@@ -39,14 +39,14 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class StressTestUtils {
 
-  public static Option HELP_OPT = new Option("h", "Print help");
-  public static Option CONFIG_OPT = new Option("conf", true, "Set configuration for the stressor.");
-  public static Option STRESSOR_OPT = new Option("stressor", true, "Stressor class.");
+  public static final Option HELP_OPT = new Option("h", "Print help");
+  public static final Option CONFIG_OPT = new Option("conf", true, "Set configuration for the stressor.");
+  public static final Option STRESSOR_OPT = new Option("stressor", true, "Stressor class.");
 
   public static final String STRESSOR_CLASS = "stressTest.stressor.class";
   public static final Class<? extends Stressor> DEFAULT_STRESSOR_CLASS = FixedOperationsStressor.class;
 
-  public static Options OPTIONS = new Options().addOption(HELP_OPT).addOption(CONFIG_OPT);
+  public static final Options OPTIONS = new Options().addOption(HELP_OPT).addOption(CONFIG_OPT);
 
   /**
    * Parse command line.

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/Stressor.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/main/java/gobblin/util/limiter/stressTest/Stressor.java
@@ -15,20 +15,18 @@
  * limitations under the License.
  */
 
-apply plugin: 'com.github.johnrengelman.shadow'
+package gobblin.util.limiter.stressTest;
 
-shadowJar {
-  zip64 true
-  dependencies {
-    exclude(dependency {
-      it.moduleGroup.startsWith("org.apache.hadoop") || it.moduleGroup.startsWith("org.apache.hive")
-    })
-  }
-  mergeServiceFiles()
-}
+import org.apache.hadoop.conf.Configuration;
 
-dependencies {
-  compile project(":gobblin-runtime")
-  compile project(":gobblin-restli:gobblin-restli-utils")
-  compile project(':gobblin-utility')
+import gobblin.util.limiter.Limiter;
+
+
+/**
+ * An experiment for throttling service stress test. A {@link Stressor} should generate a pattern of requests to the input
+ * {@link Limiter}.
+ */
+public interface Stressor {
+  void configure(Configuration configuration);
+  void run(Limiter limiter) throws InterruptedException;
 }

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/util/limiter/LocalStressTest.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/util/limiter/LocalStressTest.java
@@ -1,0 +1,212 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.limiter;
+
+import java.util.LinkedList;
+import java.util.Map;
+import java.util.Queue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.commons.cli.CommandLine;
+import org.apache.commons.cli.Option;
+import org.apache.commons.cli.Options;
+import org.apache.commons.math3.stat.descriptive.DescriptiveStatistics;
+import org.apache.hadoop.conf.Configuration;
+import org.mockito.Mockito;
+
+import com.google.common.collect.Maps;
+import com.google.inject.Injector;
+import com.google.inject.Key;
+import com.google.inject.name.Names;
+import com.linkedin.restli.client.RestClient;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.broker.BrokerConfigurationKeyGenerator;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.restli.throttling.DynamicTokenBucket;
+import gobblin.restli.throttling.LimiterServerResource;
+import gobblin.restli.throttling.QPSPolicy;
+import gobblin.restli.throttling.ThrottlingGuiceServletConfig;
+import gobblin.restli.throttling.ThrottlingPolicy;
+import gobblin.restli.throttling.ThrottlingPolicyFactory;
+import gobblin.restli.throttling.TokenBucket;
+import gobblin.util.limiter.broker.SharedLimiterKey;
+import gobblin.util.limiter.stressTest.FixedOperationsStressor;
+import gobblin.util.limiter.stressTest.RandomDelayStartStressor;
+import gobblin.util.limiter.stressTest.RandomRuntimeStressor;
+import gobblin.util.limiter.stressTest.RateComputingLimiterContainer;
+import gobblin.util.limiter.stressTest.StressTestUtils;
+import gobblin.util.limiter.stressTest.Stressor;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A stress test for throttling service. It creates a number of threads, each one running a stressor using a mock
+ * {@link RestliServiceBasedLimiter}.
+ *
+ * The mock {@link RestliServiceBasedLimiter} sends requests to an embedded {@link LimiterServerResource}, adding an
+ * artificial latency to the requests representing the network latency.
+ *
+ * The stress test prints permit granting statistics every 15 seconds.
+ */
+@Slf4j
+public class LocalStressTest {
+
+  public static final Option STRESSOR_THREADS =
+      new Option("stressorThreads", true, "Number of stressor threads");
+  public static final Option PROCESSOR_THREADS =
+      new Option("processorThreads", true, "Number of request processor threads.");
+  public static final Option ARTIFICIAL_LATENCY =
+      new Option("latency", true, "Artificial request latency in millis.");
+  public static final Option QPS =
+      new Option("qps", true, "Target qps.");
+
+  public static final Options OPTIONS = StressTestUtils.OPTIONS.addOption(STRESSOR_THREADS).addOption(PROCESSOR_THREADS);
+
+  public static final int DEFAULT_STRESSOR_THREADS = 10;
+  public static final int DEFAULT_PROCESSOR_THREADS = 10;
+  public static final int DEFAULT_ARTIFICIAL_LATENCY = 100;
+  public static final int DEFAULT_TARGET_QPS = 100;
+
+  public static void main(String[] args) throws Exception {
+
+    CommandLine cli = StressTestUtils.parseCommandLine(OPTIONS, args);
+
+    int stressorThreads = Integer.parseInt(cli.getOptionValue(STRESSOR_THREADS.getOpt(), Integer.toString(
+        DEFAULT_STRESSOR_THREADS)));
+    int processorThreads = Integer.parseInt(cli.getOptionValue(PROCESSOR_THREADS.getOpt(), Integer.toString(
+        DEFAULT_PROCESSOR_THREADS)));
+    int artificialLatency = Integer.parseInt(cli.getOptionValue(ARTIFICIAL_LATENCY.getOpt(), Integer.toString(
+        DEFAULT_ARTIFICIAL_LATENCY)));
+    long targetQps = Integer.parseInt(cli.getOptionValue(QPS.getOpt(), Integer.toString(
+        DEFAULT_TARGET_QPS)));
+
+    Configuration configuration = new Configuration();
+    StressTestUtils.populateConfigFromCli(configuration, cli);
+
+    String resourceLimited = LocalStressTest.class.getSimpleName();
+
+    Map<String, String> configMap = Maps.newHashMap();
+
+    ThrottlingPolicyFactory factory = new ThrottlingPolicyFactory();
+    SharedLimiterKey res1key = new SharedLimiterKey(resourceLimited);
+    configMap.put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, ThrottlingPolicyFactory.POLICY_KEY),
+            QPSPolicy.FACTORY_ALIAS);
+    configMap.put(BrokerConfigurationKeyGenerator.generateKey(factory, res1key, null, QPSPolicy.QPS),
+        Long.toString(targetQps));
+
+    Injector injector = ThrottlingGuiceServletConfig.getInjector(ConfigFactory.parseMap(configMap));
+    LimiterServerResource limiterServer = injector.getInstance(LimiterServerResource.class);
+
+    RateComputingLimiterContainer limiterContainer = new RateComputingLimiterContainer();
+
+    Class<? extends Stressor> stressorClass =
+        configuration.getClass(StressTestUtils.STRESSOR_CLASS, StressTestUtils.DEFAULT_STRESSOR_CLASS, Stressor.class);
+
+    ExecutorService executorService = Executors.newFixedThreadPool(stressorThreads);
+
+    SharedResourcesBroker broker =
+        injector.getInstance(Key.get(SharedResourcesBroker.class, Names.named(LimiterServerResource.BROKER_INJECT_NAME)));
+    ThrottlingPolicy policy = (ThrottlingPolicy) broker.getSharedResource(new ThrottlingPolicyFactory(),
+        new SharedLimiterKey(resourceLimited));
+    ScheduledExecutorService reportingThread = Executors.newSingleThreadScheduledExecutor();
+    reportingThread.scheduleAtFixedRate(new Reporter(limiterContainer, policy), 0, 15, TimeUnit.SECONDS);
+
+    Queue<Future<?>> futures = new LinkedList<>();
+    MockRequester requester = new MockRequester(limiterServer, artificialLatency, processorThreads);
+
+    requester.start();
+    for (int i = 0; i < stressorThreads; i++) {
+      RestliServiceBasedLimiter restliLimiter = RestliServiceBasedLimiter.builder().resourceLimited(resourceLimited)
+          .requestSender(requester).restClient(Mockito.mock(RestClient.class)).serviceIdentifier("stressor" + i).build();
+
+      Stressor stressor = stressorClass.newInstance();
+      stressor.configure(configuration);
+      futures.add(executorService.submit(new StressorRunner(limiterContainer.decorateLimiter(restliLimiter),
+          stressor)));
+    }
+    int stressorFailures = 0;
+    for (Future<?> future : futures) {
+      try {
+        future.get();
+      } catch (ExecutionException ee) {
+        stressorFailures++;
+      }
+    }
+    requester.stop();
+
+    executorService.shutdownNow();
+
+    if (stressorFailures > 0) {
+      log.error("There were " + stressorFailures + " failed stressor threads.");
+    }
+    System.exit(stressorFailures);
+  }
+
+  @RequiredArgsConstructor
+  private static class StressorRunner implements Runnable {
+    private final Limiter limiter;
+    private final Stressor stressor;
+
+    @Override
+    public void run() {
+      try {
+        this.limiter.start();
+        this.stressor.run(this.limiter);
+        this.limiter.stop();
+      } catch (InterruptedException ie) {
+        log.error("Error: ", ie);
+      }
+    }
+  }
+
+  @RequiredArgsConstructor
+  private static class Reporter implements Runnable {
+    private final RateComputingLimiterContainer limiter;
+    private final ThrottlingPolicy policy;
+
+    @Override
+    public void run() {
+      DescriptiveStatistics stats = limiter.getRateStatsSinceLastReport();
+      if (stats != null) {
+        log.info(String.format("Requests rate stats: count: %d, min: %f, max: %f, mean: %f, std: %f, sum: %f", stats.getN(),
+            stats.getMin(), stats.getMax(), stats.getMean(), stats.getStandardDeviation(), stats.getSum()));
+      }
+
+      stats = limiter.getUnusedPermitsSinceLastReport();
+      if (stats != null) {
+        log.info(String.format("Unused permits rate stats: count: %d, min: %f, max: %f, mean: %f, std: %f, sum: %f", stats.getN(),
+            stats.getMin(), stats.getMax(), stats.getMean(), stats.getStandardDeviation(), stats.getSum()));
+      }
+
+      if (this.policy instanceof QPSPolicy) {
+        QPSPolicy qpsPolicy = (QPSPolicy) this.policy;
+        DynamicTokenBucket dynamicTokenBucket = qpsPolicy.getTokenBucket();
+        TokenBucket tokenBucket = dynamicTokenBucket.getTokenBucket();
+        log.info("Stored tokens: " + tokenBucket.getStoredTokens());
+      }
+    }
+  }
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/util/limiter/MockRequester.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-client/src/test/java/gobblin/util/limiter/MockRequester.java
@@ -1,0 +1,138 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.limiter;
+
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.mockito.Mockito;
+
+import com.google.common.collect.Queues;
+import com.linkedin.common.callback.Callback;
+import com.linkedin.restli.client.Response;
+import com.linkedin.restli.client.RestLiResponseException;
+import com.linkedin.restli.common.ComplexResourceKey;
+import com.linkedin.restli.common.EmptyRecord;
+import com.linkedin.restli.server.RestLiServiceException;
+
+import gobblin.restli.throttling.LimiterServerResource;
+import gobblin.restli.throttling.PermitAllocation;
+import gobblin.restli.throttling.PermitRequest;
+
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * A mock {@link gobblin.util.limiter.BatchedPermitsRequester.RequestSender} that satisfies requests using an embedded
+ * {@link LimiterServerResource}.
+ */
+@Slf4j
+public class MockRequester extends BatchedPermitsRequester.RequestSender {
+
+  private final BlockingQueue<RequestAndCallback> requestAndCallbackQueue;
+
+  private final LimiterServerResource limiterServer;
+  private final long latencyMillis;
+  private final int requestHandlerThreads;
+
+  private boolean started;
+  private ExecutorService handlerExecutorService;
+
+  public MockRequester(LimiterServerResource limiterServer, long latencyMillis, int requestHandlerThreads) {
+    super(null);
+    this.limiterServer = limiterServer;
+    this.latencyMillis = latencyMillis;
+    this.requestHandlerThreads = requestHandlerThreads;
+    this.requestAndCallbackQueue = Queues.newLinkedBlockingQueue();
+  }
+
+  public synchronized void start() {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    this.handlerExecutorService = Executors.newFixedThreadPool(this.requestHandlerThreads);
+    for (int i = 0; i < this.requestHandlerThreads; i++) {
+      this.handlerExecutorService.submit(new RequestHandler());
+    }
+  }
+
+  public synchronized void stop() {
+    if (!this.started) {
+      return;
+    }
+    this.handlerExecutorService.shutdownNow();
+    this.started = false;
+  }
+
+  @Override
+  protected void sendRequest(PermitRequest request, Callback<Response<PermitAllocation>> callback) {
+    if (!this.started) {
+      throw new IllegalStateException(MockRequester.class.getSimpleName() + " has not been started.");
+    }
+    long nanoTime = System.nanoTime();
+    long satisfyAt = nanoTime + TimeUnit.MILLISECONDS.toNanos(this.latencyMillis);
+    this.requestAndCallbackQueue.add(new RequestAndCallback(request, callback, satisfyAt));
+  }
+
+  @Data
+  public static class RequestAndCallback {
+    private final PermitRequest request;
+    private final Callback<Response<PermitAllocation>> callback;
+    private final long processAfterNanos;
+  }
+
+  private class RequestHandler implements Runnable {
+    @Override
+    public void run() {
+      try {
+        while (true) {
+          RequestAndCallback requestAndCallback = MockRequester.this.requestAndCallbackQueue.take();
+
+          long nanoTime = System.nanoTime();
+          long delayNanos = requestAndCallback.getProcessAfterNanos() - nanoTime;
+          if (delayNanos > 0) {
+            Thread.sleep(TimeUnit.NANOSECONDS.toMillis(delayNanos));
+          }
+
+          try {
+            PermitAllocation allocation =
+                MockRequester.this.limiterServer.get(new ComplexResourceKey<>(requestAndCallback.getRequest(), new EmptyRecord()));
+
+            Response<PermitAllocation> response = Mockito.mock(Response.class);
+            Mockito.when(response.getEntity()).thenReturn(allocation);
+
+            requestAndCallback.getCallback().onSuccess(response);
+
+          } catch (RestLiServiceException rexc) {
+            RestLiResponseException returnException = Mockito.mock(RestLiResponseException.class);
+            Mockito.when(returnException.getStatus()).thenReturn(rexc.getStatus().getCode());
+            requestAndCallback.getCallback().onError(returnException);
+          }
+        }
+      } catch (Throwable t) {
+        log.error("Error", t);
+        throw new RuntimeException(t);
+      }
+    }
+  }
+
+}

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/QPSPolicy.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/QPSPolicy.java
@@ -17,6 +17,7 @@
 
 package gobblin.restli.throttling;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.linkedin.data.template.GetMode;
 import com.typesafe.config.Config;
@@ -26,11 +27,15 @@ import gobblin.annotation.Alpha;
 import gobblin.broker.SimpleScopeType;
 import gobblin.broker.iface.SharedResourcesBroker;
 
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
 
 /**
  * A {@link ThrottlingPolicy} based on a QPS (queries per second). It internally uses a {@link DynamicTokenBucket}.
  */
 @Alpha
+@Slf4j
 public class QPSPolicy implements ThrottlingPolicy {
 
   public static final String FACTORY_ALIAS = "qps";
@@ -50,6 +55,8 @@ public class QPSPolicy implements ThrottlingPolicy {
   public static final String MAX_BUCKET_SIZE_MILLIS = "maxBucketSizeMillis";
   public static final long DEFAULT_MAX_BUCKET_SIZE = 10000;
 
+  @VisibleForTesting
+  @Getter
   private final DynamicTokenBucket tokenBucket;
 
   @Alias(FACTORY_ALIAS)

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/ThrottlingGuiceServletConfig.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/ThrottlingGuiceServletConfig.java
@@ -43,6 +43,7 @@ import java.util.Enumeration;
 import java.util.Map;
 import javax.servlet.ServletContext;
 import javax.servlet.ServletContextEvent;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -50,6 +51,7 @@ import lombok.extern.slf4j.Slf4j;
  * {@link GuiceServletContextListener} for creating an injector in a gobblin-throttling-server servlet.
  */
 @Slf4j
+@Getter
 public class ThrottlingGuiceServletConfig extends GuiceServletContextListener {
 
   private ServletContext _context;

--- a/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/TokenBucket.java
+++ b/gobblin-restli/gobblin-throttling-service/gobblin-throttling-service-server/src/main/java/gobblin/restli/throttling/TokenBucket.java
@@ -21,6 +21,9 @@ import java.util.concurrent.TimeUnit;
 
 import com.google.common.base.Preconditions;
 
+import lombok.AccessLevel;
+import lombok.Getter;
+
 
 /**
  * An implementation of Token Bucket (https://en.wikipedia.org/wiki/Token_bucket).
@@ -29,6 +32,7 @@ import com.google.common.base.Preconditions;
  */
 public class TokenBucket {
 
+  @Getter(AccessLevel.PROTECTED)
   private double tokensPerMilli;
   private double maxBucketSizeInTokens;
 

--- a/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerFactory.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/SharedResourcesBrokerFactory.java
@@ -143,7 +143,7 @@ public class SharedResourcesBrokerFactory {
     return config;
   }
 
-  private static <S, T> void addBrokerKeys(Map<String, String> configMap, Iterable<Map.Entry<S, T>> entries) {
+  public static <S, T> void addBrokerKeys(Map<String, String> configMap, Iterable<Map.Entry<S, T>> entries) {
     for (Map.Entry<S, T> entry : entries) {
       Object key = entry.getKey();
       if (key instanceof String && ((String) key).startsWith(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX)) {


### PR DESCRIPTION
There are two main sets of changes in this PR:

Stres Test for Throttling
=================

* There are two stress tests: `MRStressTest` and `LocalStressTest`.
* A `Stressor` is a class that sends requests to a `Limiter`. Different stressors can simulate different usage patterns.
* The `LocalStressTest` uses and embedded throttling server and multiple threads to run a stressor. The requests do not go through the network, but the stress test can add artificial latency representing the network latency. Every 15 seconds, the stress test logs statistics about the throttling.
* The `MRStressTest` uses a real throttling server. It spawns multiple mappers each one running a stressor. The mappers emit their effective permit use rate every 15 seconds, which then gets collected by the reducer to compute the global effective QPS every 15 seconds.

Throttling algorithm updates
=====================

* Some changes to the batching algorithm. The previous algorithm was keeping the permit requests open for a long time (~7 seconds under high contention) because it allowed up to 7 seconds to acquire even a small number of permits. The new algorithm uses a short timeout instead, generally just short enough to satisfy the minimum number of permits requested. Larger permit allocations only happen if there are permits stored (meaning low contention).