### PR TITLE
Changing config client to pass runtimeConfig as a parameter to resolve dynamic tags

### DIFF
--- a/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigClient.java
+++ b/gobblin-config-management/gobblin-config-client/src/main/java/gobblin/config/client/ConfigClient.java
@@ -221,14 +221,19 @@ public class ConfigClient {
    */
   public Collection<URI> getImports(URI configKeyUri, boolean recursive)
       throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException {
+    return getImports(configKeyUri, recursive, Optional.<Config>absent());
+  }
+
+  public Collection<URI> getImports(URI configKeyUri, boolean recursive, Optional<Config> runtimeConfig)
+      throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException {
     ConfigStoreAccessor accessor = this.getConfigStoreAccessor(configKeyUri);
     ConfigKeyPath configKeypath = ConfigClientUtils.buildConfigKeyPath(configKeyUri, accessor.configStore);
     Collection<ConfigKeyPath> result;
 
     if (!recursive) {
-      result = accessor.topologyInspector.getOwnImports(configKeypath);
+      result = accessor.topologyInspector.getOwnImports(configKeypath, runtimeConfig);
     } else {
-      result = accessor.topologyInspector.getImportsRecursively(configKeypath);
+      result = accessor.topologyInspector.getImportsRecursively(configKeypath, runtimeConfig);
     }
 
     return ConfigClientUtils.buildUriInClientFormat(result, accessor.configStore, configKeyUri.getAuthority() != null);
@@ -247,14 +252,19 @@ public class ConfigClient {
    */
   public Collection<URI> getImportedBy(URI configKeyUri, boolean recursive)
       throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException {
+    return getImportedBy(configKeyUri, recursive, Optional.<Config>absent());
+  }
+
+  public Collection<URI> getImportedBy(URI configKeyUri, boolean recursive, Optional<Config> runtimeConfig)
+      throws ConfigStoreFactoryDoesNotExistsException, ConfigStoreCreationException, VersionDoesNotExistException {
     ConfigStoreAccessor accessor = this.getConfigStoreAccessor(configKeyUri);
     ConfigKeyPath configKeypath = ConfigClientUtils.buildConfigKeyPath(configKeyUri, accessor.configStore);
     Collection<ConfigKeyPath> result;
 
     if (!recursive) {
-      result = accessor.topologyInspector.getImportedBy(configKeypath);
+      result = accessor.topologyInspector.getImportedBy(configKeypath, runtimeConfig);
     } else {
-      result = accessor.topologyInspector.getImportedByRecursively(configKeypath);
+      result = accessor.topologyInspector.getImportedByRecursively(configKeypath, runtimeConfig);
     }
 
     return ConfigClientUtils.buildUriInClientFormat(result, accessor.configStore, configKeyUri.getAuthority() != null);

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreBackedTopology.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreBackedTopology.java
@@ -88,8 +88,12 @@ public class ConfigStoreBackedTopology implements ConfigStoreTopologyInspector {
    */
   @Override
   public Collection<ConfigKeyPath> getImportedBy(ConfigKeyPath configKey) {
+    return getImportedBy(configKey, Optional.<Config>absent());
+  }
+
+  public Collection<ConfigKeyPath> getImportedBy(ConfigKeyPath configKey, Optional<Config> runtimeConfig) {
     if (this.cs instanceof ConfigStoreWithImportedBy) {
-      return ((ConfigStoreWithImportedBy) this.cs).getImportedBy(configKey, this.version);
+      return ((ConfigStoreWithImportedBy) this.cs).getImportedBy(configKey, this.version, runtimeConfig);
     }
 
     throw new UnsupportedOperationException("Internal ConfigStore does not support this operation");
@@ -105,8 +109,12 @@ public class ConfigStoreBackedTopology implements ConfigStoreTopologyInspector {
    */
   @Override
   public List<ConfigKeyPath> getImportsRecursively(ConfigKeyPath configKey) {
+    return getImportsRecursively(configKey, Optional.<Config>absent());
+  }
+
+  public List<ConfigKeyPath> getImportsRecursively(ConfigKeyPath configKey, Optional<Config> runtimeConfig) {
     if (this.cs instanceof ConfigStoreWithResolution) {
-      return ((ConfigStoreWithResolution) this.cs).getImportsRecursively(configKey, this.version);
+      return ((ConfigStoreWithResolution) this.cs).getImportsRecursively(configKey, this.version, runtimeConfig);
     }
 
     throw new UnsupportedOperationException("Internal ConfigStore does not support this operation");
@@ -122,8 +130,12 @@ public class ConfigStoreBackedTopology implements ConfigStoreTopologyInspector {
    */
   @Override
   public Collection<ConfigKeyPath> getImportedByRecursively(ConfigKeyPath configKey) {
+    return getImportedByRecursively(configKey, Optional.<Config>absent());
+  }
+
+  public Collection<ConfigKeyPath> getImportedByRecursively(ConfigKeyPath configKey, Optional<Config> runtimeConfig) {
     if (this.cs instanceof ConfigStoreWithImportedByRecursively) {
-      return ((ConfigStoreWithImportedByRecursively) this.cs).getImportedByRecursively(configKey, this.version);
+      return ((ConfigStoreWithImportedByRecursively) this.cs).getImportedByRecursively(configKey, this.version, runtimeConfig);
     }
 
     throw new UnsupportedOperationException("Internal ConfigStore does not support this operation");

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreTopologyInspector.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/common/impl/ConfigStoreTopologyInspector.java
@@ -69,17 +69,21 @@ public interface ConfigStoreTopologyInspector {
    */
   public Collection<ConfigKeyPath> getImportedBy(ConfigKeyPath configKey);
 
+  public Collection<ConfigKeyPath> getImportedBy(ConfigKeyPath configKey, Optional<Config> runtimeConfig);
+
   /**
    * Obtains the list of config keys which are directly and indirectly imported by the specified
    * config key. The import graph is traversed in depth-first manner. For a given config key,
    * explicit imports are listed before implicit imports from the ancestor keys.
-   *
+   *`
    * @param  configKey      the path of the config key whose imports are needed
    * @return the paths of the directly and indirectly imported keys, including config keys imported
    *         by ancestors. The earlier config key in the list will have higher priority when resolving
    *         configuration conflict.
    */
   public List<ConfigKeyPath> getImportsRecursively(ConfigKeyPath configKey);
+
+  public List<ConfigKeyPath> getImportsRecursively(ConfigKeyPath configKey, Optional<Config> runtimeConfig);
 
   /**
    * Obtains all config keys which directly or indirectly import a given config key
@@ -88,4 +92,6 @@ public interface ConfigStoreTopologyInspector {
    *         the specified config key in the specified conf version.
    */
   public Collection<ConfigKeyPath> getImportedByRecursively(ConfigKeyPath configKey);
+
+  public Collection<ConfigKeyPath> getImportedByRecursively(ConfigKeyPath configKey, Optional<Config> runtimeConfig);
 }

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStoreWithImportedBy.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStoreWithImportedBy.java
@@ -19,6 +19,9 @@ package gobblin.config.store.api;
 
 import java.util.Collection;
 
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
 import gobblin.annotation.Alpha;
 
 
@@ -41,5 +44,8 @@ public interface ConfigStoreWithImportedBy extends ConfigStore {
    * @throws VersionDoesNotExistException if the requested config version does not exist (any longer)
    */
   public Collection<ConfigKeyPath> getImportedBy(ConfigKeyPath configKey, String version)
+      throws VersionDoesNotExistException;
+
+  public Collection<ConfigKeyPath> getImportedBy(ConfigKeyPath configKey, String version, Optional<Config> runtimeConfig)
       throws VersionDoesNotExistException;
 }

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStoreWithImportedByRecursively.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStoreWithImportedByRecursively.java
@@ -19,6 +19,9 @@ package gobblin.config.store.api;
 
 import java.util.Collection;
 
+import com.google.common.base.Optional;
+import com.typesafe.config.Config;
+
 import gobblin.annotation.Alpha;
 
 /**
@@ -41,5 +44,7 @@ public interface ConfigStoreWithImportedByRecursively extends ConfigStoreWithImp
    * @throws VersionDoesNotExistException if the requested config version does not exist (any longer)
    */
   public Collection<ConfigKeyPath> getImportedByRecursively(ConfigKeyPath configKey, String version)
+      throws VersionDoesNotExistException;
+  public Collection<ConfigKeyPath> getImportedByRecursively(ConfigKeyPath configKey, String version, Optional<Config> runtimeConfig)
       throws VersionDoesNotExistException;
 }

--- a/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStoreWithResolution.java
+++ b/gobblin-config-management/gobblin-config-core/src/main/java/gobblin/config/store/api/ConfigStoreWithResolution.java
@@ -19,6 +19,7 @@ package gobblin.config.store.api;
 
 import java.util.List;
 
+import com.google.common.base.Optional;
 import com.typesafe.config.Config;
 
 import gobblin.annotation.Alpha;
@@ -65,6 +66,8 @@ public interface ConfigStoreWithResolution extends ConfigStore {
    * @throws VersionDoesNotExistException if the requested config version does not exist (any longer)
    */
   public List<ConfigKeyPath> getImportsRecursively(ConfigKeyPath configKey, String version)
+      throws VersionDoesNotExistException;
+  public List<ConfigKeyPath> getImportsRecursively(ConfigKeyPath configKey, String version, Optional<Config> runtimeConfig)
       throws VersionDoesNotExistException;
 
 }


### PR DESCRIPTION
This PR is related to #1866

Adding parameter runtimeConfig to ConfigClient. This will enable methods to resolve dynamic tags in config URIs using the runtimeConfig.