### PR TITLE
Change AvroHttpJoinConverter type from HttpJoinConverter to AsyncHttpJoinConverter 

### DIFF
--- a/gobblin-core-base/src/main/java/gobblin/converter/AsyncConverter1to1.java
+++ b/gobblin-core-base/src/main/java/gobblin/converter/AsyncConverter1to1.java
@@ -65,7 +65,6 @@ public abstract class AsyncConverter1to1<SI, SO, DI, DO> extends Converter<SI, S
   @Override
   public RecordStreamWithMetadata<DO, SO> processStream(RecordStreamWithMetadata<DI, SI> inputStream,
       WorkUnitState workUnitState) throws SchemaConversionException {
-    init(workUnitState);
     int maxConcurrentAsyncConversions = workUnitState.getPropAsInt(MAX_CONCURRENT_ASYNC_CONVERSIONS_KEY,
         DEFAULT_MAX_CONCURRENT_ASYNC_CONVERSIONS);
     SO outputSchema = convertSchema(inputStream.getSchema(), workUnitState);

--- a/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
+++ b/gobblin-core/src/main/java/gobblin/source/extractor/filebased/FileBasedSource.java
@@ -110,8 +110,7 @@ public abstract class FileBasedSource<S, D> extends AbstractSource<S, D> {
     // Get list of files seen in the previous run
     if (!previousWorkunits.isEmpty()) {
       if (previousWorkunits.get(0).getWorkunit().contains(ConfigurationKeys.SOURCE_FILEBASED_FS_SNAPSHOT)) {
-        prevFsSnapshot =
-            previousWorkunits.get(0).getWorkunit().getPropAsSet(ConfigurationKeys.SOURCE_FILEBASED_FS_SNAPSHOT);
+        prevFsSnapshot.addAll(previousWorkunits.get(0).getWorkunit().getPropAsSet(ConfigurationKeys.SOURCE_FILEBASED_FS_SNAPSHOT));
       } else if (state.getPropAsBoolean(ConfigurationKeys.SOURCE_FILEBASED_FS_PRIOR_SNAPSHOT_REQUIRED,
             ConfigurationKeys.DEFAULT_SOURCE_FILEBASED_FS_PRIOR_SNAPSHOT_REQUIRED)) {
         // If a previous job exists, there should be a snapshot property.  If not, we need to fail so that we

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroApacheHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroApacheHttpJoinConverter.java
@@ -5,16 +5,16 @@ import java.nio.ByteBuffer;
 
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 
 import com.typesafe.config.Config;
 import lombok.extern.slf4j.Slf4j;
 
 import gobblin.broker.gobblin_scopes.GobblinScopeTypes;
 import gobblin.broker.iface.SharedResourcesBroker;
-import gobblin.http.ApacheHttpClient;
+import gobblin.http.ApacheHttpAsyncClient;
 import gobblin.http.ApacheHttpResponseHandler;
 import gobblin.http.ApacheHttpResponseStatus;
 import gobblin.http.ApacheHttpRequestBuilder;
@@ -26,10 +26,10 @@ import gobblin.utils.HttpConstants;
  * Apache version of http join converter
  */
 @Slf4j
-public class AvroApacheHttpJoinConverter extends AvroHttpJoinConverter<HttpUriRequest, CloseableHttpResponse> {
+public class AvroApacheHttpJoinConverter extends AvroHttpJoinConverter<HttpUriRequest, HttpResponse> {
   @Override
-  public ApacheHttpClient createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
-    return new ApacheHttpClient(HttpClientBuilder.create(), config, broker);
+  public ApacheHttpAsyncClient createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker) {
+    return new ApacheHttpAsyncClient(HttpAsyncClientBuilder.create(), config, broker);
   }
 
   @Override

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroHttpJoinConverter.java
@@ -31,7 +31,7 @@ import gobblin.utils.HttpUtils;
  *    User provided record plus http request & response record
  */
 @Slf4j
-public abstract class AvroHttpJoinConverter<RQ, RP> extends HttpJoinConverter<Schema, Schema, GenericRecord, GenericRecord, RQ, RP> {
+public abstract class AvroHttpJoinConverter<RQ, RP> extends AsyncHttpJoinConverter<Schema, Schema, GenericRecord, GenericRecord, RQ, RP> {
   public static final String HTTP_REQUEST_RESPONSE_FIELD = "HttpRequestResponse";
 
   @Override


### PR DESCRIPTION
1) Remove duplicate init() from AsyncConverter1To1
2) Change AvroHttpJoinConverter type from HttpJoinConverter to AsyncHttpJoinConverter 
3) Fix the UnsupportedOperationException issue during prevFsSnapshot addAll() because prevFsSnapshot may be an ImmutableSet type