### PR TITLE
Fix for issue 1776

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/HiveSerDeWrapper.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/HiveSerDeWrapper.java
@@ -19,6 +19,7 @@ package gobblin.hive;
 
 import java.io.IOException;
 
+import org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat;
 import org.apache.hadoop.hive.ql.io.avro.AvroContainerInputFormat;
 import org.apache.hadoop.hive.ql.io.avro.AvroContainerOutputFormat;
 import org.apache.hadoop.hive.ql.io.orc.OrcInputFormat;
@@ -29,6 +30,8 @@ import org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat;
 import org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe;
 import org.apache.hadoop.hive.serde2.SerDe;
 import org.apache.hadoop.hive.serde2.avro.AvroSerDe;
+import org.apache.hadoop.hive.serde2.lazy.LazySimpleSerDe;
+import org.apache.hadoop.mapred.TextInputFormat;
 
 import com.google.common.base.Enums;
 import com.google.common.base.Optional;
@@ -65,7 +68,9 @@ public class HiveSerDeWrapper {
         AvroContainerOutputFormat.class.getName()),
     ORC(OrcSerde.class.getName(), OrcInputFormat.class.getName(), OrcOutputFormat.class.getName()),
     PARQUET(ParquetHiveSerDe.class.getName(), MapredParquetInputFormat.class.getName(),
-        MapredParquetOutputFormat.class.getName());
+        MapredParquetOutputFormat.class.getName()),
+    TEXTFILE(LazySimpleSerDe.class.getName(), TextInputFormat.class.getName(),
+        HiveIgnoreKeyTextOutputFormat.class.getName());
 
     private final String serDeClassName;
     private final String inputFormatClassName;
@@ -161,7 +166,6 @@ public class HiveSerDeWrapper {
    *
    * @param state The state should contain property {@link #SERDE_SERIALIZER_TYPE}, and optionally contain properties
    * {@link #SERDE_SERIALIZER_INPUT_FORMAT_TYPE}, {@link #SERDE_SERIALIZER_OUTPUT_FORMAT_TYPE} and
-   * {@link #SERDE_SERIALIZER_FILE_EXTENSION}.
    */
   public static HiveSerDeWrapper getSerializer(State state) {
     Preconditions.checkArgument(state.contains(SERDE_SERIALIZER_TYPE),
@@ -176,7 +180,6 @@ public class HiveSerDeWrapper {
    *
    * @param state The state should contain property {@link #SERDE_DESERIALIZER_TYPE}, and optionally contain properties
    * {@link #SERDE_DESERIALIZER_INPUT_FORMAT_TYPE}, {@link #SERDE_DESERIALIZER_OUTPUT_FORMAT_TYPE} and
-   * {@link #SERDE_DESERIALIZER_FILE_EXTENSION}.
    */
   public static HiveSerDeWrapper getDeserializer(State state) {
     Preconditions.checkArgument(state.contains(SERDE_DESERIALIZER_TYPE),

--- a/gobblin-runtime/build.gradle
+++ b/gobblin-runtime/build.gradle
@@ -82,6 +82,7 @@ dependencies {
   compile externalDependency.guavaretrying
   compile externalDependency.hiveExec
   compile externalDependency.parquet
+  compile externalDependency.kryo
 
   testCompile project(path: ":gobblin-metastore", configuration: "testFixtures")
   testCompile externalDependency.calciteCore

--- a/gobblin-runtime/src/test/java/gobblin/WriterOutputFormatIntegrationTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/WriterOutputFormatIntegrationTest.java
@@ -41,6 +41,15 @@ public class WriterOutputFormatIntegrationTest {
     GobblinLocalJobLauncherUtils.invokeLocalJobLauncher(jobProperties);
   }
 
+  @Test
+  public void textfileOutputFormatTest()
+      throws Exception {
+    Properties jobProperties = getProperties();
+    jobProperties.setProperty(HiveSerDeWrapper.SERDE_SERIALIZER_TYPE, "TEXTFILE");
+    jobProperties.setProperty(ConfigurationKeys.WRITER_OUTPUT_FORMAT_KEY, "TEXTFILE");
+    GobblinLocalJobLauncherUtils.invokeLocalJobLauncher(jobProperties);
+  }
+
   private Properties getProperties()
       throws IOException {
     Properties jobProperties =

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -106,6 +106,7 @@ ext.externalDependency = [
     "salesforcePartner": "com.force.api:force-partner-api:" + salesforceVersion,
     "scala": "org.scala-lang:scala-library:2.11.8",
     "influxdbJava": "org.influxdb:influxdb-java:2.1",
+    "kryo": "com.esotericsoftware.kryo:kryo:2.22",
     "libthrift":"org.apache.thrift:libthrift:0.9.3",
     "lombok":"org.projectlombok:lombok:1.16.8",
     "mockRunnerJdbc":"com.mockrunner:mockrunner-jdbc:1.0.8",


### PR DESCRIPTION
1) Added TEXTFILE format in HiveSerDeWrapper.
2) Removed "{@link #SERDE_SERIALIZER_FILE_EXTENSION}" from javadocs as they were not declared anywhere.
3) Added "com.esotericsoftware.kryo:kryo:2.22" dependency for supporting TEXTFILE format.
4) Added a test, to convert Avro to TEXTFILE. This test is also a validation that TEXTFILE format is supported and can be used for serializing and deserializing.

Note: In order to support TEXTFILE, following properties should be passed from job/pull file.
serde.deserializer(or serializer).type=TEXTFILE