### PR TITLE
Refator HTTP writers

### DIFF
--- a/gobblin-core/src/main/java/gobblin/http/ApacheHttpClient.java
+++ b/gobblin-core/src/main/java/gobblin/http/ApacheHttpClient.java
@@ -1,0 +1,141 @@
+package gobblin.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ConnectionRequest;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j;
+
+import gobblin.configuration.State;
+import gobblin.writer.http.AbstractHttpWriterBuilder;
+import gobblin.writer.http.DelegatingHttpClientConnectionManager;
+
+
+/**
+ * A {@link HttpClient} that sends {@link HttpUriRequest} and gets {@link CloseableHttpResponse}.
+ * It encapsulates a {@link CloseableHttpClient} instance to send the {@link HttpUriRequest}
+ */
+@Log4j
+public class ApacheHttpClient implements HttpClient<HttpUriRequest, CloseableHttpResponse> {
+  public static final String HTTP_CONN_MANAGER = "conn_mgr_type";
+  public static final String POOLING_CONN_MANAGER_MAX_TOTAL_CONN = "conn_mgr.pooling.max_conn_total";
+  public static final String POOLING_CONN_MANAGER_MAX_PER_CONN = "conn_mgr.pooling.max_per_conn";
+  public static final String REQUEST_TIME_OUT_MS_KEY = "req_time_out";
+  public static final String CONNECTION_TIME_OUT_MS_KEY = "conn_time_out";
+  public static final String STATIC_SVC_ENDPOINT = "static_svc_endpoint";
+
+  public enum ConnManager {
+    POOLING,
+    BASIC
+  }
+
+  private static final Config FALLBACK =
+      ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+          .put(REQUEST_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
+          .put(CONNECTION_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
+          .put(HTTP_CONN_MANAGER, AbstractHttpWriterBuilder.ConnManager.BASIC.name())
+          .put(POOLING_CONN_MANAGER_MAX_TOTAL_CONN, 20)
+          .put(POOLING_CONN_MANAGER_MAX_PER_CONN, 2)
+          .build());
+
+  /**
+   * A helper class to track http client connection
+   */
+  class HttpClientConnectionManagerWithConnTracking extends DelegatingHttpClientConnectionManager {
+    HttpClientConnectionManagerWithConnTracking(HttpClientConnectionManager fallback) {
+      super(fallback);
+    }
+
+    @Override
+    public ConnectionRequest requestConnection(HttpRoute route, Object state) {
+      try {
+        ApacheHttpClient.this.connect(new URI(route.getTargetHost().toURI()));
+      } catch (IOException | URISyntaxException e) {
+        throw new RuntimeException("onConnect() callback failure: " + e, e);
+      }
+      return super.requestConnection(route, state);
+    }
+  }
+
+  private final CloseableHttpClient client;
+  @Getter
+  protected URI serverHost;
+
+  public ApacheHttpClient(State state, Config config) {
+    HttpClientConfiguratorLoader clientConfiguratorLoader = new HttpClientConfiguratorLoader(state);
+    clientConfiguratorLoader.getConfigurator().setStatePropertiesPrefix(AbstractHttpWriterBuilder.CONF_PREFIX);
+    HttpClientBuilder builder = clientConfiguratorLoader.getConfigurator().configure(state).getBuilder();
+
+    config = config.withFallback(FALLBACK);
+    RequestConfig requestConfig = RequestConfig.copy(RequestConfig.DEFAULT)
+        .setSocketTimeout(config.getInt(REQUEST_TIME_OUT_MS_KEY))
+        .setConnectTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
+        .setConnectionRequestTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
+        .build();
+
+    builder.disableCookieManagement().useSystemProperties().setDefaultRequestConfig(requestConfig);
+    builder.setConnectionManager(new HttpClientConnectionManagerWithConnTracking(getHttpConnManager(config)));
+    client = builder.build();
+  }
+
+  public boolean connect(URI uri) throws IOException {
+    return false;
+  }
+
+  @Override
+  public CloseableHttpResponse sendRequest(HttpUriRequest request) throws IOException {
+    return client.execute(request);
+  }
+
+  private HttpClientConnectionManager getHttpConnManager(Config config) {
+    HttpClientConnectionManager httpConnManager;
+
+    if (config.hasPath(STATIC_SVC_ENDPOINT)) {
+      try {
+        serverHost = new URI(config.getString(STATIC_SVC_ENDPOINT));
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    String connMgrStr = config.getString(HTTP_CONN_MANAGER);
+    switch (ConnManager.valueOf(connMgrStr.toUpperCase())) {
+      case BASIC:
+        httpConnManager = new BasicHttpClientConnectionManager();
+        break;
+      case POOLING:
+        PoolingHttpClientConnectionManager poolingConnMgr = new PoolingHttpClientConnectionManager();
+        poolingConnMgr.setMaxTotal(config.getInt(POOLING_CONN_MANAGER_MAX_TOTAL_CONN));
+        poolingConnMgr.setDefaultMaxPerRoute(config.getInt(POOLING_CONN_MANAGER_MAX_PER_CONN));
+        httpConnManager = poolingConnMgr;
+        break;
+      default:
+        throw new IllegalArgumentException(connMgrStr + " is not supported");
+    }
+
+    log.info("Using " + httpConnManager.getClass().getSimpleName());
+    return httpConnManager;
+  }
+
+  @Override
+  public void close() throws IOException {
+    client.close();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/http/BatchRequestBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/http/BatchRequestBuilder.java
@@ -1,0 +1,14 @@
+package gobblin.http;
+
+import java.util.Collection;
+
+
+/**
+ * An interface to build a request from a collection of record
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ */
+public interface BatchRequestBuilder<D, RQ> {
+  RQ buildRequest(Collection<D> records);
+}

--- a/gobblin-core/src/main/java/gobblin/http/HttpClient.java
+++ b/gobblin-core/src/main/java/gobblin/http/HttpClient.java
@@ -1,0 +1,19 @@
+package gobblin.http;
+
+import java.io.Closeable;
+import java.io.IOException;
+
+
+/**
+ * An interface to send a request
+ *
+ * @param <RQ> type of request
+ * @param <RP> type of response
+ */
+public interface HttpClient<RQ, RP> extends Closeable {
+  /**
+   * Send request synchronously
+   */
+  RP sendRequest(RQ request) throws IOException;
+}
+

--- a/gobblin-core/src/main/java/gobblin/http/RequestBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/http/RequestBuilder.java
@@ -1,0 +1,13 @@
+package gobblin.http;
+
+
+/**
+ * An interface to build a request from a record
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ */
+public interface RequestBuilder<D, RQ> {
+  RQ buildRequest(D record);
+}
+

--- a/gobblin-core/src/main/java/gobblin/http/ResponseHandler.java
+++ b/gobblin-core/src/main/java/gobblin/http/ResponseHandler.java
@@ -1,0 +1,13 @@
+package gobblin.http;
+
+import java.io.IOException;
+
+
+/**
+ * An interface to handle a response
+ *
+ * @param <RP> type of response
+ */
+public interface ResponseHandler<RP> {
+  void handleResponse(RP response) throws IOException;
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
@@ -46,7 +46,10 @@ import gobblin.util.ExecutorsUtils;
 
 /**
  * Base class for HTTP writers. Defines the main extension points for different implementations.
+ *
+ * @deprecated Please use {@link HttpWriterBase}
  */
+@Deprecated
 public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> implements HttpWriterDecoration<D> {
 
   // Immutable state
@@ -103,7 +106,7 @@ public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> im
     this.client.close();
     ExecutorsUtils.shutdownExecutorService(this.singleThreadPool, Optional.of(log));
   }
- 
+
   /**
    * {@inheritDoc}
    */
@@ -112,7 +115,7 @@ public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> im
     cleanup();
     super.close();
   }
-  
+
   /**
    * {@inheritDoc}
    */

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
@@ -42,6 +42,10 @@ import gobblin.writer.FluentDataWriterBuilder;
 
 import lombok.Getter;
 
+/**
+ * @deprecated Please use {@link HttpWriterBaseBuilder}
+ */
+@Deprecated
 @Getter
 public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWriterBuilder<S, D, B>>
     extends FluentDataWriterBuilder<S, D, B> {

--- a/gobblin-core/src/main/java/gobblin/writer/http/BatchAndSendSyncHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/BatchAndSendSyncHttpWriter.java
@@ -1,0 +1,86 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import com.google.common.collect.Sets;
+
+import gobblin.http.BatchRequestBuilder;
+
+
+/**
+ * Synchronous HTTP writer which buffers and sends a batch at a time
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ * @param <RP> type of response
+ */
+public class BatchAndSendSyncHttpWriter<D, RQ, RP> extends HttpWriterBase<D, RQ, RP> {
+  BatchRequestBuilder<D, RQ> batchRequestBuilder;
+  protected final Collection<D> recordSet;
+  protected final int maxBatchSize;
+  protected long numRecordsWritten = 0L;
+
+  public BatchAndSendSyncHttpWriter(BatchHttpWriterBaseBuilder builder) {
+    super(builder);
+    recordSet = createEmptyCollection();
+    client = builder.getClient();
+    batchRequestBuilder = builder.getBatchRequestBuilder();
+    responseHandler = builder.getResponseHandler();
+    maxBatchSize = builder.getMaxBatchSize();
+  }
+
+  protected Collection<D> createEmptyCollection() {
+    return Sets.newHashSet();
+  }
+
+  /**
+   * Process the record in batch
+   * {@inheritDoc}
+   */
+  @Override
+  public void writeImpl(D record) throws IOException {
+    batchRecord(record);
+    if (recordSet.size() < maxBatchSize) {
+      return;
+    }
+    writeBatch(recordSet);
+  }
+
+  protected void batchRecord(D record) {
+    recordSet.add(record);
+  }
+
+  private void writeBatch(Collection<D> records)
+      throws IOException {
+    RQ request = batchRequestBuilder.buildRequest(records);
+    if (request != null) {
+      RP response = client.sendRequest(request);
+      responseHandler.handleResponse(response);
+      numRecordsWritten += records.size();
+      recordSet.clear();
+    }
+  }
+
+  /**
+   * Prior to commit, it will invoke flush method to flush any remaining item if writer uses batch
+   * {@inheritDoc}
+   * @see gobblin.instrumented.writer.InstrumentedDataWriterBase#commit()
+   */
+  @Override
+  public void commit() throws IOException {
+    flush();
+    super.commit();
+  }
+
+  /**
+   * Flush and send remaining items
+   */
+  private void flush() {
+    try {
+      writeBatch(recordSet);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/BatchHttpWriterBaseBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/BatchHttpWriterBaseBuilder.java
@@ -1,0 +1,27 @@
+package gobblin.writer.http;
+
+import com.google.common.base.Preconditions;
+
+import lombok.Getter;
+
+/**
+ * Base builder for batch http writers
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ * @param <RP> type of response
+ * @param <B> type of builder
+ */
+@Getter
+public abstract class BatchHttpWriterBaseBuilder <D, RQ, RP, B extends BatchHttpWriterBaseBuilder<D, RQ, RP, B>>
+    extends HttpWriterBaseBuilder<D, RQ, RP, B> {
+  // No max batch size enforcement
+  public static final int DEFAULT_MAX_BATCH_SIZE = 1000;
+  protected int maxBatchSize = DEFAULT_MAX_BATCH_SIZE;
+
+  protected void validate() {
+    super.validate();
+    Preconditions
+        .checkNotNull(getMaxBatchSize(), "maxBatchSize is required for " + this.getClass().getSimpleName());
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/HttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/HttpWriter.java
@@ -32,7 +32,10 @@ import com.google.common.base.Optional;
 
 /**
  * Writes via RESTful API that accepts plain text as a body
+ *
+ * @deprecated Please use {@link RecordSyncHttpWriter}
  */
+@Deprecated
 public class HttpWriter<D> extends AbstractHttpWriter<D> {
   @SuppressWarnings("rawtypes")
   public HttpWriter(AbstractHttpWriterBuilder builder) {

--- a/gobblin-core/src/main/java/gobblin/writer/http/HttpWriterBase.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/HttpWriterBase.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.writer.http;
+
+import java.io.IOException;
+
+import lombok.extern.log4j.Log4j;
+
+import gobblin.http.HttpClient;
+import gobblin.http.RequestBuilder;
+import gobblin.http.ResponseHandler;
+import gobblin.instrumented.writer.InstrumentedDataWriter;
+
+
+/**
+ * Base class for HTTP writers
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ * @param <RP> type of response
+ */
+@Log4j
+public abstract class HttpWriterBase<D, RQ, RP> extends InstrumentedDataWriter<D> {
+  HttpClient<RQ, RP> client;
+  ResponseHandler<RP> responseHandler;
+
+  protected long numRecordsWritten = 0L;
+
+  public HttpWriterBase(HttpWriterBaseBuilder builder) {
+    super(builder.getState());
+    client = builder.getClient();
+    responseHandler = builder.getResponseHandler();
+  }
+
+  @Override
+  public long recordsWritten() {
+    return numRecordsWritten;
+  }
+
+  @Override
+  public long bytesWritten() throws IOException {
+    return 0;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void cleanup() throws IOException {
+    client.close();
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void close() throws IOException {
+    cleanup();
+    super.close();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/HttpWriterBaseBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/HttpWriterBaseBuilder.java
@@ -1,0 +1,86 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.writer.http;
+
+import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
+
+import lombok.Getter;
+
+import gobblin.config.ConfigBuilder;
+import gobblin.configuration.State;
+import gobblin.http.BatchRequestBuilder;
+import gobblin.http.HttpClient;
+import gobblin.http.RequestBuilder;
+import gobblin.http.ResponseHandler;
+import gobblin.writer.Destination;
+import gobblin.writer.FluentDataWriterBuilder;
+
+
+/**
+ * Base builder for http writers
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ * @param <RP> type of response
+ * @param <B> type of builder
+ */
+@Getter
+public abstract class HttpWriterBaseBuilder<D, RQ, RP, B extends HttpWriterBaseBuilder<D, RQ, RP, B>>
+    extends FluentDataWriterBuilder<Void, D, B> {
+  public static final String CONF_PREFIX = "gobblin.writer.http.";
+
+  private State state;
+  protected HttpClient<RQ, RP> client;
+  protected RequestBuilder<D, RQ> requestBuilder;
+  protected BatchRequestBuilder<D, RQ> batchRequestBuilder;
+  protected ResponseHandler<RP> responseHandler;
+
+  /**
+   * For backward compatibility on how Fork creates writer, invoke fromState when it's called writeTo method.
+   * @param destination
+   * @return
+   */
+  @Override
+  public B writeTo(Destination destination) {
+    super.writeTo(destination);
+    return fromState(destination.getProperties());
+  }
+
+  B fromState(State state) {
+    this.state = state;
+    Config config = ConfigBuilder.create().loadProps(state.getProperties(), CONF_PREFIX).build();
+    return fromConfig(config);
+  }
+
+  B fromConfig(Config config) {
+    createComponents(getState(), config);
+    return typedSelf();
+  }
+
+  protected abstract void createComponents(State state, Config config);
+
+  protected void validate() {
+    Preconditions.checkNotNull(getState(), "State is required for " + this.getClass().getSimpleName());
+    Preconditions
+        .checkNotNull(getClient(), "Client is required for " + this.getClass().getSimpleName());
+    Preconditions.checkArgument(getRequestBuilder() != null || getBatchRequestBuilder() != null,
+        "Must provide either a RequestBuilder or a BatchRequestBuilder for " + this.getClass().getSimpleName());
+    Preconditions
+        .checkNotNull(getResponseHandler(), "ResponseHandler is required for " + this.getClass().getSimpleName());
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/RecordSyncHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/RecordSyncHttpWriter.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.writer.http;
+
+import java.io.IOException;
+
+import lombok.extern.log4j.Log4j;
+
+import gobblin.http.RequestBuilder;
+
+
+/**
+ * Synchronous HTTP writer which sends one record at time
+ *
+ * @param <D> type of record
+ * @param <RQ> type of request
+ * @param <RP> type of response
+ */
+@Log4j
+public class RecordSyncHttpWriter<D, RQ, RP> extends HttpWriterBase<D, RQ, RP> {
+  RequestBuilder<D, RQ> requestBuilder;
+
+  public RecordSyncHttpWriter(HttpWriterBaseBuilder builder) {
+    super(builder);
+    requestBuilder = builder.getRequestBuilder();
+  }
+
+  /**
+   * Process the record
+   * {@inheritDoc}
+   */
+  @Override
+  public void writeImpl(D record) throws IOException {
+    RQ request = requestBuilder.buildRequest(record);
+    if (request != null) {
+      RP response = client.sendRequest(request);
+      responseHandler.handleResponse(response);
+      numRecordsWritten++;
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/RestJsonWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/RestJsonWriter.java
@@ -29,7 +29,10 @@ import gobblin.converter.http.RestEntry;
 
 /**
  * Writes via Restful API that accepts JSON as a body
+ *
+ * @deprecated Please use {@link RecordSyncHttpWriter}
  */
+@Deprecated
 public class RestJsonWriter extends HttpWriter<RestEntry<JsonObject>> {
 
   public RestJsonWriter(AbstractHttpWriterBuilder builder) {

--- a/gobblin-core/src/main/java/gobblin/writer/http/RestWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/RestWriter.java
@@ -28,7 +28,10 @@ import gobblin.converter.http.RestEntry;
 
 /**
  * Writes via RESTful API that accepts plain text as a body and resource path from RestEntry
+ *
+ * @deprecated Please use {@link RecordSyncHttpWriter}
  */
+@Deprecated
 public class RestWriter extends HttpWriter<RestEntry<String>> {
 
   public RestWriter(RestWriterBuilder builder) {

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesForceRestWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesForceRestWriterBuilder.java
@@ -38,7 +38,10 @@ import lombok.Getter;
 /**
  * Builder class that builds SalesForceRestWriter where it takes connection related parameter and type of operation along with the parameters
  * derived from AbstractHttpWriterBuilder
+ *
+ * @deprecated Please use {@link SalesforceWriterBuilder}
  */
+@Deprecated
 @Getter
 public class SalesForceRestWriterBuilder extends AbstractHttpWriterBuilder<Void, RestEntry<JsonObject>, SalesForceRestWriterBuilder>{
 

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceClient.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceClient.java
@@ -1,0 +1,137 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.oltu.oauth2.client.OAuthClient;
+import org.apache.oltu.oauth2.client.URLConnectionClient;
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
+import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
+import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.apache.oltu.oauth2.common.message.types.GrantType;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.configuration.State;
+import gobblin.http.ApacheHttpClient;
+import gobblin.password.PasswordManager;
+import gobblin.writer.exception.NonTransientException;
+
+
+/**
+ * An {@link ApacheHttpClient} to communicate with Salesforce services
+ */
+@Log4j
+public class SalesforceClient extends ApacheHttpClient {
+  static final String SFDC_PREFIX = SalesforceWriterBuilder.SFDC_PREFIX;
+  static final String CLIENT_ID = SFDC_PREFIX + "client_id";
+  static final String CLIENT_SECRET = SFDC_PREFIX + "client_secret";
+  static final String USER_ID = SFDC_PREFIX + "user_id";
+  static final String PASSWORD = SFDC_PREFIX + "password";
+  static final String SFDC_ENCRYPT_KEY_LOC = SFDC_PREFIX + ConfigurationKeys.ENCRYPT_KEY_LOC;
+  static final String USE_STRONG_ENCRYPTION = SFDC_PREFIX + "strong_encryption";
+  static final String SECURITY_TOKEN = SFDC_PREFIX + "security_token";
+
+  private static final Config FALLBACK = ConfigFactory.parseMap(
+      ImmutableMap.<String, String>builder()
+          .put(ApacheHttpClient.STATIC_SVC_ENDPOINT, "https://login.salesforce.com/services/oauth2/token")
+          .put(SECURITY_TOKEN, "")
+          .build()
+  );
+
+  private String clientId;
+  private String clientSecret;
+  private String userId;
+  private String password;
+  private String securityToken;
+  private final URI oauthEndpoint;
+
+  @Getter @Setter
+  private String accessToken;
+
+  public SalesforceClient(State state, Config config) {
+    super(state, config);
+
+    config = config.withFallback(FALLBACK);
+    clientId = config.getString(CLIENT_ID);
+    clientSecret = config.getString(CLIENT_SECRET);
+    userId = config.getString(USER_ID);
+    password = config.getString(PASSWORD);
+    securityToken = config.getString(SECURITY_TOKEN);
+
+    if (config.hasPath(SFDC_ENCRYPT_KEY_LOC)) {
+      Properties props = new Properties();
+      if (config.hasPath(USE_STRONG_ENCRYPTION)) {
+        props.put(ConfigurationKeys.ENCRYPT_USE_STRONG_ENCRYPTOR, config.getString(USE_STRONG_ENCRYPTION));
+      }
+
+      props.put(ConfigurationKeys.ENCRYPT_KEY_LOC, config.getString(SFDC_ENCRYPT_KEY_LOC));
+      password = PasswordManager.getInstance(props).readPassword(password);
+    }
+    oauthEndpoint = serverHost;
+
+    try {
+      connect(oauthEndpoint);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public boolean connect(URI uri) throws IOException {
+    if (!StringUtils.isEmpty(accessToken)) {
+      return true;
+    }
+
+    try {
+      log.info("Getting Oauth2 access token.");
+      OAuthClientRequest request = OAuthClientRequest.tokenLocation(uri.toString())
+          .setGrantType(GrantType.PASSWORD)
+          .setClientId(clientId)
+          .setClientSecret(clientSecret)
+          .setUsername(userId)
+          .setPassword(password + securityToken).buildQueryMessage();
+      OAuthClient client = new OAuthClient(new URLConnectionClient());
+      OAuthJSONAccessTokenResponse response = client.accessToken(request, OAuth.HttpMethod.POST);
+
+      accessToken = response.getAccessToken();
+      // Update serverHost to be the endpoint for fetching data
+      serverHost = new URI(response.getParam("instance_url"));
+    } catch (OAuthProblemException e) {
+      throw new NonTransientException("Error while authenticating with Oauth2", e);
+    } catch (OAuthSystemException e) {
+      throw new RuntimeException("Failed getting access token", e);
+    } catch (URISyntaxException e) {
+      throw new RuntimeException("Failed due to invalid instance url", e);
+    }
+
+    return true;
+  }
+
+  @Override
+  public CloseableHttpResponse sendRequest(HttpUriRequest request)
+      throws IOException {
+    if (Strings.isNullOrEmpty(accessToken)) {
+      log.info("Reacquiring access token.");
+      connect(oauthEndpoint);
+    }
+    request.addHeader(HttpHeaders.AUTHORIZATION, "OAuth " + accessToken);
+    return super.sendRequest(request);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRequestBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRequestBuilder.java
@@ -1,0 +1,139 @@
+package gobblin.writer.http;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Collection;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import lombok.extern.log4j.Log4j;
+
+import gobblin.converter.http.RestEntry;
+import gobblin.http.BatchRequestBuilder;
+
+
+@Log4j
+public class SalesforceRequestBuilder implements gobblin.http.RequestBuilder<RestEntry<JsonObject>, HttpUriRequest>,
+                                                 BatchRequestBuilder<RestEntry<JsonObject>, HttpUriRequest> {
+  private final SalesforceClient client;
+  private final SalesforceWriterBuilder.Operation operation;
+  private final Optional<String> batchResourcePath;
+
+  SalesforceRequestBuilder(SalesforceClient client, SalesforceWriterBuilder.Operation operation,
+      Optional<String> batchResourcePath) {
+    this.client = client;
+    this.operation = operation;
+    this.batchResourcePath = batchResourcePath;
+  }
+
+  @Override
+  public HttpUriRequest buildRequest(RestEntry<JsonObject> record) {
+    Preconditions.checkNotNull(record, "Record should not be null");
+
+    RequestBuilder builder;
+    switch (operation) {
+      case INSERT_ONLY_NOT_EXIST:
+        builder = RequestBuilder.post();
+        break;
+      case UPSERT:
+        builder = RequestBuilder.patch();
+        break;
+      default:
+        throw new IllegalArgumentException(operation + " is not supported.");
+    }
+
+    builder.setUri(combineUrl(client.getServerHost(), record.getResourcePath()));
+    JsonObject payload = record.getRestEntryVal();
+    return newRequest(builder, payload);
+  }
+
+  @Override
+  public HttpUriRequest buildRequest(Collection<RestEntry<JsonObject>> records) {
+    if (records == null && records.size() == 0) {
+      return null;
+    }
+
+    if (records.size() > 1) {
+      JsonObject payload = newPayloadForBatch(records);
+      RequestBuilder builder = RequestBuilder.post().setUri(combineUrl(client.getServerHost(), batchResourcePath));
+      return newRequest(builder, payload);
+    } else {
+      return buildRequest(records.iterator().next());
+    }
+  }
+
+  /**
+   * @return JsonObject contains batch records
+   */
+  private JsonObject newPayloadForBatch(Collection<RestEntry<JsonObject>> batchRecords) {
+    JsonArray batchRequests = new JsonArray();
+    for (RestEntry<JsonObject> record : batchRecords) {
+      batchRequests.add(newSubrequest(record));
+    }
+    JsonObject payload = new JsonObject();
+    payload.add("batchRequests", batchRequests);
+    return payload;
+  }
+
+  /**
+   * Create batch subrequest. For more detail @link https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite_batch.htm
+   *
+   * @param record
+   * @return
+   */
+  private JsonObject newSubrequest(RestEntry<JsonObject> record) {
+    Preconditions.checkArgument(record.getResourcePath().isPresent(), "Resource path is not defined");
+    JsonObject subReq = new JsonObject();
+    subReq.addProperty("url", record.getResourcePath().get());
+    subReq.add("richInput", record.getRestEntryVal());
+
+    switch (operation) {
+      case INSERT_ONLY_NOT_EXIST:
+        subReq.addProperty("method", "POST");
+        break;
+      case UPSERT:
+        subReq.addProperty("method", "PATCH");
+        break;
+      default:
+        throw new IllegalArgumentException(operation + " is not supported.");
+    }
+    return subReq;
+  }
+
+  private HttpUriRequest newRequest(RequestBuilder builder, JsonElement payload) {
+    try {
+      builder.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+          .setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    log.debug("Request builder: " + ToStringBuilder.reflectionToString(builder, ToStringStyle.SHORT_PREFIX_STYLE));
+    return builder.build();
+  }
+
+  static URI combineUrl(URI uri, Optional<String> resourcePath) {
+    if (!resourcePath.isPresent()) {
+      return uri;
+    }
+
+    try {
+      return new URL(uri.toURL(), resourcePath.get()).toURI();
+    } catch (MalformedURLException | URISyntaxException e) {
+      throw new RuntimeException("Failed combining URL", e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceResponseHandler.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceResponseHandler.java
@@ -1,0 +1,117 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import lombok.extern.log4j.Log4j;
+
+import gobblin.http.ResponseHandler;
+
+
+@Log4j
+public class SalesforceResponseHandler implements ResponseHandler<CloseableHttpResponse> {
+  private static final String DUPLICATE_VALUE_ERR_CODE = "DUPLICATE_VALUE";
+
+  private SalesforceClient client;
+  private final SalesforceWriterBuilder.Operation operation;
+  private final boolean isBatching;
+
+  SalesforceResponseHandler(SalesforceClient client, SalesforceWriterBuilder.Operation operation, boolean isBatching) {
+    this.client = client;
+    this.operation = operation;
+    this.isBatching = isBatching;
+  }
+
+  @Override
+  public void handleResponse(CloseableHttpResponse response)
+      throws IOException {
+    log.debug("Received response " + ToStringBuilder.reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE));
+
+    int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode == 401 || statusCode == 403) {
+      client.setAccessToken(null);
+      throw new RuntimeException(
+          "Access denied. Access token has been reacquired and retry may solve the problem. " + ToStringBuilder
+              .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE));
+    }
+
+    if (isBatching) {
+      processBatchRequestResponse(response);
+    } else {
+      processSingleRequestResponse(response);
+    }
+  }
+
+  private void processSingleRequestResponse(CloseableHttpResponse response)
+      throws IOException {
+    int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode < 400) {
+      return;
+    }
+    String entityStr = EntityUtils.toString(response.getEntity());
+    if (statusCode == 400 && SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST.equals(operation)
+        && entityStr != null) { //Ignore if it's duplicate entry error code
+
+      JsonArray jsonArray = new JsonParser().parse(entityStr).getAsJsonArray();
+      JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
+      if (isDuplicate(jsonObject, statusCode)) {
+        return;
+      }
+    }
+    throw new IOException("Failed due to " + entityStr + " (Detail: " + ToStringBuilder
+        .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE) + " )");
+  }
+
+  /**
+   * Check results from batch response, if any of the results is failure throw exception.
+   * @param response
+   * @throws IOException
+   */
+  private void processBatchRequestResponse(CloseableHttpResponse response)
+      throws IOException {
+    String entityStr = EntityUtils.toString(response.getEntity());
+    int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode >= 400) {
+      throw new RuntimeException("Failed due to " + entityStr + " (Detail: " + ToStringBuilder
+          .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE) + " )");
+    }
+
+    JsonObject jsonBody = new JsonParser().parse(entityStr).getAsJsonObject();
+    if (!jsonBody.get("hasErrors").getAsBoolean()) {
+      return;
+    }
+
+    JsonArray results = jsonBody.get("results").getAsJsonArray();
+    for (JsonElement jsonElem : results) {
+      JsonObject json = jsonElem.getAsJsonObject();
+      int subStatusCode = json.get("statusCode").getAsInt();
+      if (subStatusCode < 400) {
+        continue;
+      } else if (subStatusCode == 400 && SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST.equals(operation)) {
+        JsonElement resultJsonElem = json.get("result");
+        Preconditions.checkNotNull(resultJsonElem, "Error response should contain result property");
+        JsonObject resultJsonObject = resultJsonElem.getAsJsonArray().get(0).getAsJsonObject();
+        if (isDuplicate(resultJsonObject, subStatusCode)) {
+          continue;
+        }
+      }
+      throw new IOException("Failed due to " + jsonBody + " (Detail: " + ToStringBuilder
+          .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE) + " )");
+    }
+  }
+
+  private boolean isDuplicate(JsonObject responseJsonObject, int statusCode) {
+    return statusCode == 400 && SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST.equals(operation)
+        && DUPLICATE_VALUE_ERR_CODE.equals(responseJsonObject.get("errorCode").getAsString());
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRestWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRestWriter.java
@@ -53,7 +53,9 @@ import gobblin.writer.exception.NonTransientException;
 /**
  * Writes to Salesforce via RESTful API, supporting INSERT_ONLY_NOT_EXIST, and UPSERT.
  *
+ * @deprecated Please use {@link BatchAndSendSyncHttpWriter}
  */
+@Deprecated
 public class SalesforceRestWriter extends RestJsonWriter {
   public static enum Operation {
     INSERT_ONLY_NOT_EXIST,

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceWriterBuilder.java
@@ -1,0 +1,73 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.Getter;
+
+import gobblin.configuration.State;
+import gobblin.converter.http.RestEntry;
+import gobblin.writer.DataWriter;
+
+
+/**
+ * Builder of Salesforce http writer
+ */
+public class SalesforceWriterBuilder extends BatchHttpWriterBaseBuilder<RestEntry<JsonObject>, HttpUriRequest, CloseableHttpResponse, SalesforceWriterBuilder> {
+  static final String SFDC_PREFIX = "salesforce.";
+  static final String OPERATION = SFDC_PREFIX + "operation";
+  static final String BATCH_SIZE = SFDC_PREFIX + "batch_size";
+  static final String BATCH_RESOURCE_PATH = SFDC_PREFIX + "batch_resource_path";
+
+  public enum Operation {
+    INSERT_ONLY_NOT_EXIST,
+    UPSERT
+  }
+
+  private static final Config FALLBACK = ConfigFactory.parseMap(
+      ImmutableMap.<String, String>builder()
+          .put(BATCH_SIZE, "1")
+          .build()
+  );
+
+  @Getter
+  private Operation operation;
+  @Getter
+  private Optional<String> batchResourcePath;
+
+  @Override
+  SalesforceWriterBuilder fromConfig(Config config) {
+    operation = Operation.valueOf(config.getString(OPERATION).toUpperCase());
+    maxBatchSize = config.getInt(BATCH_SIZE);
+    batchResourcePath = Optional.of(config.getString(BATCH_RESOURCE_PATH));
+
+    return super.fromConfig(config);
+  }
+
+  @Override
+  protected void createComponents(State state, Config config) {
+    SalesforceClient client = new SalesforceClient(state, config);
+    requestBuilder = new SalesforceRequestBuilder(client, operation, batchResourcePath);
+    responseHandler = new SalesforceResponseHandler(client, operation, true);
+    this.client = client;
+  }
+
+  @Override
+  public DataWriter<RestEntry<JsonObject>> build()
+      throws IOException {
+    validate();
+    if (maxBatchSize > 1) {
+      return new BatchAndSendSyncHttpWriter<RestEntry<JsonObject>, HttpUriRequest, CloseableHttpResponse>(this);
+    } else {
+      return new RecordSyncHttpWriter<RestEntry<JsonObject>, HttpUriRequest, CloseableHttpResponse>(this);
+    }
+  }
+}


### PR DESCRIPTION
- Introduce a new framework to construct http writers
- Abstract the way to send request(`HttpClient`), the way to build a request(`RequestBuilder`), and the way to handle a response(`ResponseHandler`) of a http writer
- Provide a new Salesforce http writer solution based on the existing solution(`SalesforceRestWriter`).
- Implement `RecordSyncHttpWriter` which processes record synchronously
- Implement `BatchAndSendSyncHttpWriter` which batches records and then sends the batch synchronously.

@ibuenros @yukuai518 Please review.