### PR TITLE
Deserialize to the outputSchema specified in the convertRecord() call…

### DIFF
--- a/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/converter/LiKafkaByteArrayMsgToAvroConverter.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/converter/LiKafkaByteArrayMsgToAvroConverter.java
@@ -42,10 +42,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class LiKafkaByteArrayMsgToAvroConverter<S> extends ToAvroConverterBase<S, byte[]> {
   KafkaSchemaRegistry schemaRegistry;
+  LiAvroDeserializerBase deserializer;
 
   @Override
   public Converter<S, Schema, byte[], GenericRecord> init(WorkUnitState workUnit) {
     this.schemaRegistry = KafkaSchemaRegistryFactory.getSchemaRegistry(workUnit.getProperties());
+    this.deserializer = new LiAvroDeserializerBase(this.schemaRegistry);
     return this;
   }
 
@@ -66,7 +68,7 @@ public class LiKafkaByteArrayMsgToAvroConverter<S> extends ToAvroConverterBase<S
       throws DataConversionException {
     try {
       String topic = workUnit.getProp(KafkaSource.TOPIC_NAME);
-      GenericRecord record = new LiAvroDeserializerBase(schemaRegistry).deserialize(topic, inputRecord);
+      GenericRecord record = this.deserializer.deserialize(topic, inputRecord, outputSchema);
       return new SingleRecordIterable<>(record);
     } catch (SerializationException e) {
       log.error("Cannot decode one record.", e);

--- a/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/kafka/serialize/LiAvroDeserializerBase.java
+++ b/gobblin-modules/gobblin-kafka-common/src/main/java/gobblin/kafka/serialize/LiAvroDeserializerBase.java
@@ -78,9 +78,10 @@ public class LiAvroDeserializerBase {
    *
    * @param topic topic associated with the data
    * @param data serialized bytes
+   * @param outputSchema the schema to deserialize to. If null then the record schema is used.
    * @return deserialized object
    */
-  public GenericRecord deserialize(String topic, byte[] data)
+  public GenericRecord deserialize(String topic, byte[] data, Schema outputSchema)
       throws SerializationException {
     try {
       // MAGIC_BYTE | schemaId-bytes | avro_payload
@@ -92,6 +93,7 @@ public class LiAvroDeserializerBase {
       Schema schema = _schemaRegistry.getById(schemaId);
       Decoder decoder = DecoderFactory.get().binaryDecoder(data, 1 + MD5Digest.MD5_BYTES_LENGTH,
           data.length - MD5Digest.MD5_BYTES_LENGTH - 1, null);
+      _datumReader.setExpected(outputSchema);
       _datumReader.setSchema(schema);
       try {
         GenericRecord record = _datumReader.read(null, decoder);
@@ -103,6 +105,17 @@ public class LiAvroDeserializerBase {
     } catch (IOException | SchemaRegistryException e) {
       throw new SerializationException("Error during Deserialization", e);
     }
+  }
+
+  /**
+   *
+   * @param topic topic associated with the data
+   * @param data serialized bytes
+   * @return deserialized object
+   */
+  public GenericRecord deserialize(String topic, byte[] data)
+          throws SerializationException {
+    return deserialize(topic, data, null);
   }
 
   public void close() {


### PR DESCRIPTION
… in LiKafkaByteArrayMsgToAvroConverter.
This is required when processing a stream of records with a mix of schema versions. The latest schema needs to be used in this case so that all output records share a schema.