### PR TITLE
Fix the bug in multi-properties GSC job

### DIFF
--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/AsyncIteratorWithDataSink.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/AsyncIteratorWithDataSink.java
@@ -15,6 +15,7 @@ public abstract class AsyncIteratorWithDataSink<T> implements Iterator<T> {
   private Thread _producerThread;
   protected LinkedBlockingDeque<T> _dataSink;
   private final int _pollBlockingTime;
+  private T _next = null;
 
   protected AsyncIteratorWithDataSink(int queueSize, int pollBlockingTime) {
     log.info(String.format("Setting queue size: %d, poll blocking second: %d", queueSize, pollBlockingTime));
@@ -25,29 +26,29 @@ public abstract class AsyncIteratorWithDataSink<T> implements Iterator<T> {
   @Override
   public boolean hasNext() {
     initialize();
-    if (!_dataSink.isEmpty()) {
+    if (_next != null) {
       return true;
     }
+    //if _next doesn't exist, try polling the next one.
     try {
-      T next = _dataSink.poll(_pollBlockingTime, TimeUnit.SECONDS);
-      while (next == null) {
+      _next = _dataSink.poll(_pollBlockingTime, TimeUnit.SECONDS);
+      while (_next == null) {
         if (_producerThread.isAlive()) {
-          log.info("Job not done yet. Keep waiting...");
-          next = _dataSink.poll(_pollBlockingTime, TimeUnit.SECONDS);
-        } else {
-          synchronized (lock) {
-            if (exceptionInProducerThread != null) {
-              throw new RuntimeException(
-                  String.format("Found exception in producer thread %s", _producerThread.getName()),
-                  exceptionInProducerThread);
-            }
-          }
-          log.info("Producer job has finished. No more query data in the queue.");
-          return false;
+          log.info(String.format("Producer job not done yet. Will re-poll for %s second(s)...", _pollBlockingTime));
+          _next = _dataSink.poll(_pollBlockingTime, TimeUnit.SECONDS);
+          continue;
         }
+
+        synchronized (lock) {
+          if (exceptionInProducerThread != null) {
+            throw new RuntimeException(
+                String.format("Found exception in producer thread %s", _producerThread.getName()),
+                exceptionInProducerThread);
+          }
+        }
+        log.info("Producer job done. No more data in the queue.");
+        return false;
       }
-      //Must put it back. Implement in this way because LinkedBlockingDeque doesn't support blocking peek.
-      _dataSink.putFirst(next);
       return true;
     } catch (InterruptedException e) {
       throw new RuntimeException(e);
@@ -67,7 +68,9 @@ public abstract class AsyncIteratorWithDataSink<T> implements Iterator<T> {
   @Override
   public T next() {
     if (hasNext()) {
-      return _dataSink.remove();
+      T toReturn = _next;
+      _next = null;
+      return toReturn;
     }
     throw new NoSuchElementException();
   }

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/AsyncIteratorWithDataSink.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/AsyncIteratorWithDataSink.java
@@ -17,6 +17,7 @@ public abstract class AsyncIteratorWithDataSink<T> implements Iterator<T> {
   private final int _pollBlockingTime;
 
   protected AsyncIteratorWithDataSink(int queueSize, int pollBlockingTime) {
+    log.info(String.format("Setting queue size: %d, poll blocking second: %d", queueSize, pollBlockingTime));
     _dataSink = new LinkedBlockingDeque<>(queueSize);
     _pollBlockingTime = pollBlockingTime;
   }
@@ -31,7 +32,7 @@ public abstract class AsyncIteratorWithDataSink<T> implements Iterator<T> {
       T next = _dataSink.poll(_pollBlockingTime, TimeUnit.SECONDS);
       while (next == null) {
         if (_producerThread.isAlive()) {
-          //Job not done yet. Keep waiting...
+          log.info("Job not done yet. Keep waiting...");
           next = _dataSink.poll(_pollBlockingTime, TimeUnit.SECONDS);
         } else {
           synchronized (lock) {

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
@@ -111,7 +111,7 @@ abstract class GoogleWebMasterSource extends QueryBasedSource<String, String[]> 
    */
   public static final String KEY_QUERIES_TUNING_TIME_OUT = QUERIES_TUNING + "time_out";
   /**
-   * Optional. Default to 30.
+   * Optional. Default to 40.
    * Tune the maximum rounds of retries while getting queries.
    */
   public static final String KEY_QUERIES_TUNING_RETRIES = QUERIES_TUNING + "max_reties";

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
@@ -154,6 +154,11 @@ abstract class GoogleWebMasterSource extends QueryBasedSource<String, String[]> 
   // =============================================
   public static final String PAGES_TUNING = TUNING + "get_pages.";
   /**
+   * Optional. Default to 10.
+   * Configure the number of max retries for initial requests.
+   */
+  public static final String KEY_INITIAL_REQUESTS_RETRIES = PAGES_TUNING + "initial_requests_retries";
+  /**
    * Optional. Default to 5.0.
    * Tune the speed of API requests while getting all pages.
    */

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
@@ -154,11 +154,6 @@ abstract class GoogleWebMasterSource extends QueryBasedSource<String, String[]> 
   // =============================================
   public static final String PAGES_TUNING = TUNING + "get_pages.";
   /**
-   * Optional. Default to 5.
-   * Configure the max number of retries for the initial request to get pages.
-   */
-  public static final String KEY_PAGES_TUNING_INITIAL_REQUEST_MAX_RETRIES = PAGES_TUNING + "initial_request_retries";
-  /**
    * Optional. Default to 5.0.
    * Tune the speed of API requests while getting all pages.
    */

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebMasterSource.java
@@ -154,10 +154,10 @@ abstract class GoogleWebMasterSource extends QueryBasedSource<String, String[]> 
   // =============================================
   public static final String PAGES_TUNING = TUNING + "get_pages.";
   /**
-   * Optional. Default to 10.
-   * Configure the number of max retries for initial requests.
+   * Optional. Default to 5.
+   * Configure the max number of retries for the initial request to get pages.
    */
-  public static final String KEY_INITIAL_REQUESTS_RETRIES = PAGES_TUNING + "initial_requests_retries";
+  public static final String KEY_PAGES_TUNING_INITIAL_REQUEST_MAX_RETRIES = PAGES_TUNING + "initial_request_retries";
   /**
    * Optional. Default to 5.0.
    * Tune the speed of API requests while getting all pages.

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImpl.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImpl.java
@@ -111,8 +111,10 @@ public class GoogleWebmasterDataFetcherImpl extends GoogleWebmasterDataFetcher {
       try {
         allPages = _client.getPages(_siteProperty, startDate, endDate, country, rowLimit, requestedDimensions,
             Arrays.asList(countryFilter), 0);
+        break;
       } catch (Exception e) {
-        log.info("Retrying initial request at count " + r);
+        log.info(e.getMessage());
+        log.info("Retrying initial request at round " + r);
       }
 
       try {

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImpl.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImpl.java
@@ -145,16 +145,16 @@ public class GoogleWebmasterDataFetcherImpl extends GoogleWebmasterDataFetcher {
 
     while (true) {
       for (int i = 0; i < groupSize; ++i) {
-        startRow += GoogleWebmasterClient.API_ROW_LIMIT;
         final int start = startRow;
-        final String interruptedMsg = String
-            .format("Interrupted while trying to get the size of all pages for %s. Current start row is %d.", country,
-                start);
+        startRow += GoogleWebmasterClient.API_ROW_LIMIT;
 
         Future<Integer> submit = es.submit(new Callable<Integer>() {
           @Override
           public Integer call() {
             log.info(String.format("Getting page size from %s...", start));
+            String interruptedMsg = String
+                .format("Interrupted while trying to get the size of all pages for %s. Current start row is %d.",
+                    country, start);
             while (true) {
               try {
                 LIMITER.acquirePermits(1);

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImpl.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImpl.java
@@ -106,6 +106,7 @@ public class GoogleWebmasterDataFetcherImpl extends GoogleWebmasterDataFetcher {
         .getPages(_siteProperty, startDate, endDate, country, rowLimit, requestedDimensions,
             Arrays.asList(countryFilter), 0);
     int actualSize = allPages.size();
+    log.info(String.format("First time requested %s rows, returned %s rows", rowLimit, actualSize));
 
     if (rowLimit < GoogleWebmasterClient.API_ROW_LIMIT || actualSize < GoogleWebmasterClient.API_ROW_LIMIT) {
       log.info(String

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
@@ -121,13 +121,10 @@ public class GoogleWebmasterExtractor implements Extractor<String, String[]> {
         }
         String startDate = dateFormatter.print(_startDate);
         String endDate = dateFormatter.print(_expectedHighWaterMarkDate);
-        log.info(String
-            .format("Creating GoogleWebmasterExtractorIterator for [%s, %s] for site %s.", startDate, endDate,
-                dataFetcher.getSiteProperty()));
-
         GoogleWebmasterExtractorIterator iterator =
             new GoogleWebmasterExtractorIterator(dataFetcher, startDate, endDate, actualDimensionRequests,
                 requestedMetrics, filters, wuState);
+        log.info("Created " + iterator.toString());
         // positionMapping is to address the cases when requested dimensions/metrics order
         // is different from the column order in source.schema
         int[] positionMapping = new int[actualDimensionRequests.size() + requestedMetrics.size()];
@@ -201,8 +198,7 @@ public class GoogleWebmasterExtractor implements Extractor<String, String[]> {
       }
       GoogleWebmasterExtractorIterator done = _iterators.remove();
       _positionMaps.remove();
-      log.info(
-          String.format("Iterator Job Finished for site %s at country %s. ^_^", done.getProperty(), done.getCountry()));
+      log.info(done.toString() + " finished successfully. ^_^");
     }
 
     _successful = true;
@@ -220,7 +216,11 @@ public class GoogleWebmasterExtractor implements Extractor<String, String[]> {
       _iterators.add(new GoogleWebmasterExtractorIterator(iter));
     }
     _positionMaps = new ArrayDeque<>(_positionMapsOrig);
-    return _iterators.peek();
+    log.info(String.format("Finished resetting extractor due to failure in '%s'", iterator.toString()));
+
+    GoogleWebmasterExtractorIterator head = _iterators.peek();
+    log.info(String.format("Restarting extractor from the beginning '%s'", head.toString()));
+    return head;
   }
 
   @Override

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
@@ -219,6 +219,13 @@ public class GoogleWebmasterExtractor implements Extractor<String, String[]> {
     log.info(String.format("Finished resetting extractor due to failure in '%s'", iterator.toString()));
 
     GoogleWebmasterExtractorIterator head = _iterators.peek();
+    try {
+      //Sleep 30 seconds before restarting. Gobblin doesn't sleep for the first retry.
+      //See the quote limit at https://developers.google.com/webmaster-tools/search-console-api-original/v3/limits
+      Thread.sleep(30000);
+    } catch (InterruptedException e) {
+      throw new RuntimeException(e);
+    }
     log.info(String.format("Restarting extractor from the beginning '%s'", head.toString()));
     return head;
   }

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractor.java
@@ -219,13 +219,6 @@ public class GoogleWebmasterExtractor implements Extractor<String, String[]> {
     log.info(String.format("Finished resetting extractor due to failure in '%s'", iterator.toString()));
 
     GoogleWebmasterExtractorIterator head = _iterators.peek();
-    try {
-      //Sleep 30 seconds before restarting. Gobblin doesn't sleep for the first retry.
-      //See the quote limit at https://developers.google.com/webmaster-tools/search-console-api-original/v3/limits
-      Thread.sleep(30000);
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    }
     log.info(String.format("Restarting extractor from the beginning '%s'", head.toString()));
     return head;
   }

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -123,8 +123,7 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
     // https://developers.google.com/webmaster-tools/search-console-api-original/v3/limits
     // Setting the default QPS to be 2 batches per second with a batch of size 2.
     // So the default QPS is set at 2*2=4.
-    double batchesPerSecond =
-        wuState.getPropAsDouble(GoogleWebMasterSource.KEY_QUERIES_TUNING_BATCHES_PER_SECOND, 2);
+    double batchesPerSecond = wuState.getPropAsDouble(GoogleWebMasterSource.KEY_QUERIES_TUNING_BATCHES_PER_SECOND, 2);
     Preconditions.checkArgument(batchesPerSecond > 0, "Requests per second must be positive.");
 
     BATCH_SIZE = wuState.getPropAsInt(GoogleWebMasterSource.KEY_QUERIES_TUNING_BATCH_SIZE, 2);
@@ -303,7 +302,7 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
         log.info(String
             .format("ResponseProducer finishes for %s from %s to %s at retry round %d", _country, _startDate, _endDate,
                 r));
-      } catch (Exception e) {
+      } catch (InterruptedException e) {
         log.info(GoogleWebmasterExtractorIterator.this.toString() + " failed while executing the ResponseProducer");
         _failed = true;
         sleepBeforeRetry();

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -119,8 +119,12 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
     ROUND_COOL_DOWN = wuState.getPropAsInt(GoogleWebMasterSource.KEY_QUERIES_TUNING_COOL_DOWN, 250);
     Preconditions.checkArgument(ROUND_COOL_DOWN >= 0, "Initial cool down time cannot be negative.");
 
+    // QPS limit can be found at
+    // https://developers.google.com/webmaster-tools/search-console-api-original/v3/limits
+    // Setting the default QPS to be 2 batches per second with a batch of size 2.
+    // So the default QPS is set at 2*2=4.
     double batchesPerSecond =
-        wuState.getPropAsDouble(GoogleWebMasterSource.KEY_QUERIES_TUNING_BATCHES_PER_SECOND, 2.25);
+        wuState.getPropAsDouble(GoogleWebMasterSource.KEY_QUERIES_TUNING_BATCHES_PER_SECOND, 2);
     Preconditions.checkArgument(batchesPerSecond > 0, "Requests per second must be positive.");
 
     BATCH_SIZE = wuState.getPropAsInt(GoogleWebMasterSource.KEY_QUERIES_TUNING_BATCH_SIZE, 2);

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -148,7 +148,7 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
       Collection<ProducerJob> allJobs = _webmaster.getAllPages(_startDate, _endDate, _country, PAGE_LIMIT);
       return new ResponseProducer(allJobs);
     } catch (Exception e) {
-      log.info(String.format(this.toString() + " failed while creating a ResponseProducer"));
+      log.info(this.toString() + " failed while creating a ResponseProducer", e);
       _failed = true;
       sleepBeforeRetry();
       throw new RuntimeException(e);
@@ -157,11 +157,6 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
 
   public boolean isFailed() {
     return _failed;
-  }
-
-  public void reset() {
-    log.info("Resetting " + this.toString());
-    _failed = false;
   }
 
   public String getCountry() {
@@ -175,8 +170,8 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
   @Override
   public String toString() {
     return String
-        .format("GoogleWebmasterExtractorIterator{property=%s, startDate=%s, endDate=%s, country=%s, failed=%s}",
-            getProperty(), _startDate, _endDate, _country, _failed);
+        .format("GoogleWebmasterExtractorIterator{property=%s, startDate=%s, endDate=%s, country=%s}", getProperty(),
+            _startDate, _endDate, _country);
   }
 
   private static void sleepBeforeRetry() {

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -372,7 +372,7 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
                 public void onFailure(GoogleJsonError e, HttpHeaders responseHeaders)
                     throws IOException {
                   producer.onFailure(e.getMessage(), job, retries);
-                  log.info(job.getPage() + " failed");
+                  log.debug(job.getPage() + " failed");
                 }
 
                 @Override
@@ -382,12 +382,12 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
                   List<String[]> results =
                       GoogleWebmasterDataFetcher.convertResponse(_requestedMetrics, searchAnalyticsQueryResponse);
                   producer.onSuccess(job, results, responseQueue, retries);
-                  log.info(job.getPage() + " succeeded");
+                  log.debug(job.getPage() + " succeeded");
                 }
               });
             }
 
-            log.info("Submitting jobs: " + Arrays.toString(jobPages.toArray()));
+            log.debug("Submitting jobs: " + Arrays.toString(jobPages.toArray()));
             LIMITER.acquirePermits(1);
             _webmaster
                 .performSearchAnalyticsQueryInBatch(jobs, filterList, callbackList, _requestedDimensions, QUERY_LIMIT);

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -140,12 +140,11 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
   @Override
   protected Runnable getProducerRunnable() {
     try {
+      log.info("Start getting all pages for " + this.toString());
       Collection<ProducerJob> allJobs = _webmaster.getAllPages(_startDate, _endDate, _country, PAGE_LIMIT);
       return new ResponseProducer(allJobs);
     } catch (Exception e) {
-      log.info(String
-          .format("Iterator failed while creating a ResponseProducer for %s at %s from [%s, %s] ", getProperty(),
-              _country, _startDate, _endDate));
+      log.info(String.format(this.toString() + " failed while creating a ResponseProducer"));
       _failed = true;
       throw new RuntimeException(e);
     }
@@ -156,8 +155,7 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
   }
 
   public void reset() {
-    log.info(
-        String.format("Resetting iterator for %s at %s from [%s, %s] ", getProperty(), _country, _startDate, _endDate));
+    log.info("Resetting " + this.toString());
     _failed = false;
   }
 
@@ -167,6 +165,13 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
 
   public String getProperty() {
     return _webmaster.getSiteProperty();
+  }
+
+  @Override
+  public String toString() {
+    return String
+        .format("GoogleWebmasterExtractorIterator{property=%s, startDate=%s, endDate=%s, country=%s, failed=%s}",
+            getProperty(), _startDate, _endDate, _country, _failed);
   }
 
   /**

--- a/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
+++ b/gobblin-modules/google-ingestion/src/main/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorIterator.java
@@ -432,7 +432,7 @@ class GoogleWebmasterExtractorIterator extends AsyncIteratorWithDataSink<String[
         }
       }
 
-      log.debug(String.format("Finished %s. Records %d.", job, size));
+      log.debug(String.format("Finished %s. Current Queue size: %d. Record size: %d.", job, responseQueue.size(), size));
       try {
         for (String[] r : results) {
           responseQueue.put(r);

--- a/gobblin-modules/google-ingestion/src/test/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/gobblin/ingestion/google/webmaster/GoogleWebmasterDataFetcherImplTest.java
@@ -89,7 +89,7 @@ public class GoogleWebmasterDataFetcherImplTest {
     }
 
     Assert.assertTrue(CollectionUtils.isEqualCollection(pageStrings, allPages));
-    Mockito.verify(client, Mockito.times(1))
+    Mockito.verify(client, Mockito.times(2))
         .getPages(eq(_property), any(String.class), any(String.class), eq("ALL"), any(Integer.class), any(List.class),
             any(List.class), eq(0));
   }

--- a/gobblin-modules/google-ingestion/src/test/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorTest.java
@@ -77,7 +77,6 @@ public class GoogleWebmasterExtractorTest {
         responseToOutputSchema.get(1)); //country is Country.ALL, so the country request will be removed.
     Assert.assertEquals(new int[]{2, 1, 0}, responseToOutputSchema.get(2));
     Assert.assertEquals(new int[]{2, 0}, responseToOutputSchema.get(3));
-    Assert.assertTrue(responseToOutputSchema.isEmpty());
   }
 
   public static WorkUnitState getWorkUnitState1() {

--- a/gobblin-modules/google-ingestion/src/test/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorTest.java
+++ b/gobblin-modules/google-ingestion/src/test/java/gobblin/ingestion/google/webmaster/GoogleWebmasterExtractorTest.java
@@ -22,7 +22,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Queue;
 
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -64,19 +63,20 @@ public class GoogleWebmasterExtractorTest {
             wuState.getWorkunit().getExpectedHighWatermark(LongWatermark.class).getValue(), positionMap, dimensions,
             metrics, null, Arrays.asList(dataFetcher1, dataFetcher2));
 
-    Queue<GoogleWebmasterExtractorIterator> iterators = extractor.getIterators();
-    Assert.assertEquals("USA", iterators.poll().getCountry());
-    Assert.assertEquals("ALL", iterators.poll().getCountry());
-    Assert.assertEquals("USA", iterators.poll().getCountry());
-    Assert.assertEquals("ALL", iterators.poll().getCountry());
-    Assert.assertTrue(iterators.isEmpty());
+    List<GoogleWebmasterExtractorIterator> iterators = extractor.getIterators();
+    Assert.assertEquals(iterators.size(), 4);
+    Assert.assertEquals(iterators.get(0).getCountry(), "USA");
+    Assert.assertEquals(iterators.get(1).getCountry(), "ALL");
+    Assert.assertEquals(iterators.get(2).getCountry(), "USA");
+    Assert.assertEquals(iterators.get(3).getCountry(), "ALL");
 
-    Queue<int[]> responseToOutputSchema = extractor.getPositionMaps();
-    Assert.assertEquals(new int[]{2, 1, 0}, responseToOutputSchema.poll()); //country is Country.USA
+    List<int[]> responseToOutputSchema = extractor.getPositionMaps();
+    Assert.assertEquals(responseToOutputSchema.size(), 4);
+    Assert.assertEquals(new int[]{2, 1, 0}, responseToOutputSchema.get(0)); //country is Country.USA
     Assert.assertEquals(new int[]{2, 0},
-        responseToOutputSchema.poll()); //country is Country.ALL, so the country request will be removed.
-    Assert.assertEquals(new int[]{2, 1, 0}, responseToOutputSchema.poll());
-    Assert.assertEquals(new int[]{2, 0}, responseToOutputSchema.poll());
+        responseToOutputSchema.get(1)); //country is Country.ALL, so the country request will be removed.
+    Assert.assertEquals(new int[]{2, 1, 0}, responseToOutputSchema.get(2));
+    Assert.assertEquals(new int[]{2, 0}, responseToOutputSchema.get(3));
     Assert.assertTrue(responseToOutputSchema.isEmpty());
   }
 


### PR DESCRIPTION
Due to the limitation of Gobblin's retry mechanism, Gobblin doesn't reset the state of extractors, or cannot create new extractor objects, when doing retries. Therefore, do this PR to keep the states in iterators and reset the extractor to restart from the very beginning if necessary. This PR also improves the error handling and logging for the GSC module. This PR also fixes a bug in AsyncIteratorWithDataSink which is causing a deadlock with LinkedBlockingDeque.