### PR TITLE
Implement FlattenNestedKeyConverter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/converter/avro/FlattenNestedKeyConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/FlattenNestedKeyConverter.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package gobblin.converter.avro;
 
 import java.util.ArrayList;
@@ -25,6 +42,18 @@ import gobblin.util.ConfigUtils;
 import static gobblin.util.AvroUtils.FIELD_LOCATION_DELIMITER;
 
 
+/**
+ * Flatten a nested key and create a camel-cased name of a field which has the same value
+ *
+ * <p>
+ *   Given configuration:
+ *   <code>FlattenNestedKeyConverter.fieldsToFlatten = "address,address.city"</code>.
+ *   A {@link FlattenNestedKeyConverter} will only process <code>"address.city"</code>. It makes
+ *   a copy of the {@link Field} with a new name <code>"addressCity"</code> and adds it to the
+ *   top level fields of the output schema. The value of field <code>"addressCity"</code> is equal
+ *   to the one referred by <code>"address.city"</code>
+ * </p>
+ */
 public class FlattenNestedKeyConverter extends Converter<Schema, Schema, GenericRecord, GenericRecord> {
   public static final String FIELDS_TO_FLATTEN = "fieldsToFlatten";
   // A map from new field name to the nested key

--- a/gobblin-core/src/main/java/gobblin/converter/avro/FlattenNestedKeyConverter.java
+++ b/gobblin-core/src/main/java/gobblin/converter/avro/FlattenNestedKeyConverter.java
@@ -1,0 +1,107 @@
+package gobblin.converter.avro;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.avro.Schema;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+
+import com.google.common.base.CaseFormat;
+import com.google.common.base.Optional;
+import com.google.common.collect.Maps;
+import com.typesafe.config.Config;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.Converter;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.converter.SingleRecordIterable;
+import gobblin.util.AvroUtils;
+import gobblin.util.ConfigUtils;
+
+import static gobblin.util.AvroUtils.FIELD_LOCATION_DELIMITER;
+
+
+public class FlattenNestedKeyConverter extends Converter<Schema, Schema, GenericRecord, GenericRecord> {
+  public static final String FIELDS_TO_FLATTEN = "fieldsToFlatten";
+  // A map from new field name to the nested key
+  private Map<String, String> fieldNameMap = Maps.newHashMap();
+
+  @Override
+  public Schema convertSchema(Schema inputSchema, WorkUnitState workUnit)
+      throws SchemaConversionException {
+    // Clear previous state
+    fieldNameMap.clear();
+
+    Config config = ConfigUtils.propertiesToConfig(workUnit.getProperties()).getConfig(getClass().getSimpleName());
+    List<String> nestedKeys = ConfigUtils.getStringList(config, FIELDS_TO_FLATTEN);
+
+    List<Field> fields = new ArrayList<>();
+    // Clone the existing fields
+    for (Field field : inputSchema.getFields()) {
+      fields.add(new Field(field.name(), field.schema(), field.doc(), field.defaultVal(), field.order()));
+    }
+
+    // Convert each of nested keys into a top level field
+    for (String key : nestedKeys) {
+      if (!key.contains(FIELD_LOCATION_DELIMITER)) {
+        continue;
+      }
+
+      String nestedKey = key.trim();
+      // Create camel-cased name
+      String hyphenizedKey = nestedKey.replace(FIELD_LOCATION_DELIMITER, "-");
+      String name = CaseFormat.LOWER_HYPHEN.to(CaseFormat.LOWER_CAMEL, hyphenizedKey);
+      if (fieldNameMap.containsKey(name)) {
+        // Duplicate
+        continue;
+      }
+      fieldNameMap.put(name, nestedKey);
+
+      // Find the field
+      Optional<Field> optional = AvroUtils.getField(inputSchema, nestedKey);
+      if (!optional.isPresent()) {
+        throw new SchemaConversionException("Unable to get field with location: " + nestedKey);
+      }
+      Field field = optional.get();
+
+      // Make a copy under a new name
+      Field copy = new Field(name, field.schema(), field.doc(), field.defaultVal(), field.order());
+      fields.add(copy);
+    }
+
+    Schema outputSchema = Schema
+        .createRecord(inputSchema.getName(), inputSchema.getDoc(), inputSchema.getNamespace(), inputSchema.isError());
+    outputSchema.setFields(fields);
+    return outputSchema;
+  }
+
+  @Override
+  public Iterable<GenericRecord> convertRecord(Schema outputSchema, GenericRecord inputRecord, WorkUnitState workUnit)
+      throws DataConversionException {
+    GenericRecord outputRecord = new GenericData.Record(outputSchema);
+    for (Field field : outputSchema.getFields()) {
+      String fieldName = field.name();
+      if (fieldNameMap.containsKey(fieldName)) {
+        // Skip new field for now
+        continue;
+      }
+
+      outputRecord.put(fieldName, inputRecord.get(fieldName));
+    }
+
+    // Deal with new fields
+    for (Map.Entry<String, String> entry : fieldNameMap.entrySet()) {
+      Optional<Object> optional = AvroUtils.getFieldValue(inputRecord, entry.getValue());
+      if (!optional.isPresent()) {
+        throw new DataConversionException("Unable to get field value with location: " + entry.getValue());
+      }
+      outputRecord.put(entry.getKey(), optional.get());
+    }
+
+    return new SingleRecordIterable<>(outputRecord);
+  }
+}

--- a/gobblin-core/src/test/java/gobblin/converter/avro/FlattenNestedKeyConverterTest.java
+++ b/gobblin-core/src/test/java/gobblin/converter/avro/FlattenNestedKeyConverterTest.java
@@ -1,0 +1,94 @@
+package gobblin.converter.avro;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.testng.annotations.Test;
+
+import junit.framework.Assert;
+
+import gobblin.configuration.WorkUnitState;
+import gobblin.converter.DataConversionException;
+import gobblin.converter.SchemaConversionException;
+import gobblin.util.AvroUtils;
+
+
+@Test
+public class FlattenNestedKeyConverterTest {
+  /**
+   * Test schema and record conversion
+   *  1. A successful schema and record conversion
+   *  2. Another successful conversion by reusing the converter
+   *  3. An expected failed conversion by reusing the converter
+   */
+  public void testConversion()
+      throws IOException {
+    String key = FlattenNestedKeyConverter.class.getSimpleName() + "." + FlattenNestedKeyConverter.FIELDS_TO_FLATTEN;
+    Properties props = new Properties();
+    props.put(key, "name,address.street_number");
+    WorkUnitState workUnitState = new WorkUnitState();
+    workUnitState.addAll(props);
+
+    Schema inputSchema = new Schema.Parser().parse(getClass().getResourceAsStream("/converter/nested.avsc"));
+    GenericDatumReader<GenericRecord> datumReader = new GenericDatumReader<GenericRecord>(inputSchema);
+
+    File tmp = File.createTempFile(this.getClass().getSimpleName(), null);
+    FileUtils.copyInputStreamToFile(getClass().getResourceAsStream("/converter/nested.avro"), tmp);
+    DataFileReader<GenericRecord> dataFileReader = new DataFileReader<GenericRecord>(tmp, datumReader);
+    GenericRecord inputRecord = dataFileReader.next();
+
+    FlattenNestedKeyConverter converter = new FlattenNestedKeyConverter();
+    Schema outputSchema = null;
+    try {
+      outputSchema = converter.convertSchema(inputSchema, workUnitState);
+    } catch (SchemaConversionException e) {
+      Assert.fail(e.getMessage());
+    }
+    Assert.assertTrue(outputSchema.getFields().size() == inputSchema.getFields().size() + 1);
+    Assert.assertTrue(outputSchema.getField("addressStreet_number") != null);
+
+    GenericRecord outputRecord = null;
+    try {
+      outputRecord = converter.convertRecord(outputSchema, inputRecord, workUnitState).iterator().next();
+    } catch (DataConversionException e) {
+      Assert.fail(e.getMessage());
+    }
+    Object expected = AvroUtils.getFieldValue(outputRecord, "address.street_number").get();
+    Assert.assertTrue(outputRecord.get("addressStreet_number") == expected);
+
+    // Reuse the converter to do another successful conversion
+    props.put(key, "name,address.city");
+    workUnitState.addAll(props);
+    try {
+      outputSchema = converter.convertSchema(inputSchema, workUnitState);
+    } catch (SchemaConversionException e) {
+      Assert.fail(e.getMessage());
+    }
+    Assert.assertTrue(outputSchema.getFields().size() == inputSchema.getFields().size() + 1);
+    Assert.assertTrue(outputSchema.getField("addressCity") != null);
+    try {
+      outputRecord = converter.convertRecord(outputSchema, inputRecord, workUnitState).iterator().next();
+    } catch (DataConversionException e) {
+      Assert.fail(e.getMessage());
+    }
+    expected = AvroUtils.getFieldValue(outputRecord, "address.city").get();
+    Assert.assertTrue(outputRecord.get("addressCity") == expected);
+
+    // Reuse the converter to do a failed conversion
+    props.put(key, "name,address.anInvalidField");
+    workUnitState.addAll(props);
+    boolean hasAnException = false;
+    try {
+      converter.convertSchema(inputSchema, workUnitState);
+    } catch (SchemaConversionException e) {
+      hasAnException = true;
+    }
+    Assert.assertTrue(hasAnException);
+  }
+}


### PR DESCRIPTION
Given configuration:
```
FlattenNestedKeyConverter.fieldsToFlatten="address.city,address.zipcode"
```

A `FlattenNestedKeyConverter` will add top level fields "addressCity" and "addressZipcode" into the outputSchema. Their values will be the same as what the nested keys refer to in the inputRecord.