### PR TITLE
new salesforce writer

### DIFF
--- a/gobblin-core/src/main/java/gobblin/http/ApacheHttpClient.java
+++ b/gobblin-core/src/main/java/gobblin/http/ApacheHttpClient.java
@@ -1,0 +1,137 @@
+package gobblin.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.conn.ConnectionRequest;
+import org.apache.http.conn.HttpClientConnectionManager;
+import org.apache.http.conn.routing.HttpRoute;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.conn.BasicHttpClientConnectionManager;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j;
+
+import gobblin.configuration.State;
+import gobblin.writer.http.AbstractHttpWriterBuilder;
+import gobblin.writer.http.DelegatingHttpClientConnectionManager;
+
+
+/**
+ * A {@link HttpClient} that sends {@link HttpUriRequest} and gets {@link CloseableHttpResponse}.
+ * It encapsulates a {@link CloseableHttpClient} instance to send the {@link HttpUriRequest}
+ */
+@Log4j
+public class ApacheHttpClient implements HttpClient<HttpUriRequest, CloseableHttpResponse> {
+  public static final String HTTP_CONN_MANAGER = "conn_mgr_type";
+  public static final String POOLING_CONN_MANAGER_MAX_TOTAL_CONN = "conn_mgr.pooling.max_conn_total";
+  public static final String POOLING_CONN_MANAGER_MAX_PER_CONN = "conn_mgr.pooling.max_per_conn";
+  public static final String REQUEST_TIME_OUT_MS_KEY = "req_time_out";
+  public static final String CONNECTION_TIME_OUT_MS_KEY = "conn_time_out";
+  public static final String STATIC_SVC_ENDPOINT = "static_svc_endpoint";
+
+  public enum ConnManager {
+    POOLING,
+    BASIC
+  }
+
+  private static final Config FALLBACK =
+      ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+          .put(REQUEST_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
+          .put(CONNECTION_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(5L))
+          .put(HTTP_CONN_MANAGER, AbstractHttpWriterBuilder.ConnManager.BASIC.name())
+          .put(POOLING_CONN_MANAGER_MAX_TOTAL_CONN, 20)
+          .put(POOLING_CONN_MANAGER_MAX_PER_CONN, 2)
+          .build());
+
+  /**
+   * A helper class to customize and track http connection
+   */
+  class HttpClientConnectionManagerWithConnTracking extends DelegatingHttpClientConnectionManager {
+    HttpClientConnectionManagerWithConnTracking(HttpClientConnectionManager fallback) {
+      super(fallback);
+    }
+
+    @Override
+    public ConnectionRequest requestConnection(HttpRoute route, Object state) {
+      try {
+        ApacheHttpClient.this.connect(new URI(route.getTargetHost().toURI()));
+      } catch (IOException | URISyntaxException e) {
+        throw new RuntimeException("onConnect() callback failure: " + e, e);
+      }
+      return super.requestConnection(route, state);
+    }
+  }
+
+  private final CloseableHttpClient client;
+  @Getter
+  protected URI serverHost;
+
+  public ApacheHttpClient(HttpClientBuilder builder, Config config) {
+    config = config.withFallback(FALLBACK);
+    RequestConfig requestConfig = RequestConfig.copy(RequestConfig.DEFAULT)
+        .setSocketTimeout(config.getInt(REQUEST_TIME_OUT_MS_KEY))
+        .setConnectTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
+        .setConnectionRequestTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
+        .build();
+
+    builder.disableCookieManagement().useSystemProperties().setDefaultRequestConfig(requestConfig);
+    builder.setConnectionManager(new HttpClientConnectionManagerWithConnTracking(getHttpConnManager(config)));
+    client = builder.build();
+  }
+
+  public boolean connect(URI uri) throws IOException {
+    return false;
+  }
+
+  @Override
+  public CloseableHttpResponse sendRequest(HttpUriRequest request) throws IOException {
+    return client.execute(request);
+  }
+
+  private HttpClientConnectionManager getHttpConnManager(Config config) {
+    HttpClientConnectionManager httpConnManager;
+
+    if (config.hasPath(STATIC_SVC_ENDPOINT)) {
+      try {
+        serverHost = new URI(config.getString(STATIC_SVC_ENDPOINT));
+      } catch (URISyntaxException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    String connMgrStr = config.getString(HTTP_CONN_MANAGER);
+    switch (ConnManager.valueOf(connMgrStr.toUpperCase())) {
+      case BASIC:
+        httpConnManager = new BasicHttpClientConnectionManager();
+        break;
+      case POOLING:
+        PoolingHttpClientConnectionManager poolingConnMgr = new PoolingHttpClientConnectionManager();
+        poolingConnMgr.setMaxTotal(config.getInt(POOLING_CONN_MANAGER_MAX_TOTAL_CONN));
+        poolingConnMgr.setDefaultMaxPerRoute(config.getInt(POOLING_CONN_MANAGER_MAX_PER_CONN));
+        httpConnManager = poolingConnMgr;
+        break;
+      default:
+        throw new IllegalArgumentException(connMgrStr + " is not supported");
+    }
+
+    log.info("Using " + httpConnManager.getClass().getSimpleName());
+    return httpConnManager;
+  }
+
+  @Override
+  public void close() throws IOException {
+    client.close();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/http/OAuthAccessToken.java
+++ b/gobblin-core/src/main/java/gobblin/http/OAuthAccessToken.java
@@ -1,0 +1,72 @@
+package gobblin.http;
+
+import java.io.IOException;
+
+import org.apache.oltu.oauth2.client.OAuthClient;
+import org.apache.oltu.oauth2.client.URLConnectionClient;
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
+import org.apache.oltu.oauth2.client.response.OAuthAccessTokenResponse;
+import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.apache.oltu.oauth2.common.message.types.GrantType;
+
+
+import lombok.Getter;
+import lombok.extern.log4j.Log4j;
+
+
+@Log4j
+public class OAuthAccessToken {
+  private final String clientId;
+  private final String clientSecret;
+  private final String userId;
+  private final String password;
+  private final String securityToken;
+  private final String oauthPath;
+
+  @Getter
+  protected String accessToken;
+
+  public OAuthAccessToken(String clientId, String clientSecret, String userId, String password, String securityToken,
+      String oauthPath) {
+    this.clientId = clientId;
+    this.clientSecret = clientSecret;
+    this.userId = userId;
+    this.password = password;
+    this.securityToken = securityToken;
+    this.oauthPath = oauthPath;
+  }
+
+  protected OAuthClientRequest buildAuthRequest() {
+    OAuthClientRequest request;
+    try {
+      request = OAuthClientRequest.tokenLocation(oauthPath)
+          .setGrantType(GrantType.PASSWORD)
+          .setClientId(clientId)
+          .setClientSecret(clientSecret)
+          .setUsername(userId)
+          .setPassword(password + securityToken).buildQueryMessage();
+    } catch (OAuthSystemException e) {
+      throw new RuntimeException("Failed to construct auth request", e);
+    }
+    return request;
+  }
+
+  public boolean authenticate() {
+    log.info("Getting Oauth2 access token.");
+    OAuthClient client = new OAuthClient(new URLConnectionClient());
+    OAuthClientRequest request = buildAuthRequest();
+    try {
+      OAuthAccessTokenResponse response = client.accessToken(request, OAuth.HttpMethod.POST);
+      handleAuthResponse(response);
+      return true;
+    } catch (OAuthSystemException | OAuthProblemException | IOException e) {
+      throw new RuntimeException("Failed getting access token", e);
+    }
+  }
+
+  protected void handleAuthResponse(OAuthAccessTokenResponse response) throws IOException {
+    accessToken = response.getAccessToken();
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/http/SalesforceAuth.java
+++ b/gobblin-core/src/main/java/gobblin/http/SalesforceAuth.java
@@ -1,0 +1,79 @@
+package gobblin.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import org.apache.oltu.oauth2.client.response.OAuthAccessTokenResponse;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import lombok.Getter;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.password.PasswordManager;
+
+
+public class SalesforceAuth extends OAuthAccessToken {
+  private static final Config FALLBACK = ConfigFactory.parseMap(ImmutableMap.<String, String>builder()
+      .put(ApacheHttpClient.STATIC_SVC_ENDPOINT, "https://login.salesforce.com/services/oauth2/token")
+      .put(SalesforceAuth.SECURITY_TOKEN, "").build());
+
+  private static final String INSTANCE_URL = "instance_url";
+
+  public static final String SFDC_PREFIX = "salesforce.";
+  public static final String CLIENT_ID = SFDC_PREFIX + "client_id";
+  public static final String CLIENT_SECRET = SFDC_PREFIX + "client_secret";
+  public static final String USER_ID = SFDC_PREFIX + "user_id";
+  public static final String PASSWORD = SFDC_PREFIX + "password";
+  public static final String SFDC_ENCRYPT_KEY_LOC = SFDC_PREFIX + ConfigurationKeys.ENCRYPT_KEY_LOC;
+  public static final String USE_STRONG_ENCRYPTION = SFDC_PREFIX + "strong_encryption";
+  public static final String SECURITY_TOKEN = SFDC_PREFIX + "security_token";
+  public static final String OAUTH_ENDPOINT = SFDC_PREFIX + "oauth_endpoint";
+
+  @Getter
+  private URI instanceUrl;
+
+  public SalesforceAuth(String clientId, String clientSecret, String userId, String password, String securityToken,
+      String oauthPath) {
+    super(clientId, clientSecret, userId, password, securityToken, oauthPath);
+  }
+
+  public static SalesforceAuth create(Config config) {
+    config = config.withValue(SalesforceAuth.OAUTH_ENDPOINT, config.getValue(ApacheHttpClient.STATIC_SVC_ENDPOINT));
+    config = config.withFallback(FALLBACK);
+
+    String clientId = config.getString(CLIENT_ID);
+    String clientSecret = config.getString(CLIENT_SECRET);
+    String userId = config.getString(USER_ID);
+    String password = config.getString(PASSWORD);
+    String securityToken = config.getString(SECURITY_TOKEN);
+
+    if (config.hasPath(SFDC_ENCRYPT_KEY_LOC)) {
+      Properties props = new Properties();
+      if (config.hasPath(USE_STRONG_ENCRYPTION)) {
+        props.put(ConfigurationKeys.ENCRYPT_USE_STRONG_ENCRYPTOR, config.getString(USE_STRONG_ENCRYPTION));
+      }
+
+      props.put(ConfigurationKeys.ENCRYPT_KEY_LOC, config.getString(SFDC_ENCRYPT_KEY_LOC));
+      password = PasswordManager.getInstance(props).readPassword(password);
+    }
+    String oauthPath = config.getString(OAUTH_ENDPOINT);
+    return new SalesforceAuth(clientId, clientSecret, userId, password, securityToken, oauthPath);
+  }
+
+  @Override
+  protected void handleAuthResponse(OAuthAccessTokenResponse response)
+      throws IOException {
+    super.handleAuthResponse(response);
+    try {
+      instanceUrl = new URI(response.getParam(INSTANCE_URL));
+    } catch (URISyntaxException e) {
+      throw new IOException("Failed due to invalid instance url", e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/http/SalesforceClient.java
+++ b/gobblin-core/src/main/java/gobblin/http/SalesforceClient.java
@@ -1,0 +1,80 @@
+package gobblin.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Properties;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.oltu.oauth2.client.OAuthClient;
+import org.apache.oltu.oauth2.client.URLConnectionClient;
+import org.apache.oltu.oauth2.client.request.OAuthClientRequest;
+import org.apache.oltu.oauth2.client.response.OAuthJSONAccessTokenResponse;
+import org.apache.oltu.oauth2.common.OAuth;
+import org.apache.oltu.oauth2.common.exception.OAuthProblemException;
+import org.apache.oltu.oauth2.common.exception.OAuthSystemException;
+import org.apache.oltu.oauth2.common.message.types.GrantType;
+
+import com.google.common.base.Strings;
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+import com.typesafe.config.ConfigValueFactory;
+
+import lombok.Getter;
+import lombok.Setter;
+import lombok.extern.log4j.Log4j;
+
+import gobblin.http.ApacheHttpClient;
+import gobblin.http.SalesforceAuth;
+
+
+/**
+ * An {@link ApacheHttpClient} to communicate with Salesforce services
+ */
+@Log4j
+public class SalesforceClient extends ApacheHttpClient {
+  private final SalesforceAuth auth;
+
+  @Getter @Setter
+  private String accessToken;
+
+  public SalesforceClient(SalesforceAuth auth, HttpClientBuilder builder, Config config) {
+    super(builder, config);
+    this.auth = auth;
+    authenticate();
+  }
+
+  public void authenticate() {
+    log.info("Authenticating");
+    accessToken = null;
+    serverHost = null;
+    if (auth.authenticate()){
+      accessToken = auth.getAccessToken();
+      serverHost = auth.getInstanceUrl();
+    }
+  }
+
+  @Override
+  public boolean connect(URI uri) throws IOException {
+    if (!StringUtils.isEmpty(accessToken)) {
+      return true;
+    }
+    authenticate();
+    return true;
+  }
+
+  @Override
+  public CloseableHttpResponse sendRequest(HttpUriRequest request)
+      throws IOException {
+    if (Strings.isNullOrEmpty(accessToken)) {
+      authenticate();
+    }
+    request.addHeader(HttpHeaders.AUTHORIZATION, "OAuth " + accessToken);
+    return super.sendRequest(request);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriter.java
@@ -46,7 +46,10 @@ import gobblin.util.ExecutorsUtils;
 
 /**
  * Base class for HTTP writers. Defines the main extension points for different implementations.
+ *
+ * @deprecated Please use {@link AsyncHttpWriter}
  */
+@Deprecated
 public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> implements HttpWriterDecoration<D> {
 
   // Immutable state
@@ -103,7 +106,7 @@ public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> im
     this.client.close();
     ExecutorsUtils.shutdownExecutorService(this.singleThreadPool, Optional.of(log));
   }
- 
+
   /**
    * {@inheritDoc}
    */
@@ -112,7 +115,7 @@ public abstract class AbstractHttpWriter<D> extends InstrumentedDataWriter<D> im
     cleanup();
     super.close();
   }
-  
+
   /**
    * {@inheritDoc}
    */

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractHttpWriterBuilder.java
@@ -42,6 +42,10 @@ import gobblin.writer.FluentDataWriterBuilder;
 
 import lombok.Getter;
 
+/**
+ * @deprecated Please use {@link AsyncHttpWriterBuilder}
+ */
+@Deprecated
 @Getter
 public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWriterBuilder<S, D, B>>
     extends FluentDataWriterBuilder<S, D, B> {
@@ -55,7 +59,7 @@ public abstract class AbstractHttpWriterBuilder<S, D, B extends AbstractHttpWrit
   public static final String CONNECTION_TIME_OUT_MS_KEY = "conn_time_out";
   public static final String STATIC_SVC_ENDPOINT = "static_svc_endpoint";
 
-  public static enum ConnManager {
+  public enum ConnManager {
     POOLING,
     BASIC;
   }

--- a/gobblin-core/src/main/java/gobblin/writer/http/AsyncHttpWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AsyncHttpWriterBuilder.java
@@ -64,7 +64,7 @@ public abstract class AsyncHttpWriterBuilder<D, RQ, RP> extends FluentDataWriter
     return fromState(destination.getProperties());
   }
 
-  AsyncHttpWriterBuilder<D, RQ, RP> fromState(State state) {
+  public AsyncHttpWriterBuilder<D, RQ, RP> fromState(State state) {
     this.state = state;
     Config config = ConfigBuilder.create().loadProps(state.getProperties(), CONF_PREFIX).build();
     return fromConfig(config);

--- a/gobblin-core/src/main/java/gobblin/writer/http/HttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/HttpWriter.java
@@ -32,7 +32,10 @@ import com.google.common.base.Optional;
 
 /**
  * Writes via RESTful API that accepts plain text as a body
+ *
+ * @deprecated Please use {@link AsyncHttpWriter}
  */
+@Deprecated
 public class HttpWriter<D> extends AbstractHttpWriter<D> {
   @SuppressWarnings("rawtypes")
   public HttpWriter(AbstractHttpWriterBuilder builder) {

--- a/gobblin-core/src/main/java/gobblin/writer/http/RestJsonWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/RestJsonWriter.java
@@ -29,7 +29,10 @@ import gobblin.converter.http.RestEntry;
 
 /**
  * Writes via Restful API that accepts JSON as a body
+ *
+ * @deprecated Please use {@link AsyncHttpWriter}
  */
+@Deprecated
 public class RestJsonWriter extends HttpWriter<RestEntry<JsonObject>> {
 
   public RestJsonWriter(AbstractHttpWriterBuilder builder) {

--- a/gobblin-core/src/main/java/gobblin/writer/http/RestWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/RestWriter.java
@@ -28,7 +28,10 @@ import gobblin.converter.http.RestEntry;
 
 /**
  * Writes via RESTful API that accepts plain text as a body and resource path from RestEntry
+ *
+ * @deprecated Please use {@link AsyncHttpWriter}
  */
+@Deprecated
 public class RestWriter extends HttpWriter<RestEntry<String>> {
 
   public RestWriter(RestWriterBuilder builder) {

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesForceRestWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesForceRestWriterBuilder.java
@@ -38,7 +38,10 @@ import lombok.Getter;
 /**
  * Builder class that builds SalesForceRestWriter where it takes connection related parameter and type of operation along with the parameters
  * derived from AbstractHttpWriterBuilder
+ *
+ * @deprecated Please use {@link SalesforceWriterBuilder}
  */
+@Deprecated
 @Getter
 public class SalesForceRestWriterBuilder extends AbstractHttpWriterBuilder<Void, RestEntry<JsonObject>, SalesForceRestWriterBuilder>{
 

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRequestBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRequestBuilder.java
@@ -1,0 +1,165 @@
+package gobblin.writer.http;
+
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.Queue;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.base.Preconditions;
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import lombok.extern.log4j.Log4j;
+
+import gobblin.converter.http.RestEntry;
+import gobblin.http.SalesforceClient;
+
+
+@Log4j
+public class SalesforceRequestBuilder implements AsyncWriteRequestBuilder<RestEntry<JsonObject>, HttpUriRequest> {
+  private final SalesforceClient client;
+  private final SalesforceWriterBuilder.Operation operation;
+  private final Optional<String> batchResourcePath;
+  private final int maxRecordsInBatch;
+
+  SalesforceRequestBuilder(SalesforceClient client, SalesforceWriterBuilder.Operation operation,
+      Optional<String> batchResourcePath, int maxRecordsInBatch) {
+    this.client = client;
+    this.operation = operation;
+    this.batchResourcePath = batchResourcePath;
+    this.maxRecordsInBatch = maxRecordsInBatch;
+  }
+
+  @Override
+  public AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> buildRequest(
+      Queue<BufferedRecord<RestEntry<JsonObject>>> buffer) {
+    if (maxRecordsInBatch > 1) {
+      return buildBatchRequest(buffer);
+    } else {
+      return buildRequest(buffer.poll());
+    }
+  }
+
+  private AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> buildRequest(
+      BufferedRecord<RestEntry<JsonObject>> record) {
+    if (record == null) {
+      return null;
+    }
+
+    RequestBuilder builder;
+    switch (operation) {
+      case INSERT_ONLY_NOT_EXIST:
+        builder = RequestBuilder.post();
+        break;
+      case UPSERT:
+        builder = RequestBuilder.patch();
+        break;
+      default:
+        throw new IllegalArgumentException(operation + " is not supported.");
+    }
+
+    RestEntry<JsonObject> rawRecord = record.getRecord();
+    builder.setUri(combineUrl(client.getServerHost(), rawRecord.getResourcePath()));
+    JsonObject payload = rawRecord.getRestEntryVal();
+    AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> request = new AsyncWriteRequest<>();
+    request.markRecord(record, payload.toString().length());
+    request.setRawRequest(newRequest(builder, payload));
+    return request;
+  }
+
+  private AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> buildBatchRequest(
+      Queue<BufferedRecord<RestEntry<JsonObject>>> buffer) {
+    if (buffer.size() == 0) {
+      return null;
+    }
+
+    AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> request = new AsyncWriteRequest<>();
+    BufferedRecord<RestEntry<JsonObject>> record;
+    int count = maxRecordsInBatch;
+    JsonArray batchRequests = new JsonArray();
+    while (count > 0) {
+      if ((record = buffer.poll()) == null) {
+        break;
+      }
+      RestEntry<JsonObject> rawRecord = record.getRecord();
+      batchRequests.add(newSubrequest(rawRecord));
+      request.markRecord(record, rawRecord.getRestEntryVal().toString().length());
+      count--;
+    }
+
+    JsonObject payload = new JsonObject();
+    payload.add("batchRequests", batchRequests);
+    RequestBuilder builder = RequestBuilder.post().setUri(combineUrl(client.getServerHost(), batchResourcePath));
+    request.setRawRequest(newRequest(builder, payload));
+    return request;
+  }
+
+  /**
+   * Create batch subrequest. For more detail @link https://developer.salesforce.com/docs/atlas.en-us.api_rest.meta/api_rest/requests_composite_batch.htm
+   *
+   * @param record
+   * @return
+   */
+  private JsonObject newSubrequest(RestEntry<JsonObject> record) {
+    Preconditions.checkArgument(record.getResourcePath().isPresent(), "Resource path is not defined");
+    JsonObject subReq = new JsonObject();
+    subReq.addProperty("url", record.getResourcePath().get());
+    subReq.add("richInput", record.getRestEntryVal());
+
+    switch (operation) {
+      case INSERT_ONLY_NOT_EXIST:
+        subReq.addProperty("method", "POST");
+        break;
+      case UPSERT:
+        subReq.addProperty("method", "PATCH");
+        break;
+      default:
+        throw new IllegalArgumentException(operation + " is not supported.");
+    }
+    return subReq;
+  }
+
+  private HttpUriRequest newRequest(RequestBuilder builder, JsonElement payload) {
+    try {
+      builder.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+          .setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    log.debug("Request builder: " + ToStringBuilder.reflectionToString(builder, ToStringStyle.SHORT_PREFIX_STYLE));
+    return build(builder);
+  }
+
+  /**
+   * Add this method for argument capture in test
+   */
+  @VisibleForTesting
+  public HttpUriRequest build(RequestBuilder builder) {
+    return builder.build();
+  }
+
+  static URI combineUrl(URI uri, Optional<String> resourcePath) {
+    if (!resourcePath.isPresent()) {
+      return uri;
+    }
+
+    try {
+      return new URL(uri.toURL(), resourcePath.get()).toURI();
+    } catch (MalformedURLException | URISyntaxException e) {
+      throw new RuntimeException("Failed combining URL", e);
+    }
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceResponseHandler.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceResponseHandler.java
@@ -1,0 +1,146 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.util.EntityUtils;
+
+import com.google.common.base.Preconditions;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
+import lombok.extern.log4j.Log4j;
+
+import gobblin.http.ResponseHandler;
+import gobblin.http.ResponseStatus;
+import gobblin.http.SalesforceClient;
+import gobblin.http.StatusType;
+
+
+@Log4j
+public class SalesforceResponseHandler implements ResponseHandler<CloseableHttpResponse> {
+  public static final String DUPLICATE_VALUE_ERR_CODE = "DUPLICATE_VALUE";
+
+  private SalesforceClient client;
+  private final SalesforceWriterBuilder.Operation operation;
+  private final boolean isBatching;
+
+  SalesforceResponseHandler(SalesforceClient client, SalesforceWriterBuilder.Operation operation, boolean isBatching) {
+    this.client = client;
+    this.operation = operation;
+    this.isBatching = isBatching;
+  }
+
+  @Override
+  public ResponseStatus handleResponse(CloseableHttpResponse response) {
+    log.debug("Received response " + ToStringBuilder.reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE));
+
+    ResponseStatus status = new ResponseStatus(StatusType.OK);
+    int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode == 401 || statusCode == 403) {
+      client.setAccessToken(null);
+      log.error("Access denied. Access token has been reacquired and retry may solve the problem. " + ToStringBuilder
+          .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE));
+      status.setType(StatusType.SERVER_ERROR);
+      return status;
+    }
+
+    if (isBatching) {
+      processBatchRequestResponse(response, status);
+    } else {
+      processSingleRequestResponse(response, status);
+    }
+
+    return status;
+  }
+
+  private void processSingleRequestResponse(CloseableHttpResponse response, ResponseStatus status) {
+    int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode < 400) {
+      return;
+    }
+    String entityStr = getEntityAsString(response);
+    if (entityStr == null) {
+      status.setType(StatusType.SERVER_ERROR);
+      return;
+    }
+
+    if (statusCode == 400 && SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST.equals(operation)
+        && entityStr != null) { //Ignore if it's duplicate entry error code
+
+      JsonArray jsonArray = new JsonParser().parse(entityStr).getAsJsonArray();
+      JsonObject jsonObject = jsonArray.get(0).getAsJsonObject();
+      if (isDuplicate(jsonObject, statusCode)) {
+        return;
+      }
+    }
+    status.setType(StatusType.CLIENT_ERROR);
+    log.error("Failed due to " + entityStr + " (Detail: " + ToStringBuilder
+        .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE) + " )");
+  }
+
+  /**
+   * Check results from batch response, if any of the results is failure throw exception.
+   * @param response
+   * @throws IOException
+   */
+  private void processBatchRequestResponse(CloseableHttpResponse response, ResponseStatus status) {
+    String entityStr = getEntityAsString(response);
+    if (entityStr == null) {
+      status.setType(StatusType.SERVER_ERROR);
+      return;
+    }
+
+    int statusCode = response.getStatusLine().getStatusCode();
+    if (statusCode >= 400) {
+      log.error("Failed due to " + entityStr + " (Detail: " + ToStringBuilder
+          .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE) + " )");
+      status.setType(StatusType.CLIENT_ERROR);
+      return;
+    }
+
+    JsonObject jsonBody = new JsonParser().parse(entityStr).getAsJsonObject();
+    if (!jsonBody.get("hasErrors").getAsBoolean()) {
+      return;
+    }
+
+    JsonArray results = jsonBody.get("results").getAsJsonArray();
+    for (JsonElement jsonElem : results) {
+      JsonObject json = jsonElem.getAsJsonObject();
+      int subStatusCode = json.get("statusCode").getAsInt();
+      if (subStatusCode < 400) {
+        continue;
+      } else if (subStatusCode == 400 && SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST.equals(operation)) {
+        JsonElement resultJsonElem = json.get("result");
+        Preconditions.checkNotNull(resultJsonElem, "Error response should contain result property");
+        JsonObject resultJsonObject = resultJsonElem.getAsJsonArray().get(0).getAsJsonObject();
+        if (isDuplicate(resultJsonObject, subStatusCode)) {
+          continue;
+        }
+      }
+      log.error("Failed due to " + jsonBody + " (Detail: " + ToStringBuilder
+          .reflectionToString(response, ToStringStyle.SHORT_PREFIX_STYLE) + " )");
+      status.setType(StatusType.CLIENT_ERROR);
+      return;
+    }
+  }
+
+  private boolean isDuplicate(JsonObject responseJsonObject, int statusCode) {
+    return statusCode == 400 && SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST.equals(operation)
+        && DUPLICATE_VALUE_ERR_CODE.equals(responseJsonObject.get("errorCode").getAsString());
+  }
+
+  private String getEntityAsString(CloseableHttpResponse response) {
+    String entityStr = null;
+    try {
+      entityStr = EntityUtils.toString(response.getEntity());
+    } catch (IOException e) {
+      log.error("Fail to stringify entity from response", e);
+    }
+    return entityStr;
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRestWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceRestWriter.java
@@ -53,7 +53,9 @@ import gobblin.writer.exception.NonTransientException;
 /**
  * Writes to Salesforce via RESTful API, supporting INSERT_ONLY_NOT_EXIST, and UPSERT.
  *
+ * @deprecated Please use {@link AsyncHttpWriter}
  */
+@Deprecated
 public class SalesforceRestWriter extends RestJsonWriter {
   public static enum Operation {
     INSERT_ONLY_NOT_EXIST,

--- a/gobblin-core/src/main/java/gobblin/writer/http/SalesforceWriterBuilder.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/SalesforceWriterBuilder.java
@@ -1,0 +1,83 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.HttpClientBuilder;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableMap;
+import com.google.gson.JsonObject;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import gobblin.configuration.State;
+import gobblin.converter.http.RestEntry;
+import gobblin.http.HttpClientConfiguratorLoader;
+import gobblin.http.SalesforceAuth;
+import gobblin.http.SalesforceClient;
+import gobblin.util.ConfigUtils;
+import gobblin.writer.AsyncWriterManager;
+import gobblin.writer.DataWriter;
+
+
+/**
+ * Builder of Salesforce http writer
+ */
+public class SalesforceWriterBuilder extends AsyncHttpWriterBuilder<RestEntry<JsonObject>, HttpUriRequest, CloseableHttpResponse> {
+  static final String SFDC_PREFIX = "salesforce.";
+  static final String OPERATION = SFDC_PREFIX + "operation";
+  static final String BATCH_SIZE = SFDC_PREFIX + "batch_size";
+  static final String BATCH_RESOURCE_PATH = SFDC_PREFIX + "batch_resource_path";
+
+  public enum Operation {
+    INSERT_ONLY_NOT_EXIST,
+    UPSERT
+  }
+
+  private static final Config FALLBACK = ConfigFactory.parseMap(
+      ImmutableMap.<String, String>builder()
+          .put(BATCH_SIZE, "1")
+          .build()
+  );
+
+  @Override
+  public SalesforceWriterBuilder fromConfig(Config config) {
+    config = config.withFallback(FALLBACK);
+    Operation operation = Operation.valueOf(config.getString(OPERATION).toUpperCase());
+    int maxRecordsInBatch = config.getInt(BATCH_SIZE);
+    Optional<String> batchResourcePath = Optional.of(config.getString(BATCH_RESOURCE_PATH));
+
+    HttpClientBuilder builder = createHttpClientBuilder(getState());
+    SalesforceClient client = new SalesforceClient(createSalesforceAuth(config), builder, config);
+    this.client = client;
+    this.asyncRequestBuilder = new SalesforceRequestBuilder(client, operation, batchResourcePath, maxRecordsInBatch);
+    responseHandler = new SalesforceResponseHandler(client, operation, maxRecordsInBatch > 1);
+    return this;
+  }
+
+  @VisibleForTesting
+  public HttpClientBuilder createHttpClientBuilder(State state) {
+    HttpClientConfiguratorLoader clientConfiguratorLoader = new HttpClientConfiguratorLoader(state);
+    clientConfiguratorLoader.getConfigurator().setStatePropertiesPrefix(AsyncHttpWriterBuilder.CONF_PREFIX);
+    return clientConfiguratorLoader.getConfigurator().configure(getState()).getBuilder();
+  }
+
+  @VisibleForTesting
+  public SalesforceAuth createSalesforceAuth(Config config) {
+    return SalesforceAuth.create(config);
+  }
+
+  @Override
+  public DataWriter<RestEntry<JsonObject>> build()
+      throws IOException {
+    validate();
+      return AsyncWriterManager.builder()
+          .config(ConfigUtils.propertiesToConfig(getState().getProperties()))
+          .asyncDataWriter(new AsyncHttpWriter(this))
+          .retriesEnabled(false) // retries are done in HttpBatchDispatcher
+          .failureAllowanceRatio(0).build();
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/writer/http/SalesforceRequestBuilderTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/SalesforceRequestBuilderTest.java
@@ -1,0 +1,150 @@
+package gobblin.writer.http;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayDeque;
+import java.util.Queue;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.http.Header;
+import org.apache.http.HttpEntity;
+import org.apache.http.HttpHeaders;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.client.methods.RequestBuilder;
+import org.apache.http.entity.ContentType;
+import org.apache.http.entity.StringEntity;
+import org.mockito.ArgumentCaptor;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.base.Optional;
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+
+import gobblin.converter.http.RestEntry;
+import gobblin.http.SalesforceClient;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@Test
+public class SalesforceRequestBuilderTest {
+  static final Gson GSON = new Gson();
+
+  /**
+   * Test build request with a single record
+   */
+  public void testBuildRequest()
+      throws URISyntaxException, IOException {
+    SalesforceClient client = mock(SalesforceClient.class);
+    when(client.getAccessToken()).thenReturn("token");
+    when(client.getServerHost()).thenReturn(new URI("http://host"));
+
+    SalesforceRequestBuilder builder =
+        new SalesforceRequestBuilder(client, SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST,
+            Optional.<String>absent(), 1);
+    doSingleRecordTest(builder, RequestBuilder.post());
+
+    builder =
+        new SalesforceRequestBuilder(client, SalesforceWriterBuilder.Operation.UPSERT,
+            Optional.<String>absent(), 1);
+    doSingleRecordTest(builder, RequestBuilder.patch());
+  }
+
+  public void testBuildBatchRequest()
+      throws URISyntaxException, IOException {
+    SalesforceClient client = mock(SalesforceClient.class);
+    when(client.getAccessToken()).thenReturn("token");
+    when(client.getServerHost()).thenReturn(new URI("http://host"));
+    Optional<String> batchResourcePath = Optional.of("batchResource");
+    SalesforceRequestBuilder builder =
+        new SalesforceRequestBuilder(client, SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST,
+            batchResourcePath, 2);
+    doBatchTest(builder, RequestBuilder.post(),
+        "{\"batchRequests\":[{\"url\":\"resource\",\"richInput\":{\"id\":0},\"method\":\"POST\"},{\"url\":\"resource\",\"richInput\":{\"id\":1},\"method\":\"POST\"}]}");
+    builder =
+        new SalesforceRequestBuilder(client, SalesforceWriterBuilder.Operation.UPSERT,
+            batchResourcePath, 2);
+    doBatchTest(builder, RequestBuilder.post(),
+        "{\"batchRequests\":[{\"url\":\"resource\",\"richInput\":{\"id\":0},\"method\":\"PATCH\"},{\"url\":\"resource\",\"richInput\":{\"id\":1},\"method\":\"PATCH\"}]}");
+  }
+
+  private void doBatchTest(SalesforceRequestBuilder salesforceBuilder, RequestBuilder expected, String payloadStr)
+      throws IOException {
+    SalesforceRequestBuilder builder = spy(salesforceBuilder);
+    Queue<BufferedRecord<RestEntry<JsonObject>>> queue = createQueue(4);
+    AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> request = builder.buildRequest(queue);
+    ArgumentCaptor<RequestBuilder> requestBuilderArgument = ArgumentCaptor.forClass(RequestBuilder.class);
+    verify(builder).build(requestBuilderArgument.capture());
+
+    // Construct expected raw request
+    expected.setUri("http://host/batchResource");
+    JsonObject payload = GSON.fromJson(payloadStr, JsonObject.class);
+    expected.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+        .setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
+    // Compare HttpUriRequest
+    assertEqual(requestBuilderArgument.getValue(), expected);
+    Assert.assertEquals(request.getRecordCount(), 2);
+    Assert.assertEquals(queue.size(), 2);
+  }
+
+  private void doSingleRecordTest(SalesforceRequestBuilder salesforceBuilder, RequestBuilder expected)
+      throws IOException {
+    SalesforceRequestBuilder builder = spy(salesforceBuilder);
+    AsyncWriteRequest<RestEntry<JsonObject>, HttpUriRequest> request = builder.buildRequest(createQueue(1));
+    ArgumentCaptor<RequestBuilder> requestBuilderArgument = ArgumentCaptor.forClass(RequestBuilder.class);
+    verify(builder).build(requestBuilderArgument.capture());
+
+    // Construct expected raw request
+    expected.setUri("http://host/resource");
+    String payloadStr = "{\"id\":0}";
+    JsonObject payload = GSON.fromJson(payloadStr, JsonObject.class);
+    expected.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+        .setEntity(new StringEntity(payload.toString(), ContentType.APPLICATION_JSON));
+    // Compare HttpUriRequest
+    assertEqual(requestBuilderArgument.getValue(), expected);
+    Assert.assertEquals(request.bytesWritten, payload.toString().length());
+    Assert.assertEquals(request.getRecordCount(), 1);
+  }
+
+  private Queue<BufferedRecord<RestEntry<JsonObject>>> createQueue(int size) {
+    Queue<BufferedRecord<RestEntry<JsonObject>>> queue = new ArrayDeque<>(1);
+    for (int i = 0; i < size; i++) {
+      JsonObject json = new JsonObject();
+      json.addProperty("id", i);
+      RestEntry<JsonObject> entry = new RestEntry<>("resource", json);
+      BufferedRecord<RestEntry<JsonObject>> record = new BufferedRecord<>(entry, null);
+      queue.add(record);
+    }
+    return queue;
+  }
+
+  private void assertEqual(RequestBuilder actual, RequestBuilder expect)
+      throws IOException {
+    // Check entity
+    HttpEntity actualEntity = actual.getEntity();
+    HttpEntity expectedEntity = expect.getEntity();
+    Assert.assertEquals(actualEntity.getContentLength(), expectedEntity.getContentLength());
+    String actualContent = IOUtils.toString(actualEntity.getContent(), StandardCharsets.UTF_8);
+    String expectedContent = IOUtils.toString(expectedEntity.getContent(), StandardCharsets.UTF_8);
+    Assert.assertEquals(actualContent, expectedContent);
+
+    // Check request
+    HttpUriRequest actualRequest = actual.build();
+    HttpUriRequest expectedRequest = expect.build();
+    Assert.assertEquals(actualRequest.getMethod(), expectedRequest.getMethod());
+    Assert.assertEquals(actualRequest.getURI().toString(), expectedRequest.getURI().toString());
+
+    Header[] actualHeaders = actualRequest.getAllHeaders();
+    Header[] expectedHeaders = expectedRequest.getAllHeaders();
+    Assert.assertEquals(actualHeaders.length, expectedHeaders.length);
+    for (int i = 0; i < actualHeaders.length; i++) {
+      Assert.assertEquals(actualHeaders[i].toString(), expectedHeaders[i].toString());
+    }
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/writer/http/SalesforceResponseHandlerTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/SalesforceResponseHandlerTest.java
@@ -1,0 +1,197 @@
+package gobblin.writer.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+
+import gobblin.http.ResponseStatus;
+import gobblin.http.SalesforceClient;
+import gobblin.http.StatusType;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+@Test
+public class SalesforceResponseHandlerTest {
+  /**
+   * Test handle response for single record request
+   */
+  public void testHandleResponse()
+      throws IOException {
+    SalesforceClient client = mock(SalesforceClient.class);
+    SalesforceResponseHandler handler = new SalesforceResponseHandler(client, SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST, false);
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    when(response.getStatusLine()).thenReturn(statusLine);
+
+    // Success 200
+    when(statusLine.getStatusCode()).thenReturn(200);
+    ResponseStatus status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.OK.toString());
+    // Success 300
+    when(statusLine.getStatusCode()).thenReturn(300);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.OK.toString());
+
+    // Server error 401
+    when(statusLine.getStatusCode()).thenReturn(401);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.SERVER_ERROR.toString());
+    verify(client, times(1)).setAccessToken(null);
+    // Server error 403
+    when(statusLine.getStatusCode()).thenReturn(403);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.SERVER_ERROR.toString());
+
+    when(statusLine.getStatusCode()).thenReturn(400);
+    HttpEntity entity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(entity);
+    // Server error 400
+    when(statusLine.getStatusCode()).thenReturn(400);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.SERVER_ERROR.toString());
+    // Success 400 duplicate
+    JsonObject json = new JsonObject();
+    json.addProperty("errorCode", SalesforceResponseHandler.DUPLICATE_VALUE_ERR_CODE);
+    JsonArray jsonArray = new JsonArray();
+    jsonArray.add(json);
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(jsonArray.toString().getBytes()));
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.OK.toString());
+
+    // Fail 400
+    handler = new SalesforceResponseHandler(client, SalesforceWriterBuilder.Operation.UPSERT, false);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.CLIENT_ERROR.toString());
+  }
+
+  /**
+   * Test handle response for successful batch request
+   */
+  public void testHandleSuccessBatchResponse()
+      throws IOException {
+    final int recordSize = 2;
+    SalesforceClient client = mock(SalesforceClient.class);
+    SalesforceResponseHandler handler = new SalesforceResponseHandler(client, SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST, true);
+
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    HttpEntity entity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(entity);
+
+    JsonObject jsonResponse = new JsonObject();
+    jsonResponse.addProperty("hasErrors", false);
+
+    ByteArrayInputStream[] streams = new ByteArrayInputStream[recordSize];
+    for (int i=0; i < recordSize-1; i++) {
+      streams[i] = new ByteArrayInputStream(jsonResponse.toString().getBytes());
+    }
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(jsonResponse.toString().getBytes()), streams);
+
+
+    // Success 200
+    when(statusLine.getStatusCode()).thenReturn(200);
+    ResponseStatus status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.OK.toString());
+    // Success 300
+    when(statusLine.getStatusCode()).thenReturn(300);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.OK.toString());
+  }
+
+  /**
+   * Test handle response for batch request with duplicate
+   */
+  public void testHandleBatchResponseWithDuplicate()
+      throws IOException {
+    SalesforceClient client = mock(SalesforceClient.class);
+    SalesforceResponseHandler handler = new SalesforceResponseHandler(client, SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST, true);
+
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    HttpEntity entity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(entity);
+
+    JsonObject jsonResponse = new JsonObject();
+    jsonResponse.addProperty("hasErrors", true);
+    JsonArray resultJsonArr = new JsonArray();
+
+    jsonResponse.add("results", resultJsonArr);
+    JsonObject subResult1 = new JsonObject();
+    subResult1.addProperty("statusCode", 400);
+    JsonArray subResultArr = new JsonArray();
+    JsonObject errJson = new JsonObject();
+    errJson.addProperty("errorCode", SalesforceRestWriter.DUPLICATE_VALUE_ERR_CODE);
+    subResultArr.add(errJson);
+    subResult1.add("result", subResultArr);
+
+    JsonObject subResult2 = new JsonObject();
+    subResult2.addProperty("statusCode", 400);
+    subResult2.add("result", subResultArr);
+
+    resultJsonArr.add(subResult1);
+    resultJsonArr.add(subResult2);
+
+    // Success
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(jsonResponse.toString().getBytes()));
+    ResponseStatus status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.OK.toString());
+    // Fail
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(jsonResponse.toString().getBytes()));
+    handler = new SalesforceResponseHandler(client, SalesforceWriterBuilder.Operation.UPSERT, true);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.CLIENT_ERROR.toString());
+  }
+
+  /**
+   * Test handle response for failed batch request
+   */
+  public void testHandleFailedBatchResponse()
+      throws IOException {
+    SalesforceClient client = mock(SalesforceClient.class);
+    SalesforceResponseHandler handler = new SalesforceResponseHandler(client, SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST, true);
+
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    HttpEntity entity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(entity);
+
+    JsonObject jsonResponse = new JsonObject();
+    jsonResponse.addProperty("hasErrors", true);
+    JsonArray resultJsonArr = new JsonArray();
+    jsonResponse.add("results", resultJsonArr);
+    JsonObject subResult1 = new JsonObject();
+    subResult1.addProperty("statusCode", 201); //Success
+    JsonObject subResult2 = new JsonObject();
+    subResult2.addProperty("statusCode", 500); //Failure
+
+    resultJsonArr.add(subResult1);
+    resultJsonArr.add(subResult2);
+
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(jsonResponse.toString().getBytes()));
+
+    // Fail 200
+    when(statusLine.getStatusCode()).thenReturn(200);
+    ResponseStatus status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.CLIENT_ERROR.toString());
+    // Fail 405
+    when(statusLine.getStatusCode()).thenReturn(405);
+    status = handler.handleResponse(response);
+    Assert.assertEquals(status.getType().toString(), StatusType.CLIENT_ERROR.toString());
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/writer/http/SalesforceWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/SalesforceWriterTest.java
@@ -1,0 +1,105 @@
+package gobblin.writer.http;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+
+import org.apache.http.HttpEntity;
+import org.apache.http.StatusLine;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.mockito.Matchers;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.gson.JsonObject;
+import com.typesafe.config.Config;
+
+import gobblin.configuration.State;
+import gobblin.converter.http.RestEntry;
+import gobblin.http.SalesforceAuth;
+import gobblin.writer.AsyncWriterManager;
+
+import static gobblin.http.ApacheHttpClient.STATIC_SVC_ENDPOINT;
+import static gobblin.writer.http.AsyncHttpWriterBuilder.CONF_PREFIX;
+import static gobblin.writer.http.SalesForceRestWriterBuilder.OPERATION;
+import static gobblin.writer.http.SalesforceWriterBuilder.BATCH_RESOURCE_PATH;
+import static gobblin.writer.http.SalesforceWriterBuilder.BATCH_SIZE;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.when;
+
+
+@Test
+public class SalesforceWriterTest {
+  /**
+   * Integration test for batch insert success
+   */
+  public void testBatchInsertSuccess()
+      throws URISyntaxException, IOException {
+    final int recordSize = 20;
+    final int batchSize = 10;
+
+    SalesforceWriterBuilder.Operation operation = SalesforceWriterBuilder.Operation.INSERT_ONLY_NOT_EXIST;
+    State state = new State();
+    state.appendToSetProp(CONF_PREFIX + BATCH_SIZE, Integer.toString(batchSize));
+    state.appendToSetProp(CONF_PREFIX + BATCH_RESOURCE_PATH, "test");
+
+    state.appendToSetProp(CONF_PREFIX + STATIC_SVC_ENDPOINT, "test");
+    state.appendToSetProp(CONF_PREFIX + SalesforceAuth.CLIENT_ID, "test");
+    state.appendToSetProp(CONF_PREFIX + SalesforceAuth.CLIENT_SECRET, "test");
+    state.appendToSetProp(CONF_PREFIX + SalesforceAuth.USER_ID, "test");
+    state.appendToSetProp(CONF_PREFIX + SalesforceAuth.PASSWORD, "test");
+    state.appendToSetProp(CONF_PREFIX + SalesforceAuth.USE_STRONG_ENCRYPTION, "test");
+    state.appendToSetProp(CONF_PREFIX + SalesforceAuth.SECURITY_TOKEN, "test");
+    state.appendToSetProp(CONF_PREFIX + OPERATION, operation.name());
+
+    SalesforceWriterBuilder builder = new SalesforceWriterBuilder();
+    builder = spy(builder);
+    HttpClientBuilder httpClientBuilder = mock(HttpClientBuilder.class);
+    doReturn(httpClientBuilder).when(builder).createHttpClientBuilder(Matchers.any(State.class));
+
+    SalesforceAuth auth = mock(SalesforceAuth.class);
+    when(auth.authenticate()).thenReturn(true);
+    when(auth.getAccessToken()).thenReturn("token");
+    when(auth.getInstanceUrl()).thenReturn(new URI("http://data"));
+    doReturn(auth).when(builder).createSalesforceAuth(Matchers.any(Config.class));
+
+    CloseableHttpClient client = mock(CloseableHttpClient.class);
+    when(httpClientBuilder.build()).thenReturn(client);
+
+    AsyncWriterManager<RestEntry<JsonObject>> writer =
+        (AsyncWriterManager<RestEntry<JsonObject>>) builder.fromState(state).build();
+
+    CloseableHttpResponse response = mock(CloseableHttpResponse.class);
+    StatusLine statusLine = mock(StatusLine.class);
+    when(client.execute(any(HttpUriRequest.class))).thenReturn(response);
+    when(response.getStatusLine()).thenReturn(statusLine);
+    when(statusLine.getStatusCode()).thenReturn(200);
+    HttpEntity entity = mock(HttpEntity.class);
+    when(response.getEntity()).thenReturn(entity);
+
+    JsonObject jsonResponse = new JsonObject();
+    jsonResponse.addProperty("hasErrors", false);
+
+    ByteArrayInputStream[] streams = new ByteArrayInputStream[recordSize];
+    for (int i=0; i < recordSize-1; i++) {
+      streams[i] = new ByteArrayInputStream(jsonResponse.toString().getBytes());
+    }
+    when(entity.getContent()).thenReturn(new ByteArrayInputStream(jsonResponse.toString().getBytes()), streams);
+
+    RestEntry<JsonObject> restEntry = new RestEntry<JsonObject>("test", new JsonObject());
+    writer = spy(writer);
+    for (int i = 0; i < recordSize; i++) {
+      writer.write(restEntry);
+    }
+    writer.commit();
+    Assert.assertEquals(recordSize, writer.recordsWritten());
+    writer.close();
+  }
+}


### PR DESCRIPTION
### Overview
An async salesforce writer built on top of the async http writer framework. Old suite of `HttpWriter` and `SalesforceRestWriter` are marked as deprecated.
### Auth
`OAuthAccessToken` provides a standard way to authenticate using OAuth. `SalesforceAuth` is a `OAuthAccessToken` with specific way to extract information from config.
### Client
`ApacheClient` provides a standard way to send apache `HttpUriRequest` and get `CloseableHttpResponse`. `SalesforceClient` is a `ApacheClient` integrated with authentication.
### Writer
`SalesforceWriterBuilder` instantiates `SalesforceClient`, `SalesforceRequestBuilder`, `SalesforceResponseHandler` and plugs them into an instance of `AsyncHttpWriter`. It builds an `AsyncWriterManager` that wraps the `AsyncHttpWriter` instance.
