### PR TITLE
Support state persistence for partial commit; Add Sla to Azkaban launcher

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -402,6 +402,8 @@ public class ConfigurationKeys {
   public static final String PUBLISH_DATA_AT_JOB_LEVEL = "publish.data.at.job.level";
   public static final boolean DEFAULT_PUBLISH_DATA_AT_JOB_LEVEL = true;
   public static final String PUBLISHER_DIRS = DATA_PUBLISHER_PREFIX + ".output.dirs";
+  public static final String DATA_PUBLISHER_CAN_BE_SKIPPED = DATA_PUBLISHER_PREFIX + ".canBeSkipped";
+  public static final boolean DEFAULT_DATA_PUBLISHER_CAN_BE_SKIPPED = false;
 
   /**
    * Configuration properties used by the extractor.

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRJobLauncher.java
@@ -265,6 +265,8 @@ public class MRJobLauncher extends AbstractJobLauncher {
       if (this.hadoopJobSubmitted && !this.job.isComplete()) {
         LOG.info("Killing the Hadoop MR job for job " + this.jobContext.getJobId());
         this.job.killJob();
+        // Collect final task states.
+        this.taskStateCollectorService.stopAsync().awaitTerminated();
       }
     } catch (IllegalStateException ise) {
       LOG.error("The Hadoop MR job has not started for job " + this.jobContext.getJobId());

--- a/gobblin-runtime/src/test/java/gobblin/runtime/DummyJobContext.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/DummyJobContext.java
@@ -18,6 +18,7 @@
 package gobblin.runtime;
 
 import com.typesafe.config.Config;
+
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -44,8 +45,8 @@ public class DummyJobContext extends JobContext {
 
   public DummyJobContext(Properties jobProps, Logger logger, Map<String, JobState.DatasetState> datasetStateMap)
       throws Exception {
-    super(jobProps, logger, SharedResourcesBrokerFactory.createDefaultTopLevelBroker(ConfigFactory.empty(),
-        GobblinScopeTypes.GLOBAL.defaultScopeInstance()));
+    super(jobProps, logger, SharedResourcesBrokerFactory
+        .createDefaultTopLevelBroker(ConfigFactory.empty(), GobblinScopeTypes.GLOBAL.defaultScopeInstance()));
     this.datasetStateMap = datasetStateMap;
   }
 
@@ -78,7 +79,7 @@ public class DummyJobContext extends JobContext {
   }
 
   @Override
-  protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob,
+  protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob, boolean isJobCancelled,
       DeliverySemantics deliverySemantics, String datasetUrn, JobState.DatasetState datasetState,
       boolean isMultithreaded, JobContext jobContext) {
     return new Callable<Void>() {

--- a/gobblin-runtime/src/test/java/gobblin/runtime/JobContextTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/JobContextTest.java
@@ -50,7 +50,8 @@ import lombok.extern.slf4j.Slf4j;
 public class JobContextTest {
 
   @Test
-  public void testNonParallelCommit() throws Exception {
+  public void testNonParallelCommit()
+      throws Exception {
 
     Properties jobProps = new Properties();
 
@@ -65,12 +66,13 @@ public class JobContextTest {
 
     final BlockingQueue<ControllableCallable<Void>> callables = Queues.newLinkedBlockingQueue();
 
-    final JobContext jobContext = new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
-      @Override
-      public boolean apply(@Nullable String input) {
-        return true;
-      }
-    }, callables);
+    final JobContext jobContext =
+        new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
+          @Override
+          public boolean apply(@Nullable String input) {
+            return true;
+          }
+        }, callables);
 
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     Future future = executorService.submit(new Runnable() {
@@ -103,7 +105,8 @@ public class JobContextTest {
   }
 
   @Test
-  public void testParallelCommit() throws Exception {
+  public void testParallelCommit()
+      throws Exception {
 
     Properties jobProps = new Properties();
 
@@ -119,12 +122,13 @@ public class JobContextTest {
 
     final BlockingQueue<ControllableCallable<Void>> callables = Queues.newLinkedBlockingQueue();
 
-    final JobContext jobContext = new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
-      @Override
-      public boolean apply(@Nullable String input) {
-        return true;
-      }
-    }, callables);
+    final JobContext jobContext =
+        new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
+          @Override
+          public boolean apply(@Nullable String input) {
+            return true;
+          }
+        }, callables);
 
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     Future future = executorService.submit(new Runnable() {
@@ -157,7 +161,8 @@ public class JobContextTest {
   }
 
   @Test
-  public void testSingleExceptionSemantics() throws Exception {
+  public void testSingleExceptionSemantics()
+      throws Exception {
 
     Properties jobProps = new Properties();
 
@@ -173,12 +178,13 @@ public class JobContextTest {
     final BlockingQueue<ControllableCallable<Void>> callables = Queues.newLinkedBlockingQueue();
 
     // There are three datasets, "0", "1", and "2", middle one will fail
-    final JobContext jobContext = new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
-      @Override
-      public boolean apply(@Nullable String input) {
-        return !input.equals("1");
-      }
-    }, callables);
+    final JobContext jobContext =
+        new ControllableCommitJobContext(jobProps, log, datasetStateMap, new Predicate<String>() {
+          @Override
+          public boolean apply(@Nullable String input) {
+            return !input.equals("1");
+          }
+        }, callables);
 
     ExecutorService executorService = Executors.newSingleThreadExecutor();
     Future future = executorService.submit(new Runnable() {
@@ -257,7 +263,7 @@ public class JobContextTest {
     }
 
     @Override
-    protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob,
+    protected Callable<Void> createSafeDatasetCommit(boolean shouldCommitDataInJob, boolean isJobCancelled,
         DeliverySemantics deliverySemantics, String datasetUrn, JobState.DatasetState datasetState,
         boolean isMultithreaded, JobContext jobContext) {
       ControllableCallable<Void> callable;


### PR DESCRIPTION
- Added SLA in `AzkabanJobLauncher` to have enough time for our own `cancel` logic;
- Previous Job cancellation does not persist state. Added state persistence for job cancellation.
- Added skippable to `DataPublisher`, so that tasks that are finished successfully with skippable `publisher` can have their states persisted. One example would be `HiveRegistrationPublisher`, which does not have any effect to state store, and user can choose to skip it as long as tasks are committed using partial `JobCommitPolicy`.
@htran1 or @ibuenros  can you take a look?