### PR TITLE
Add support for a FlushControlMessage. The DataWriter is modified to …

### DIFF
--- a/gobblin-api/src/main/java/gobblin/records/FlushControlMessageHandler.java
+++ b/gobblin-api/src/main/java/gobblin/records/FlushControlMessageHandler.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.records;
+
+import java.io.Flushable;
+import java.io.IOException;
+
+import gobblin.stream.ControlMessage;
+import gobblin.stream.FlushControlMessage;
+
+
+/**
+ * Flush control message handler that will flush a {@link Flushable} when handling a {@link FlushControlMessage}
+ */
+public class FlushControlMessageHandler implements ControlMessageHandler {
+  Flushable flushable;
+
+  /**
+   * Create a flush control message that will flush the given {@link Flushable}
+   * @param flushable the flushable to flush when a {@link FlushControlMessage} is received
+   */
+  public FlushControlMessageHandler(Flushable flushable) {
+    this.flushable = flushable;
+  }
+
+  @Override
+  public void handleMessage(ControlMessage message) {
+    if (message instanceof FlushControlMessage) {
+      try {
+        flushable.flush();
+      } catch (IOException e) {
+        throw new RuntimeException("Could not flush when handling FlushControlMessage", e);
+      }
+    }
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/source/extractor/Extractor.java
+++ b/gobblin-api/src/main/java/gobblin/source/extractor/Extractor.java
@@ -100,6 +100,13 @@ public interface Extractor<S, D> extends Closeable {
   }
 
   /**
+   * Read an {@link StreamEntity}. By default, just return result of {@link #readRecordEnvelope()}.
+   */
+  default StreamEntity<D> readStreamEntity() throws DataRecordException, IOException {
+    return readRecordEnvelope();
+  }
+
+  /**
    * @param shutdownRequest an {@link AtomicBoolean} that becomes true when a shutdown has been requested.
    * @return a {@link Flowable} with the records from this source. Note the flowable should honor downstream backpressure.
    */
@@ -110,7 +117,7 @@ public interface Extractor<S, D> extends Closeable {
         emitter.onComplete();
       }
       try {
-        RecordEnvelope<D> record = readRecordEnvelope();
+        StreamEntity<D> record = readStreamEntity();
         if (record != null) {
           emitter.onNext(record);
         } else {

--- a/gobblin-api/src/main/java/gobblin/stream/FlushControlMessage.java
+++ b/gobblin-api/src/main/java/gobblin/stream/FlushControlMessage.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.stream;
+
+import lombok.AllArgsConstructor;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+
+
+/**
+ * Control message for flushing writers
+ * @param <D>
+ */
+@AllArgsConstructor
+@EqualsAndHashCode
+public class FlushControlMessage<D> extends ControlMessage<D> {
+  @Getter
+  private final FlushReason flushReason;
+
+  @Override
+  protected StreamEntity<D> buildClone() {
+    return new FlushControlMessage(flushReason);
+  }
+
+  @AllArgsConstructor
+  @EqualsAndHashCode
+  public static class FlushReason {
+    @Getter
+    private final String reason;
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/writer/DataWriter.java
+++ b/gobblin-api/src/main/java/gobblin/writer/DataWriter.java
@@ -18,9 +18,11 @@
 package gobblin.writer;
 
 import java.io.Closeable;
+import java.io.Flushable;
 import java.io.IOException;
 
 import gobblin.records.ControlMessageHandler;
+import gobblin.records.FlushControlMessageHandler;
 import gobblin.stream.RecordEnvelope;
 
 
@@ -31,7 +33,7 @@ import gobblin.stream.RecordEnvelope;
  *
  * @author Yinan Li
  */
-public interface DataWriter<D> extends Closeable {
+public interface DataWriter<D> extends Closeable, Flushable {
 
   /**
    * Write a source data record in Avro format using the given converter.
@@ -83,9 +85,17 @@ public interface DataWriter<D> extends Closeable {
   }
 
   /**
+   * Default handler calls flush on this object when a {@link gobblin.stream.FlushControlMessage} is received
    * @return A {@link ControlMessageHandler}.
    */
   default ControlMessageHandler getMessageHandler() {
-    return ControlMessageHandler.NOOP;
+    return new FlushControlMessageHandler(this);
+  }
+
+  /**
+   * Flush data written by the writer. By default, does nothing.
+   * @throws IOException
+   */
+  default void flush() throws IOException {
   }
 }

--- a/gobblin-core-base/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterDecorator.java
+++ b/gobblin-core-base/src/main/java/gobblin/instrumented/writer/InstrumentedDataWriterDecorator.java
@@ -151,4 +151,9 @@ public class InstrumentedDataWriterDecorator<D> extends InstrumentedDataWriterBa
   public ControlMessageHandler getMessageHandler() {
     return this.embeddedWriter.getMessageHandler();
   }
+
+  @Override
+  public void flush() throws IOException {
+    this.embeddedWriter.flush();
+  }
 }

--- a/gobblin-core-base/src/main/java/gobblin/writer/AsyncWriterManager.java
+++ b/gobblin-core-base/src/main/java/gobblin/writer/AsyncWriterManager.java
@@ -487,6 +487,14 @@ public class AsyncWriterManager<D> implements WatermarkAwareWriter<D>, DataWrite
     log.info("Successfully committed {} records.", recordsWrittenFinal);
   }
 
+  /**
+   * Flush the underlying writer.
+   */
+  @Override
+  public void flush() throws IOException {
+    this.asyncDataWriter.flush();
+  }
+
   public static AsyncWriterManagerBuilder builder() {
     return new AsyncWriterManagerBuilder();
   }

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -110,4 +110,13 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   public boolean isSpeculativeAttemptSafe() {
     return this.writerAttemptIdOptional.isPresent() && this.getClass() == AvroHdfsDataWriter.class;
   }
+
+  /**
+   * Flush the writer
+   * @throws IOException
+   */
+  @Override
+  public void flush() throws IOException {
+    this.writer.flush();
+  }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/ConsoleWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/ConsoleWriter.java
@@ -101,5 +101,12 @@ public class ConsoleWriter<D> implements WatermarkAwareWriter<D> {
     throw new UnsupportedOperationException("This writer does not keep track of uncommitted watermarks");
   }
 
+  /**
+   * Flush console output
+   */
+  @Override
+  public void flush() throws IOException {
+    System.out.flush();
+  }
 }
 

--- a/gobblin-core/src/main/java/gobblin/writer/MetadataWriterWrapper.java
+++ b/gobblin-core/src/main/java/gobblin/writer/MetadataWriterWrapper.java
@@ -154,4 +154,9 @@ public class MetadataWriterWrapper<D> implements DataWriter<Object> {
       throws IOException {
     wrappedWriter.close();
   }
+
+  @Override
+  public void flush() throws IOException {
+    wrappedWriter.flush();
+  }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/RetryWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/RetryWriter.java
@@ -205,4 +205,9 @@ public class RetryWriter<D> extends WatermarkAwareWriterWrapper<D> implements Da
   public ControlMessageHandler getMessageHandler() {
     return this.writer.getMessageHandler();
   }
+
+  @Override
+  public void flush() throws IOException {
+    this.writer.flush();
+  }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/SimpleDataWriter.java
@@ -126,4 +126,13 @@ public class SimpleDataWriter extends FsDataWriter<byte[]> {
   public boolean isSpeculativeAttemptSafe() {
     return this.writerAttemptIdOptional.isPresent() && this.getClass() == SimpleDataWriter.class;
   }
+
+  /**
+   * Flush the staging file
+   * @throws IOException
+   */
+  @Override
+  public void flush() throws IOException {
+    this.stagingFileOutputStream.flush();
+  }
 }

--- a/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/ThrottleWriter.java
@@ -210,4 +210,9 @@ public class ThrottleWriter<D> extends WriterWrapper<D> implements Decorator, Fi
     state.setProp(THROTTLED_TIME_KEY, this.throttledTime);
     return state;
   }
+
+  @Override
+  public void flush() throws IOException {
+    this.writer.flush();
+  }
 }

--- a/gobblin-utility/src/main/java/gobblin/util/test/StdoutWriter.java
+++ b/gobblin-utility/src/main/java/gobblin/util/test/StdoutWriter.java
@@ -64,6 +64,11 @@ public class StdoutWriter<D> implements DataWriter<D> {
     return _numBytesWritten;
   }
 
+  @Override
+  public void flush() throws IOException {
+    System.out.flush();
+  }
+
   public static class Builder<D> extends DataWriterBuilder<Object, D> {
     @Override
     public DataWriter<D> build() throws IOException {


### PR DESCRIPTION
…have a flush() method that defaults to doing nothing. Implementation of the flush() method was added to the DataWriters where an implementation was possible.

Changed Extractor.recordStream() to receive records to process from readStreamEntity(). The default implementation of readStreamEntity() returns the result of readRecordEnvelope().