### PR TITLE
Percentage string converter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/string/PercentageDoubleStringConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/string/PercentageDoubleStringConverter.java
@@ -1,0 +1,73 @@
+package gobblin.converter.string;
+
+import java.math.BigDecimal;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.converter.SingleRecordIterable;
+
+
+/**
+ * This converter simply converts double string than ends with % to a validate double number.
+ * e.g. 99% -> 0.99
+ */
+public class PercentageDoubleStringConverter extends Converter<JsonArray, JsonArray, JsonObject, JsonObject> {
+  private static final String JSON_KEY_COLUMN_NAME = "columnName";
+  private static final String JSON_KEY_DATA_TYPE = "dataType";
+  private static final String JSON_KEY_TYPE = "type";
+
+  @Override
+  public Converter<JsonArray, JsonArray, JsonObject, JsonObject> init(WorkUnitState workUnit) {
+    super.init(workUnit);
+    return this;
+  }
+
+  @Override
+  public JsonArray convertSchema(JsonArray inputSchema, WorkUnitState workUnit)
+      throws SchemaConversionException {
+    return inputSchema;
+  }
+
+  @Override
+  public Iterable<JsonObject> convertRecord(JsonArray outputSchema, JsonObject inputRecord, WorkUnitState workUnit)
+      throws DataConversionException {
+
+    JsonObject outputRecord = new JsonObject();
+    for (int i = 0; i < outputSchema.size(); i++) {
+      JsonElement schemaElement = outputSchema.get(i);
+      String col = getColumnName(schemaElement);
+      JsonElement record = inputRecord.get(col);
+
+      if ("double".equals(getTypeName(schemaElement))) {
+        String recordString = record.getAsString().trim();
+        if (recordString.endsWith("%")) {
+          outputRecord.addProperty(col, convertPercentage(recordString));
+          continue;
+        }
+      }
+      outputRecord.add(col, record);
+    }
+
+    return new SingleRecordIterable<>(outputRecord);
+  }
+
+  private String convertPercentage(String record) {
+    BigDecimal d = new BigDecimal(record.substring(0, record.length() - 1));
+    return d.divide(BigDecimal.valueOf(100)).toString();
+  }
+
+  private static String getColumnName(JsonElement schemaElement) {
+    return schemaElement.getAsJsonObject().get(JSON_KEY_COLUMN_NAME).getAsString();
+  }
+
+  private static String getTypeName(JsonElement schemaElement) {
+    return schemaElement.getAsJsonObject().get(JSON_KEY_DATA_TYPE).getAsJsonObject().get(JSON_KEY_TYPE).getAsString()
+        .toLowerCase();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/converter/string/PercentageDoubleStringConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/string/PercentageDoubleStringConverter.java
@@ -14,8 +14,11 @@ import gobblin.converter.SingleRecordIterable;
 
 
 /**
- * This converter simply converts double string than ends with % to a validate double number.
+ * This converter converts a string that stands for a percentage number ending with %
+ * to a validate double number as specified by the OutputSchemaType
  * e.g. 99% -> 0.99
+ * 
+ * A detailed example can be found at PercentageDoubleStringConverterTest
  */
 public class PercentageDoubleStringConverter extends Converter<JsonArray, JsonArray, JsonObject, JsonObject> {
   private static final String JSON_KEY_COLUMN_NAME = "columnName";

--- a/gobblin-core/src/test/java/gobblin/converter/string/PercentageDoubleStringConverterTest.java
+++ b/gobblin-core/src/test/java/gobblin/converter/string/PercentageDoubleStringConverterTest.java
@@ -1,0 +1,51 @@
+package gobblin.converter.string;
+
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import gobblin.converter.DataConversionException;
+import gobblin.converter.string.PercentageDoubleStringConverter;
+
+
+@Test(groups = {"gobblin.converter"})
+public class PercentageDoubleStringConverterTest {
+  public void convertOutput()
+      throws IOException, DataConversionException {
+    JsonParser parser = new JsonParser();
+    JsonElement jsonElement = parser
+        .parse(new InputStreamReader(getClass().getResourceAsStream("/converter/csv/schema_with_10_fields.json")));
+
+    JsonObject inputRecord = parser
+        .parse(new InputStreamReader(getClass().getResourceAsStream("/converter/csv/10_fields_with_percentage.json")))
+        .getAsJsonObject();
+
+    PercentageDoubleStringConverter converter = new PercentageDoubleStringConverter();
+    Iterable<JsonObject> iterable = converter.convertRecord(jsonElement.getAsJsonArray(), inputRecord, null);
+    converter.close();
+
+    JsonObject converted = iterable.iterator().next();
+    Assert.assertEquals(converted.toString(), getExpectedJson().toString());
+  }
+
+  private JsonObject getExpectedJson() {
+    JsonObject json = new JsonObject();
+    json.addProperty("Date", "20160924");
+    json.addProperty("DeviceCategory", "desktop");
+    json.addProperty("Sessions", "4");
+    json.addProperty("BounceRate", "0.044");
+    json.addProperty("AvgSessionDuration", "0.001");
+    json.addProperty("Pageviews", "3");
+    json.addProperty("PageviewsPerSession", "8.1");
+    json.addProperty("UniquePageviews", "2");
+    json.addProperty("AvgTimeOnPage", "1.0");
+    json.addProperty("User_count", "17");
+    return json;
+  }
+}

--- a/gobblin-core/src/test/resources/converter/csv/10_fields_with_percentage.json
+++ b/gobblin-core/src/test/resources/converter/csv/10_fields_with_percentage.json
@@ -1,0 +1,12 @@
+{
+  "Date": "20160924",
+  "DeviceCategory": "desktop",
+  "Sessions": "4",
+  "BounceRate": "4.4%",
+  "AvgSessionDuration": ".1%",
+  "Pageviews": "3",
+  "PageviewsPerSession": "8.1",
+  "UniquePageviews": "2",
+  "AvgTimeOnPage": "1.0",
+  "User_count": "17"
+}


### PR DESCRIPTION
Add a converter that converts a string which stands for a percentage number ending with %
to a validate double number.