### PR TITLE
Reduce lock aquisition using local map cache

### DIFF
--- a/gobblin-hive-registration/src/main/java/gobblin/hive/avro/HiveAvroSerDeManager.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/avro/HiveAvroSerDeManager.java
@@ -17,6 +17,9 @@
 
 package gobblin.hive.avro;
 
+import com.codahale.metrics.Timer;
+import gobblin.instrumented.Instrumented;
+import gobblin.metrics.MetricContext;
 import java.io.IOException;
 
 import org.apache.avro.Schema;
@@ -52,12 +55,16 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
   public static final String DEFAULT_SCHEMA_FILE_NAME = "_schema.avsc";
   public static final String SCHEMA_LITERAL_LENGTH_LIMIT = "schema.literal.length.limit";
   public static final int DEFAULT_SCHEMA_LITERAL_LENGTH_LIMIT = 4000;
+  public static final String HIVE_SPEC_SCHEMA_READING_TIMER = "AvroReading";
+  public static final String HIVE_SPEC_SCHEMA_WRITING_TIMER = "AvroWriting";
 
   protected final FileSystem fs;
   protected final boolean useSchemaFile;
   protected final String schemaFileName;
   protected final int schemaLiteralLengthLimit;
   protected final HiveSerDeWrapper serDeWrapper = HiveSerDeWrapper.get("AVRO");
+
+  private final MetricContext metricContext ;
 
   public HiveAvroSerDeManager(State props) throws IOException {
     super(props);
@@ -66,6 +73,8 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
     this.schemaFileName = props.getProp(SCHEMA_FILE_NAME, DEFAULT_SCHEMA_FILE_NAME);
     this.schemaLiteralLengthLimit =
         props.getPropAsInt(SCHEMA_LITERAL_LENGTH_LIMIT, DEFAULT_SCHEMA_LITERAL_LENGTH_LIMIT);
+
+    this.metricContext = Instrumented.getMetricContext(props, HiveAvroSerDeManager.class);
   }
 
   /**
@@ -118,8 +127,13 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
     if (this.useSchemaFile) {
       hiveUnit.setSerDeProp(SCHEMA_URL, schemaFile.toString());
     } else {
-      Schema schema = getDirectorySchema(path);
-      addSchemaFromAvroFile(schema, schemaFile, hiveUnit);
+      Schema schema ;
+      try (Timer.Context context = metricContext.timer(HIVE_SPEC_SCHEMA_READING_TIMER).time()) {
+        schema = getDirectorySchema(path);
+      }
+      try (Timer.Context context = metricContext.timer(HIVE_SPEC_SCHEMA_WRITING_TIMER).time()) {
+        addSchemaFromAvroFile(schema, schemaFile, hiveUnit);
+      }
     }
   }
 

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/avro/HiveAvroSerDeManager.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/avro/HiveAvroSerDeManager.java
@@ -55,8 +55,8 @@ public class HiveAvroSerDeManager extends HiveSerDeManager {
   public static final String DEFAULT_SCHEMA_FILE_NAME = "_schema.avsc";
   public static final String SCHEMA_LITERAL_LENGTH_LIMIT = "schema.literal.length.limit";
   public static final int DEFAULT_SCHEMA_LITERAL_LENGTH_LIMIT = 4000;
-  public static final String HIVE_SPEC_SCHEMA_READING_TIMER = "AvroReading";
-  public static final String HIVE_SPEC_SCHEMA_WRITING_TIMER = "AvroWriting";
+  public static final String HIVE_SPEC_SCHEMA_READING_TIMER = "hiveAvroSerdeManager.schemaReadTimer";
+  public static final String HIVE_SPEC_SCHEMA_WRITING_TIMER = "hiveAvroSerdeManager.schemaWriteTimer";
 
   protected final FileSystem fs;
   protected final boolean useSchemaFile;

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -19,7 +19,6 @@ package gobblin.hive.metastore;
 
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
 
 import java.util.concurrent.ConcurrentHashMap;
@@ -39,12 +38,10 @@ import org.joda.time.DateTime;
 import com.codahale.metrics.Timer;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
-import com.google.common.base.Throwables;
 import com.google.common.primitives.Ints;
 
 import gobblin.annotation.Alpha;
 import gobblin.configuration.State;
-import gobblin.configuration.ConfigurationKeys;
 import gobblin.hive.HiveMetaStoreClientFactory;
 import gobblin.hive.HiveLock;
 import gobblin.hive.HiveMetastoreClientPool;
@@ -94,6 +91,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String GET_HIVE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "getTableTimer";
   public static final String DROP_TABLE = HIVE_REGISTER_METRICS_PREFIX + "dropTableTimer";
   public static final String PATH_REGISTER_TIMER = HIVE_REGISTER_METRICS_PREFIX + "pathRegisterTimer";
+  public static final String OPTIMIZED_CHECK_ENABLED = "hiveRegister.doubleLockPatternCheck.enabled";
 
   private final HiveMetastoreClientPool clientPool;
   private final HiveLock locks = new HiveLock();
@@ -106,7 +104,7 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public HiveMetaStoreBasedRegister(State state, Optional<String> metastoreURI) throws IOException {
     super(state);
 
-    this.optimizedChecks = state.getPropAsBoolean("gobblin.test.optimize", false);
+    this.optimizedChecks = state.getPropAsBoolean(this.OPTIMIZED_CHECK_ENABLED, true);
 
     GenericObjectPoolConfig config = new GenericObjectPoolConfig();
     config.setMaxTotal(this.props.getNumThreads());

--- a/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
+++ b/gobblin-hive-registration/src/main/java/gobblin/hive/metastore/HiveMetaStoreBasedRegister.java
@@ -91,7 +91,14 @@ public class HiveMetaStoreBasedRegister extends HiveRegister {
   public static final String GET_HIVE_TABLE = HIVE_REGISTER_METRICS_PREFIX + "getTableTimer";
   public static final String DROP_TABLE = HIVE_REGISTER_METRICS_PREFIX + "dropTableTimer";
   public static final String PATH_REGISTER_TIMER = HIVE_REGISTER_METRICS_PREFIX + "pathRegisterTimer";
-  public static final String OPTIMIZED_CHECK_ENABLED = "hiveRegister.doubleLockPatternCheck.enabled";
+  /**
+   * To reduce lock aquisition and RPC to metaStoreClient, we cache the result of query regarding to
+   * the existence of databases and tables in {@link #dbsExist} and {@link #tbsExist} respectively,
+   * so that for databases/tables existed in cache, a RPC for query the existence can be saved.
+   *
+   * We make this optimization configurable by setting {@link #OPTIMIZED_CHECK_ENABLED} to be true.
+   */
+  public static final String OPTIMIZED_CHECK_ENABLED = "hiveRegister.cacheDbTableExistence";
 
   private final HiveMetastoreClientPool clientPool;
   private final HiveLock locks = new HiveLock();


### PR DESCRIPTION
1. Implemented a database status map to cache the check result of hive database / tables. `hiveRegister.doubleLockPatternCheck.enabled` is the configuration key to enable this optimization.

2. Put some metric for Schema R/w during HiveSpec Computation
(May not be useful now but for future investigation reference) 