### PR TITLE
- Add a little bit of hierarchical config for converter encryption - previously converters

### DIFF
--- a/gobblin-core-base/src/test/java/gobblin/crypto/EncryptionConfigParserTest.java
+++ b/gobblin-core-base/src/test/java/gobblin/crypto/EncryptionConfigParserTest.java
@@ -105,6 +105,34 @@ public class EncryptionConfigParserTest {
     Assert.assertNull(parsedWriterProperties, "Did not expect to find writer properties");
   }
 
+  @Test
+  public void testConverterWithEntityPrefix() {
+    final String entityName = "MyConverter";
+
+    WorkUnitState wuState = new WorkUnitState();
+    wuState.getJobState().setProp(
+        EncryptionConfigParser.CONVERTER_ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_ALGORITHM_KEY, "any");
+    wuState.getJobState().setProp(
+        EncryptionConfigParser.CONVERTER_ENCRYPT_PREFIX + "." + entityName + "." + EncryptionConfigParser.ENCRYPTION_ALGORITHM_KEY, "aes_rotating");
+    wuState.getJobState().setProp(
+        EncryptionConfigParser.CONVERTER_ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PATH_KEY,
+        "/tmp/foobar");
+    wuState.getJobState().setProp(
+        EncryptionConfigParser.CONVERTER_ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEYSTORE_PASSWORD_KEY,
+        "abracadabra");
+    wuState.getJobState().setProp(
+        EncryptionConfigParser.CONVERTER_ENCRYPT_PREFIX + "." + EncryptionConfigParser.ENCRYPTION_KEY_NAME,
+        "keyname");
+    wuState.setProp(EncryptionConfigParser.CONVERTER_ENCRYPT_PREFIX + "abc.def", "foobar");
+
+    Map<String, Object> parsedProperties = EncryptionConfigParser.getConfigForBranch(EncryptionConfigParser.EntityType.CONVERTER, entityName, wuState);
+    Assert.assertNotNull(parsedProperties, "Expected parser to only return one record");
+    Assert.assertEquals(parsedProperties.size(), 4, "Did not expect abc.def to be picked up in config");
+    Assert.assertEquals(EncryptionConfigParser.getEncryptionType(parsedProperties), "aes_rotating");
+    Map<String, Object> parsedWriterProperties = EncryptionConfigParser.getConfigForBranch(EncryptionConfigParser.EntityType.WRITER, wuState);
+    Assert.assertNull(parsedWriterProperties, "Did not expect to find writer properties");
+  }
+
   private void testWithWriterPrefix(int numBranches, int branch) {
     String branchString = "";
     if (numBranches > 1) {

--- a/gobblin-modules/gobblin-crypto-provider/src/main/java/gobblin/converter/SerializedRecordToEncryptedSerializedRecordConverter.java
+++ b/gobblin-modules/gobblin-crypto-provider/src/main/java/gobblin/converter/SerializedRecordToEncryptedSerializedRecordConverter.java
@@ -34,7 +34,7 @@ public class SerializedRecordToEncryptedSerializedRecordConverter extends Serial
   @Override
   protected StreamCodec buildEncryptor(WorkUnitState config) {
     Map<String, Object> encryptionConfig =
-        EncryptionConfigParser.getConfigForBranch(EncryptionConfigParser.EntityType.CONVERTER, config);
+        EncryptionConfigParser.getConfigForBranch(EncryptionConfigParser.EntityType.CONVERTER, getClass().getSimpleName(), config);
     if (encryptionConfig == null) {
       throw new IllegalStateException("No encryption config specified in job - can't encrypt!");
     }

--- a/gobblin-modules/gobblin-crypto-provider/src/main/java/gobblin/converter/StringFieldEncryptorConverter.java
+++ b/gobblin-modules/gobblin-crypto-provider/src/main/java/gobblin/converter/StringFieldEncryptorConverter.java
@@ -49,7 +49,7 @@ public abstract class StringFieldEncryptorConverter<SCHEMA, DATA> extends Conver
   public Converter<SCHEMA, SCHEMA, DATA, DATA> init(WorkUnitState workUnit) {
     super.init(workUnit);
     Map<String, Object> config =
-        EncryptionConfigParser.getConfigForBranch(EncryptionConfigParser.EntityType.CONVERTER, workUnit);
+        EncryptionConfigParser.getConfigForBranch(EncryptionConfigParser.EntityType.CONVERTER, getClass().getSimpleName(), workUnit);
     encryptor = EncryptionFactory.buildStreamCryptoProvider(config);
 
     String fieldsToEncryptConfig = workUnit.getProp(FIELDS_TO_ENCRYPT_CONFIG_NAME, null);


### PR DESCRIPTION
only looked converter.encrypt.*, but this breaks down if there are
multiple converters in a chain that are doing encryption. This change
allows you to specify config at `converter.<ConverterName>.encrypt.*`

I think this approach is a little cleaner than a positional approach (converter.0.encrypt.foo), but don't know if you have thoughts @htran1 or @ibuenros . Also definitely want to document this somewhere and/or make the config parsing a little more generic. I know Typesafe Config can handle some of the heirarchy stuff as well.