### PR TITLE
Adding dynamic tag resolver using runtime property for config store

### DIFF
--- a/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigClient.java
+++ b/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigClient.java
@@ -30,6 +30,7 @@ import java.util.TreeMap;
 import org.apache.log4j.Logger;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Optional;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import com.typesafe.config.Config;
@@ -116,9 +117,14 @@ public class ConfigClient {
    */
   public Config getConfig(URI configKeyUri)
       throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException {
+    return getConfig(configKeyUri, Optional.<Config>absent());
+  }
+
+  public Config getConfig(URI configKeyUri, Optional<Config> runtimeConfig)
+      throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException {
     ConfigStoreAccessor accessor = this.getConfigStoreAccessor(configKeyUri);
     ConfigKeyPath configKeypath = ConfigClientUtils.buildConfigKeyPath(configKeyUri, accessor.configStore);
-    return accessor.valueInspector.getResolvedConfig(configKeypath);
+    return accessor.valueInspector.getResolvedConfig(configKeypath, runtimeConfig);
   }
 
   /**
@@ -170,8 +176,15 @@ public class ConfigClient {
    */
   public Config getConfig(String configKeyStr) throws ConfigStoreFactoryDoesNotExistsException,
       ConfigStoreCreationException, VersionDoesNotExistException, URISyntaxException {
-    return this.getConfig(new URI(configKeyStr));
+    return getConfig(configKeyStr, Optional.<Config>absent());
   }
+
+  public Config getConfig(String configKeyStr, Optional<Config> runtimeConfig)
+      throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException,
+             URISyntaxException {
+    return this.getConfig(new URI(configKeyStr), runtimeConfig);
+  }
+
 
   /**
    * batch process for {@link #getConfig(String)} method

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreBackedTopology.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreBackedTopology.java
@@ -20,6 +20,9 @@ package gobblin.config.common.impl;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
 import gobblin.config.store.api.ConfigKeyPath;
 import gobblin.config.store.api.ConfigStore;
 import gobblin.config.store.api.ConfigStoreWithImportedBy;
@@ -65,6 +68,13 @@ public class ConfigStoreBackedTopology implements ConfigStoreTopologyInspector {
    */
   @Override
   public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey) {
+    return getOwnImports(configKey, Optional.<Config>absent());
+  }
+
+  public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey, Optional<Config> runtimeConfig) {
+    if (runtimeConfig.isPresent()) {
+      return this.cs.getOwnImports(configKey, this.version, runtimeConfig);
+    }
     return this.cs.getOwnImports(configKey, this.version);
   }
 

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreTopologyInspector.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreTopologyInspector.java
@@ -20,6 +20,9 @@ package gobblin.config.common.impl;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
 import gobblin.config.store.api.ConfigKeyPath;
 
 /**
@@ -55,6 +58,8 @@ public interface ConfigStoreTopologyInspector {
    * when resolving configuration conflicts.
    */
   public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey);
+
+  public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey, Optional<Config> runtimeConfig);
 
   /**
    * Obtains the collection of config keys which import a given config key.

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreValueInspector.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreValueInspector.java
@@ -20,6 +20,7 @@ package gobblin.config.common.impl;
 import java.util.Collection;
 import java.util.Map;
 
+import com.google.common.base.Optional;
 import com.typesafe.config.Config;
 
 import gobblin.config.store.api.ConfigKeyPath;
@@ -54,6 +55,8 @@ public interface ConfigStoreValueInspector {
    *         and indirect imports resolved.
    */
   public Config getResolvedConfig(ConfigKeyPath configKey);
+
+  public Config getResolvedConfig(ConfigKeyPath configKey, Optional<Config> runtimeConfig);
 
   /**
   *

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/InMemoryTopology.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/InMemoryTopology.java
@@ -27,7 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
+import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.typesafe.config.Config;
 
 import gobblin.config.store.api.ConfigKeyPath;
 
@@ -245,11 +247,16 @@ public class InMemoryTopology implements ConfigStoreTopologyInspector {
    */
   @Override
   public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey) {
+    return getOwnImports(configKey, Optional.<Config>absent());
+  }
+
+  @Override
+  public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey, Optional<Config> runtimeConfig) {
     if (this.ownImportMap.containsKey(configKey)) {
       return this.ownImportMap.get(configKey);
     }
 
-    List<ConfigKeyPath> result = this.fallback.getOwnImports(configKey);
+    List<ConfigKeyPath> result = this.fallback.getOwnImports(configKey, runtimeConfig);
     addToListMapForListValue(this.ownImportMap, configKey, result);
     return result;
   }

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/InMemoryValueInspector.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/InMemoryValueInspector.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
 
+import com.google.common.base.Optional;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.typesafe.config.Config;
@@ -94,11 +95,16 @@ public class InMemoryValueInspector implements ConfigStoreValueInspector{
    */
   @Override
   public Config getResolvedConfig(final ConfigKeyPath configKey) {
+    return getResolvedConfig(configKey, Optional.<Config>absent());
+  }
+
+  @Override
+  public Config getResolvedConfig(final ConfigKeyPath configKey, final Optional<Config> runtimeConfig) {
     try {
       return this.recursiveConfigCache.get(configKey, new Callable<Config>() {
         @Override
         public Config call()  {
-          return InMemoryValueInspector.this.valueFallback.getResolvedConfig(configKey);
+          return InMemoryValueInspector.this.valueFallback.getResolvedConfig(configKey, runtimeConfig);
         }
       });
     } catch (ExecutionException e) {

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStore.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStore.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.base.Optional;
 import com.typesafe.config.Config;
 
 import gobblin.annotation.Alpha;
@@ -88,6 +89,9 @@ public interface ConfigStore {
    *
    */
   public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey, String version)
+      throws VersionDoesNotExistException;
+
+  public List<ConfigKeyPath> getOwnImports(ConfigKeyPath configKey, String version, Optional<Config> runtimeConfig)
       throws VersionDoesNotExistException;
 
   /**

--- a/gobblin-utility/src/main/java/gobblin/broker/TTLResourceEntry.java
+++ b/gobblin-utility/src/main/java/gobblin/broker/TTLResourceEntry.java
@@ -17,6 +17,7 @@
 
 package gobblin.broker;
 
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import lombok.extern.slf4j.Slf4j;
 
 
@@ -24,6 +25,7 @@ import lombok.extern.slf4j.Slf4j;
  * A {@link ResourceEntry} that automatically expires after a given number of milliseconds.
  */
 @Slf4j
+@SuppressWarnings
 public class TTLResourceEntry<T> extends ResourceInstance<T> {
   private final long expireAt;
   private final boolean closeOnInvalidation;


### PR DESCRIPTION
There are many occasions where imports should be resolved at runtime using dynamic tags. Current implementation supports only resolution of environment variables as dynamic tags. This pr aims to generalize resolution of dynamic tags by passing a runtime config(optional).