### PR TITLE
Add support for publishing aggregated writer metrics in the metadata.json optionally produced by BaseDataPublisher.

### DIFF
--- a/gobblin-api/src/main/java/gobblin/writer/FsWriterMetrics.java
+++ b/gobblin-api/src/main/java/gobblin/writer/FsWriterMetrics.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.writer;
+
+import java.io.IOException;
+import java.util.Collection;
+
+import org.codehaus.jackson.map.ObjectMapper;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+
+/**
+ * Metrics that can be stored in workUnitState by filesystem based writers.
+ */
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Slf4j
+public class FsWriterMetrics {
+  // Note: all of these classes are @NoArgsConstructor because Jackson requires
+  // an empty object to construct from JSON
+  @Data
+  @NoArgsConstructor
+  @AllArgsConstructor
+  @Getter
+  public static class FileInfo {
+    String fileName;
+    long numRecords;
+  }
+
+  String writerId;
+  PartitionIdentifier partitionInfo;
+  Collection<FileInfo> fileInfos;
+
+  /**
+   * Serialize this class to Json
+   */
+  public String toJson() {
+    try {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (IOException e) {
+      log.error("IOException serializing FsWriterMetrics as JSON! Returning no metrics", e);
+      return "{}";
+    }
+  }
+
+  /**
+   * Instantiate an object of this class from its JSON representation
+   */
+  public static FsWriterMetrics fromJson(String in) throws IOException {
+    return new ObjectMapper().readValue(in, FsWriterMetrics.class);
+  }
+}

--- a/gobblin-api/src/main/java/gobblin/writer/PartitionIdentifier.java
+++ b/gobblin-api/src/main/java/gobblin/writer/PartitionIdentifier.java
@@ -14,29 +14,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package gobblin.metadata;
+package gobblin.writer;
 
-import gobblin.writer.FsWriterMetrics;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
 
-/**
- * Interface for an object that can merge metadata from several work units together.
- * @param <T> Type of the metadata record that will be merged
- */
-public interface MetadataMerger<T> {
-  /**
-   * Process a metadata record, merging it with all previously processed records.
-   * @param metadata Record to process
-   */
-  void update(T metadata);
-
-  /**
-   * Process a metrics record, merging it with all previously processed records.
-   */
-  void update(FsWriterMetrics metrics);
-
-  /**
-   * Get a metadata record that is a representation of all records passed into update().
-   */
-  T getMergedMetadata();
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class PartitionIdentifier {
+  String partitionKey;
+  int branchId;
 }

--- a/gobblin-api/src/test/java/gobblin/writer/FsWriterMetricsTest.java
+++ b/gobblin-api/src/test/java/gobblin/writer/FsWriterMetricsTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.writer;
+
+import java.io.IOException;
+import java.util.Set;
+
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import com.google.common.collect.ImmutableSet;
+
+
+public class FsWriterMetricsTest {
+  @Test
+  public void testSerialization() throws IOException {
+    final String WRITER_ID = "foobar123";
+    final PartitionIdentifier PARTITION_KEY = new PartitionIdentifier("_partitionInfo", 3);
+    final Set<FsWriterMetrics.FileInfo> FILE_INFOS = ImmutableSet.of(
+        new FsWriterMetrics.FileInfo("file1", 1234),
+        new FsWriterMetrics.FileInfo("file2", 4321)
+    );
+
+    String metricsJson = new FsWriterMetrics(WRITER_ID, PARTITION_KEY, FILE_INFOS).toJson();
+    FsWriterMetrics parsedMetrics = FsWriterMetrics.fromJson(metricsJson);
+
+    Assert.assertEquals(parsedMetrics.writerId, WRITER_ID);
+    Assert.assertEquals(parsedMetrics.partitionInfo, PARTITION_KEY);
+    Assert.assertEquals(parsedMetrics.fileInfos, FILE_INFOS);
+  }
+}

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -151,7 +151,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
 
     this.partitionKey = builder.getPartitionPath(properties);
     if (builder.getPartitionPath(properties) != null) {
-      properties.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + builder.getWriterId(), partitionKey);
+      properties.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + "_" + builder.getWriterId(), partitionKey);
     }
   }
 

--- a/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/FsDataWriter.java
@@ -31,6 +31,7 @@ import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Lists;
 import com.google.common.io.Closer;
 
@@ -59,6 +60,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
 
   public static final String WRITER_INCLUDE_RECORD_COUNT_IN_FILE_NAMES =
       ConfigurationKeys.WRITER_PREFIX + ".include.record.count.in.file.names";
+  public static final String FS_WRITER_METRICS_KEY = "fs_writer_metrics";
 
   protected final State properties;
   protected final String id;
@@ -67,6 +69,7 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
   protected final String fileName;
   protected final FileSystem fs;
   protected final Path stagingFile;
+  protected final String partitionKey;
   private final GlobalMetadata defaultMetadata;
   protected Path outputFile;
   protected final String allOutputFilesPropName;
@@ -146,9 +149,9 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
       this.defaultMetadata.addTransferEncoding(c.getTag());
     }
 
-    String partitionPath = builder.getPartitionPath(properties);
+    this.partitionKey = builder.getPartitionPath(properties);
     if (builder.getPartitionPath(properties) != null) {
-      properties.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + builder.getWriterId(), partitionPath);
+      properties.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + builder.getWriterId(), partitionKey);
     }
   }
 
@@ -275,6 +278,13 @@ public abstract class FsDataWriter<D> implements DataWriter<D>, FinalState, Meta
     } else {
       this.properties.appendToSetProp(this.allOutputFilesPropName, getOutputFilePath());
     }
+
+    FsWriterMetrics metrics = new FsWriterMetrics(
+        this.id,
+        new PartitionIdentifier(this.partitionKey, this.branchId),
+        ImmutableSet.of(new FsWriterMetrics.FileInfo(this.outputFile.getName(), recordsWritten()))
+    );
+    this.properties.setProp(FS_WRITER_METRICS_KEY, metrics.toJson());
   }
 
   private synchronized String addRecordCountToFileName()

--- a/gobblin-core/src/test/java/gobblin/publisher/BaseDataPublisherTest.java
+++ b/gobblin-core/src/test/java/gobblin/publisher/BaseDataPublisherTest.java
@@ -22,10 +22,12 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import java.util.stream.Collectors;
 
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
@@ -41,6 +43,9 @@ import gobblin.configuration.WorkUnitState;
 import gobblin.metadata.MetadataMerger;
 import gobblin.metadata.types.GlobalMetadata;
 import gobblin.util.ForkOperatorUtils;
+import gobblin.writer.FsDataWriter;
+import gobblin.writer.FsWriterMetrics;
+import gobblin.writer.PartitionIdentifier;
 
 
 /**
@@ -192,6 +197,217 @@ public class BaseDataPublisherTest {
   }
 
   @Test
+  public void testWithFsMetricsNoPartitions() throws IOException {
+    File publishPath = Files.createTempDir();
+    try {
+      State s = buildDefaultState(1);
+      String md = new GlobalMetadata().toJson();
+
+      s.removeProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR);
+      s.setProp(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY, "true");
+      s.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, publishPath.getAbsolutePath());
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_APPEND_EXTRACT_TO_FINAL_DIR, "false");
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE, "metadata.json");
+
+      WorkUnitState wuState1 = new WorkUnitState();
+      FsWriterMetrics metrics1 = buildWriterMetrics("foo1.json", null, 0, 10);
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY, metrics1.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      addStateToWorkunit(s, wuState1);
+
+      WorkUnitState wuState2 = new WorkUnitState();
+      FsWriterMetrics metrics3 = buildWriterMetrics("foo3.json", null, 1, 30);
+      wuState2.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      wuState2.setProp(FsDataWriter.FS_WRITER_METRICS_KEY, metrics3.toJson());
+      addStateToWorkunit(s, wuState2);
+
+      WorkUnitState wuState3 = new WorkUnitState();
+      FsWriterMetrics metrics4 = buildWriterMetrics("foo4.json", null, 2, 55);
+      wuState3.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      wuState3.setProp(FsDataWriter.FS_WRITER_METRICS_KEY, metrics4.toJson());
+      addStateToWorkunit(s, wuState3);
+
+      BaseDataPublisher publisher = new BaseDataPublisher(s);
+      publisher.publishMetadata(ImmutableList.of(wuState1, wuState2, wuState3));
+
+      checkMetadata(new File(publishPath.getAbsolutePath(), "metadata.json"), 3, 95,
+          new FsWriterMetrics.FileInfo("foo3.json", 30),
+          new FsWriterMetrics.FileInfo("foo1.json", 10),
+          new FsWriterMetrics.FileInfo("foo4.json", 55));
+    } finally {
+      FileUtils.deleteDirectory(publishPath);
+    }
+  }
+
+  @Test
+  public void testWithFsMetricsAndPartitions() throws IOException {
+    File publishPath = Files.createTempDir();
+    try {
+      File part1 = new File(publishPath, "1-2-3-4");
+      part1.mkdir();
+
+      File part2 = new File(publishPath, "5-6-7-8");
+      part2.mkdir();
+
+      State s = buildDefaultState(1);
+      String md = new GlobalMetadata().toJson();
+
+      s.removeProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR);
+      s.setProp(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY, "true");
+      s.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR, publishPath.getAbsolutePath());
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_APPEND_EXTRACT_TO_FINAL_DIR, "false");
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE, "metadata.json");
+
+      WorkUnitState wuState1 = new WorkUnitState();
+      FsWriterMetrics metrics1 = buildWriterMetrics("foo1.json", "1-2-3-4", 0, 10);
+      FsWriterMetrics metrics2 = buildWriterMetrics("foo1.json", "5-6-7-8",10, 20);
+      wuState1.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY, "1-2-3-4");
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY, metrics1.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + "_0", "1-2-3-4");
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + " _0", metrics2.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + "_1", "5-6-7-8");
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + " _1", metrics2.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      addStateToWorkunit(s, wuState1);
+
+      WorkUnitState wuState2 = new WorkUnitState();
+      FsWriterMetrics metrics3 = buildWriterMetrics("foo3.json", "1-2-3-4", 1, 30);
+      wuState2.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY, "1-2-3-4");
+      wuState2.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      wuState2.setProp(FsDataWriter.FS_WRITER_METRICS_KEY, metrics3.toJson());
+      addStateToWorkunit(s, wuState2);
+
+      WorkUnitState wuState3 = new WorkUnitState();
+      FsWriterMetrics metrics4 = buildWriterMetrics("foo4.json", "5-6-7-8", 2, 55);
+      wuState3.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY, "5-6-7-8");
+      wuState3.setProp(ConfigurationKeys.WRITER_METADATA_KEY, md);
+      wuState3.setProp(FsDataWriter.FS_WRITER_METRICS_KEY, metrics4.toJson());
+      addStateToWorkunit(s, wuState3);
+
+      BaseDataPublisher publisher = new BaseDataPublisher(s);
+      publisher.publishMetadata(ImmutableList.of(wuState1, wuState2, wuState3));
+
+      checkMetadata(new File(part1, "metadata.json"), 2, 40,
+          new FsWriterMetrics.FileInfo("foo3.json", 30),
+          new FsWriterMetrics.FileInfo("foo1.json", 10));
+      checkMetadata(new File(part2, "metadata.json"), 2, 75,
+          new FsWriterMetrics.FileInfo("foo1.json", 20),
+          new FsWriterMetrics.FileInfo("foo4.json", 55));
+    } finally {
+      FileUtils.deleteDirectory(publishPath);
+    }
+  }
+
+  @Test
+  public void testWithFsMetricsBranchesAndPartitions() throws IOException {
+    File publishPaths[] = new File[] {
+        Files.createTempDir(), // branch 0
+        Files.createTempDir(), // branch 1
+    };
+
+    try {
+      List<File[]> branchPaths = Arrays.stream(publishPaths).map(branchPath -> new File[] {
+          new File(branchPath, "1-2-3-4"),
+          new File(branchPath, "5-6-7-8")
+      }).collect(Collectors.toList());
+
+      branchPaths.forEach(partitionPaths -> Arrays.stream(partitionPaths).forEach(File::mkdir));
+
+      State s = buildDefaultState(2);
+      String md = new GlobalMetadata().toJson();
+
+      s.removeProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_DIR);
+      s.setProp(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY + ".0", "true");
+      s.setProp(ConfigurationKeys.DATA_PUBLISH_WRITER_METADATA_KEY + ".1", "true");
+      s.setProp(ConfigurationKeys.WRITER_METADATA_KEY + ".0", md);
+      s.setProp(ConfigurationKeys.WRITER_METADATA_KEY + ".1", md);
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".0", publishPaths[0].getAbsolutePath());
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_FINAL_DIR + ".1", publishPaths[1].getAbsolutePath());
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_APPEND_EXTRACT_TO_FINAL_DIR, "false");
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_APPEND_EXTRACT_TO_FINAL_DIR + ".0", "false");
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_APPEND_EXTRACT_TO_FINAL_DIR + ".1", "false");
+      s.setProp(ConfigurationKeys.DATA_PUBLISHER_METADATA_OUTPUT_FILE, "metadata.json");
+
+      WorkUnitState wuState1 = new WorkUnitState();
+      FsWriterMetrics metrics1 = buildWriterMetrics("foo1.json", "1-2-3-4", 0, 10);
+      FsWriterMetrics metrics2 = buildWriterMetrics("foo1.json", "5-6-7-8",10, 20);
+      wuState1.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + ".0", "1-2-3-4");
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + ".0", metrics1.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + ".0_0", "1-2-3-4");
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + ".0_0", metrics2.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + ".0" + "_1", "5-6-7-8");
+      wuState1.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + ".0_1", metrics2.toJson());
+      wuState1.setProp(ConfigurationKeys.WRITER_METADATA_KEY + ".0", md);
+      addStateToWorkunit(s, wuState1);
+
+      WorkUnitState wuState2 = new WorkUnitState();
+      FsWriterMetrics metrics3 = buildWriterMetrics("foo3.json", "1-2-3-4", 1, 1, 30);
+      wuState2.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + ".1", "1-2-3-4");
+      wuState2.setProp(ConfigurationKeys.WRITER_METADATA_KEY + ".1", md);
+      wuState2.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + ".1", metrics3.toJson());
+      addStateToWorkunit(s, wuState2);
+
+      WorkUnitState wuState3 = new WorkUnitState();
+      FsWriterMetrics metrics4 = buildWriterMetrics("foo4.json", "5-6-7-8", 2, 55);
+      wuState3.setProp(ConfigurationKeys.WRITER_PARTITION_PATH_KEY + ".0", "5-6-7-8");
+      wuState3.setProp(ConfigurationKeys.WRITER_METADATA_KEY + ".0", md);
+      wuState3.setProp(FsDataWriter.FS_WRITER_METRICS_KEY + ".0", metrics4.toJson());
+      addStateToWorkunit(s, wuState3);
+
+      BaseDataPublisher publisher = new BaseDataPublisher(s);
+      publisher.publishMetadata(ImmutableList.of(wuState1, wuState2, wuState3));
+
+      checkMetadata(new File(branchPaths.get(0)[0], "metadata.json.0"), 1, 10,
+          new FsWriterMetrics.FileInfo("foo1.json", 10));
+      checkMetadata(new File(branchPaths.get(0)[1], "metadata.json.0"), 2, 75,
+          new FsWriterMetrics.FileInfo("foo1.json", 20),
+          new FsWriterMetrics.FileInfo("foo4.json", 55));
+      checkMetadata(new File(branchPaths.get(1)[0], "metadata.json.1"), 1, 30,
+          new FsWriterMetrics.FileInfo("foo3.json", 30));
+    } finally {
+      Arrays.stream(publishPaths).forEach(dir -> {
+        try {
+          FileUtils.deleteDirectory(dir);
+        } catch (IOException e) {
+          throw new RuntimeException("IOError");
+        }
+      });
+    }
+  }
+
+  private void checkMetadata(File file, int expectedNumFiles, int expectedNumRecords,
+      FsWriterMetrics.FileInfo... expectedFileInfo)
+      throws IOException {
+    Assert.assertTrue(file.exists(), "Expected file " + file.getAbsolutePath() + " to exist");
+    String contents = IOUtils.toString(new FileInputStream(file), StandardCharsets.UTF_8);
+    GlobalMetadata metadata = GlobalMetadata.fromJson(contents);
+
+    Assert.assertEquals(metadata.getNumFiles(), expectedNumFiles, "# of files do not match");
+    Assert.assertEquals(metadata.getNumRecords(), expectedNumRecords, "# of records do not match");
+    for (FsWriterMetrics.FileInfo fileInfo : expectedFileInfo) {
+      long recordsInMetadata =
+          ((Number) metadata.getFileMetadata(fileInfo.getFileName(), GlobalMetadata.NUM_RECORDS_KEY)).longValue();
+      Assert.assertEquals(recordsInMetadata, fileInfo.getNumRecords(),
+          "# of records in file-level metadata do not match");
+    }
+  }
+
+
+  private FsWriterMetrics buildWriterMetrics(String fileName, String partitionKey, int writerId, int numRecords) {
+    return buildWriterMetrics(fileName, partitionKey, writerId, 0, numRecords);
+  }
+
+  private FsWriterMetrics buildWriterMetrics(String fileName, String partitionKey, int writerId, int branchId, int numRecords) {
+    return new FsWriterMetrics(
+        String.format("writer%d", writerId),
+        new PartitionIdentifier(partitionKey, branchId),
+        ImmutableList.of(new FsWriterMetrics.FileInfo(fileName, numRecords))
+    );
+  }
+
+  @Test
   public void testWithPartitionKey() throws IOException {
     File publishPath = Files.createTempDir();
     try {
@@ -240,6 +456,11 @@ public class BaseDataPublisherTest {
     }
 
     @Override
+    public void update(FsWriterMetrics metrics) {
+
+    }
+
+    @Override
     public String getMergedMetadata() {
       return String.valueOf(sum);
     }
@@ -260,6 +481,11 @@ public class BaseDataPublisherTest {
     @Override
     public String getMergedMetadata() {
       return String.valueOf(product);
+    }
+
+    @Override
+    public void update(FsWriterMetrics metrics) {
+
     }
   }
 

--- a/gobblin-core/src/test/resources/publisher/sample_metadata.json
+++ b/gobblin-core/src/test/resources/publisher/sample_metadata.json
@@ -1,0 +1,18 @@
+{
+  "id": "A6E45F39C936BEE1FF83B42740C0E63D",
+  "dataset": {
+    "Num-Records": 95,
+    "Num-Files": 3
+  },
+  "file": {
+    "foo3.json": {
+      "Num-Records": 30
+    },
+    "foo4.json": {
+      "Num-Records": 55
+    },
+    "foo1.json": {
+      "Num-Records": 10
+    }
+  }
+}

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/types/GlobalMetadata.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/types/GlobalMetadata.java
@@ -58,10 +58,12 @@ public class GlobalMetadata {
 
   private transient boolean markedImmutable;
 
-  private final static String DATASET_URN_KEY = "Dataset-URN";
-  private final static String TRANSFER_ENCODING_KEY = "Transfer-Encoding";
-  private final static String CONTENT_TYPE_KEY = "Content-Type";
-  private final static String INNER_CONTENT_TYPE_KEY = "Inner-Content-Type";
+  public final static String DATASET_URN_KEY = "Dataset-URN";
+  public final static String TRANSFER_ENCODING_KEY = "Transfer-Encoding";
+  public final static String CONTENT_TYPE_KEY = "Content-Type";
+  public final static String INNER_CONTENT_TYPE_KEY = "Inner-Content-Type";
+  public final static String NUM_RECORDS_KEY = "Num-Records";
+  public final static String NUM_FILES_KEY = "Num-Files";
 
 
   /**
@@ -238,6 +240,21 @@ public class GlobalMetadata {
   public String getInnerContentType() {
     return (String)getDatasetMetadata(INNER_CONTENT_TYPE_KEY);
   }
+
+  /**
+   * Convenience method to set the number of files in the dataset
+   */
+  public void setNumOutputFiles(int numFiles) {
+    setDatasetMetadata(NUM_FILES_KEY, numFiles);
+  }
+
+  /**
+   * Convenience method to set the number of records in the dataset
+   */
+  public void setNumRecords(long numRecords) {
+    setDatasetMetadata(NUM_RECORDS_KEY, numRecords);
+  }
+
   /**
    * Get an arbitrary dataset-level metadata key
    */
@@ -275,6 +292,17 @@ public class GlobalMetadata {
     encodings.add(encoding);
 
     setDatasetMetadata(TRANSFER_ENCODING_KEY, encodings);
+  }
+
+  public long getNumRecords() {
+    // When reading from JSON, Jackson could parse as an int so we need to use a more generic type
+    Number numRecords = (Number)getDatasetMetadata(NUM_RECORDS_KEY);
+    return (numRecords != null) ? numRecords.longValue() : 0L;
+  }
+
+  public int getNumFiles() {
+    Integer numFiles = (Integer)getDatasetMetadata(NUM_FILES_KEY);
+    return (numFiles != null)  ? numFiles : 0;
   }
 
   // File-level  metadata

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/types/GlobalMetadataJsonMerger.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/types/GlobalMetadataJsonMerger.java
@@ -19,6 +19,7 @@ package gobblin.metadata.types;
 import java.io.IOException;
 
 import gobblin.metadata.MetadataMerger;
+import gobblin.writer.FsWriterMetrics;
 
 
 /**
@@ -40,6 +41,23 @@ public class GlobalMetadataJsonMerger implements MetadataMerger<String> {
     } catch (IOException e) {
       throw new IllegalArgumentException("Error parsing metadata", e);
     }
+  }
+
+  @Override
+  public void update(FsWriterMetrics metrics) {
+    long numRecords = mergedMetadata.getNumRecords();
+    int numFiles = mergedMetadata.getNumFiles();
+
+    for (FsWriterMetrics.FileInfo fileInfo: metrics.getFileInfos()) {
+      numRecords += fileInfo.getNumRecords();
+      numFiles += 1;
+
+      mergedMetadata.setFileMetadata(fileInfo.getFileName(), GlobalMetadata.NUM_RECORDS_KEY,
+          Long.valueOf(fileInfo.getNumRecords()));
+    }
+
+    mergedMetadata.setNumRecords(numRecords);
+    mergedMetadata.setNumOutputFiles(numFiles);
   }
 
   @Override

--- a/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/types/StaticStringMetadataMerger.java
+++ b/gobblin-modules/gobblin-metadata/src/main/java/gobblin/metadata/types/StaticStringMetadataMerger.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package gobblin.metadata.types;
+
+import gobblin.metadata.MetadataMerger;
+import gobblin.writer.FsWriterMetrics;
+
+
+/**
+ * Metadata 'Merger' that is pre-provisioned with a static string and can not
+ * actually merge data. This is to support backwards-compatible uses cases where a
+ * user specifies metadata in job config and does _not_ want to publish
+ * any other pipeline-produced metadata.
+ */
+public class StaticStringMetadataMerger implements MetadataMerger<String> {
+  private final String metadata;
+
+  public StaticStringMetadataMerger(String staticMetadata) {
+    this.metadata = staticMetadata;
+  }
+
+  @Override
+  public void update(String metadata) {
+    /*
+     * Since we don't know what format the string is in, we also don't know how to
+     * merge anything.
+     */
+    throw new UnsupportedOperationException("Do not know how to merge with other strings!");
+  }
+
+  @Override
+  public void update(FsWriterMetrics metrics) {
+    throw new UnsupportedOperationException("Do not know how to merge FsWriterMetrics");
+  }
+
+  @Override
+  public String getMergedMetadata() {
+    return metadata;
+  }
+}


### PR DESCRIPTION


- Each writer will emit a set of internal writer metric tuples
(writerId, partitionKey, branchId, list of [filename, numRecords in
file]) in its job state. If a PartitionedWriter is being used there may
be multiple keys emitted - it does not try to do any rollup itself

- The BaseDataPublisher will go through each set of writer metrics and
group them by (partitionKey, branchId). An aggregated set of those
metrics will be published to the metadata file in the appropriate output
paths.

- A global Num-Records/Num-Files field is also published as dataset
level metadata for each (partitionKey, branchId) generated by the job