### PR TITLE
gobblin-docker files for 0.9.0 and 0.10.0 release

### DIFF
--- a/gobblin-docker/gobblin-distributions/ubuntu-gobblin-0.10.0/Dockerfile
+++ b/gobblin-docker/gobblin-distributions/ubuntu-gobblin-0.10.0/Dockerfile
@@ -1,0 +1,12 @@
+FROM gobblin/gobblin-base:ubuntu
+
+ENV RELEASE_VERSION "0.10.0"
+
+RUN mkdir -p /opt/gobblin/
+WORKDIR /opt/gobblin/
+
+# Download gobblin-distribution-$RELEASE_VERSION
+RUN curl -OL --progress-bar https://github.com/linkedin/gobblin/releases/download/gobblin_$RELEASE_VERSION/gobblin-distribution-$RELEASE_VERSION.tar.gz
+
+# Un-tar gobblin-distribution-$RELEASE_VERSION
+RUN tar -xf gobblin-distribution-$RELEASE_VERSION.tar.gz

--- a/gobblin-docker/gobblin-distributions/ubuntu-gobblin-0.9.0/Dockerfile
+++ b/gobblin-docker/gobblin-distributions/ubuntu-gobblin-0.9.0/Dockerfile
@@ -1,0 +1,12 @@
+FROM gobblin/gobblin-base:ubuntu
+
+ENV RELEASE_VERSION "0.9.0"
+
+RUN mkdir -p /opt/gobblin/
+WORKDIR /opt/gobblin/
+
+# Download gobblin-distribution-$RELEASE_VERSION
+RUN curl -OL --progress-bar https://github.com/linkedin/gobblin/releases/download/gobblin_$RELEASE_VERSION/gobblin-distribution-$RELEASE_VERSION.tar.gz
+
+# Un-tar gobblin-distribution-$RELEASE_VERSION
+RUN tar -xf gobblin-distribution-$RELEASE_VERSION.tar.gz

--- a/gobblin-docker/gobblin-standalone/ubuntu-gobblin-0.10.0/Dockerfile
+++ b/gobblin-docker/gobblin-standalone/ubuntu-gobblin-0.10.0/Dockerfile
@@ -1,0 +1,9 @@
+FROM gobblin/gobblin-distributions:ubuntu-gobblin-0.10.0
+
+RUN mkdir -p /etc/opt/job-conf
+RUN mkdir -p /home/gobblin/work-dir
+
+ENV GOBBLIN_WORK_DIR /home/gobblin/work-dir
+ENV GOBBLIN_JOB_CONFIG_DIR /etc/opt/job-conf
+
+CMD ["java", "-cp", "/opt/gobblin/gobblin-dist/lib/*", "-Dlog4j.configuration=file:/opt/gobblin/gobblin-dist/conf/log4j-standalone.xml", "-Dgobblin.logs.dir=/var/log/gobblin", "-Dorg.quartz.properties=/opt/gobblin/gobblin-dist/conf/quartz.properties", "gobblin.scheduler.SchedulerDaemon", "/opt/gobblin/gobblin-dist/conf/gobblin-standalone.properties"]

--- a/gobblin-docker/gobblin-standalone/ubuntu-gobblin-0.9.0/Dockerfile
+++ b/gobblin-docker/gobblin-standalone/ubuntu-gobblin-0.9.0/Dockerfile
@@ -1,0 +1,9 @@
+FROM gobblin/gobblin-distributions:ubuntu-gobblin-0.9.0
+
+RUN mkdir -p /etc/opt/job-conf
+RUN mkdir -p /home/gobblin/work-dir
+
+ENV GOBBLIN_WORK_DIR /home/gobblin/work-dir
+ENV GOBBLIN_JOB_CONFIG_DIR /etc/opt/job-conf
+
+CMD ["java", "-cp", "/opt/gobblin/gobblin-dist/lib/*", "-Dlog4j.configuration=file:/opt/gobblin/gobblin-dist/conf/log4j-standalone.xml", "-Dgobblin.logs.dir=/var/log/gobblin", "-Dorg.quartz.properties=/opt/gobblin/gobblin-dist/conf/quartz.properties", "gobblin.scheduler.SchedulerDaemon", "/opt/gobblin/gobblin-dist/conf/gobblin-standalone.properties"]

--- a/gobblin-docker/gobblin-standalone/ubuntu-gobblin-latest
+++ b/gobblin-docker/gobblin-standalone/ubuntu-gobblin-latest
@@ -1,1 +1,1 @@
-ubuntu-gobblin-0.8.0
+ubuntu-gobblin-0.10.0

--- a/gobblin-docker/gobblin-wikipedia/ubuntu-gobblin-0.10.0/Dockerfile
+++ b/gobblin-docker/gobblin-wikipedia/ubuntu-gobblin-0.10.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM gobblin/gobblin-distributions:ubuntu-gobblin-0.10.0
+
+ENV RELEASE_VERSION "0.10.0"
+ENV GOBBLIN_WORK_DIR /home/gobblin/work-dir
+
+RUN echo "Downloading Gobblin Wikipedia Configuration Files"
+RUN mkdir -p /etc/opt/gobblin/job-conf
+
+# Downloading wikipedia.pull
+RUN curl -L --progress-bar https://raw.githubusercontent.com/linkedin/gobblin/gobblin_$RELEASE_VERSION/gobblin-example/src/main/resources/wikipedia.pull -o /etc/opt/gobblin/job-conf/wikipedia.pull
+
+# Start Gobblin Wikipedia Example
+CMD ["java", "-cp", "/opt/gobblin/gobblin-dist/lib/*", "-Dlog4j.configuration=file:/opt/gobblin/gobblin-dist/conf/log4j.properties", "gobblin.runtime.local.CliLocalJobLauncher", "--sysconfig", "/opt/gobblin/gobblin-dist/conf/gobblin-cli.properties", "--jobconfig", "/etc/opt/gobblin/job-conf/wikipedia.pull"]

--- a/gobblin-docker/gobblin-wikipedia/ubuntu-gobblin-0.9.0/Dockerfile
+++ b/gobblin-docker/gobblin-wikipedia/ubuntu-gobblin-0.9.0/Dockerfile
@@ -1,0 +1,13 @@
+FROM gobblin/gobblin-distributions:ubuntu-gobblin-0.9.0
+
+ENV RELEASE_VERSION "0.9.0"
+ENV GOBBLIN_WORK_DIR /home/gobblin/work-dir
+
+RUN echo "Downloading Gobblin Wikipedia Configuration Files"
+RUN mkdir -p /etc/opt/gobblin/job-conf
+
+# Downloading wikipedia.pull
+RUN curl -L --progress-bar https://raw.githubusercontent.com/linkedin/gobblin/gobblin_$RELEASE_VERSION/gobblin-example/src/main/resources/wikipedia.pull -o /etc/opt/gobblin/job-conf/wikipedia.pull
+
+# Start Gobblin Wikipedia Example
+CMD ["java", "-cp", "/opt/gobblin/gobblin-dist/lib/*", "-Dlog4j.configuration=file:/opt/gobblin/gobblin-dist/conf/log4j.properties", "gobblin.runtime.local.CliLocalJobLauncher", "--sysconfig", "/opt/gobblin/gobblin-dist/conf/gobblin-cli.properties", "--jobconfig", "/etc/opt/gobblin/job-conf/wikipedia.pull"]

--- a/gobblin-docker/gobblin-wikipedia/ubuntu-gobblin-latest
+++ b/gobblin-docker/gobblin-wikipedia/ubuntu-gobblin-latest
@@ -1,1 +1,1 @@
-ubuntu-gobblin-0.8.0
+ubuntu-gobblin-0.10.0

--- a/gobblin-docs/user-guide/Docker-Integration.md
+++ b/gobblin-docs/user-guide/Docker-Integration.md
@@ -2,11 +2,9 @@
 
 [TOC]
 
-**Disclaimer: Gobblin-Docker integration is currently in beta.**
-
 # Introduction
 
-Gobblin integrates with Docker by running a Gobblin standalone service inside a Docker container. The Gobblin service inside the container can monitor the host filesystem for new job configuration files, run the jobs, and write the resulting data to the host filesystem.
+Gobblin integrates with Docker by running a Gobblin standalone service inside a Docker container. The Gobblin service inside the container can monitor the host filesystem for new job configuration files, run the jobs, and write the resulting data to the host filesystem. The Gobblin Docker images can be found on Docker Hub at: https://hub.docker.com/u/gobblin/
 
 # Docker
 
@@ -14,7 +12,7 @@ For more information on Docker, including how to install it, check out the docum
 
 # Docker Repositories
 
-Gobblin currently has four different repositories, and all are on Docker Hub.
+Gobblin currently has four different repositories, and all are on Docker Hub [here](https://hub.docker.com/u/gobblin/).
 
 The `gobblin/gobblin-wikipedia` repository contains images that run the Gobblin Wikipedia job found in the [getting started guide](../Getting-Started). These images are useful for users new to Docker or Gobblin, they primarily act as a "Hello World" example for the Gobblin Docker integration.
 
@@ -45,7 +43,7 @@ The logs are printed to the console, and no errors should pop up. This should pr
 * Preserving the output of a Docker container requires using a [data volume](https://docs.docker.com/engine/tutorials/dockervolumes/). To do this, run the below command:
 
 ```
-docker run -v /home/gobblin/work-dir:/home/gobblin/work-dir gobblin-standalone
+docker run -v /home/gobblin/work-dir:/home/gobblin/work-dir gobblin-wikipedia
 ```
 
 The output of the Gobblin-Wikipedia job should now be written to `/home/gobblin/work-dir/job-output`. The `-v` command in Docker uses a feature of Docker called [data volumes](https://docs.docker.com/engine/tutorials/dockervolumes/). The `-v` option mounts a host directory into a container and is of the form `[host-directory]:[container-directory]`. Now any modifications to the host directory can be seen inside the container-directory, and any modifications to the container-directory can be seen inside the host-directory. This is a standard way to ensure data persists even after a Docker container finishes. It's important to note that the `[host-directory]` in the `-v` option can be changed to any directory (on OSX it must be under the `/Users/` directory), but the `[container-directory]` must remain `/home/gobblin/work-dir` (at least for now).


### PR DESCRIPTION
Only had time to test that the `gobblin-wikipedia` files work, haven't had time to test the `gobblin-standalone` files work correctly.

Haven't pushed the image to Docker Hub yet, publishing the Docker files here first for review.