### PR TITLE
Prevent closing before buffer is empty

### DIFF
--- a/gobblin-core/src/main/java/gobblin/async/AsyncDataDispatcher.java
+++ b/gobblin-core/src/main/java/gobblin/async/AsyncDataDispatcher.java
@@ -146,11 +146,11 @@ public abstract class AsyncDataDispatcher<D> extends AbstractExecutionThreadServ
     }
   }
 
-  protected void waitForABufferEmptyOccurrence() {
-    checkRunning("waitForABufferEmptyOccurrence");
+  protected void waitForBufferEmpty() {
+    checkRunning("waitForBufferEmpty");
     try {
       lock.lock();
-      // Waiting for a buffer empty occurrence
+      // Waiting buffer empty
       while (!buffer.isEmpty()) {
         try {
           isBufferEmpty.await();
@@ -160,7 +160,7 @@ public abstract class AsyncDataDispatcher<D> extends AbstractExecutionThreadServ
       }
     } finally {
       lock.unlock();
-      checkRunning("waitForABufferEmptyOccurrence");
+      checkRunning("waitForBufferEmpty");
     }
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/http/AbstractAsyncDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AbstractAsyncDataWriter.java
@@ -71,6 +71,6 @@ public abstract class AbstractAsyncDataWriter<D> extends AsyncDataDispatcher<Buf
   @Override
   public void flush()
       throws IOException {
-    waitForABufferEmptyOccurrence();
+    waitForBufferEmpty();
   }
 }

--- a/gobblin-core/src/test/java/gobblin/async/AsyncDataDispatcherTest.java
+++ b/gobblin-core/src/test/java/gobblin/async/AsyncDataDispatcherTest.java
@@ -22,7 +22,7 @@ public class AsyncDataDispatcherTest {
       throws ExecutionException, InterruptedException {
     final TestAsyncDataDispatcher dispatcher = new TestAsyncDataDispatcher();
     // This should work when there is nothing to process
-    dispatcher.waitForABufferEmptyOccurrence();
+    dispatcher.waitForBufferEmpty();
 
     ExecutorService service = Executors.newFixedThreadPool(2);
     Writer writer1 = new Writer(dispatcher);
@@ -141,11 +141,11 @@ public class AsyncDataDispatcherTest {
 
     hasAnException = false;
     try {
-      dispatcher.waitForABufferEmptyOccurrence();
+      dispatcher.waitForBufferEmpty();
     } catch (Exception e) {
       hasAnException = true;
     }
-    Assert.assertTrue(hasAnException, "waitForABufferEmptyOccurrence should get an exception");
+    Assert.assertTrue(hasAnException, "waitForBufferEmpty should get an exception");
 
     hasAnException = false;
     try {
@@ -241,7 +241,7 @@ public class AsyncDataDispatcherTest {
       while (!shouldExit) {
         dispather.put(new Object());
         if (shouldWaitForABufferEmpty) {
-          dispather.waitForABufferEmptyOccurrence();
+          dispather.waitForBufferEmpty();
           aBufferEmptyWaited = true;
         }
         try {


### PR DESCRIPTION
This fix the following scenario:

consumer: `buffer.size()==0`
consumer: `notifyBufferEmptyOccurrence`
producer: `buffer.put()`
producer: `close: waitForABufferEmptyOccurrence` will return immediately
producer: `close: stopAsync.awaitTermination`
consumer: `isRunning`
consumer: `return` without knowing there is a record in the buffer
