### PR TITLE
Fix failed http test

### DIFF
--- a/gobblin-modules/gobblin-http/src/test/java/gobblin/http/ApacheHttpRequestBuilderTest.java
+++ b/gobblin-modules/gobblin-http/src/test/java/gobblin/http/ApacheHttpRequestBuilderTest.java
@@ -28,7 +28,7 @@ public class ApacheHttpRequestBuilderTest {
    */
   public void testBuildWriteRequest()
       throws IOException {
-    String urlTemplate = "a/part1:${part1}/a/part2:${part2}";
+    String urlTemplate = "http://www.test.com/a/part1:${part1}/a/part2:${part2}";
     String verb = "post";
     ApacheHttpRequestBuilder builder = spy(new ApacheHttpRequestBuilder(urlTemplate, verb, "application/json"));
     ArgumentCaptor<RequestBuilder> requestBuilderArgument = ArgumentCaptor.forClass(RequestBuilder.class);
@@ -38,7 +38,7 @@ public class ApacheHttpRequestBuilderTest {
     verify(builder).build(requestBuilderArgument.capture());
 
     RequestBuilder expected = RequestBuilder.post();
-    expected.setUri("a/part1:01/a/part2:02?param1=01");
+    expected.setUri("http://www.test.com/a/part1:01/a/part2:02?param1=01");
     String payloadStr = "{\"id\":\"id0\"}";
     expected.addHeader(HttpHeaders.CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
         .setEntity(new StringEntity(payloadStr, ContentType.APPLICATION_JSON));

--- a/gobblin-modules/gobblin-http/src/test/java/gobblin/restli/R2RestRequestBuilderTest.java
+++ b/gobblin-modules/gobblin-http/src/test/java/gobblin/restli/R2RestRequestBuilderTest.java
@@ -32,7 +32,7 @@ public class R2RestRequestBuilderTest {
    */
   public void testBuildWriteRequest()
       throws URISyntaxException, IOException {
-    String urlTemplate = "a/part1:${part1}/a/part2:${part2}";
+    String urlTemplate = "http://www.test.com/a/part1:${part1}/a/part2:${part2}";
     String verb = "update";
     String protocolVersion = "2.0.0";
 
@@ -43,7 +43,7 @@ public class R2RestRequestBuilderTest {
     AsyncRequest<GenericRecord, RestRequest> request = builder.buildRequest(queue);
     verify(builder).build(requestBuilderArgument.capture());
 
-    RestRequestBuilder expected = new RestRequestBuilder(new URI("a/part1:01/a/part2:02?param1=01"));
+    RestRequestBuilder expected = new RestRequestBuilder(new URI("http://www.test.com/a/part1:01/a/part2:02?param1=01"));
     expected.setMethod("PUT");
     expected.setHeader(RestConstants.HEADER_RESTLI_PROTOCOL_VERSION, protocolVersion);
     expected.setHeader(RestConstants.HEADER_RESTLI_REQUEST_METHOD, verb.toLowerCase());


### PR DESCRIPTION
Prevent `a/part1:${part1}/a/part2:${part2}` from being prefixed with a `/`.