### PR TITLE
Remove redundant runtime attributes in hive table properties

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -198,7 +198,6 @@ public class HiveMetaStoreUtils {
       if (!propKey.equals(RUNTIME_PROPS)) {
         parameters.put(propKey, props.getProp(propKey));
       }
-      else continue;
     }
     return parameters;
   }

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -111,18 +111,6 @@ public class HiveMetaStoreUtils {
     if (table.getTableType().equals(TableType.EXTERNAL_TABLE.toString())) {
       table.getParameters().put(EXTERNAL, Boolean.TRUE.toString().toUpperCase());
     }
-    if (hiveTable.getProps().contains(RUNTIME_PROPS)) {
-      String runtimePropsString = hiveTable.getProps().getProp(RUNTIME_PROPS);
-      for (String propValue : LIST_SPLITTER_COMMA.splitToList(runtimePropsString)) {
-        List<String> tokens = LIST_SPLITTER_COLON.splitToList(propValue);
-        Preconditions.checkState(tokens.size() == 2,
-            propValue + " is not a valid Hive table/partition property");
-        table.getParameters().put(tokens.get(0), tokens.get(1));
-      }
-      if (table.getParameters().containsKey(RUNTIME_PROPS)) {
-        table.getParameters().remove(RUNTIME_PROPS);
-      }
-    }
     table.setPartitionKeys(getFieldSchemas(hiveTable.getPartitionKeys()));
     table.setSd(getStorageDescriptor(hiveTable));
     return table;
@@ -197,8 +185,20 @@ public class HiveMetaStoreUtils {
 
   private static Map<String, String> getParameters(State props) {
     Map<String, String> parameters = Maps.newHashMap();
+    if (props.contains(RUNTIME_PROPS)) {
+      String runtimePropsString = props.getProp(RUNTIME_PROPS);
+      for (String propValue : LIST_SPLITTER_COMMA.splitToList(runtimePropsString)) {
+        List<String> tokens = LIST_SPLITTER_COLON.splitToList(propValue);
+        Preconditions.checkState(tokens.size() == 2,
+            propValue + " is not a valid Hive table/partition property");
+        parameters.put(tokens.get(0), tokens.get(1));
+      }
+    }
     for (String propKey : props.getPropertyNames()) {
-      parameters.put(propKey, props.getProp(propKey));
+      if (!propKey.equals(RUNTIME_PROPS)) {
+        parameters.put(propKey, props.getProp(propKey));
+      }
+      else continue;
     }
     return parameters;
   }

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreUtils.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreUtils.java
@@ -119,6 +119,9 @@ public class HiveMetaStoreUtils {
             propValue + " is not a valid Hive table/partition property");
         table.getParameters().put(tokens.get(0), tokens.get(1));
       }
+      if (table.getParameters().containsKey(RUNTIME_PROPS)) {
+        table.getParameters().remove(RUNTIME_PROPS);
+      }
     }
     table.setPartitionKeys(getFieldSchemas(hiveTable.getPartitionKeys()));
     table.setSd(getStorageDescriptor(hiveTable));

--- a/gobblin-modules/gobblin-couchbase/src/test/java/gobblin/couchbase/CouchbaseTestServer.java
+++ b/gobblin-modules/gobblin-couchbase/src/test/java/gobblin/couchbase/CouchbaseTestServer.java
@@ -25,6 +25,7 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Arrays;
 
+import java.util.concurrent.TimeUnit;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.testng.Assert;
@@ -183,6 +184,7 @@ public class CouchbaseTestServer {
       CouchbaseEnvironment cbEnv = DefaultCouchbaseEnvironment.builder().bootstrapHttpEnabled(true)
           .bootstrapHttpDirectPort(port)
           .bootstrapCarrierDirectPort(serverPort)
+          .connectTimeout(TimeUnit.SECONDS.toMillis(15))
           .bootstrapCarrierEnabled(true).build();
       CouchbaseCluster cbCluster = CouchbaseCluster.create(cbEnv, "localhost");
       Bucket bucket = cbCluster.openBucket("default","");


### PR DESCRIPTION
Problem statement:There's a `runtime.props` contained in hive table properties. The value of this props is all the metadata k-v pair that we obtained in runtime, including kafka topic for example. Keeping this value in final metadata is not necessary. This is a minor fix for removal.

@ibuenros Can you help review? Thanks.