### PR TITLE
Fix the failed task hanging issue in compaction flow

### DIFF
--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
@@ -48,6 +48,7 @@ public class MRCompactionTask extends MRTask {
     for (CompactionVerifier verifier : verifiers) {
       if (!verifier.verify(dataset)) {
         log.error("Verification {} for {} is not passed.", verifier.getName(), dataset.datasetURN());
+        this.onMRTaskComplete (false, null);
         return;
       }
     }

--- a/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/mapreduce/MRCompactionTask.java
@@ -62,11 +62,12 @@ public class MRCompactionTask extends MRTask {
         for (CompactionCompleteAction action: actions) {
           action.onCompactionJobComplete(dataset);
         }
+        super.onMRTaskComplete(true, null);
       } catch (IOException e) {
-        throw new RuntimeException(e);
+        super.onMRTaskComplete(false, e);
       }
     } else {
-      super.onMRTaskComplete(isSuccess, throwable);
+      super.onMRTaskComplete(false, throwable);
     }
   }
 

--- a/gobblin-compaction/src/main/java/gobblin/compaction/source/CompactionFailedTask.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/source/CompactionFailedTask.java
@@ -1,7 +1,10 @@
 package gobblin.compaction.source;
 
+import lombok.extern.slf4j.Slf4j;
+
 import gobblin.compaction.suite.CompactionSuite;
 import gobblin.compaction.suite.CompactionSuiteUtils;
+import gobblin.configuration.WorkUnitState;
 import gobblin.dataset.Dataset;
 import gobblin.runtime.TaskContext;
 import gobblin.runtime.task.FailedTask;
@@ -11,6 +14,7 @@ import gobblin.runtime.task.TaskIFace;
  * A task which throws an exception when executed
  * The exception contains dataset information
  */
+@Slf4j
 public class CompactionFailedTask extends FailedTask {
   protected final CompactionSuite suite;
   protected final Dataset dataset;
@@ -24,7 +28,8 @@ public class CompactionFailedTask extends FailedTask {
 
   @Override
   public void run() {
-    throw new RuntimeException("Dataset " + dataset.datasetURN() + " failed");
+    log.error ("Compaction job for " + dataset.datasetURN() + " is failed. Please take a look");
+    this.workingState = WorkUnitState.WorkingState.FAILED;
   }
 
   public static class CompactionFailedTaskFactory extends FailedTaskFactory {

--- a/gobblin-compaction/src/main/java/gobblin/compaction/source/CompactionSource.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/source/CompactionSource.java
@@ -117,8 +117,9 @@ public class CompactionSource implements WorkUnitStreamSource<String, String> {
         Stopwatch stopwatch = Stopwatch.createStarted();
         int threads = this.state.getPropAsInt(CompactionVerifier.COMPACTION_VERIFICATION_THREADS, 5);
         long timeOutInMinute = this.state.getPropAsLong(CompactionVerifier.COMPACTION_VERIFICATION_TIMEOUT_MINUTES, 30);
-
-        while (datasets.size() > 0) {
+        long iterationCountLimit = this.state.getPropAsLong(CompactionVerifier.COMPACTION_VERIFICATION_ITERATION_COUNT_LIMIT, Integer.MAX_VALUE);
+        long iteration = 0;
+        while (datasets.size() > 0 && iteration++ < iterationCountLimit) {
           Iterator<Callable<VerifiedDataset>> verifierIterator =
                   Iterators.transform (datasets.iterator(), new Function<Dataset, Callable<VerifiedDataset>>() {
                     @Override

--- a/gobblin-compaction/src/main/java/gobblin/compaction/verify/CompactionVerifier.java
+++ b/gobblin-compaction/src/main/java/gobblin/compaction/verify/CompactionVerifier.java
@@ -8,6 +8,7 @@ import gobblin.dataset.Dataset;
 public interface CompactionVerifier<D extends Dataset> {
    String COMPACTION_VERIFIER_PREFIX = "compaction-verifier-";
    String COMPACTION_VERIFICATION_TIMEOUT_MINUTES = "compaction.verification.timeoutMinutes";
+   String COMPACTION_VERIFICATION_ITERATION_COUNT_LIMIT = "compaction.verification.iteration.countLimit";
    String COMPACTION_VERIFICATION_THREADS= "compaction.verification.threads";
    boolean verify(D dataset);
    boolean isRetriable ();

--- a/gobblin-compaction/src/test/java/gobblin/compaction/mapreduce/MRCompactionTaskTest.java
+++ b/gobblin-compaction/src/test/java/gobblin/compaction/mapreduce/MRCompactionTaskTest.java
@@ -4,6 +4,7 @@ import com.google.common.io.Files;
 import gobblin.compaction.audit.AuditCountClientFactory;
 import gobblin.compaction.dataset.TimeBasedSubDirDatasetsFinder;
 import gobblin.compaction.source.CompactionSource;
+import gobblin.compaction.suite.TestCompactionSuiteFactories;
 import gobblin.compaction.verify.CompactionAuditCountVerifier;
 import gobblin.compaction.verify.CompactionVerifier;
 import gobblin.compaction.verify.InputRecordCountHelper;
@@ -155,7 +156,8 @@ public class MRCompactionTaskTest {
             .setConfiguration(MRCompactor.COMPACTION_DEST_SUBDIR, "hourly")
             .setConfiguration(MRCompactor.COMPACTION_TMP_DEST_DIR, "/tmp/compaction/" + name)
             .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MAX_TIME_AGO, "3000d")
-            .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MIN_TIME_AGO, "1d");
+            .setConfiguration(TimeBasedSubDirDatasetsFinder.COMPACTION_TIMEBASED_MIN_TIME_AGO, "1d")
+            .setConfiguration(ConfigurationKeys.MAX_TASK_RETRIES_KEY, "0");
 
   }
 
@@ -165,8 +167,12 @@ public class MRCompactionTaskTest {
         .setConfiguration(CompactionAuditCountVerifier.GOBBLIN_TIER, "dummy")
         .setConfiguration(CompactionAuditCountVerifier.ORIGIN_TIER, "dummy")
         .setConfiguration(CompactionAuditCountVerifier.PRODUCER_TIER, "dummy")
-        .setConfiguration(ConfigurationKeys.MAX_TASK_RETRIES_KEY, "0")
         .setConfiguration(CompactionVerifier.COMPACTION_VERIFICATION_ITERATION_COUNT_LIMIT, "2");
+  }
+
+  private EmbeddedGobblin createEmbeddedGobblinForHiveRegistrationFailure (String name, String basePath) {
+    return createEmbeddedGobblin(name, basePath)
+        .setConfiguration(ConfigurationKeys.COMPACTION_SUITE_FACTORY, "HiveRegistrationFailureFactory");
   }
 
    @Test
@@ -175,7 +181,7 @@ public class MRCompactionTaskTest {
      basePath.deleteOnExit();
      GenericRecord r1 = createRandomRecord();
      // verify 24 hours
-     for (int i = 22; i < 25; ++i) {
+     for (int i = 22; i < 24; ++i) {
        String path = "Identity/MemberAccount/minutely/2017/04/03/" + i + "/20_30/run_2017-04-03-10-20";
        File jobDir = new File(basePath, path);
        Assert.assertTrue(jobDir.mkdirs());
@@ -195,7 +201,7 @@ public class MRCompactionTaskTest {
     basePath.deleteOnExit();
     GenericRecord r1 = createRandomRecord();
     // verify 24 hours
-    for (int i = 1; i < 25; ++i) {
+    for (int i = 1; i < 24; ++i) {
       String path = "Identity/MemberAccount/minutely/2017/04/03/" + i + "/20_30/run_2017-04-03-10-20";
       File jobDir = new File(basePath, path);
       Assert.assertTrue(jobDir.mkdirs());
@@ -203,7 +209,31 @@ public class MRCompactionTaskTest {
       writeFileWithContent(jobDir, "file_random", r1, 20);
     }
 
-    EmbeddedGobblin embeddedGobblin = createEmbeddedGobblinForAllFailures("workunit_stream_partial", basePath.getAbsolutePath().toString());
+    EmbeddedGobblin embeddedGobblin = createEmbeddedGobblinForAllFailures("workunit_stream_all_failure", basePath.getAbsolutePath().toString());
+    JobExecutionResult result = embeddedGobblin.run();
+
+    Assert.assertFalse(result.isSuccessful());
+  }
+
+  @Test
+  public void testHiveRegistrationFailure () throws Exception {
+    File basePath = Files.createTempDir();
+    basePath.deleteOnExit();
+    GenericRecord r1 = createRandomRecord();
+
+    // success dataset
+    String path1 = TestCompactionSuiteFactories.DATASET_SUCCESS + "/20_30/run_2017-04-03-10-20";
+    File jobDir1 = new File(basePath, path1);
+    Assert.assertTrue(jobDir1.mkdirs());
+    writeFileWithContent(jobDir1, "file_random", r1, 20);
+
+    // failed dataset
+    String path2 = TestCompactionSuiteFactories.DATASET_FAIL + "/20_30/run_2017-04-03-10-20";
+    File jobDir2 = new File(basePath, path2);
+    Assert.assertTrue(jobDir2.mkdirs());
+    writeFileWithContent(jobDir2, "file_random", r1, 20);
+
+    EmbeddedGobblin embeddedGobblin = createEmbeddedGobblinForHiveRegistrationFailure("hive_registration_failure", basePath.getAbsolutePath().toString());
     JobExecutionResult result = embeddedGobblin.run();
 
     Assert.assertFalse(result.isSuccessful());

--- a/gobblin-compaction/src/test/java/gobblin/compaction/suite/TestCompactionSuiteFactories.java
+++ b/gobblin-compaction/src/test/java/gobblin/compaction/suite/TestCompactionSuiteFactories.java
@@ -1,0 +1,19 @@
+package gobblin.compaction.suite;
+
+import gobblin.annotation.Alias;
+import gobblin.configuration.State;
+
+
+public class TestCompactionSuiteFactories {
+  public static final String DATASET_SUCCESS = "Identity/MemberAccount/minutely/2017/04/03/22";
+  public static final String DATASET_FAIL= "Identity/MemberAccount/minutely/2017/04/03/23";
+  /**
+   * Test hive registration failure
+   */
+  @Alias("HiveRegistrationFailureFactory")
+  public static class HiveRegistrationFailureFactory extends CompactionAvroSuiteFactory {
+    public TestCompactionSuites.HiveRegistrationCompactionSuite createSuite (State state) {
+      return new TestCompactionSuites.HiveRegistrationCompactionSuite(state);
+    }
+  }
+}

--- a/gobblin-compaction/src/test/java/gobblin/compaction/suite/TestCompactionSuites.java
+++ b/gobblin-compaction/src/test/java/gobblin/compaction/suite/TestCompactionSuites.java
@@ -1,0 +1,34 @@
+package gobblin.compaction.suite;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import lombok.extern.slf4j.Slf4j;
+
+import gobblin.compaction.action.CompactionCompleteAction;
+import gobblin.configuration.State;
+import gobblin.dataset.FileSystemDataset;
+
+@Slf4j
+public class TestCompactionSuites {
+
+  /**
+   * Test hive registration failure
+   */
+  public static class HiveRegistrationCompactionSuite extends CompactionAvroSuite {
+
+    public HiveRegistrationCompactionSuite(State state) {
+      super(state);
+    }
+
+    public List<CompactionCompleteAction<FileSystemDataset>> getCompactionCompleteActions() {
+      ArrayList<CompactionCompleteAction<FileSystemDataset>> array = new ArrayList<>();
+      array.add((dataset) -> {
+        log.info ("############# => " + dataset.datasetURN());
+        if (dataset.datasetURN().contains(TestCompactionSuiteFactories.DATASET_FAIL))
+          throw new RuntimeException("test-hive-registration-failure");
+      });
+      return array;
+    }
+  }
+}

--- a/gobblin-compaction/src/test/java/gobblin/compaction/suite/TestCompactionSuites.java
+++ b/gobblin-compaction/src/test/java/gobblin/compaction/suite/TestCompactionSuites.java
@@ -24,7 +24,6 @@ public class TestCompactionSuites {
     public List<CompactionCompleteAction<FileSystemDataset>> getCompactionCompleteActions() {
       ArrayList<CompactionCompleteAction<FileSystemDataset>> array = new ArrayList<>();
       array.add((dataset) -> {
-        log.info ("############# => " + dataset.datasetURN());
         if (dataset.datasetURN().contains(TestCompactionSuiteFactories.DATASET_FAIL))
           throw new RuntimeException("test-hive-registration-failure");
       });

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTask.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTask.java
@@ -26,6 +26,7 @@ import gobblin.runtime.task.BaseAbstractTask;
 import java.io.IOException;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang.exception.ExceptionUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.mapreduce.Job;
 
@@ -70,12 +71,18 @@ public class MRTask extends BaseAbstractTask {
   }
 
   public void onMRTaskComplete (boolean isSuccess, Throwable t) throws RuntimeException {
-    if (isSuccess)
-      log.info ("Successfully run MR job.");
-    else if (t == null)
-      log.info ("Failed to run MR job");
-    else
-      log.info ("Failed to run MR job with exception {}", t.toString());
+    if (isSuccess) {
+      this.workingState = WorkUnitState.WorkingState.SUCCESSFUL;
+    } else if (t == null) {
+      this.workingState = WorkUnitState.WorkingState.FAILED;
+    } else {
+      log.error ("Failed to run MR job with exception {}", ExceptionUtils.getStackTrace(t));
+      this.workingState = WorkUnitState.WorkingState.FAILED;
+    }
+  }
+
+  public void commit() {
+    log.debug ("Mark state " + this.workingState);
   }
 
   @Override
@@ -90,17 +97,14 @@ public class MRTask extends BaseAbstractTask {
 
       if (job.isSuccessful()) {
         this.eventSubmitter.submit(Events.MR_JOB_SUCCESSFUL, Events.JOB_URL, job.getTrackingURL());
-        this.workingState = WorkUnitState.WorkingState.SUCCESSFUL;
         this.onMRTaskComplete(true, null);
       } else {
         this.eventSubmitter.submit(Events.MR_JOB_FAILED, Events.JOB_URL, job.getTrackingURL());
-        this.workingState = WorkUnitState.WorkingState.FAILED;
         this.onMRTaskComplete (false, null);
       }
     } catch (Throwable t) {
       log.error("Failed to run MR job.", t);
       this.eventSubmitter.submit(Events.MR_JOB_FAILED, Events.FAILURE_CONTEXT, t.getMessage());
-      this.workingState = WorkUnitState.WorkingState.FAILED;
       this.onMRTaskComplete (false, t);
     }
   }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTask.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/mapreduce/MRTask.java
@@ -81,8 +81,9 @@ public class MRTask extends BaseAbstractTask {
     }
   }
 
+  @Override
   public void commit() {
-    log.debug ("Mark state " + this.workingState);
+    log.debug ("State is set to {} inside onMRTaskComplete.", this.workingState);
   }
 
   @Override

--- a/gobblin-runtime/src/main/java/gobblin/runtime/task/FailedTask.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/task/FailedTask.java
@@ -1,5 +1,6 @@
 package gobblin.runtime.task;
 
+import gobblin.configuration.WorkUnitState;
 import gobblin.publisher.DataPublisher;
 import gobblin.publisher.NoopPublisher;
 import gobblin.runtime.JobState;
@@ -14,9 +15,13 @@ public class FailedTask extends BaseAbstractTask {
     super(taskContext);
   }
 
+  public void commit() {
+    this.workingState = WorkUnitState.WorkingState.FAILED;
+  }
+
   @Override
   public void run() {
-    throw new RuntimeException();
+    this.workingState = WorkUnitState.WorkingState.FAILED;
   }
 
   public static class FailedWorkUnit extends WorkUnit {


### PR DESCRIPTION
1. Set failed state instead of throwing an exception from FailedTask.java
2. Add failure test case in MRCompactionTaskTest.java
3. Add an upper bound for verification upper bound. Both time (in minutes) and count limit will be checked.