### PR TITLE
issue 1901 add any properties from the collected workunits to the compacted Workunit

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/source/extractor/extract/kafka/workunit/packer/KafkaWorkUnitPacker.java
@@ -221,6 +221,8 @@ public abstract class KafkaWorkUnitPacker {
 
   /**
    * Combine all {@link WorkUnit}s in the {@link MultiWorkUnit} into a single {@link WorkUnit}.
+   *
+   * all WorkUnits need to either be empty or belong to the same topic 
    */
   protected WorkUnit squeezeMultiWorkUnit(MultiWorkUnit multiWorkUnit) {
     WatermarkInterval interval = getWatermarkIntervalFromMultiWorkUnit(multiWorkUnit);
@@ -234,6 +236,11 @@ public abstract class KafkaWorkUnitPacker {
     WorkUnit workUnit = WorkUnit.create(extract, interval);
     populateMultiPartitionWorkUnit(partitions, workUnit);
     workUnit.setProp(ESTIMATED_WORKUNIT_SIZE, multiWorkUnit.getProp(ESTIMATED_WORKUNIT_SIZE));
+
+    // copy over any topic specific settings from the old workunits
+    for (WorkUnit workUnitToCompact: multiWorkUnit.getWorkUnits()) {
+        workUnit.addAllIfNotExist(workUnitToCompact);
+    }
     LOG.info(String.format("Created MultiWorkUnit for partitions %s", partitions));
     return workUnit;
   }


### PR DESCRIPTION
This used to drop any topic specific settings when using the BI_LEVEL workunitpacker.

also made it more explicit in the documentation about what workunits the squeezeMultiWorkUnit method is supposed to work with.

See #1901 