### PR TITLE
Add metadata aware filesystem instrumentation

### DIFF
--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/DatasetAwareFsMetadataProvider.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/DatasetAwareFsMetadataProvider.java
@@ -15,25 +15,21 @@
  * limitations under the License.
  */
 
-apply plugin: 'java'
+package gobblin.metadata.provider;
 
-dependencies {
-  /*
-   * Keep these dependencies as small as possible: we should not rely on
-   * gobblin-runtime, -core etc as they pull in huge transitive dependency trees!
-   */
-  compile project(":gobblin-api")
-  compile project(":gobblin-modules:gobblin-codecs")
-  compile project(":gobblin-utility")
+import org.apache.hadoop.fs.Path;
 
-  compile externalDependency.gson
-  compile externalDependency.jacksonCore
-  compile externalDependency.jacksonMapper
-  compile externalDependency.slf4j
+import gobblin.metadata.types.GlobalMetadata;
 
-  testCompile project(":gobblin-test-utils")
-  testCompile externalDependency.testng
+
+/**
+ * Fs based {@link DatasetAwareMetadataProvider} which can extract datasetUrn from a given {@link Path},
+ * and provide {@link GlobalMetadata} for it.
+ */
+public abstract class DatasetAwareFsMetadataProvider implements DatasetAwareMetadataProvider {
+  public abstract String datasetUrnAtPath(Path path);
+
+  public GlobalMetadata getGlobalMetadataForDatasetAtPath(Path datasetAwarePath) {
+    return this.getGlobalMetadataForDataset(datasetUrnAtPath(datasetAwarePath));
+  }
 }
-
-ext.classification="library"
-

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/DatasetAwareMetadataProvider.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/DatasetAwareMetadataProvider.java
@@ -15,25 +15,20 @@
  * limitations under the License.
  */
 
-apply plugin: 'java'
+package gobblin.metadata.provider;
 
-dependencies {
-  /*
-   * Keep these dependencies as small as possible: we should not rely on
-   * gobblin-runtime, -core etc as they pull in huge transitive dependency trees!
+import gobblin.annotation.Alpha;
+import gobblin.metadata.types.GlobalMetadata;
+
+
+/**
+ * Provides dataset-aware {@link GlobalMetadata}.
+ */
+@Alpha
+public interface DatasetAwareMetadataProvider {
+  /**
+   * @param datasetUrnSource for retrieving dataset urn.
+   * @return returns a given dataset's related {@link GlobalMetadata}.
    */
-  compile project(":gobblin-api")
-  compile project(":gobblin-modules:gobblin-codecs")
-  compile project(":gobblin-utility")
-
-  compile externalDependency.gson
-  compile externalDependency.jacksonCore
-  compile externalDependency.jacksonMapper
-  compile externalDependency.slf4j
-
-  testCompile project(":gobblin-test-utils")
-  testCompile externalDependency.testng
+  GlobalMetadata getGlobalMetadataForDataset(String datasetUrnSource);
 }
-
-ext.classification="library"
-

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/DatasetAwareMetadataProviderFactory.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/DatasetAwareMetadataProviderFactory.java
@@ -15,25 +15,14 @@
  * limitations under the License.
  */
 
-apply plugin: 'java'
+package gobblin.metadata.provider;
 
-dependencies {
-  /*
-   * Keep these dependencies as small as possible: we should not rely on
-   * gobblin-runtime, -core etc as they pull in huge transitive dependency trees!
-   */
-  compile project(":gobblin-api")
-  compile project(":gobblin-modules:gobblin-codecs")
-  compile project(":gobblin-utility")
+import com.typesafe.config.Config;
 
-  compile externalDependency.gson
-  compile externalDependency.jacksonCore
-  compile externalDependency.jacksonMapper
-  compile externalDependency.slf4j
 
-  testCompile project(":gobblin-test-utils")
-  testCompile externalDependency.testng
+/**
+ * A factory that creates {@link DatasetAwareMetadataProvider} from {@link Config}.
+ */
+interface DatasetAwareMetadataProviderFactory {
+  DatasetAwareMetadataProvider createMetadataProvider(Config config);
 }
-
-ext.classification="library"
-

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/MetadataAwareFileSystem.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/MetadataAwareFileSystem.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metadata.provider;
+
+import java.io.IOException;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+
+import com.typesafe.config.Config;
+
+import gobblin.broker.iface.ConfigView;
+import gobblin.broker.iface.ScopeType;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.util.ClassAliasResolver;
+import gobblin.util.ConfigUtils;
+import gobblin.util.filesystem.FileSystemInstrumentation;
+import gobblin.util.filesystem.FileSystemInstrumentationFactory;
+import gobblin.util.filesystem.FileSystemKey;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Extends {@link FileSystemInstrumentation} and is metadata aware when setting permissions and owners.
+ */
+@Slf4j
+public class MetadataAwareFileSystem extends FileSystemInstrumentation {
+
+  public static final String METADATA_PROVIDER_ALIAS = "metadataProviderAlias";
+
+  public static class Factory<S extends ScopeType<S>> extends FileSystemInstrumentationFactory<S> {
+    @Override
+    public FileSystem instrumentFileSystem(FileSystem fs, SharedResourcesBroker<S> broker,
+        ConfigView<S, FileSystemKey> config) {
+      Config metaConfig = config.getConfig();
+      String metadataProviderAlias = ConfigUtils.getString(metaConfig, METADATA_PROVIDER_ALIAS, "");
+      log.info("Metadata provider alias is: " + metadataProviderAlias);
+      if (!metadataProviderAlias.isEmpty()) {
+        DatasetAwareFsMetadataProvider metadataProvider = null;
+        try {
+          metadataProvider =
+              (DatasetAwareFsMetadataProvider) new ClassAliasResolver<>(DatasetAwareMetadataProviderFactory.class)
+                  .resolveClass(metadataProviderAlias).newInstance().createMetadataProvider(metaConfig);
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException e) {
+          log.error("Failed to create metadataProvider.", e);
+        }
+        if (metadataProvider != null) {
+          return new MetadataAwareFileSystem(fs, metadataProvider);
+        }
+      }
+      log.warn("No valid {} found. Will use filesystem {}.", METADATA_PROVIDER_ALIAS, fs.getClass().getName());
+      return fs;
+    }
+  }
+
+  private DatasetAwareFsMetadataProvider metadataProvider;
+
+  public MetadataAwareFileSystem(FileSystem underlying, DatasetAwareFsMetadataProvider provider) {
+    super(underlying);
+    this.metadataProvider = provider;
+  }
+
+  @Override
+  public boolean mkdirs(Path f, FsPermission permission)
+      throws IOException {
+    FsPermission realPermission = getPermAtPathFromMetadataIfPresent(permission, f);
+    return super.mkdirs(f, realPermission);
+  }
+
+  @Override
+  public FSDataOutputStream create(Path f, FsPermission permission, boolean overwrite, int bufferSize,
+      short replication, long blockSize, Progressable progress)
+      throws IOException {
+    FsPermission realPermission = getPermAtPathFromMetadataIfPresent(permission, f);
+    return super.create(f, realPermission, overwrite, bufferSize, replication, blockSize, progress);
+  }
+
+  @Override
+  public void setPermission(Path f, final FsPermission permission)
+      throws IOException {
+    super.setPermission(f, getPermAtPathFromMetadataIfPresent(permission, f));
+  }
+
+  @Override
+  public void setOwner(Path f, String user, String group)
+      throws IOException {
+    super.setOwner(f, user, getGroupAtPathFromMetadataIfPresent(group, f));
+  }
+
+  private String getGroupAtPathFromMetadataIfPresent(String defaultGroup, Path path) {
+    String realGroup = defaultGroup;
+    if (this.metadataProvider != null) {
+      realGroup = PermissionMetadataParser.getGroupOwner(metadataProvider.getGlobalMetadataForDatasetAtPath(path));
+    }
+    return realGroup;
+  }
+
+  private FsPermission getPermAtPathFromMetadataIfPresent(FsPermission defaultPermission, Path path) {
+    FsPermission realPermission = defaultPermission;
+    if (this.metadataProvider != null) {
+      realPermission = new FsPermission(Short
+          .parseShort(PermissionMetadataParser.getPermission(metadataProvider.getGlobalMetadataForDatasetAtPath(path)),
+              ConfigurationKeys.PERMISSION_PARSING_RADIX));
+    }
+    return realPermission;
+  }
+}

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/PermissionMetadataParser.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/PermissionMetadataParser.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metadata.provider;
+
+import gobblin.metadata.types.GlobalMetadata;
+
+
+/**
+ * Parses permission information from a given {@link GlobalMetadata}.
+ */
+public class PermissionMetadataParser {
+
+  private final static String PERMISSION_KEY = "Permission";
+  private final static String GROUP_OWNER = "GroupOwner";
+
+  public static void setPermission(GlobalMetadata metadata, String permission) {
+    metadata.setDatasetMetadata(PERMISSION_KEY, permission);
+  }
+
+  public static String getPermission(GlobalMetadata metadata) {
+    return (String) metadata.getDatasetMetadata(PERMISSION_KEY);
+  }
+
+  public static void setGroupOwner(GlobalMetadata metadata, String groupOwner) {
+    metadata.setDatasetMetadata(GROUP_OWNER, groupOwner);
+  }
+
+  public static String getGroupOwner(GlobalMetadata metadata) {
+    return (String) metadata.getDatasetMetadata(GROUP_OWNER);
+  }
+}

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/SimpleConfigMetadataProvider.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/SimpleConfigMetadataProvider.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metadata.provider;
+
+import org.apache.hadoop.fs.Path;
+
+import gobblin.annotation.Alpha;
+import gobblin.metadata.types.GlobalMetadata;
+
+import lombok.RequiredArgsConstructor;
+
+
+/**
+ * Simple implementation of {@link DatasetAwareMetadataProvider}, which directly
+ * reads global permission from config.
+ */
+@Alpha
+@RequiredArgsConstructor
+public class SimpleConfigMetadataProvider extends DatasetAwareFsMetadataProvider {
+
+  private final String permission;
+
+  @Override
+  public GlobalMetadata getGlobalMetadataForDataset(String datasetUrn) {
+    GlobalMetadata defaultMetadata = new GlobalMetadata();
+    defaultMetadata.setDatasetUrn(datasetUrn);
+    PermissionMetadataParser.setPermission(defaultMetadata, permission);
+    return defaultMetadata;
+  }
+
+  @Override
+  public String datasetUrnAtPath(Path path) {
+    return path.toString();
+  }
+}

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/SimpleMetadataProviderFactory.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/provider/SimpleMetadataProviderFactory.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metadata.provider;
+
+import com.typesafe.config.Config;
+
+import gobblin.annotation.Alias;
+import gobblin.util.ConfigUtils;
+
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Simple {@link DatasetAwareMetadataProviderFactory} that uses a user-defined permission and creates
+ * {@link SimpleConfigMetadataProvider}.
+ */
+@Slf4j
+@Alias(value = "SimpleMetadataProvider")
+public class SimpleMetadataProviderFactory implements DatasetAwareMetadataProviderFactory {
+
+  /**
+   * Permission defined in config that will be used for all paths.
+   */
+  public static final String ALL_PERMISSOIN = "allPermission";
+
+  @Override
+  public DatasetAwareMetadataProvider createMetadataProvider(Config metaConfig) {
+    String permission = ConfigUtils.getString(metaConfig, ALL_PERMISSOIN, "");
+    log.info("User defined permission is: " + permission);
+    return new SimpleConfigMetadataProvider(permission);
+  }
+}

--- a/gobblin-modules/gobblin-metadata/src/main/resources/META-INF/services/gobblin.util.filesystem.FileSystemInstrumentationFactory
+++ b/gobblin-modules/gobblin-metadata/src/main/resources/META-INF/services/gobblin.util.filesystem.FileSystemInstrumentationFactory
@@ -1,0 +1,17 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+gobblin.metadata.provider.MetadataAwareFileSystem$Factory


### PR DESCRIPTION
Main changes:
1. Added `MetadataAwareFileSystem` which instruments permission change related `FileSystem` operations.
2. Created `DatasetAwareMetadataProvider` to provide metadata at dataset level. Reused the existing `GlobalMetadata`.
3. Tested with the `SimpleConfigMetadataProvider` using Gobblin-kafka jobs.