### PR TITLE
Remove record count from state because setting operation is not threa…

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/CompactionAvroJobConfigurator.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/CompactionAvroJobConfigurator.java
@@ -6,6 +6,7 @@ import com.google.common.collect.Sets;
 import com.google.common.primitives.Ints;
 import gobblin.compaction.mapreduce.avro.*;
 import gobblin.compaction.parser.CompactionPathParser;
+import gobblin.compaction.verify.InputRecordCountHelper;
 import gobblin.configuration.ConfigurationKeys;
 import gobblin.configuration.State;
 import gobblin.dataset.Dataset;
@@ -56,6 +57,8 @@ public class CompactionAvroJobConfigurator {
   protected boolean isJobCreated = false;
   @Getter
   protected Collection<Path> mapReduceInputPaths = null;
+  @Getter
+  private long fileNameRecordCount = 0;
 
   /**
    * Constructor
@@ -291,21 +294,33 @@ public class CompactionAvroJobConfigurator {
    */
   protected Collection<Path> getGranularInputPaths (Path path) throws IOException {
 
-    boolean renamingRequired = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_ENABLED,
+    boolean appendDelta = this.state.getPropAsBoolean(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_ENABLED,
             MRCompactor.DEFAULT_COMPACTION_RENAME_SOURCE_DIR_ENABLED);
 
-    Set<Path> output = Sets.newHashSet();
+    Set<Path> uncompacted = Sets.newHashSet();
+    Set<Path> total = Sets.newHashSet();
+
     for (FileStatus fileStatus : FileListUtils.listFilesRecursively(fs, path)) {
-      if (renamingRequired) {
+      if (appendDelta) {
+        // use source dir suffix to identify the delta input paths
         if (!fileStatus.getPath().getParent().toString().endsWith(MRCompactor.COMPACTION_RENAME_SOURCE_DIR_SUFFIX)) {
-          output.add(fileStatus.getPath().getParent());
+          uncompacted.add(fileStatus.getPath().getParent());
         }
+        total.add(fileStatus.getPath().getParent());
       } else {
-        output.add(fileStatus.getPath().getParent());
+        uncompacted.add(fileStatus.getPath().getParent());
       }
     }
 
-    return output;
+    if (appendDelta) {
+      // When the output record count from mr counter doesn't match
+      // the record count from input file names, we prefer file names because
+      // it will be used to calculate the difference of count in next run.
+      this.fileNameRecordCount = new InputRecordCountHelper(this.state).calculateRecordCount (total);
+      log.info ("{} has total input record count (based on file name) {}", path, this.fileNameRecordCount);
+    }
+
+    return uncompacted;
   }
 }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/verify/CompactionThresholdVerifier.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/verify/CompactionThresholdVerifier.java
@@ -59,7 +59,6 @@ public class CompactionThresholdVerifier implements CompactionVerifier<FileSyste
       double oldRecords = InputRecordCountHelper.readRecordCount (helper.getFs(), new Path(result.getDstAbsoluteDir()));
 
       log.info ("Dataset {} : previous records {}, current records {}", dataset.datasetURN(), oldRecords, newRecords);
-      this.state.setProp(InputRecordCountHelper.INPUT_TOTAL_RECORD_COUNT, (long)newRecords);
       if (oldRecords == 0) {
         return true;
       }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/verify/InputRecordCountHelper.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/verify/InputRecordCountHelper.java
@@ -39,7 +39,7 @@ public class InputRecordCountHelper {
   private final String AVRO = "avro";
 
   public final static String RECORD_COUNT_FILE = "_record_count";
-  public final static String INPUT_TOTAL_RECORD_COUNT = "input.total.record.count";
+
   /**
    * Constructor
    */


### PR DESCRIPTION
@htran1 , this is to follow up the last PR1892 where the record count is passing by state. This could cause parallelism issue.