### PR TITLE
Add conversion of the DecodeableKafkaRecord to the extract schema (la…

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/source/extractor/extract/kafka/KafkaAvroExtractor.java
@@ -113,12 +113,23 @@ public abstract class KafkaAvroExtractor<K> extends KafkaExtractor<Schema, Gener
     this.reader.get().setSchema(recordSchema);
     try {
       GenericRecord record = this.reader.get().read(null, decoder);
-      record = AvroUtils.convertRecordSchema(record, this.schema.get());
+      record = convertRecord(record);
       return record;
     } catch (IOException e) {
       log.error(String.format("Error during decoding record for partition %s: ", this.getCurrentPartition()));
       throw e;
     }
+  }
+
+  /**
+   * Convert the record to the output schema of this extractor
+   * @param record the input record
+   * @return the converted record
+   * @throws IOException
+   */
+  @Override
+  protected GenericRecord convertRecord(GenericRecord record) throws IOException {
+    return AvroUtils.convertRecordSchema(record, this.schema.get());
   }
 
   /**

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/source/extractor/extract/kafka/KafkaExtractor.java
@@ -170,7 +170,8 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
           if (nextValidMessage instanceof ByteArrayBasedKafkaRecord) {
             record = decodeRecord((ByteArrayBasedKafkaRecord)nextValidMessage);
           } else if (nextValidMessage instanceof DecodeableKafkaRecord){
-            record = ((DecodeableKafkaRecord<?, D>) nextValidMessage).getValue();
+            // get value from decodeable record and convert to the output schema if necessary
+            record = convertRecord(((DecodeableKafkaRecord<?, D>) nextValidMessage).getValue());
           } else {
             throw new IllegalStateException(
                 "Unsupported KafkaConsumerRecord type. The returned record can either be ByteArrayBasedKafkaRecord"
@@ -276,6 +277,17 @@ public abstract class KafkaExtractor<S, D> extends EventBasedExtractor<S, D> {
   }
 
   protected abstract D decodeRecord(ByteArrayBasedKafkaRecord kafkaConsumerRecord) throws IOException;
+
+  /**
+   * Convert a record to the output format
+   * @param record the input record
+   * @return the converted record
+   * @throws IOException
+   */
+  protected D convertRecord(D record) throws IOException {
+    // default implementation does no conversion
+    return record;
+  }
 
   @Override
   public long getExpectedRecordCount() {


### PR DESCRIPTION
…test schema) since the DecodeableKafkaReocord may have a value with an older schema.