### PR TITLE
Add throttling for asynchttpwriter

### DIFF
--- a/gobblin-core/src/main/java/gobblin/http/ThrottledHttpClient.java
+++ b/gobblin-core/src/main/java/gobblin/http/ThrottledHttpClient.java
@@ -1,0 +1,56 @@
+package gobblin.http;
+
+import java.io.IOException;
+
+import org.apache.commons.lang.exception.ExceptionUtils;
+
+import com.typesafe.config.Config;
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import gobblin.broker.iface.NotConfiguredException;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.util.http.HttpLimiterKey;
+import gobblin.util.limiter.Limiter;
+import gobblin.util.limiter.broker.SharedLimiterFactory;
+
+
+/**
+ * A {@link HttpClient} for throttling calls to the underlying TX operation using the input
+ * {@link Limiter}.
+ */
+@Slf4j
+public abstract class ThrottledHttpClient<RQ, RP> implements HttpClient<RQ, RP>  {
+
+  protected final Limiter limiter;
+  protected final SharedResourcesBroker<GobblinScopeTypes> broker;
+  protected final Config config;
+
+  public ThrottledHttpClient (Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
+    this.config = config;
+    this.broker = broker;
+    try {
+      limiter = broker.getSharedResource(new SharedLimiterFactory<>(), new HttpLimiterKey(getLimiterKey ()));
+    } catch (NotConfiguredException e) {
+      log.error ("Limiter cannot be initialized due to exception " + ExceptionUtils.getFullStackTrace(e));
+      throw new RuntimeException(e);
+    }
+  }
+
+  public RP sendRequest(RQ request) throws IOException {
+    try {
+      if (limiter.acquirePermits(1) != null) {
+        log.debug ("Acquired permits successfully");
+        return sendRequestImpl (request);
+      } else {
+        throw new IOException ("Acquired permits return null");
+      }
+    } catch (InterruptedException e) {
+      throw new IOException("Throttling is interrupted");
+    }
+  }
+
+  public abstract RP sendRequestImpl (RQ request) throws IOException;
+
+  protected abstract String getLimiterKey () throws NotConfiguredException;
+}

--- a/gobblin-core/src/main/java/gobblin/http/ThrottledHttpClient.java
+++ b/gobblin-core/src/main/java/gobblin/http/ThrottledHttpClient.java
@@ -4,12 +4,17 @@ import java.io.IOException;
 
 import org.apache.commons.lang.exception.ExceptionUtils;
 
+import com.codahale.metrics.Timer;
 import com.typesafe.config.Config;
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.NotConfiguredException;
 import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.metrics.MetricContext;
+import gobblin.metrics.broker.MetricContextFactory;
+import gobblin.metrics.broker.MetricContextKey;
 import gobblin.util.http.HttpLimiterKey;
 import gobblin.util.limiter.Limiter;
 import gobblin.util.limiter.broker.SharedLimiterFactory;
@@ -26,11 +31,17 @@ public abstract class ThrottledHttpClient<RQ, RP> implements HttpClient<RQ, RP> 
   protected final SharedResourcesBroker<GobblinScopeTypes> broker;
   protected final Config config;
 
+  @Getter
+  private final Timer sendTimer;
+  private final MetricContext metricContext;
+
   public ThrottledHttpClient (Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
     this.config = config;
     this.broker = broker;
     try {
-      limiter = broker.getSharedResource(new SharedLimiterFactory<>(), new HttpLimiterKey(getLimiterKey ()));
+      this.limiter = broker.getSharedResource(new SharedLimiterFactory<>(), new HttpLimiterKey(getLimiterKey ()));
+      this.metricContext = broker.getSharedResource(new MetricContextFactory<>(), new MetricContextKey());
+      this.sendTimer = this.metricContext.timer(getLimiterKey());
     } catch (NotConfiguredException e) {
       log.error ("Limiter cannot be initialized due to exception " + ExceptionUtils.getFullStackTrace(e));
       throw new RuntimeException(e);
@@ -38,6 +49,7 @@ public abstract class ThrottledHttpClient<RQ, RP> implements HttpClient<RQ, RP> 
   }
 
   public RP sendRequest(RQ request) throws IOException {
+    final Timer.Context context = sendTimer.time();
     try {
       if (limiter.acquirePermits(1) != null) {
         log.debug ("Acquired permits successfully");
@@ -47,6 +59,8 @@ public abstract class ThrottledHttpClient<RQ, RP> implements HttpClient<RQ, RP> 
       }
     } catch (InterruptedException e) {
       throw new IOException("Throttling is interrupted");
+    } finally {
+      context.stop();
     }
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/http/AsyncHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AsyncHttpWriter.java
@@ -20,6 +20,7 @@ package gobblin.writer.http;
 import java.io.IOException;
 import java.util.Queue;
 
+import lombok.extern.slf4j.Slf4j;
 import gobblin.async.DispatchException;
 import gobblin.http.HttpClient;
 import gobblin.http.ResponseHandler;
@@ -35,17 +36,17 @@ import gobblin.writer.WriteResponse;
  * @param <RQ> type of request
  * @param <RP> type of response
  */
+@Slf4j
 public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
   public static final int DEFAULT_MAX_ATTEMPTS = 3;
-
-  private final HttpClient<RQ, RP> client;
+  private final HttpClient<RQ, RP> httpClient;
   private final ResponseHandler<RP> responseHandler;
   private final AsyncWriteRequestBuilder<D, RQ> requestBuilder;
   private final int maxAttempts;
 
   public AsyncHttpWriter(AsyncHttpWriterBuilder builder) {
     super(builder.getQueueCapacity());
-    this.client = builder.getClient();
+    this.httpClient = builder.getClient();
     this.requestBuilder = builder.getAsyncRequestBuilder();
     this.responseHandler = builder.getResponseHandler();
     this.maxAttempts = builder.getMaxAttempts();
@@ -64,7 +65,7 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
     int attempt = 0;
     while (attempt < maxAttempts) {
       try {
-        response = client.sendRequest(rawRequest);
+          response = httpClient.sendRequest(rawRequest);
       } catch (IOException e) {
         // Retry
         attempt++;
@@ -105,7 +106,7 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
     try {
       super.close();
     } finally {
-      client.close();
+      httpClient.close();
     }
   }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/http/AsyncHttpWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/http/AsyncHttpWriter.java
@@ -20,11 +20,16 @@ package gobblin.writer.http;
 import java.io.IOException;
 import java.util.Queue;
 
+import com.codahale.metrics.Timer;
+
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import gobblin.async.DispatchException;
 import gobblin.http.HttpClient;
 import gobblin.http.ResponseHandler;
 import gobblin.http.ResponseStatus;
+import gobblin.instrumented.Instrumented;
+import gobblin.metrics.MetricContext;
 import gobblin.writer.WriteResponse;
 
 
@@ -39,10 +44,16 @@ import gobblin.writer.WriteResponse;
 @Slf4j
 public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
   public static final int DEFAULT_MAX_ATTEMPTS = 3;
+  public static final String DISPATCH_TIMER = "dispatch.timer";
+
   private final HttpClient<RQ, RP> httpClient;
   private final ResponseHandler<RP> responseHandler;
   private final AsyncWriteRequestBuilder<D, RQ> requestBuilder;
   private final int maxAttempts;
+  private final MetricContext metricContext;
+
+  @Getter
+  private final Timer dispatchTimer;
 
   public AsyncHttpWriter(AsyncHttpWriterBuilder builder) {
     super(builder.getQueueCapacity());
@@ -50,6 +61,8 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
     this.requestBuilder = builder.getAsyncRequestBuilder();
     this.responseHandler = builder.getResponseHandler();
     this.maxAttempts = builder.getMaxAttempts();
+    this.metricContext = Instrumented.getMetricContext(builder.getState(), AsyncHttpWriter.class);
+    this.dispatchTimer = this.metricContext.timer(DISPATCH_TIMER);
   }
 
   @Override
@@ -64,6 +77,7 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
 
     int attempt = 0;
     while (attempt < maxAttempts) {
+      final Timer.Context context = dispatchTimer.time();
       try {
           response = httpClient.sendRequest(rawRequest);
       } catch (IOException e) {
@@ -75,6 +89,8 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
         } else {
           continue;
         }
+      } finally {
+        context.stop();
       }
 
       ResponseStatus status = responseHandler.handleResponse(response);

--- a/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
@@ -9,25 +9,39 @@ import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.testng.annotations.Test;
 
+import com.google.common.base.Joiner;
+import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
 
 import junit.framework.Assert;
+import lombok.extern.slf4j.Slf4j;
 
-import gobblin.configuration.State;
+import gobblin.broker.BrokerConstants;
+import gobblin.broker.SharedResourcesBrokerFactory;
+import gobblin.broker.SharedResourcesBrokerImpl;
+import gobblin.broker.SimpleScopeType;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.configuration.WorkUnitState;
 import gobblin.http.HttpClient;
 import gobblin.http.ResponseHandler;
 import gobblin.http.ResponseStatus;
 import gobblin.http.StatusType;
+import gobblin.http.ThrottledHttpClient;
+import gobblin.util.limiter.RateBasedLimiter;
+import gobblin.util.limiter.broker.SharedLimiterFactory;
 import gobblin.writer.DataWriter;
 import gobblin.writer.WriteCallback;
 import gobblin.writer.WriteResponse;
 
 
 @Test
+@Slf4j
 public class AsyncHttpWriterTest {
   /**
    * Test successful writes of 4 records
    */
+  @Test
   public void testSuccessfulWrites() {
     MockHttpClient client = new MockHttpClient();
     MockRequestBuilder requestBuilder = new MockRequestBuilder();
@@ -62,6 +76,47 @@ public class AsyncHttpWriterTest {
     }
 
     Assert.assertTrue(client.isCloseCalled);
+  }
+
+  @Test
+  public void testSuccessfulWritesWithLimiter () {
+    MockThrottledHttpClient client = new MockThrottledHttpClient(null, createMockBroker());
+    MockRequestBuilder requestBuilder = new MockRequestBuilder();
+    MockResponseHandler responseHandler = new MockResponseHandler();
+    MockAsyncHttpWriterBuilder builder = new MockAsyncHttpWriterBuilder(client, requestBuilder, responseHandler);
+    TestAsyncHttpWriter asyncHttpWriter = new TestAsyncHttpWriter(builder);
+
+    List<MockWriteCallback> callbacks = new ArrayList<>();
+
+    for (int i = 0; i < 50; i++) {
+      MockWriteCallback callback = new MockWriteCallback();
+      callbacks.add(callback);
+      asyncHttpWriter.write(new Object(), callback);
+    }
+
+    try {
+      asyncHttpWriter.close();
+    } catch (IOException e) {
+      Assert.fail("Close failed");
+    }
+
+    // Assert all successful callbacks are invoked
+    for (MockWriteCallback callback : callbacks) {
+      Assert.assertTrue(callback.isSuccess);
+    }
+
+    Assert.assertTrue(client.isCloseCalled);
+  }
+
+  private static SharedResourcesBroker createMockBroker() {
+    Joiner JOINER = Joiner.on(".");
+    Config config = ConfigFactory.parseMap(ImmutableMap.of(
+        JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, SharedLimiterFactory.NAME, SharedLimiterFactory.LIMITER_CLASS_KEY), "qps",
+        JOINER.join(BrokerConstants.GOBBLIN_BROKER_CONFIG_PREFIX, SharedLimiterFactory.NAME, RateBasedLimiter.Factory.QPS_KEY), "10"
+    ));
+
+    SharedResourcesBrokerImpl broker = SharedResourcesBrokerFactory.<SimpleScopeType>createDefaultTopLevelBroker(config, SimpleScopeType.GLOBAL.defaultScopeInstance());
+    return broker;
   }
 
   /**
@@ -169,6 +224,36 @@ public class AsyncHttpWriterTest {
     }
   }
 
+  class MockThrottledHttpClient extends ThrottledHttpClient<HttpUriRequest, CloseableHttpResponse> {
+    boolean isCloseCalled = false;
+    int attempts = 0;
+    boolean shouldSendSucceed = true;
+    public MockThrottledHttpClient (Config config, SharedResourcesBroker broker) {
+      super (config, broker);
+    }
+    @Override
+    public CloseableHttpResponse sendRequestImpl(HttpUriRequest request)
+        throws IOException {
+      attempts++;
+      if (shouldSendSucceed) {
+        // We won't consume the response anyway
+        return null;
+      }
+      throw new IOException("Send failed");
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+      isCloseCalled = true;
+    }
+
+    @Override
+    public String getLimiterKey() {
+      return "resource";
+    }
+  }
+
   class MockRequestBuilder implements AsyncWriteRequestBuilder<Object, HttpUriRequest> {
 
     @Override
@@ -215,12 +300,12 @@ public class AsyncHttpWriterTest {
   }
 
   class MockAsyncHttpWriterBuilder extends AsyncHttpWriterBuilder<Object, HttpUriRequest, CloseableHttpResponse> {
-    MockAsyncHttpWriterBuilder(MockHttpClient client, MockRequestBuilder requestBuilder,
+    MockAsyncHttpWriterBuilder(HttpClient client, MockRequestBuilder requestBuilder,
         MockResponseHandler responseHandler) {
       this.client = client;
       this.asyncRequestBuilder = requestBuilder;
       this.responseHandler = responseHandler;
-      this.state = new State();
+      this.state = new WorkUnitState();
       this.queueCapacity = 2;
     }
 

--- a/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
@@ -105,6 +105,7 @@ public class AsyncHttpWriterTest {
       Assert.assertTrue(callback.isSuccess);
     }
 
+    Assert.assertTrue(asyncHttpWriter.getDispatchTimer().getCount() == 50);
     Assert.assertTrue(client.isCloseCalled);
   }
 

--- a/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
@@ -80,7 +80,7 @@ public class AsyncHttpWriterTest {
 
   @Test
   public void testSuccessfulWritesWithLimiter () {
-    MockThrottledHttpClient client = new MockThrottledHttpClient(null, createMockBroker());
+    MockThrottledHttpClient client = new MockThrottledHttpClient(createMockBroker());
     MockRequestBuilder requestBuilder = new MockRequestBuilder();
     MockResponseHandler responseHandler = new MockResponseHandler();
     MockAsyncHttpWriterBuilder builder = new MockAsyncHttpWriterBuilder(client, requestBuilder, responseHandler);
@@ -229,8 +229,8 @@ public class AsyncHttpWriterTest {
     boolean isCloseCalled = false;
     int attempts = 0;
     boolean shouldSendSucceed = true;
-    public MockThrottledHttpClient (Config config, SharedResourcesBroker broker) {
-      super (config, broker);
+    public MockThrottledHttpClient (SharedResourcesBroker broker) {
+      super (broker, "resource");
     }
     @Override
     public CloseableHttpResponse sendRequestImpl(HttpUriRequest request)
@@ -247,11 +247,6 @@ public class AsyncHttpWriterTest {
     public void close()
         throws IOException {
       isCloseCalled = true;
-    }
-
-    @Override
-    public String getLimiterKey() {
-      return "resource";
     }
   }
 

--- a/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
+++ b/gobblin-core/src/test/java/gobblin/writer/http/AsyncHttpWriterTest.java
@@ -105,7 +105,7 @@ public class AsyncHttpWriterTest {
       Assert.assertTrue(callback.isSuccess);
     }
 
-    Assert.assertTrue(asyncHttpWriter.getDispatchTimer().getCount() == 50);
+    Assert.assertTrue(client.getSendTimer().getCount() == 50);
     Assert.assertTrue(client.isCloseCalled);
   }
 

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
@@ -36,8 +36,8 @@ import gobblin.http.ThrottledHttpClient;
 public class R2Client extends ThrottledHttpClient<RestRequest, RestResponse> {
   private final Client client;
 
-  public R2Client(Config config, Client client, SharedResourcesBroker broker) {
-    super (config, broker);
+  public R2Client(Client client, SharedResourcesBroker broker) {
+    super (broker, getLimiterKey());
     this.client = client;
   }
 
@@ -60,7 +60,7 @@ public class R2Client extends ThrottledHttpClient<RestRequest, RestResponse> {
     client.shutdown(Callbacks.<None>empty());
   }
 
-  public String getLimiterKey () throws NotConfiguredException {
+  private static String getLimiterKey () {
     return "D2request/" + "serviceName";
   }
 }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
@@ -26,19 +26,23 @@ import com.linkedin.common.util.None;
 import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestResponse;
 import com.linkedin.r2.transport.common.Client;
+import com.typesafe.config.Config;
 
-import gobblin.http.HttpClient;
+import gobblin.broker.iface.NotConfiguredException;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.http.ThrottledHttpClient;
 
 
-public class R2Client implements HttpClient<RestRequest, RestResponse> {
+public class R2Client extends ThrottledHttpClient<RestRequest, RestResponse> {
   private final Client client;
 
-  public R2Client(Client client) {
+  public R2Client(Config config, Client client, SharedResourcesBroker broker) {
+    super (config, broker);
     this.client = client;
   }
 
   @Override
-  public RestResponse sendRequest(RestRequest request)
+  public RestResponse sendRequestImpl(RestRequest request)
       throws IOException {
     Future<RestResponse> responseFuture = client.restRequest(request);
     RestResponse response;
@@ -54,5 +58,9 @@ public class R2Client implements HttpClient<RestRequest, RestResponse> {
   public void close()
       throws IOException {
     client.shutdown(Callbacks.<None>empty());
+  }
+
+  public String getLimiterKey () throws NotConfiguredException {
+    return "D2request/" + "serviceName";
   }
 }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/AvroHttpWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/AvroHttpWriterBuilder.java
@@ -1,14 +1,17 @@
 package gobblin.writer;
 
+import java.net.URL;
+
 import org.apache.avro.generic.GenericRecord;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.entity.ContentType;
 import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
+
+import lombok.extern.slf4j.Slf4j;
 
 import gobblin.http.ApacheHttpClient;
 import gobblin.http.HttpRequestBuilder;
@@ -16,8 +19,9 @@ import gobblin.http.HttpResponseHandler;
 import gobblin.utils.HttpConstants;
 import gobblin.writer.http.AsyncHttpWriterBuilder;
 
-
+@Slf4j
 public class AvroHttpWriterBuilder extends AsyncHttpWriterBuilder<GenericRecord, HttpUriRequest, CloseableHttpResponse> {
+
   private static final Config FALLBACK =
       ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
           .put(HttpConstants.CONTENT_TYPE, "application/json")
@@ -26,7 +30,7 @@ public class AvroHttpWriterBuilder extends AsyncHttpWriterBuilder<GenericRecord,
   @Override
   public AvroHttpWriterBuilder fromConfig(Config config) {
     config = config.withFallback(FALLBACK);
-    ApacheHttpClient client = new ApacheHttpClient(HttpClientBuilder.create(), config);
+    ApacheHttpClient client = new ApacheHttpClient(HttpClientBuilder.create(), config, broker);
     this.client = client;
 
     String urlTemplate = config.getString(HttpConstants.URL_TEMPLATE);

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
@@ -37,5 +37,6 @@ public abstract class R2RestWriterBuilder extends AsyncHttpWriterBuilder<Generic
   }
 
   protected abstract R2Client createClient(Config config);
+
 }
 

--- a/gobblin-utility/src/main/java/gobblin/util/http/HttpLimiterKey.java
+++ b/gobblin-utility/src/main/java/gobblin/util/http/HttpLimiterKey.java
@@ -1,0 +1,51 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.util.http;
+
+import gobblin.util.limiter.broker.SharedLimiterKey;
+
+
+/**
+ * {@link HttpLimiterKey} used for http client throttling.
+ */
+public class HttpLimiterKey extends SharedLimiterKey {
+
+  public HttpLimiterKey(String resourceId) {
+    super(resourceId);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+
+    return true;
+  }
+
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
+}


### PR DESCRIPTION
Below configuration should be added in the job profile.

gobblin.broker.limiter.GLOBAL.class=qps
gobblin.broker.limiter.qps=1

@ibuenros @zxcware Can you please review?