### PR TITLE
addOptionalWatermarkPredicate function

### DIFF
--- a/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcExtractor.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/extract/jdbc/JdbcExtractor.java
@@ -369,6 +369,15 @@ public abstract class JdbcExtractor extends QueryBasedExtractor<JsonArray, JsonE
       }
     }
 
+    query = addOptionalWatermarkPredicate(query);
+    return query;
+  }
+
+  /**
+   * @param query
+   * @return query with watermark predicate symbol
+   */
+  protected String addOptionalWatermarkPredicate(String query) {
     String watermarkPredicateSymbol = ConfigurationKeys.DEFAULT_SOURCE_QUERYBASED_WATERMARK_PREDICATE_SYMBOL;
     if (!query.contains(watermarkPredicateSymbol)) {
       query = SqlQueryUtils.addPredicate(query, watermarkPredicateSymbol);


### PR DESCRIPTION
Moved the code to add the watermark predicate in getExtractQuery to a separate function called addOptionalWatermarkPredicate because SqlQueryUtils.addPredicate does not allow for group by or order by in the inputQuery. So an extractor that extends JDBCExtractor can override addOptionalWatermarkPredicate and allow it to use a query with group by/order by.