### PR TITLE
Fix R2 DataMap conversion from nested objects in a json string

### DIFF
--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2RestRequestBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/restli/R2RestRequestBuilder.java
@@ -96,8 +96,8 @@ public class R2RestRequestBuilder implements AsyncRequestBuilder<GenericRecord, 
     }
 
     builder.setHeader(RestConstants.HEADER_CONTENT_TYPE, RestConstants.HEADER_VALUE_APPLICATION_JSON);
-    DataMap data = new DataMap(HttpUtils.toMap(payload));
     try {
+      DataMap data = JACKSON_DATA_CODEC.stringToMap(payload);
       byte[] bytes = JACKSON_DATA_CODEC.mapToBytes(data);
       builder.setEntity(bytes);
       return bytes.length;


### PR DESCRIPTION
Using gson to convert a json string to a `HashMap` then to `DataMap` fails because gson introduced `LinkedTreeMap` which `DataMap` doesn't like.