### PR TITLE
Changes to PathAlterationDetector/PathAlterationObserverScheduler

### DIFF
--- a/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/ImmutableFSJobCatalog.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/job_catalog/ImmutableFSJobCatalog.java
@@ -49,7 +49,7 @@ import gobblin.runtime.api.JobSpec;
 import gobblin.runtime.api.JobSpecNotFoundException;
 import gobblin.util.PathUtils;
 import gobblin.util.PullFileLoader;
-import gobblin.util.filesystem.PathAlterationDetector;
+import gobblin.util.filesystem.PathAlterationObserverScheduler;
 import gobblin.util.filesystem.PathAlterationObserver;
 
 import lombok.AllArgsConstructor;
@@ -71,7 +71,7 @@ public class ImmutableFSJobCatalog extends JobCatalogBase implements JobCatalog 
 
   // A monitor for changes to job conf files for general FS
   // This embedded monitor is monitoring job configuration files instead of JobSpec Object.
-  protected final PathAlterationDetector pathAlterationDetector;
+  protected final PathAlterationObserverScheduler pathAlterationDetector;
   public static final String FS_CATALOG_KEY_PREFIX = "gobblin.fsJobCatalog";
   public static final String VERSION_KEY_IN_JOBSPEC = "gobblin.fsJobCatalog.version";
   // Key used in the metadata of JobSpec.
@@ -120,7 +120,7 @@ public class ImmutableFSJobCatalog extends JobCatalogBase implements JobCatalog 
       this.pathAlterationDetector = null;
     }
     else {
-      this.pathAlterationDetector = new PathAlterationDetector(pollingInterval);
+      this.pathAlterationDetector = new PathAlterationObserverScheduler(pollingInterval);
 
       // If absent, the Optional object will be created automatically by addPathAlterationObserver
       Optional<PathAlterationObserver> observerOptional = Optional.fromNullable(observer);

--- a/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
+++ b/gobblin-runtime/src/main/java/gobblin/scheduler/JobScheduler.java
@@ -72,7 +72,7 @@ import gobblin.runtime.listeners.JobListener;
 import gobblin.runtime.listeners.RunOnceJobListener;
 import gobblin.util.ExecutorsUtils;
 import gobblin.util.SchedulerUtils;
-import gobblin.util.filesystem.PathAlterationDetector;
+import gobblin.util.filesystem.PathAlterationObserverScheduler;
 
 
 /**
@@ -125,7 +125,7 @@ public class JobScheduler extends AbstractIdleService {
   public final Path jobConfigFileDirPath;
 
   // A monitor for changes to job conf files for general FS
-  public final PathAlterationDetector pathAlterationDetector;
+  public final PathAlterationObserverScheduler pathAlterationDetector;
   public final PathAlterationListenerAdaptorForMonitor listener;
 
   // A period of time for scheduler to wait until jobs are finished
@@ -149,7 +149,7 @@ public class JobScheduler extends AbstractIdleService {
     long pollingInterval = Long.parseLong(
         this.properties.getProperty(ConfigurationKeys.JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL_KEY,
             Long.toString(ConfigurationKeys.DEFAULT_JOB_CONFIG_FILE_MONITOR_POLLING_INTERVAL)));
-    this.pathAlterationDetector = new PathAlterationDetector(pollingInterval);
+    this.pathAlterationDetector = new PathAlterationObserverScheduler(pollingInterval);
 
     this.waitForJobCompletion = Boolean.parseBoolean(
         this.properties.getProperty(ConfigurationKeys.SCHEDULER_WAIT_FOR_JOB_COMPLETION_KEY,

--- a/gobblin-runtime/src/main/java/gobblin/util/SchedulerUtils.java
+++ b/gobblin-runtime/src/main/java/gobblin/util/SchedulerUtils.java
@@ -42,7 +42,7 @@ import gobblin.runtime.api.JobTemplate;
 import gobblin.runtime.api.SpecNotFoundException;
 import gobblin.runtime.job_catalog.PackagedTemplatesJobCatalogDecorator;
 import gobblin.runtime.template.ResourceBasedJobTemplate;
-import gobblin.util.filesystem.PathAlterationDetector;
+import gobblin.util.filesystem.PathAlterationObserverScheduler;
 import gobblin.util.filesystem.PathAlterationListener;
 import gobblin.util.filesystem.PathAlterationObserver;
 
@@ -138,15 +138,15 @@ public class SchedulerUtils {
   }
 
   /**
-   * Add {@link PathAlterationDetector}s for the given
+   * Add {@link PathAlterationObserverScheduler}s for the given
    * root directory and any nested subdirectories under the root directory to the given
-   * {@link PathAlterationDetector}.
+   * {@link PathAlterationObserverScheduler}.
    *
-   * @param monitor a {@link PathAlterationDetector}
+   * @param monitor a {@link PathAlterationObserverScheduler}
    * @param listener a {@link gobblin.util.filesystem.PathAlterationListener}
    * @param rootDirPath root directory
    */
-  public static void addPathAlterationObserver(PathAlterationDetector monitor, PathAlterationListener listener,
+  public static void addPathAlterationObserver(PathAlterationObserverScheduler monitor, PathAlterationListener listener,
       Path rootDirPath)
       throws IOException {
     PathAlterationObserver observer = new PathAlterationObserver(rootDirPath);

--- a/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/FSJobCatalogHelperTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/runtime/job_catalog/FSJobCatalogHelperTest.java
@@ -50,7 +50,7 @@ import gobblin.runtime.job_catalog.FSJobCatalog;
 import gobblin.runtime.job_catalog.ImmutableFSJobCatalog;
 import gobblin.util.ConfigUtils;
 import gobblin.util.PullFileLoader;
-import gobblin.util.filesystem.PathAlterationDetector;
+import gobblin.util.filesystem.PathAlterationObserverScheduler;
 import gobblin.util.filesystem.PathAlterationListener;
 import gobblin.util.filesystem.PathAlterationListenerAdaptor;
 import gobblin.util.filesystem.PathAlterationObserver;
@@ -225,7 +225,7 @@ public class FSJobCatalogHelperTest {
   @Test(dependsOnMethods = {"testloadGenericJobConfig"})
   public void testPathAlterationObserver()
       throws Exception {
-    PathAlterationDetector detector = new PathAlterationDetector(1000);
+    PathAlterationObserverScheduler detector = new PathAlterationObserverScheduler(1000);
     final Set<Path> fileAltered = Sets.newHashSet();
     final Semaphore semaphore = new Semaphore(0);
     PathAlterationListener listener = new PathAlterationListenerAdaptor() {

--- a/gobblin-runtime/src/test/java/gobblin/util/SchedulerUtilsTest.java
+++ b/gobblin-runtime/src/test/java/gobblin/util/SchedulerUtilsTest.java
@@ -21,7 +21,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import gobblin.util.filesystem.PathAlterationListener;
 import gobblin.util.filesystem.PathAlterationListenerAdaptor;
-import gobblin.util.filesystem.PathAlterationDetector;
+import gobblin.util.filesystem.PathAlterationObserverScheduler;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -226,7 +226,7 @@ public class SchedulerUtilsTest {
   @Test(dependsOnMethods = {"testLoadJobConfigsForCommonPropsFile", "testloadGenericJobConfig"})
   public void testPathAlterationObserver()
       throws Exception {
-    PathAlterationDetector monitor = new PathAlterationDetector(1000);
+    PathAlterationObserverScheduler monitor = new PathAlterationObserverScheduler(1000);
     final Set<Path> fileAltered = Sets.newHashSet();
     final Semaphore semaphore = new Semaphore(0);
     PathAlterationListener listener = new PathAlterationListenerAdaptor() {


### PR DESCRIPTION
- Rename PathAlterationDetector to PathAlterationObserverScheduler as the current name is confusing. The class does not detect anything.
- Currently, passing an interval <= 0 will throw an exception in start(). Change the logic to not schedule anything instead.
- Trivial simplification in addPathAlterationObserver()