### PR TITLE
Rename directory after compaction is complete

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionCompleteAction.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionCompleteAction.java
@@ -6,5 +6,5 @@ import gobblin.dataset.Dataset;
  * An interface which represents an action that is invoked after a compaction job is finished.
  */
 public interface CompactionCompleteAction<D extends Dataset> {
-  void onCompactionJobComplete(D dataset);
+  void onCompactionJobComplete(D dataset) throws Exception;
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionCompleteAction.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionCompleteAction.java
@@ -1,10 +1,12 @@
 package gobblin.compaction.action;
 import gobblin.dataset.Dataset;
 
+import java.io.IOException;
+
 
 /**
  * An interface which represents an action that is invoked after a compaction job is finished.
  */
 public interface CompactionCompleteAction<D extends Dataset> {
-  void onCompactionJobComplete(D dataset) throws Exception;
+  void onCompactionJobComplete(D dataset) throws IOException;
 }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionCompleteFileOperationAction.java
@@ -58,11 +58,11 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
       Counter counter = job.getCounters().findCounter(AvroKeyMapper.EVENT_COUNTER.RECORD_COUNT);
       long recordCount = counter.getValue();
 
-
-      boolean renamingRequired = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_ENABLED,
+      // this is append delta mode due to the compaction rename source dir mode being enabled
+      boolean appendDeltaOutput = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_ENABLED,
               MRCompactor.DEFAULT_COMPACTION_RENAME_SOURCE_DIR_ENABLED);
 
-      if (renamingRequired) {
+      if (appendDeltaOutput) {
         FsPermission permission = HadoopUtils.deserializeFsPermission(this.state,
                 MRCompactorJobRunner.COMPACTION_JOB_OUTPUT_DIR_PERMISSION,
                 FsPermission.getDefault());
@@ -82,7 +82,7 @@ public class CompactionCompleteFileOperationAction implements CompactionComplete
 
         // update record count (adding previous count)
         long delta = InputRecordCountHelper.readRecordCount(fs, dstPath);
-        log.info("Will change record count from {} to {} at {}", recordCount, delta, dstPath);
+        log.info("Will change record count from {} to {} at {}", recordCount, recordCount + delta, dstPath);
         recordCount += delta;
         
       } else {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionHiveRegistrationAction.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionHiveRegistrationAction.java
@@ -24,18 +24,15 @@ public class CompactionHiveRegistrationAction implements CompactionCompleteActio
     this.state = state;
   }
 
-  public void onCompactionJobComplete(FileSystemDataset dataset) {
+  public void onCompactionJobComplete(FileSystemDataset dataset) throws IOException {
     if (state.contains(ConfigurationKeys.HIVE_REGISTRATION_POLICY)) {
       HiveRegister hiveRegister = HiveRegister.get(state);
       HiveRegistrationPolicy hiveRegistrationPolicy = HiveRegistrationPolicyBase.getPolicy(state);
       CompactionPathParser.CompactionParserResult result = new CompactionPathParser(state).parse(dataset);
-      try {
-        for (HiveSpec spec : hiveRegistrationPolicy.getHiveSpecs(new Path(result.getDstAbsoluteDir()))) {
-          hiveRegister.register(spec);
-          log.info("Hive registration is done for {}", result.getDstAbsoluteDir());
-        }
-      } catch (IOException e) {
-        throw new RuntimeException(e);
+
+      for (HiveSpec spec : hiveRegistrationPolicy.getHiveSpecs(new Path(result.getDstAbsoluteDir()))) {
+        hiveRegister.register(spec);
+        log.info("Hive registration is done for {}", result.getDstAbsoluteDir());
       }
     }
   }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionMarkDirectoryAction.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/action/CompactionMarkDirectoryAction.java
@@ -1,0 +1,43 @@
+package gobblin.compaction.action;
+
+import gobblin.compaction.mapreduce.CompactionAvroJobConfigurator;
+import gobblin.compaction.mapreduce.MRCompactor;
+import gobblin.configuration.State;
+import gobblin.dataset.FileSystemDataset;
+
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+
+import java.io.IOException;
+import java.util.Collection;
+
+@Slf4j
+@AllArgsConstructor
+public class CompactionMarkDirectoryAction implements CompactionCompleteAction<FileSystemDataset> {
+  protected State state;
+  private CompactionAvroJobConfigurator configurator;
+  private FileSystem fs;
+
+  public CompactionMarkDirectoryAction(State state, CompactionAvroJobConfigurator configurator) {
+    this.state = state;
+    this.configurator = configurator;
+    this.fs = configurator.getFs();
+  }
+
+  public void onCompactionJobComplete (FileSystemDataset dataset) throws IOException {
+    boolean renamingRequired = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_ENABLED,
+            MRCompactor.DEFAULT_COMPACTION_RENAME_SOURCE_DIR_ENABLED);
+
+    if (renamingRequired) {
+      Collection<Path> paths = configurator.getMapReduceInputPaths();
+      for (Path path: paths) {
+        Path newPath = new Path (path.getParent(), path.getName() + MRCompactor.COMPACTION_RENAME_SOURCE_DIR_SUFFIX);
+        log.info("[{}] Renaming {} to {}", dataset.datasetURN(), path, newPath);
+        fs.rename(path, newPath);
+      }
+    }
+  }
+}

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/CompactionAvroJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/CompactionAvroJobConfigurator.java
@@ -291,9 +291,18 @@ public class CompactionAvroJobConfigurator {
    */
   protected Collection<Path> getGranularInputPaths (Path path) throws IOException {
 
+    boolean renamingRequired = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_ENABLED,
+            MRCompactor.DEFAULT_COMPACTION_RENAME_SOURCE_DIR_ENABLED);
+
     Set<Path> output = Sets.newHashSet();
     for (FileStatus fileStatus : FileListUtils.listFilesRecursively(fs, path)) {
-      output.add(fileStatus.getPath().getParent());
+      if (renamingRequired) {
+        if (!fileStatus.getPath().getParent().toString().endsWith(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_SUFFIX)) {
+          output.add(fileStatus.getPath().getParent());
+        }
+      } else {
+        output.add(fileStatus.getPath().getParent());
+      }
     }
 
     return output;

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
@@ -55,14 +55,14 @@ public class MRCompactionTask extends MRTask {
     super.run();
   }
 
-  public void onMRTaskComplete (boolean isSuccess, Throwable throwable) throws RuntimeException {
+  public void onMRTaskComplete (boolean isSuccess, Throwable throwable) {
     if (isSuccess) {
       try {
         List<CompactionCompleteAction> actions = this.suite.getCompactionCompleteActions();
         for (CompactionCompleteAction action: actions) {
           action.onCompactionJobComplete(dataset);
         }
-      } catch (Exception e) {
+      } catch (IOException e) {
         throw new RuntimeException(e);
       }
     } else {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
@@ -53,10 +53,20 @@ public class MRCompactionTask extends MRTask {
     }
 
     super.run();
+  }
 
-    List<CompactionCompleteAction> actions = this.suite.getCompactionCompleteActions();
-    for (CompactionCompleteAction action: actions) {
-      action.onCompactionJobComplete(dataset);
+  public void onMRTaskComplete (boolean isSuccess, Throwable throwable) throws RuntimeException {
+    if (isSuccess) {
+      try {
+        List<CompactionCompleteAction> actions = this.suite.getCompactionCompleteActions();
+        for (CompactionCompleteAction action: actions) {
+          action.onCompactionJobComplete(dataset);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    } else {
+      super.onMRTaskComplete(isSuccess, throwable);
     }
   }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/suite/CompactionAvroSuite.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/suite/CompactionAvroSuite.java
@@ -2,6 +2,7 @@ package gobblin.compaction.suite;
 
 import gobblin.compaction.action.CompactionCompleteAction;
 import gobblin.compaction.action.CompactionCompleteFileOperationAction;
+import gobblin.compaction.action.CompactionMarkDirectoryAction;
 import gobblin.compaction.action.CompactionHiveRegistrationAction;
 import gobblin.compaction.mapreduce.CompactionAvroJobConfigurator;
 import gobblin.compaction.verify.CompactionAuditCountVerifier;
@@ -99,6 +100,7 @@ public class CompactionAvroSuite implements CompactionSuite<FileSystemDataset> {
     ArrayList<CompactionCompleteAction<FileSystemDataset>> array = new ArrayList<>();
     array.add(new CompactionCompleteFileOperationAction(state, configurator));
     array.add(new CompactionHiveRegistrationAction(state));
+    array.add(new CompactionMarkDirectoryAction(state, configurator));
     return array;
   }
 

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTask.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTask.java
@@ -69,6 +69,15 @@ public class MRTask extends BaseAbstractTask {
         .addMetadata(additionalEventMetadata()).build();
   }
 
+  public void onMRTaskComplete (boolean isSuccess, Throwable t) throws RuntimeException {
+    if (isSuccess)
+      log.info ("Successfully run MR job.");
+    else if (t == null)
+      log.info ("Failed to run MR job");
+    else
+      log.info ("Failed to run MR job with exception {}", t.toString());
+  }
+
   @Override
   public void run() {
 
@@ -82,14 +91,17 @@ public class MRTask extends BaseAbstractTask {
       if (job.isSuccessful()) {
         this.eventSubmitter.submit(Events.MR_JOB_SUCCESSFUL, Events.JOB_URL, job.getTrackingURL());
         this.workingState = WorkUnitState.WorkingState.SUCCESSFUL;
+        this.onMRTaskComplete(true, null);
       } else {
         this.eventSubmitter.submit(Events.MR_JOB_FAILED, Events.JOB_URL, job.getTrackingURL());
         this.workingState = WorkUnitState.WorkingState.FAILED;
+        this.onMRTaskComplete (false, null);
       }
     } catch (Throwable t) {
       log.error("Failed to run MR job.", t);
       this.eventSubmitter.submit(Events.MR_JOB_FAILED, Events.FAILURE_CONTEXT, t.getMessage());
       this.workingState = WorkUnitState.WorkingState.FAILED;
+      this.onMRTaskComplete (false, t);
     }
   }
 


### PR DESCRIPTION
This change is to bridge the gap between old renaming logic for databus-etl, and the new compaction logic in MRCompactionTask. 

In old renaming logic, after the compaction is compete, the directory will be renamed to {DIRNAME}_COMPLETE. Replicate the same logic in the MRCompactionTask now. 

The change will only take effect when compaction.rename.source.dir.enabled=true