### PR TITLE
Extract RestResponse from exception and make ResponseHandler aware of Request

### DIFF
--- a/gobblin-core/src/main/java/gobblin/async/AsyncRequest.java
+++ b/gobblin-core/src/main/java/gobblin/async/AsyncRequest.java
@@ -23,6 +23,8 @@ import java.util.List;
 import lombok.Getter;
 import lombok.Setter;
 
+import gobblin.net.Request;
+
 
 /**
  * A type of write request which may batch several records at a time. It encapsulates the
@@ -31,7 +33,7 @@ import lombok.Setter;
  * @param <D> type of data record
  * @param <RQ> type of raw request
  */
-public class AsyncRequest<D, RQ> {
+public class AsyncRequest<D, RQ> implements Request<RQ> {
   @Getter
   private int recordCount = 0;
   @Getter

--- a/gobblin-core/src/main/java/gobblin/net/Request.java
+++ b/gobblin-core/src/main/java/gobblin/net/Request.java
@@ -15,17 +15,14 @@
  * limitations under the License.
  */
 
-package gobblin.http;
-
-import gobblin.net.Request;
+package gobblin.net;
 
 
 /**
- * An interface to handle a response
+ * The request adapter for any kind of request/response model
  *
- * @param <RQ> type of raw request
- * @param <RP> type of response
+ * @param <RQ> the actual type of raw request
  */
-public interface ResponseHandler<RQ, RP> {
-  ResponseStatus handleResponse(Request<RQ> request, RP response);
+public interface Request<RQ> {
+  RQ getRawRequest();
 }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroR2JoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AvroR2JoinConverter.java
@@ -20,10 +20,10 @@ import gobblin.http.HttpRequestResponseRecord;
 import gobblin.http.ResponseHandler;
 import gobblin.http.ResponseStatus;
 import gobblin.r2.R2ClientFactory;
-import gobblin.restli.R2Client;
-import gobblin.restli.R2ResponseStatus;
-import gobblin.restli.R2RestRequestBuilder;
-import gobblin.restli.R2RestResponseHandler;
+import gobblin.r2.R2Client;
+import gobblin.r2.R2ResponseStatus;
+import gobblin.r2.R2RestRequestBuilder;
+import gobblin.r2.R2RestResponseHandler;
 import gobblin.utils.HttpConstants;
 
 
@@ -60,7 +60,7 @@ public class AvroR2JoinConverter extends AvroHttpJoinConverter<RestRequest, Rest
   }
 
   @Override
-  protected ResponseHandler<RestResponse> createResponseHandler(Config config) {
+  protected ResponseHandler<RestRequest, RestResponse> createResponseHandler(Config config) {
     return new R2RestResponseHandler();
   }
 

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/HttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/HttpJoinConverter.java
@@ -47,7 +47,7 @@ public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converte
           .build());
 
   protected HttpClient<RQ, RP> httpClient = null;
-  protected ResponseHandler<RP> responseHandler = null;
+  protected ResponseHandler<RQ, RP> responseHandler = null;
   protected AsyncRequestBuilder<GenericRecord, RQ> requestBuilder = null;
 
   public HttpJoinConverter init(WorkUnitState workUnitState) {
@@ -68,7 +68,7 @@ public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converte
   }
 
   protected abstract HttpClient<RQ, RP>   createHttpClient(Config config, SharedResourcesBroker<GobblinScopeTypes> broker);
-  protected abstract ResponseHandler<RP> createResponseHandler(Config config);
+  protected abstract ResponseHandler<RQ, RP> createResponseHandler(Config config);
   protected abstract AsyncRequestBuilder<GenericRecord, RQ> createRequestBuilder(Config config);
   protected abstract HttpOperation generateHttpOperation (DI inputRecord, State state);
   protected abstract SO convertSchemaImpl (SI inputSchema, WorkUnitState workUnitState) throws SchemaConversionException;
@@ -93,7 +93,7 @@ public abstract class HttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Converte
     try {
       RP response = httpClient.sendRequest(rawRequest);
 
-      ResponseStatus status = responseHandler.handleResponse(response);
+      ResponseStatus status = responseHandler.handleResponse(request, response);
 
 
       switch (status.getType()) {

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpResponseHandler.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/http/ApacheHttpResponseHandler.java
@@ -6,8 +6,11 @@ import java.util.Set;
 
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.util.EntityUtils;
 import lombok.extern.slf4j.Slf4j;
+
+import gobblin.net.Request;
 import gobblin.utils.HttpUtils;
 
 
@@ -21,7 +24,7 @@ import gobblin.utils.HttpUtils;
  * </p>
  */
 @Slf4j
-public class ApacheHttpResponseHandler<RP extends HttpResponse> implements ResponseHandler<RP> {
+public class ApacheHttpResponseHandler<RP extends HttpResponse> implements ResponseHandler<HttpUriRequest, RP> {
   private final Set<String> errorCodeWhitelist;
 
   public ApacheHttpResponseHandler() {
@@ -33,7 +36,7 @@ public class ApacheHttpResponseHandler<RP extends HttpResponse> implements Respo
   }
 
   @Override
-  public ApacheHttpResponseStatus handleResponse(RP response) {
+  public ApacheHttpResponseStatus handleResponse(Request<HttpUriRequest> request, RP response) {
     ApacheHttpResponseStatus status = new ApacheHttpResponseStatus(StatusType.OK);
     int statusCode = response.getStatusLine().getStatusCode();
     status.setStatusCode(statusCode);

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/r2/R2ResponseStatus.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/r2/R2ResponseStatus.java
@@ -1,4 +1,4 @@
-package gobblin.restli;
+package gobblin.r2;
 
 import com.linkedin.data.ByteString;
 

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/r2/R2RestRequestBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/r2/R2RestRequestBuilder.java
@@ -1,4 +1,4 @@
-package gobblin.restli;
+package gobblin.r2;
 
 import java.io.IOException;
 import java.net.URI;
@@ -18,9 +18,7 @@ import com.linkedin.restli.common.ResourceMethod;
 import com.linkedin.restli.common.RestConstants;
 
 import gobblin.http.HttpOperation;
-import gobblin.r2.R2Request;
 import gobblin.utils.HttpUtils;
-import gobblin.async.AsyncRequest;
 import gobblin.async.AsyncRequestBuilder;
 import gobblin.async.BufferedRecord;
 

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/r2/R2RestResponseHandler.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/r2/R2RestResponseHandler.java
@@ -1,13 +1,15 @@
-package gobblin.restli;
+package gobblin.r2;
 
 import java.util.HashSet;
 import java.util.Set;
 
+import com.linkedin.r2.message.rest.RestRequest;
 import com.linkedin.r2.message.rest.RestResponse;
 import lombok.extern.slf4j.Slf4j;
 
 import gobblin.http.ResponseHandler;
 import gobblin.http.StatusType;
+import gobblin.net.Request;
 import gobblin.utils.HttpUtils;
 
 
@@ -21,7 +23,7 @@ import gobblin.utils.HttpUtils;
  * </p>
  */
 @Slf4j
-public class R2RestResponseHandler implements ResponseHandler<RestResponse> {
+public class R2RestResponseHandler implements ResponseHandler<RestRequest, RestResponse> {
 
   public static final String CONTENT_TYPE_HEADER = "Content-Type";
   private final Set<String> errorCodeWhitelist;
@@ -35,7 +37,7 @@ public class R2RestResponseHandler implements ResponseHandler<RestResponse> {
   }
 
   @Override
-  public R2ResponseStatus handleResponse(RestResponse response) {
+  public R2ResponseStatus handleResponse(Request<RestRequest> request, RestResponse response) {
     R2ResponseStatus status = new R2ResponseStatus(StatusType.OK);
     int statusCode = response.getStatus();
     status.setStatusCode(statusCode);

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/AsyncHttpWriter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/AsyncHttpWriter.java
@@ -49,7 +49,7 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
   public static final int DEFAULT_MAX_ATTEMPTS = 3;
 
   private final HttpClient<RQ, RP> httpClient;
-  private final ResponseHandler<RP> responseHandler;
+  private final ResponseHandler<RQ, RP> responseHandler;
   private final AsyncRequestBuilder<D, RQ> requestBuilder;
   private final int maxAttempts;
 
@@ -89,7 +89,7 @@ public class AsyncHttpWriter<D, RQ, RP> extends AbstractAsyncDataWriter<D> {
         }
       }
 
-      ResponseStatus status = responseHandler.handleResponse(response);
+      ResponseStatus status = responseHandler.handleResponse(asyncRequest, response);
       switch (status.getType()) {
         case OK:
           // Write succeeds

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/AsyncHttpWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/AsyncHttpWriterBuilder.java
@@ -61,7 +61,7 @@ public abstract class AsyncHttpWriterBuilder<D, RQ, RP> extends FluentDataWriter
   @Getter
   protected AsyncRequestBuilder<D, RQ> asyncRequestBuilder = null;
   @Getter
-  protected ResponseHandler<RP> responseHandler = null;
+  protected ResponseHandler<RQ, RP> responseHandler = null;
   @Getter
   protected int queueCapacity = AbstractAsyncDataWriter.DEFAULT_BUFFER_CAPACITY;
   @Getter

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/writer/R2RestWriterBuilder.java
@@ -29,9 +29,9 @@ import com.typesafe.config.Config;
 import com.typesafe.config.ConfigFactory;
 
 import gobblin.r2.R2ClientFactory;
-import gobblin.restli.R2Client;
-import gobblin.restli.R2RestRequestBuilder;
-import gobblin.restli.R2RestResponseHandler;
+import gobblin.r2.R2Client;
+import gobblin.r2.R2RestRequestBuilder;
+import gobblin.r2.R2RestResponseHandler;
 import gobblin.utils.HttpConstants;
 import gobblin.utils.HttpUtils;
 

--- a/gobblin-modules/gobblin-http/src/test/java/gobblin/r2/R2RestRequestBuilderTest.java
+++ b/gobblin-modules/gobblin-http/src/test/java/gobblin/r2/R2RestRequestBuilderTest.java
@@ -1,4 +1,4 @@
-package gobblin.restli;
+package gobblin.r2;
 
 import java.io.IOException;
 import java.net.URI;
@@ -19,6 +19,7 @@ import com.linkedin.restli.common.RestConstants;
 import gobblin.HttpTestUtils;
 import gobblin.async.AsyncRequest;
 import gobblin.async.BufferedRecord;
+import gobblin.r2.R2RestRequestBuilder;
 
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.verify;

--- a/gobblin-modules/gobblin-http/src/test/java/gobblin/writer/AsyncHttpWriterTest.java
+++ b/gobblin-modules/gobblin-http/src/test/java/gobblin/writer/AsyncHttpWriterTest.java
@@ -32,6 +32,7 @@ import gobblin.http.ResponseHandler;
 import gobblin.http.ResponseStatus;
 import gobblin.http.StatusType;
 import gobblin.http.ThrottledHttpClient;
+import gobblin.net.Request;
 import gobblin.util.limiter.RateBasedLimiter;
 import gobblin.util.limiter.broker.SharedLimiterFactory;
 
@@ -272,12 +273,12 @@ public class AsyncHttpWriterTest {
     }
   }
 
-  class MockResponseHandler implements ResponseHandler<CloseableHttpResponse> {
+  class MockResponseHandler implements ResponseHandler<HttpUriRequest, CloseableHttpResponse> {
     volatile StatusType type = StatusType.OK;
     int attempts = 0;
 
     @Override
-    public ResponseStatus handleResponse(CloseableHttpResponse response) {
+    public ResponseStatus handleResponse(Request<HttpUriRequest> request, CloseableHttpResponse response) {
       attempts++;
       switch (type) {
         case OK:


### PR DESCRIPTION
## Exception as a way to report http error
A restli service can choose to throw an exception to report an error instead of replying a normal response. Most cases, the R2 client will receive a cause of type `RestException`, which internally contains a valid `RestResponse`

## `Request<RQ>` adapter
Previously, the `ResponseHandler` is agnostic about the request associated with the response. To support rich events emission while handling response, now it is provided with request information.

## Move package restli content to r2
The stuff in the restli package is really about r2. `gobblin-http` module or extension now supports 3 different types of clients: `ApacheHttp`, `ApacheAsyncHttp`, and `R2Client`