### PR TITLE
Add AsyncHttpJoinConverter

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/audit/KafkaAuditCountHttpClient.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/audit/KafkaAuditCountHttpClient.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonParser;
 import gobblin.configuration.State;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.http.annotation.ThreadSafe;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.methods.HttpUriRequest;
@@ -27,7 +26,6 @@ import java.util.concurrent.TimeUnit;
  * to perform audit count query.
  */
 @Slf4j
-@ThreadSafe
 public class KafkaAuditCountHttpClient implements AuditCountClient {
 
   // Keys

--- a/gobblin-compaction/src/main/java/gobblin/compaction/audit/KafkaAuditCountHttpClient.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/audit/KafkaAuditCountHttpClient.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import gobblin.configuration.State;
+
+import javax.annotation.concurrent.ThreadSafe;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -26,6 +28,7 @@ import java.util.concurrent.TimeUnit;
  * to perform audit count query.
  */
 @Slf4j
+@ThreadSafe
 public class KafkaAuditCountHttpClient implements AuditCountClient {
 
   // Keys

--- a/gobblin-compaction/src/main/java/gobblin/compaction/audit/PinotAuditCountHttpClient.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/audit/PinotAuditCountHttpClient.java
@@ -6,6 +6,8 @@ import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import gobblin.configuration.State;
+
+import javax.annotation.concurrent.ThreadSafe;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -26,6 +28,7 @@ import java.util.Map;
  * to perform audit count query.
  */
 @Slf4j
+@ThreadSafe
 public class PinotAuditCountHttpClient implements AuditCountClient {
 
   // Keys

--- a/gobblin-compaction/src/main/java/gobblin/compaction/audit/PinotAuditCountHttpClient.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/audit/PinotAuditCountHttpClient.java
@@ -8,7 +8,6 @@ import com.google.gson.JsonParser;
 import gobblin.configuration.State;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.http.HttpEntity;
-import org.apache.http.annotation.ThreadSafe;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpGet;
 import org.apache.http.client.protocol.HttpClientContext;
@@ -27,7 +26,6 @@ import java.util.Map;
  * to perform audit count query.
  */
 @Slf4j
-@ThreadSafe
 public class PinotAuditCountHttpClient implements AuditCountClient {
 
   // Keys

--- a/gobblin-core-base/src/main/java/gobblin/converter/AsyncConverter1to1.java
+++ b/gobblin-core-base/src/main/java/gobblin/converter/AsyncConverter1to1.java
@@ -73,7 +73,6 @@ public abstract class AsyncConverter1to1<SI, SO, DI, DO> extends Converter<SI, S
         inputStream.getRecordStream()
             .flatMapSingle(in -> new SingleAsync(in, convertRecordAsync(outputSchema, in.getRecord(), workUnitState)),
                 false, maxConcurrentAsyncConversions);
-    outputStream = outputStream.doOnComplete(this::close);
     return inputStream.withRecordStream(outputStream, outputSchema);
   }
 

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/converter/InstrumentedConverterDecorator.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/converter/InstrumentedConverterDecorator.java
@@ -26,6 +26,7 @@ import gobblin.converter.DataConversionException;
 import gobblin.converter.SchemaConversionException;
 import gobblin.instrumented.Instrumented;
 import gobblin.metrics.MetricContext;
+import gobblin.records.RecordStreamWithMetadata;
 import gobblin.util.Decorator;
 import gobblin.util.DecoratorUtils;
 
@@ -90,5 +91,10 @@ public class InstrumentedConverterDecorator<SI, SO, DI, DO> extends Instrumented
   @Override
   public Object getDecoratedObject() {
     return this.embeddedConverter;
+  }
+  @Override
+  public RecordStreamWithMetadata<DO, SO> processStream(RecordStreamWithMetadata<DI, SI> inputStream,
+      WorkUnitState workUnitState) throws SchemaConversionException {
+    return this.embeddedConverter.processStream(inputStream, workUnitState);
   }
 }

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/converter/InstrumentedConverterDecorator.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/converter/InstrumentedConverterDecorator.java
@@ -92,6 +92,11 @@ public class InstrumentedConverterDecorator<SI, SO, DI, DO> extends Instrumented
   public Object getDecoratedObject() {
     return this.embeddedConverter;
   }
+
+  /**
+   * This workarounds the issue that {@link Converter#processStream(RecordStreamWithMetadata, WorkUnitState)} will invoke
+   * {@link gobblin.converter.AsyncConverter1to1#convertRecord(Object, Object, WorkUnitState)} directly, which is an unsupported method.
+   */
   @Override
   public RecordStreamWithMetadata<DO, SO> processStream(RecordStreamWithMetadata<DI, SI> inputStream,
       WorkUnitState workUnitState) throws SchemaConversionException {

--- a/gobblin-core/build.gradle
+++ b/gobblin-core/build.gradle
@@ -47,6 +47,7 @@ dependencies {
   compile externalDependency.hiveExec
   compile externalDependency.hiveSerDe
   compile externalDependency.httpclient
+  compile externalDependency.httpasyncclient
   compile externalDependency.httpcore
   compile externalDependency.metricsCore
   compile externalDependency.scala

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AsyncHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AsyncHttpJoinConverter.java
@@ -2,6 +2,7 @@ package gobblin.converter;
 
 import java.io.IOException;
 import java.util.Queue;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.LinkedBlockingDeque;
 
 import org.apache.avro.generic.GenericRecord;
@@ -10,11 +11,13 @@ import com.google.common.collect.ImmutableMap;
 import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 import gobblin.async.AsyncRequest;
 import gobblin.async.AsyncRequestBuilder;
 import gobblin.async.BufferedRecord;
+import gobblin.async.Callback;
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.SharedResourcesBroker;
 import gobblin.config.ConfigBuilder;
@@ -38,7 +41,7 @@ import gobblin.writer.WriteCallback;
  * Combine info (DI, RQ, RP, status, etc..) to generate output DO
  */
 @Slf4j
-public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converter<SI, SO, DI, DO> {
+public abstract class AsyncHttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends AsyncConverter1to1<SI, SO, DI, DO> {
   public static final String CONF_PREFIX = "gobblin.converter.http.";
   public static final Config DEFAULT_FALLBACK =
       ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
@@ -50,7 +53,7 @@ public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converte
   protected ResponseHandler<RP> responseHandler = null;
   protected AsyncRequestBuilder<GenericRecord, RQ> requestBuilder = null;
 
-  public HttpJoinConverter init(WorkUnitState workUnitState) {
+  public AsyncHttpJoinConverter init(WorkUnitState workUnitState) {
     super.init(workUnitState);
     Config config = ConfigBuilder.create().loadProps(workUnitState.getProperties(), CONF_PREFIX).build();
     config = config.withFallback(DEFAULT_FALLBACK);
@@ -74,8 +77,66 @@ public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converte
   protected abstract SO convertSchemaImpl (SI inputSchema, WorkUnitState workUnitState) throws SchemaConversionException;
   protected abstract DO convertRecordImpl (SO outputSchema, DI input, RQ rawRequest, ResponseStatus status) throws DataConversionException;
 
+  /**
+   * A helper class which performs the conversion from http response to DO type output, saved as a {@link CompletableFuture}
+   */
+  private class AsyncHttpJoinConverterContext<SO, DI, DO, RP, RQ> {
+    private final CompletableFuture<DO> future;
+    private final AsyncHttpJoinConverter<SI, SO, DI, DO, RQ, RP> converter;
+
+    @Getter
+    private final Callback<RP> callback;
+
+    public AsyncHttpJoinConverterContext(AsyncHttpJoinConverter converter, SO outputSchema, DI input, RQ rawRequest) {
+      this.future = new CompletableFuture();
+      this.converter = converter;
+      this.callback = new Callback<RP>() {
+        @Override
+        public void onSuccess(RP result) {
+          try {
+            ResponseStatus status = AsyncHttpJoinConverterContext.this.converter.responseHandler.handleResponse(result);
+            switch (status.getType()) {
+              case OK:
+                AsyncHttpJoinConverterContext.this.onSuccess(rawRequest, status, outputSchema, input);
+                break;
+              case CLIENT_ERROR:
+                AsyncHttpJoinConverterContext.this.onSuccess(rawRequest, status, outputSchema, input);
+                break;
+              case SERVER_ERROR:
+                // Server side error. Retry
+                throw new DataConversionException(rawRequest + " send failed due to server error");
+              default:
+                throw new DataConversionException(rawRequest + " Should not reach here");
+            }
+          } catch (Exception e) {
+            AsyncHttpJoinConverterContext.this.future.completeExceptionally(e);
+          }
+        }
+
+        @Override
+        public void onFailure(Throwable throwable) {
+          AsyncHttpJoinConverterContext.this.future.completeExceptionally(throwable);
+        }
+      };
+    }
+
+    private void onSuccess(RQ rawRequest, ResponseStatus status, SO outputSchema, DI input) throws DataConversionException {
+      log.debug("{} send with status type {}", rawRequest, status.getType());
+      DO output = this.converter.convertRecordImpl(outputSchema, input, rawRequest, status);
+      AsyncHttpJoinConverterContext.this.future.complete(output);
+    }
+  }
+
+  /**
+   * Convert an input record to a future object where an output record will be filled in sometime later
+   * Sequence:
+   *    Convert input (DI) to an http request
+   *    Send http request asynchronously, and registers an http callback
+   *    Create an {@link CompletableFuture} object. When the callback is invoked, this future object is filled in by an output record which is converted from http response.
+   *    Return the future object.
+   */
   @Override
-  public final Iterable<DO> convertRecord(SO outputSchema, DI inputRecord, WorkUnitState workUnitState)
+  public final CompletableFuture<DO> convertRecordAsync(SO outputSchema, DI inputRecord, WorkUnitState workUnitState)
       throws DataConversionException {
 
     // Convert DI to HttpOperation
@@ -89,29 +150,15 @@ public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converte
     RQ rawRequest = request.getRawRequest();
 
     // Execute query and get response
+    AsyncHttpJoinConverterContext context = new AsyncHttpJoinConverterContext(this, outputSchema, inputRecord, rawRequest);
 
     try {
-      RP response = httpClient.sendRequest(rawRequest);
-
-      ResponseStatus status = responseHandler.handleResponse(response);
-
-
-      switch (status.getType()) {
-        case OK:
-        case CLIENT_ERROR:
-          // Convert (DI, RQ, RP etc..) to output DO
-          log.debug ("{} send with status type {}", rawRequest, status.getType());
-          DO output = convertRecordImpl (outputSchema, inputRecord, rawRequest, status);
-          return new SingleRecordIterable<>(output);
-        case SERVER_ERROR:
-          // Server side error. Retry
-          throw new DataConversionException(rawRequest + " send failed due to server error");
-        default:
-          throw new DataConversionException(rawRequest + " Should not reach here");
-      }
+      httpClient.sendAsyncRequest(rawRequest, context.getCallback());
     } catch (IOException e) {
       throw new DataConversionException(e);
     }
+
+    return context.future;
   }
 
   public void close() throws IOException {

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroApacheHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroApacheHttpJoinConverter.java
@@ -5,19 +5,18 @@ import java.nio.ByteBuffer;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
 
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.SharedResourcesBroker;
-import gobblin.http.ApacheHttpClient;
+import gobblin.http.ApacheHttpAsyncClient;
 import gobblin.http.ApacheHttpResponseHandler;
 import gobblin.http.ApacheHttpResponseStatus;
-import gobblin.http.HttpClient;
 import gobblin.http.ApacheHttpRequestBuilder;
 import gobblin.http.HttpRequestResponseRecord;
 import gobblin.http.ResponseStatus;
@@ -27,10 +26,10 @@ import gobblin.utils.HttpConstants;
  * Apache version of http join converter
  */
 @Slf4j
-public class AvroApacheHttpJoinConverter extends AvroHttpJoinConverter<HttpUriRequest, CloseableHttpResponse> {
+public class AvroApacheHttpJoinConverter extends AvroHttpJoinConverter<HttpUriRequest, HttpResponse> {
   @Override
-  public HttpClient<HttpUriRequest, CloseableHttpResponse> createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
-    return new ApacheHttpClient(HttpClientBuilder.create(), config, broker);
+  public ApacheHttpAsyncClient createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
+    return new ApacheHttpAsyncClient(HttpAsyncClientBuilder.create(), config, broker);
   }
 
   @Override

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroApacheHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroApacheHttpJoinConverter.java
@@ -5,16 +5,16 @@ import java.nio.ByteBuffer;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.client.HttpClientBuilder;
 
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
 
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.SharedResourcesBroker;
-import gobblin.http.ApacheHttpAsyncClient;
+import gobblin.http.ApacheHttpClient;
 import gobblin.http.ApacheHttpResponseHandler;
 import gobblin.http.ApacheHttpResponseStatus;
 import gobblin.http.ApacheHttpRequestBuilder;
@@ -26,10 +26,10 @@ import gobblin.utils.HttpConstants;
  * Apache version of http join converter
  */
 @Slf4j
-public class AvroApacheHttpJoinConverter extends AvroHttpJoinConverter<HttpUriRequest, HttpResponse> {
+public class AvroApacheHttpJoinConverter extends AvroHttpJoinConverter<HttpUriRequest, CloseableHttpResponse> {
   @Override
-  public ApacheHttpAsyncClient createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
-    return new ApacheHttpAsyncClient(HttpAsyncClientBuilder.create(), config, broker);
+  public ApacheHttpClient createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
+    return new ApacheHttpClient(HttpClientBuilder.create(), config, broker);
   }
 
   @Override

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpAsyncClient.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpAsyncClient.java
@@ -1,0 +1,196 @@
+package gobblin.http;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.client.config.RequestConfig;
+import org.apache.http.client.methods.HttpUriRequest;
+import org.apache.http.concurrent.FutureCallback;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.nio.client.CloseableHttpAsyncClient;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
+import org.apache.http.impl.nio.conn.PoolingNHttpClientConnectionManager;
+import org.apache.http.impl.nio.reactor.DefaultConnectingIOReactor;
+import org.apache.http.nio.conn.NHttpClientConnectionManager;
+import org.apache.http.nio.reactor.ConnectingIOReactor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.collect.ImmutableMap;
+import com.typesafe.config.Config;
+import com.typesafe.config.ConfigFactory;
+
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.async.Callback;
+import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
+import gobblin.broker.iface.SharedResourcesBroker;
+import gobblin.utils.HttpUtils;
+
+/**
+ * An asynchronous {@link HttpClient} which sends {@link HttpUriRequest} and registers a callback.
+ * It encapsulates a {@link CloseableHttpClient} instance to send the {@link HttpUriRequest}
+ *
+ * {@link CloseableHttpAsyncClient} is used
+ */
+@Slf4j
+public class ApacheHttpAsyncClient extends ThrottledHttpClient<HttpUriRequest, HttpResponse>  {
+  private static final Logger LOG = LoggerFactory.getLogger(ApacheHttpClient.class);
+
+  public static final String HTTP_CONN_MANAGER = "connMgrType";
+  public static final String POOLING_CONN_MANAGER_MAX_TOTAL_CONN = "connMgr.pooling.maxTotalConn";
+  public static final String POOLING_CONN_MANAGER_MAX_PER_CONN = "connMgr.pooling.maxPerConn";
+  public static final String REQUEST_TIME_OUT_MS_KEY = "reqTimeout";
+  public static final String CONNECTION_TIME_OUT_MS_KEY = "connTimeout";
+
+
+  private static final Config FALLBACK =
+      ConfigFactory.parseMap(ImmutableMap.<String, Object>builder()
+          .put(REQUEST_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(10L))
+          .put(CONNECTION_TIME_OUT_MS_KEY, TimeUnit.SECONDS.toMillis(10L))
+          .put(HTTP_CONN_MANAGER, ApacheHttpClient.ConnManager.POOLING.name())
+          .put(POOLING_CONN_MANAGER_MAX_TOTAL_CONN, 20)
+          .put(POOLING_CONN_MANAGER_MAX_PER_CONN, 2)
+          .build());
+
+  private final CloseableHttpAsyncClient client;
+
+  public ApacheHttpAsyncClient(HttpAsyncClientBuilder builder, Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
+    super (broker, HttpUtils.createApacheHttpClientLimiterKey(config));
+    config = config.withFallback(FALLBACK);
+
+    RequestConfig requestConfig = RequestConfig.copy(RequestConfig.DEFAULT)
+        .setSocketTimeout(config.getInt(REQUEST_TIME_OUT_MS_KEY))
+        .setConnectTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
+        .setConnectionRequestTimeout(config.getInt(CONNECTION_TIME_OUT_MS_KEY))
+        .build();
+
+    try {
+      builder.disableCookieManagement().useSystemProperties().setDefaultRequestConfig(requestConfig);
+      builder.setConnectionManager(getNHttpConnManager(config));
+      client = builder.build();
+      client.start();
+    } catch (IOException e) {
+      throw new RuntimeException("ApacheHttpAsyncClient cannot be initialized");
+    }
+  }
+
+  private NHttpClientConnectionManager getNHttpConnManager(Config config) throws IOException {
+    NHttpClientConnectionManager httpConnManager;
+
+    String connMgrStr = config.getString(HTTP_CONN_MANAGER);
+    switch (ApacheHttpClient.ConnManager.valueOf(connMgrStr.toUpperCase())) {
+      case POOLING:
+        ConnectingIOReactor ioReactor = new DefaultConnectingIOReactor();
+        PoolingNHttpClientConnectionManager poolingConnMgr = new PoolingNHttpClientConnectionManager(ioReactor);
+        poolingConnMgr.setMaxTotal(config.getInt(POOLING_CONN_MANAGER_MAX_TOTAL_CONN));
+        poolingConnMgr.setDefaultMaxPerRoute(config.getInt(POOLING_CONN_MANAGER_MAX_PER_CONN));
+        httpConnManager = poolingConnMgr;
+        break;
+      default:
+        throw new IllegalArgumentException(connMgrStr + " is not supported");
+    }
+
+    LOG.info("Using " + httpConnManager.getClass().getSimpleName());
+    return httpConnManager;
+  }
+
+  /**
+   * A helper class which contains a latch so that we can achieve synchronization.
+   * The same can be achieved by invoking {@link Future#get()}. However the future object returned by
+   * {@link org.apache.http.nio.client.HttpAsyncClient#execute(HttpUriRequest, FutureCallback)} seems not working properly.
+   */
+  @Getter
+  private static class SyncHttpResponseCallback implements FutureCallback<HttpResponse> {
+    private HttpUriRequest request = null;
+    private HttpResponse response = null;
+    private Exception exception = null;
+    private Callback callback = null;
+
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    public SyncHttpResponseCallback(HttpUriRequest request) {
+      this.request = request;
+    }
+
+    @Override
+    public void completed(HttpResponse result) {
+      log.info ("Sync apache version request: {}, statusCode: {}", request, result.getStatusLine().getStatusCode());
+      response = result;
+      latch.countDown();
+    }
+
+    @Override
+    public void failed(Exception ex) {
+      exception = ex;
+      latch.countDown();
+    }
+
+    @Override
+    public void cancelled() {
+      throw new UnsupportedOperationException("Should not be cancelled");
+    }
+
+    public void await() throws InterruptedException {
+      latch.await();
+    }
+  }
+
+
+  /**
+   * A wrapper class which passes result from {@link FutureCallback} to {@link Callback}
+   */
+  private static class AsyncHttpResponseCallbackWrapper implements FutureCallback<HttpResponse> {
+    private Callback<HttpResponse> callback = null;
+
+    public AsyncHttpResponseCallbackWrapper(Callback<HttpResponse> callback) {
+      this.callback = callback;
+    }
+
+    @Override
+    public void completed(HttpResponse result) {
+      this.callback.onSuccess(result);
+    }
+
+    @Override
+    public void failed(Exception ex) {
+      this.callback.onFailure(ex);
+    }
+
+    @Override
+    public void cancelled() {
+      throw new UnsupportedOperationException("Should not be cancelled");
+    }
+  }
+
+  @Override
+  public HttpResponse sendRequestImpl(HttpUriRequest request) throws IOException {
+    SyncHttpResponseCallback callback = new SyncHttpResponseCallback(request);
+    this.client.execute(request, callback);
+
+    try {
+      callback.await();
+      if (callback.getException() != null) {
+        throw new IOException(callback.getException());
+      }
+      return callback.getResponse();
+    } catch (InterruptedException e) {
+      throw new IOException(e);
+    }
+  }
+
+  @Override
+  public void sendAsyncRequestImpl(HttpUriRequest request, Callback<HttpResponse> callback) throws IOException {
+    AsyncHttpResponseCallbackWrapper wrapper = new AsyncHttpResponseCallbackWrapper(callback);
+    this.client.execute(request, wrapper);
+  }
+
+  @Override
+  public void close() throws IOException {
+    client.close();
+  }
+}

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpAsyncClient.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpAsyncClient.java
@@ -100,16 +100,17 @@ public class ApacheHttpAsyncClient extends ThrottledHttpClient<HttpUriRequest, H
   }
 
   /**
-   * A helper class which contains a latch so that we can achieve synchronization.
-   * The same can be achieved by invoking {@link Future#get()}. However the future object returned by
-   * {@link org.apache.http.nio.client.HttpAsyncClient#execute(HttpUriRequest, FutureCallback)} seems not working properly.
+   * A helper class which contains a latch so that we can achieve blocking calls even using
+   * http async client APIs. Same can be achieved by invoking {@link Future#get()} returned by
+   * {@link org.apache.http.nio.client.HttpAsyncClient#execute(HttpUriRequest, FutureCallback)}.
+   * However this method seems to have a synchronization problem. It seems like {@link Future#get()}
+   * is not fully blocked before callback is triggered.
    */
   @Getter
   private static class SyncHttpResponseCallback implements FutureCallback<HttpResponse> {
     private HttpUriRequest request = null;
     private HttpResponse response = null;
     private Exception exception = null;
-    private Callback callback = null;
 
     private final CountDownLatch latch = new CountDownLatch(1);
 

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpResponseHandler.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpResponseHandler.java
@@ -5,19 +5,14 @@ import java.util.HashSet;
 import java.util.Set;
 
 import org.apache.http.HttpEntity;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.HttpResponse;
 import org.apache.http.util.EntityUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import lombok.extern.slf4j.Slf4j;
-
-import gobblin.restli.R2RestResponseHandler;
 import gobblin.utils.HttpUtils;
 
 
 /**
- * Basic logic to handle a {@link CloseableHttpResponse} from a http service
+ * Basic logic to handle a {@link HttpResponse} from a http service
  *
  * <p>
  *   A more specific handler understands the content inside the response and is able to customize
@@ -26,8 +21,7 @@ import gobblin.utils.HttpUtils;
  * </p>
  */
 @Slf4j
-public class ApacheHttpResponseHandler implements ResponseHandler<CloseableHttpResponse> {
-  private static final Logger LOG = LoggerFactory.getLogger(R2RestResponseHandler.class);
+public class ApacheHttpResponseHandler<RP extends HttpResponse> implements ResponseHandler<RP> {
   private final Set<String> errorCodeWhitelist;
 
   public ApacheHttpResponseHandler() {
@@ -39,7 +33,7 @@ public class ApacheHttpResponseHandler implements ResponseHandler<CloseableHttpR
   }
 
   @Override
-  public ApacheHttpResponseStatus handleResponse(CloseableHttpResponse response) {
+  public ApacheHttpResponseStatus handleResponse(RP response) {
     ApacheHttpResponseStatus status = new ApacheHttpResponseStatus(StatusType.OK);
     int statusCode = response.getStatusLine().getStatusCode();
     status.setStatusCode(statusCode);
@@ -50,7 +44,7 @@ public class ApacheHttpResponseHandler implements ResponseHandler<CloseableHttpR
       status.setContent(getEntityAsByteArray(response.getEntity()));
       status.setContentType(response.getEntity().getContentType().getValue());
     } else {
-      LOG.info("Receive an unsuccessful response with status code: " + statusCode);
+      log.info("Receive an unsuccessful response with status code: " + statusCode);
     }
 
     HttpEntity entity = response.getEntity();

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/http/HttpClient.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/http/HttpClient.java
@@ -37,5 +37,7 @@ public interface HttpClient<RQ, RP> extends Closeable {
   /**
    * Send request asynchronously
    */
-  void sendAsyncRequest(RQ request, Callback<RP> callback) throws IOException;
+  default void sendAsyncRequest(RQ request, Callback<RP> callback) throws IOException {
+    throw new UnsupportedOperationException();
+  }
 }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/http/HttpClient.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/http/HttpClient.java
@@ -20,6 +20,7 @@ package gobblin.http;
 import java.io.Closeable;
 import java.io.IOException;
 
+import gobblin.async.Callback;
 
 /**
  * An interface to send a request
@@ -32,5 +33,9 @@ public interface HttpClient<RQ, RP> extends Closeable {
    * Send request synchronously
    */
   RP sendRequest(RQ request) throws IOException;
-}
 
+  /**
+   * Send request asynchronously
+   */
+  void sendAsyncRequest(RQ request, Callback<RP> callback) throws IOException;
+}

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2Client.java
@@ -57,8 +57,17 @@ public class R2Client extends ThrottledHttpClient<RestRequest, RestResponse> {
   @Override
   public void sendAsyncRequestImpl(RestRequest request, Callback<RestResponse> callback)
       throws IOException {
-    AsyncR2CallbackWrapper wrapper = new AsyncR2CallbackWrapper(callback);
-    client.restRequest(request, wrapper);
+    client.restRequest(request, new com.linkedin.common.callback.Callback<RestResponse>() {
+      @Override
+      public void onError(Throwable e) {
+        callback.onFailure(e);
+      }
+
+      @Override
+      public void onSuccess(RestResponse result) {
+        callback.onSuccess(result);
+      }
+    });
   }
 
   @Override
@@ -70,27 +79,4 @@ public class R2Client extends ThrottledHttpClient<RestRequest, RestResponse> {
   private static String getLimiterKey () {
     return "D2request/" + "serviceName";
   }
-
-  /**
-   * A wrapper class which passes result from {@link com.linkedin.common.callback.Callback<RestResponse>} to {@link Callback}
-   */
-  @Getter
-  private static class AsyncR2CallbackWrapper implements com.linkedin.common.callback.Callback<RestResponse> {
-    private Callback<RestResponse>  callback = null;
-
-    public AsyncR2CallbackWrapper(Callback<RestResponse>  callback) {
-      this.callback = callback;
-    }
-
-    @Override
-    public void onError(Throwable e) {
-      this.callback.onFailure(e);
-    }
-
-    @Override
-    public void onSuccess(RestResponse result) {
-      this.callback.onSuccess(result);
-    }
-  }
-
 }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2RestResponseHandler.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2RestResponseHandler.java
@@ -3,15 +3,12 @@ package gobblin.restli;
 import java.util.HashSet;
 import java.util.Set;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 import com.linkedin.r2.message.rest.RestResponse;
+import lombok.extern.slf4j.Slf4j;
 
 import gobblin.http.ResponseHandler;
 import gobblin.http.StatusType;
 import gobblin.utils.HttpUtils;
-import gobblin.writer.AsyncHttpWriter;
 
 
 /**
@@ -23,8 +20,8 @@ import gobblin.writer.AsyncHttpWriter;
  *   sent from the service for a post response, executing more detailed status code handling, etc.
  * </p>
  */
+@Slf4j
 public class R2RestResponseHandler implements ResponseHandler<RestResponse> {
-  private static final Logger LOG = LoggerFactory.getLogger(R2RestResponseHandler.class);
 
   public static final String CONTENT_TYPE_HEADER = "Content-Type";
   private final Set<String> errorCodeWhitelist;
@@ -49,9 +46,8 @@ public class R2RestResponseHandler implements ResponseHandler<RestResponse> {
       status.setContent(response.getEntity());
       status.setContentType(response.getHeader(CONTENT_TYPE_HEADER));
     } else {
-      LOG.info("Receive an unsuccessful response with status code: " + statusCode);
+      log.info("Receive an unsuccessful response with status code: " + statusCode);
     }
-
 
     return status;
   }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/utils/HttpUtils.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/utils/HttpUtils.java
@@ -1,7 +1,9 @@
 package gobblin.utils;
 
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -20,6 +22,8 @@ import com.google.common.base.Splitter;
 import com.google.gson.Gson;
 import com.typesafe.config.Config;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.http.HttpOperation;
 import gobblin.http.ResponseStatus;
 import gobblin.http.StatusType;
@@ -29,8 +33,8 @@ import gobblin.util.AvroUtils;
 /**
  * Utilities to build gobblin http components
  */
+@Slf4j
 public class HttpUtils {
-  private static final Logger LOG = LoggerFactory.getLogger(HttpUtils.class);
   private static final Gson GSON = new Gson();
   private static final Splitter LIST_SPLITTER = Splitter.on(",").trimResults().omitEmptyStrings();
 
@@ -155,5 +159,21 @@ public class HttpUtils {
   public static Map<String, Object> toMap(String jsonString) {
     Map<String, Object> map = new HashMap<>();
     return GSON.fromJson(jsonString, map.getClass());
+  }
+
+
+  public static String createApacheHttpClientLimiterKey(Config config) {
+    try {
+      String urlTemplate = config.getString(HttpConstants.URL_TEMPLATE);
+      URL url = new URL(urlTemplate);
+      String key = url.getProtocol() + "/" + url.getHost();
+      if (url.getPort() > 0) {
+        key = key + "/" + url.getPort();
+      }
+      log.info("Get limiter key [" + key + "]");
+      return key;
+    } catch (MalformedURLException e) {
+      throw new IllegalStateException("Cannot get limiter key.", e);
+    }
   }
 }

--- a/gobblin-modules/gobblin-http/src/test/java/gobblin/writer/AsyncHttpWriterTest.java
+++ b/gobblin-modules/gobblin-http/src/test/java/gobblin/writer/AsyncHttpWriterTest.java
@@ -20,6 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 import gobblin.async.AsyncRequest;
 import gobblin.async.AsyncRequestBuilder;
 import gobblin.async.BufferedRecord;
+import gobblin.async.Callback;
 import gobblin.broker.BrokerConstants;
 import gobblin.broker.SharedResourcesBrokerFactory;
 import gobblin.broker.SharedResourcesBrokerImpl;
@@ -219,6 +220,11 @@ public class AsyncHttpWriterTest {
     }
 
     @Override
+    public void sendAsyncRequest(HttpUriRequest request, Callback<CloseableHttpResponse> callback) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
     public void close()
         throws IOException {
       isCloseCalled = true;
@@ -247,6 +253,11 @@ public class AsyncHttpWriterTest {
     public void close()
         throws IOException {
       isCloseCalled = true;
+    }
+
+    @Override
+    public void sendAsyncRequestImpl(HttpUriRequest request, Callback callback) {
+      throw new UnsupportedOperationException();
     }
   }
 

--- a/gradle/scripts/dependencyDefinitions.gradle
+++ b/gradle/scripts/dependencyDefinitions.gradle
@@ -70,6 +70,7 @@ ext.externalDependency = [
     "hiveSerDe": "org.apache.hive:hive-serde:" + hiveVersion,
     "httpclient": "org.apache.httpcomponents:httpclient:4.5.2",
     "httpcore": "org.apache.httpcomponents:httpcore:4.4.4",
+    "httpasyncclient": "org.apache.httpcomponents:httpasyncclient:4.1.3",
     "kafka08": "org.apache.kafka:kafka_2.11:" + kafka08Version,
     "kafka08Test": "org.apache.kafka:kafka_2.11:" + kafka08Version + ":test",
     "kafka08Client": "org.apache.kafka:kafka-clients:" + kafka08Version,


### PR DESCRIPTION
1. Add ApacheHttpAsyncClient
2. Add AsyncHttpJoinConverter inheriting AsyncConverter1To1
3. Add processStream to InstrumentedConverterDecorator to workaround convertRecord unsupported operation issue.
4. Replace threadSafe annotation to a javax package version
5. Remove doOnComplete from AsyncConverter1To1 because it will duplicate shutdown logic