### PR TITLE
Add configurable EventMetadataGenerator that is used to generate addi…

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -185,6 +185,12 @@ public class ConfigurationKeys {
   public static final String REQUIRED_ATRRIBUTES_LIST = "gobblin.template.required_attributes";
 
   /**
+   * Configuration for emitting job events
+   */
+  public static final String EVENT_METADATA_GENERATOR_CLASS_KEY = "event.metadata.generator.class";
+  public static final String DEFAULT_EVENT_METADATA_GENERATOR_CLASS_KEY = "noop";
+
+  /**
    * Configuration properties used internally.
    */
   public static final String JOB_ID_KEY = "job.id";

--- a/gobblin-cluster/src/main/java/gobblin/cluster/ClusterEventMetadataGenerator.java
+++ b/gobblin-cluster/src/main/java/gobblin/cluster/ClusterEventMetadataGenerator.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.cluster;
+
+import java.util.List;
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import gobblin.annotation.Alias;
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.event.TimingEvent;
+import gobblin.runtime.JobContext;
+import gobblin.runtime.TaskState;
+import gobblin.runtime.api.EventMetadataGenerator;
+
+
+/**
+ * {@link EventMetadataGenerator} that outputs the processed message count and error messages
+ * used for job status tracking
+ */
+@Alias("cluster")
+public class ClusterEventMetadataGenerator implements EventMetadataGenerator{
+  public static final String TASK_FAILURE_MESSAGE_KEY = "task.failure.message";
+
+  private JobContext jobContext;
+
+  public ClusterEventMetadataGenerator(JobContext jobContext) {
+    this.jobContext = jobContext;
+  }
+
+  public Map<String, String> getMetadata(String eventName) {
+    switch (eventName) {
+      case TimingEvent.LauncherTimings.JOB_COMPLETE:
+        return ImmutableMap.of("processedCount", Long.toString(getProcessedCount()));
+      case TimingEvent.LauncherTimings.JOB_FAILED:
+        return ImmutableMap.of("message", getTaskFailureExceptions());
+      default:
+        break;
+    }
+
+    return ImmutableMap.of();
+  }
+
+  /**
+   * Get the number of records written by all the writers
+   * @return Sum of the writer records written count across all tasks
+   */
+  private long getProcessedCount() {
+    List<TaskState> taskStates = this.jobContext.getJobState().getTaskStates();
+    long value = 0;
+
+    for (TaskState taskState : taskStates) {
+      value += taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN, 0);
+    }
+
+    return value;
+  }
+
+  /**
+   * Get failure messages
+   * @return The concatenated failure messages from all the task states
+   */
+  private String getTaskFailureExceptions() {
+    StringBuffer sb = new StringBuffer();
+
+    // Add task failure messages in a group followed by task failure exceptions
+    appendTaskStateValues(sb, TASK_FAILURE_MESSAGE_KEY);
+    appendTaskStateValues(sb, ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY);
+
+    return sb.toString();
+  }
+
+  /**
+   * Append values for the given key from all {@link TaskState}s
+   * @param sb a {@link StringBuffer} to hold the output
+   * @param key the key of the values to retrieve
+   */
+  private void appendTaskStateValues(StringBuffer sb, String key) {
+    List<TaskState> taskStates = this.jobContext.getJobState().getTaskStates();
+
+    // Add task failure messages in a group followed by task failure exceptions
+    for (TaskState taskState : taskStates) {
+      if (taskState.contains(key)) {
+        if (sb.length() != 0) {
+          sb.append(",");
+        }
+        sb.append(taskState.getProp(key));
+      }
+    }
+  }
+}
+

--- a/gobblin-cluster/src/test/java/gobblin/cluster/ClusterEventMetadataGeneratorTest.java
+++ b/gobblin-cluster/src/test/java/gobblin/cluster/ClusterEventMetadataGeneratorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.cluster;
+
+import java.util.Map;
+
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import gobblin.configuration.ConfigurationKeys;
+import gobblin.metrics.event.TimingEvent;
+import gobblin.runtime.JobContext;
+import gobblin.runtime.JobState;
+import gobblin.runtime.TaskState;
+
+/**
+ * Unit tests for {@link ClusterEventMetadataGenerator}.
+ */
+@Test(groups = { "gobblin.cluster" })
+public class ClusterEventMetadataGeneratorTest {
+  public final static Logger LOG = LoggerFactory.getLogger(ClusterEventMetadataGeneratorTest.class);
+
+  @Test
+  public void testProcessedCount() throws Exception {
+    JobContext jobContext = Mockito.mock(JobContext.class);
+    JobState jobState = new JobState("jobName", "1234");
+    TaskState taskState1 = new TaskState();
+    TaskState taskState2 = new TaskState();
+
+    taskState1.setTaskId("1");
+    taskState1.setProp(ConfigurationKeys.WRITER_RECORDS_WRITTEN, "1");
+    taskState2.setTaskId("2");
+    taskState2.setProp(ConfigurationKeys.WRITER_RECORDS_WRITTEN, "22");
+
+    jobState.addTaskState(taskState1);
+    jobState.addTaskState(taskState2);
+
+    Mockito.when(jobContext.getJobState()).thenReturn(jobState);
+
+    ClusterEventMetadataGenerator metadataGenerator = new ClusterEventMetadataGenerator(jobContext);
+
+    Map<String, String> metadata;
+
+    // processed count is not in job cancel event
+    metadata = metadataGenerator.getMetadata(TimingEvent.LauncherTimings.JOB_CANCEL);
+    Assert.assertEquals(metadata.get("processedCount"), null);
+
+    // processed count is in job complete event
+    metadata = metadataGenerator.getMetadata(TimingEvent.LauncherTimings.JOB_COMPLETE);
+    Assert.assertEquals(metadata.get("processedCount"), "23");
+  }
+
+  @Test
+  public void testErrorMessage() throws Exception {
+    JobContext jobContext = Mockito.mock(JobContext.class);
+    JobState jobState = new JobState("jobName", "1234");
+    TaskState taskState1 = new TaskState();
+    TaskState taskState2 = new TaskState();
+
+    taskState1.setTaskId("1");
+    taskState1.setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, "exception1");
+    taskState2.setTaskId("2");
+    taskState2.setProp(ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY, "exception2");
+    taskState2.setProp(ClusterEventMetadataGenerator.TASK_FAILURE_MESSAGE_KEY, "failureMessage2");
+
+    jobState.addTaskState(taskState1);
+    jobState.addTaskState(taskState2);
+
+    Mockito.when(jobContext.getJobState()).thenReturn(jobState);
+
+    ClusterEventMetadataGenerator metadataGenerator = new ClusterEventMetadataGenerator(jobContext);
+
+    Map<String, String> metadata;
+
+    // error message is not in job commit event
+    metadata = metadataGenerator.getMetadata(TimingEvent.LauncherTimings.JOB_COMMIT);
+    Assert.assertEquals(metadata.get("message"), null);
+
+    // error message is in job failed event
+    metadata = metadataGenerator.getMetadata(TimingEvent.LauncherTimings.JOB_FAILED);
+    Assert.assertTrue(metadata.get("message").startsWith("failureMessage"));
+    Assert.assertTrue(metadata.get("message").contains("exception1"));
+    Assert.assertTrue(metadata.get("message").contains("exception2"));
+  }
+}

--- a/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/event/EventName.java
+++ b/gobblin-metrics-libs/gobblin-metrics-base/src/main/java/gobblin/metrics/event/EventName.java
@@ -1,0 +1,66 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.metrics.event;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Enum for event names
+ */
+public enum EventName {
+  FULL_JOB_EXECUTION("FullJobExecutionTimer"),
+  WORK_UNITS_CREATION("WorkUnitsCreationTimer"),
+  WORK_UNITS_PREPARATION("WorkUnitsPreparationTimer"),
+  JOB_PREPARE("JobPrepareTimer"),
+  JOB_START("JobStartTimer"),
+  JOB_RUN("JobRunTimer"),
+  JOB_COMMIT("JobCommitTimer"),
+  JOB_CLEANUP("JobCleanupTimer"),
+  JOB_CANCEL("JobCancelTimer"),
+  JOB_COMPLETE("JobCompleteTimer"),
+  JOB_FAILED("JobFailedTimer"),
+  MR_STAGING_DATA_CLEAN("JobMrStagingDataCleanTimer"),
+  UNKNOWN("Unknown");
+
+  // for mapping event id to enum object
+  private static final Map<String,EventName> idMap;
+
+  static {
+    idMap = new HashMap<String, EventName>();
+    for (EventName value : EventName.values()) {
+      idMap.put(value.eventId, value);
+    }
+  }
+
+  private String eventId;
+
+  EventName(String eventId) {
+    this.eventId = eventId;
+  }
+
+  public String getEventId() {
+    return eventId;
+  }
+
+  public static EventName getEnumFromEventId(String eventId) {
+    EventName eventNameEnum = idMap.get(eventId);
+
+    return eventNameEnum == null ? UNKNOWN : eventNameEnum;
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/EventMetadataUtils.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/EventMetadataUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime;
+
+import java.util.List;
+
+import gobblin.configuration.ConfigurationKeys;
+
+
+/**
+ * Utility methods for generating event metadata
+ */
+public class EventMetadataUtils {
+  public static final String TASK_FAILURE_MESSAGE_KEY = "task.failure.message";
+
+  /**
+   * Get the number of records written by all the writers
+   * @return Sum of the writer records written count across all tasks
+   */
+  public static long getProcessedCount(List<TaskState> taskStates) {
+    long value = 0;
+
+    for (TaskState taskState : taskStates) {
+      value += taskState.getPropAsLong(ConfigurationKeys.WRITER_RECORDS_WRITTEN, 0);
+    }
+
+    return value;
+  }
+
+  /**
+   * Get failure messages
+   * @return The concatenated failure messages from all the task states
+   */
+  public static String getTaskFailureExceptions(List<TaskState> taskStates) {
+    StringBuffer sb = new StringBuffer();
+
+    // Add task failure messages in a group followed by task failure exceptions
+    appendTaskStateValues(taskStates, sb, TASK_FAILURE_MESSAGE_KEY);
+    appendTaskStateValues(taskStates, sb, ConfigurationKeys.TASK_FAILURE_EXCEPTION_KEY);
+
+    return sb.toString();
+  }
+
+  /**
+   * Append values for the given key from all {@link TaskState}s
+   * @param sb a {@link StringBuffer} to hold the output
+   * @param key the key of the values to retrieve
+   */
+  private static void appendTaskStateValues(List<TaskState> taskStates, StringBuffer sb, String key) {
+    // Add task failure messages in a group followed by task failure exceptions
+    for (TaskState taskState : taskStates) {
+      if (taskState.contains(key)) {
+        if (sb.length() != 0) {
+          sb.append(",");
+        }
+        sb.append(taskState.getProp(key));
+      }
+    }
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/NoopEventMetadataGenerator.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/NoopEventMetadataGenerator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime;
+
+import java.util.Map;
+
+import com.google.common.collect.ImmutableMap;
+
+import gobblin.annotation.Alias;
+import gobblin.runtime.api.EventMetadataGenerator;
+
+@Alias("noop")
+public class NoopEventMetadataGenerator implements EventMetadataGenerator{
+  JobContext jobContext;
+
+  public NoopEventMetadataGenerator(JobContext jobContext) {
+    this.jobContext = jobContext;
+  }
+
+  public Map<String, String> getMetadata(String eventName) {
+    return ImmutableMap.of();
+  }
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/NoopEventMetadataGenerator.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/NoopEventMetadataGenerator.java
@@ -22,17 +22,12 @@ import java.util.Map;
 import com.google.common.collect.ImmutableMap;
 
 import gobblin.annotation.Alias;
+import gobblin.metrics.event.EventName;
 import gobblin.runtime.api.EventMetadataGenerator;
 
 @Alias("noop")
 public class NoopEventMetadataGenerator implements EventMetadataGenerator{
-  JobContext jobContext;
-
-  public NoopEventMetadataGenerator(JobContext jobContext) {
-    this.jobContext = jobContext;
-  }
-
-  public Map<String, String> getMetadata(String eventName) {
+  public Map<String, String> getMetadata(JobContext jobContext, EventName eventName) {
     return ImmutableMap.of();
   }
 }

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/EventMetadataGenerator.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/EventMetadataGenerator.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package gobblin.runtime.api;
+
+import java.util.Map;
+
+/**
+ * For generating additional event metadata to associate with an event.
+ */
+public interface EventMetadataGenerator {
+  /**
+   * Generate a map of additional metadata for the specified event name.
+   * @param eventName the event name used to determine which additional metadata should be emitted
+   * @return {@link Map} with the additional metadata
+   */
+  Map<String, String> getMetadata(String eventName);
+}

--- a/gobblin-runtime/src/main/java/gobblin/runtime/api/EventMetadataGenerator.java
+++ b/gobblin-runtime/src/main/java/gobblin/runtime/api/EventMetadataGenerator.java
@@ -19,6 +19,9 @@ package gobblin.runtime.api;
 
 import java.util.Map;
 
+import gobblin.metrics.event.EventName;
+import gobblin.runtime.JobContext;
+
 /**
  * For generating additional event metadata to associate with an event.
  */
@@ -28,5 +31,5 @@ public interface EventMetadataGenerator {
    * @param eventName the event name used to determine which additional metadata should be emitted
    * @return {@link Map} with the additional metadata
    */
-  Map<String, String> getMetadata(String eventName);
+  Map<String, String> getMetadata(JobContext jobContext, EventName eventName);
 }


### PR DESCRIPTION
…tional metadata to emit in the timing events. The ClusterEventMetadataGenerator is an implementation of this interface that emits processed record count to the JOB_COMPLETE event and error messages to the JOB_FAILED event.