### PR TITLE
Fix R2Client not closing gracefully

### DIFF
--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
@@ -45,7 +45,7 @@ public class R2Client implements HttpClient<RestRequest, RestResponse> {
     try {
       response = responseFuture.get();
     } catch (InterruptedException | ExecutionException e) {
-      throw new RuntimeException(e);
+      throw new IOException(e);
     }
     return response;
   }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
@@ -38,3 +38,4 @@ public abstract class R2RestWriterBuilder extends AsyncHttpWriterBuilder<Generic
 
   protected abstract R2Client createClient(Config config);
 }
+

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
@@ -38,5 +38,5 @@ public abstract class R2RestWriterBuilder extends AsyncHttpWriterBuilder<Generic
     return this;
   }
 
-  public abstract R2Client createClient(Config config);
+  protected abstract R2Client createClient(Config config);
 }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
@@ -5,11 +5,9 @@ import org.apache.avro.generic.GenericRecord;
 import com.google.common.collect.ImmutableMap;
 import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestResponse;
-import com.linkedin.r2.transport.common.Client;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
-import gobblin.proxies.LiD2ClientBuilder;
 import gobblin.restli.R2Client;
 import gobblin.restli.R2RestRequestBuilder;
 import gobblin.restli.R2RestResponseHandler;


### PR DESCRIPTION
- Throw IOException on sending failure, which will be handled by its consumer