### PR TITLE
Upgraded johnrengelman shadow plugin to 1.2.4 to fix mavenResolver issue

### DIFF
--- a/gobblin-yarn/build.gradle
+++ b/gobblin-yarn/build.gradle
@@ -16,7 +16,7 @@
  */
 
 plugins {
-  id 'com.github.johnrengelman.shadow' version '1.2.3'
+  id 'com.github.johnrengelman.shadow' version '1.2.4'
 }
 
 apply plugin: 'java'


### PR DESCRIPTION
Upgraded johnrengelman shadow plugin to 1.2.4 to fix mavenResolver issue with internal dependencies.