### PR TITLE
Preserving partition params during avro2orc conversion

### DIFF
--- a/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/writer/HiveQueryExecutionWriter.java
+++ b/gobblin-data-management/src/main/java/gobblin/data/management/conversion/hive/writer/HiveQueryExecutionWriter.java
@@ -18,13 +18,21 @@ package gobblin.data.management.conversion.hive.writer;
 
 import java.io.IOException;
 import java.sql.SQLException;
+import java.util.Arrays;
 import java.util.List;
+
+import org.apache.commons.lang3.StringUtils;
+
+import com.google.common.base.Optional;
 
 import lombok.AllArgsConstructor;
 
 import gobblin.configuration.State;
+import gobblin.data.management.conversion.hive.dataset.ConvertibleHiveDataset;
 import gobblin.data.management.conversion.hive.entities.QueryBasedHiveConversionEntity;
+import gobblin.data.management.conversion.hive.entities.SchemaAwareHivePartition;
 import gobblin.data.management.conversion.hive.events.EventWorkunitUtils;
+import gobblin.data.management.conversion.hive.publisher.HiveConvertPublisher;
 import gobblin.util.HiveJdbcConnector;
 import gobblin.writer.DataWriter;
 import lombok.extern.slf4j.Slf4j;
@@ -40,6 +48,7 @@ public class HiveQueryExecutionWriter implements DataWriter<QueryBasedHiveConver
 
   private final HiveJdbcConnector hiveJdbcConnector;
   private final State workUnit;
+  private static final String AT_CHAR = "@";
 
   @Override
   public void write(QueryBasedHiveConversionEntity hiveConversionEntity) throws IOException {
@@ -48,6 +57,8 @@ public class HiveQueryExecutionWriter implements DataWriter<QueryBasedHiveConver
       conversionQueries = hiveConversionEntity.getQueries();
       EventWorkunitUtils.setBeginConversionDDLExecuteTimeMetadata(this.workUnit, System.currentTimeMillis());
       this.hiveJdbcConnector.executeStatements(conversionQueries.toArray(new String[conversionQueries.size()]));
+      // Adding properties for preserving partitionParams:
+      addPropsForPublisher(hiveConversionEntity);
       EventWorkunitUtils.setEndConversionDDLExecuteTimeMetadata(this.workUnit, System.currentTimeMillis());
     } catch (SQLException e) {
       log.warn("Failed to execute queries: ");
@@ -55,6 +66,38 @@ public class HiveQueryExecutionWriter implements DataWriter<QueryBasedHiveConver
         log.warn("Conversion query attempted by Hive Query writer: " + conversionQuery);
       }
       throw new IOException(e);
+    }
+  }
+
+  /**
+   * Method to add properties needed by publisher to preserve partition params
+   */
+  private void addPropsForPublisher(QueryBasedHiveConversionEntity hiveConversionEntity) {
+    if (!hiveConversionEntity.getHivePartition().isPresent()) {
+      return;
+    }
+    ConvertibleHiveDataset convertibleHiveDataset = hiveConversionEntity.getConvertibleHiveDataset();
+    for (String format : convertibleHiveDataset.getDestFormats()) {
+      Optional<ConvertibleHiveDataset.ConversionConfig> conversionConfigForFormat =
+          convertibleHiveDataset.getConversionConfigForFormat(format);
+      if (!conversionConfigForFormat.isPresent()) {
+        continue;
+      }
+      SchemaAwareHivePartition sourcePartition = hiveConversionEntity.getHivePartition().get();
+
+      // Get complete source partition name dbName@tableName@partitionName
+      String completeSourcePartitionName = StringUtils.join(Arrays
+          .asList(sourcePartition.getTable().getDbName(), sourcePartition.getTable().getTableName(),
+              sourcePartition.getName()), AT_CHAR);
+      ConvertibleHiveDataset.ConversionConfig config = conversionConfigForFormat.get();
+
+      // Get complete destination partition name dbName@tableName@partitionName
+      String completeDestPartitionName = StringUtils.join(
+          Arrays.asList(config.getDestinationDbName(), config.getDestinationTableName(), sourcePartition.getName()),
+          AT_CHAR);
+
+      workUnit.setProp(HiveConvertPublisher.COMPLETE_SOURCE_PARTITION_NAME, completeSourcePartitionName);
+      workUnit.setProp(HiveConvertPublisher.COMPLETE_DEST_PARTITION_NAME, completeDestPartitionName);
     }
   }
 

--- a/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/CopyPartitionParametersTest.java
+++ b/gobblin-data-management/src/test/java/gobblin/data/management/conversion/hive/CopyPartitionParametersTest.java
@@ -1,0 +1,66 @@
+package gobblin.data.management.conversion.hive;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.hadoop.hive.metastore.api.Partition;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.data.management.conversion.hive.publisher.HiveConvertPublisher;
+
+
+/**
+ * @author adsharma
+ */
+@Test
+public class CopyPartitionParametersTest {
+  private static final String SRC_PARTITION = "srcDb@srcTable@srcPartition";
+  private static final String DEST_PARTITION = "destDb@destTable@destPartition";
+  private static final String ALL = "*";
+  private static final String MY_VALUE = "myValue";
+  private static final String MY_PROP = "myProp";
+
+  private HiveConvertPublisher publisherMock = Mockito.mock(HiveConvertPublisher.class);
+  private WorkUnitState workUnitState = new WorkUnitState();
+
+  private Partition sourcePartition = Mockito.mock(Partition.class);
+  private Partition destPartition = Mockito.mock(Partition.class);
+
+  private Map<String, String> sourceParams = new HashMap<>();
+  private Map<String, String> destParams = new HashMap<>();
+
+  @BeforeTest
+  private void init() {
+    Mockito.doReturn(Optional.fromNullable(this.sourcePartition)).when(this.publisherMock)
+        .getPartitionObject(SRC_PARTITION);
+    Mockito.doReturn(Optional.fromNullable(this.destPartition)).when(this.publisherMock)
+        .getPartitionObject(DEST_PARTITION);
+    Mockito.doReturn(true).when(this.publisherMock).dropPartition(DEST_PARTITION);
+    Mockito.doReturn(true).when(this.publisherMock).addPartition(this.destPartition, DEST_PARTITION);
+    Mockito.doCallRealMethod().when(this.publisherMock)
+        .copyPartitionParams(SRC_PARTITION, DEST_PARTITION, Collections.singletonList(ALL), Collections.EMPTY_LIST);
+    Mockito.doCallRealMethod().when(this.publisherMock)
+        .preservePartitionParams(Collections.singleton(this.workUnitState));
+
+    Mockito.doReturn(this.sourceParams).when(this.sourcePartition).getParameters();
+    Mockito.doReturn(this.destParams).when(this.destPartition).getParameters();
+  }
+
+  public void test() {
+    this.workUnitState.setWorkingState(WorkUnitState.WorkingState.COMMITTED);
+    this.workUnitState.setProp(HiveConvertPublisher.COMPLETE_SOURCE_PARTITION_NAME, SRC_PARTITION);
+    this.workUnitState.setProp(HiveConvertPublisher.COMPLETE_DEST_PARTITION_NAME, DEST_PARTITION);
+    this.workUnitState.setProp(HiveConvertPublisher.PARTITION_PARAMETERS_WHITELIST, ALL);
+
+    this.sourceParams.put(MY_PROP, MY_VALUE);
+    this.publisherMock.preservePartitionParams(Collections.singleton(this.workUnitState));
+    Assert.assertTrue(this.destParams.get(MY_PROP).equalsIgnoreCase(MY_VALUE));
+  }
+}


### PR DESCRIPTION
1) Passing the necessary source partition info and destination partition info from HiveQueryExecutionWriter.java to HiveConvertPublisher.java via WorkUnit
2) Params which need to be preserved should be passed via configuration property "hive.conversion.preserve.partitionParameters"
3) Adding params into the destination partition inside HiveConvertPublisher.java 