### PR TITLE
 Skip bad record from asynchttpconverter

### DIFF
--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -278,7 +278,7 @@ public class ConfigurationKeys {
   public static final String DEFAULT_CONVERTER_CSV_TO_JSON_ENCLOSEDCHAR = "\0";
   public static final String CONVERTER_AVRO_FIELD_PICK_FIELDS = "converter.avro.fields";
   public static final String CONVERTER_AVRO_JDBC_ENTRY_FIELDS_PAIRS = "converter.avro.jdbc.entry_fields_pairs";
-
+  public static final String CONVERTER_SKIP_FAILED_RECORD = "converter.skipFailedRecord";
 
   /**
    * Fork operator configuration properties.
@@ -322,6 +322,7 @@ public class ConfigurationKeys {
   public static final String WRITER_CODEC_TYPE = WRITER_PREFIX + ".codec.type";
   public static final String WRITER_EAGER_INITIALIZATION_KEY = WRITER_PREFIX + ".eager.initialization";
   public static final String WRITER_PARTITIONER_CLASS = WRITER_PREFIX + ".partitioner.class";
+  public static final String WRITER_SKIP_FAILED_RECORD = WRITER_PREFIX + ".skipFailedRecord";
   public static final boolean DEFAULT_WRITER_EAGER_INITIALIZATION = false;
   public static final String WRITER_GROUP_NAME = WRITER_PREFIX + ".group.name";
   public static final String DEFAULT_WRITER_FILE_BASE_NAME = "part";

--- a/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
+++ b/gobblin-api/src/main/java/gobblin/configuration/ConfigurationKeys.java
@@ -322,7 +322,7 @@ public class ConfigurationKeys {
   public static final String WRITER_CODEC_TYPE = WRITER_PREFIX + ".codec.type";
   public static final String WRITER_EAGER_INITIALIZATION_KEY = WRITER_PREFIX + ".eager.initialization";
   public static final String WRITER_PARTITIONER_CLASS = WRITER_PREFIX + ".partitioner.class";
-  public static final String WRITER_SKIP_FAILED_RECORD = WRITER_PREFIX + ".skipFailedRecord";
+  public static final String WRITER_SKIP_NULL_RECORD = WRITER_PREFIX + ".skipNullRecord";
   public static final boolean DEFAULT_WRITER_EAGER_INITIALIZATION = false;
   public static final String WRITER_GROUP_NAME = WRITER_PREFIX + ".group.name";
   public static final String DEFAULT_WRITER_FILE_BASE_NAME = "part";

--- a/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
+++ b/gobblin-core/src/main/java/gobblin/writer/AvroHdfsDataWriter.java
@@ -54,7 +54,7 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   private final OutputStream stagingFileOutputStream;
   private final DatumWriter<GenericRecord> datumWriter;
   private final DataFileWriter<GenericRecord> writer;
-  private final boolean skipEmptyRecord;
+  private final boolean skipNullRecord;
 
   // Number of records successfully written
   protected final AtomicLong count = new AtomicLong(0);
@@ -72,7 +72,7 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
     this.stagingFileOutputStream = createStagingFileOutputStream();
     this.datumWriter = new GenericDatumWriter<>();
     this.writer = this.closer.register(createDataFileWriter(codecFactory));
-    this.skipEmptyRecord = state.getPropAsBoolean(ConfigurationKeys.CONVERTER_SKIP_FAILED_RECORD, false);
+    this.skipNullRecord = state.getPropAsBoolean(ConfigurationKeys.WRITER_SKIP_NULL_RECORD, false);
   }
 
   public FileSystem getFileSystem() {
@@ -82,7 +82,7 @@ public class AvroHdfsDataWriter extends FsDataWriter<GenericRecord> {
   @Override
   public void write(GenericRecord record) throws IOException {
 
-    if (skipEmptyRecord && record == null) {
+    if (skipNullRecord && record == null) {
       return;
     }
 

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AsyncHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AsyncHttpJoinConverter.java
@@ -31,6 +31,7 @@ import gobblin.http.ResponseStatus;
 import gobblin.net.Request;
 import gobblin.utils.HttpConstants;
 import gobblin.writer.WriteCallback;
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 
 /**
  * This converter converts an input record (DI) to an output record (DO) which
@@ -119,12 +120,14 @@ public abstract class AsyncHttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Asy
           }
         }
 
+        @SuppressWarnings(value = "NP_NONNULL_PARAM_VIOLATION",
+            justification = "CompletableFuture will replace null value with NIL")
         @Override
         public void onFailure(Throwable throwable) {
           log.error ("Http converter on failure with request {}", request.getRawRequest());
 
           if (skipFailedRecord) {
-            AsyncHttpJoinConverterContext.this.future.complete(null);
+            AsyncHttpJoinConverterContext.this.future.complete( null);
           } else {
             AsyncHttpJoinConverterContext.this.future.completeExceptionally(throwable);
           }

--- a/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AsyncHttpJoinConverter.java
+++ b/gobblin-modules/gobblin-http/src/main/java/gobblin/converter/AsyncHttpJoinConverter.java
@@ -54,13 +54,13 @@ public abstract class AsyncHttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Asy
   protected HttpClient<RQ, RP> httpClient = null;
   protected ResponseHandler<RQ, RP> responseHandler = null;
   protected AsyncRequestBuilder<GenericRecord, RQ> requestBuilder = null;
-  protected boolean skipEmtptyRecord;
+  protected boolean skipFailedRecord;
 
   public AsyncHttpJoinConverter init(WorkUnitState workUnitState) {
     super.init(workUnitState);
     Config config = ConfigBuilder.create().loadProps(workUnitState.getProperties(), CONF_PREFIX).build();
     config = config.withFallback(DEFAULT_FALLBACK);
-    skipEmtptyRecord = workUnitState.getPropAsBoolean(ConfigurationKeys.CONVERTER_SKIP_FAILED_RECORD, false);
+    skipFailedRecord = workUnitState.getPropAsBoolean(ConfigurationKeys.CONVERTER_SKIP_FAILED_RECORD, false);
     httpClient = createHttpClient(config, workUnitState.getTaskBroker());
     responseHandler = createResponseHandler(config);
     requestBuilder = createRequestBuilder(config);
@@ -123,7 +123,7 @@ public abstract class AsyncHttpJoinConverter<SI, SO, DI, DO, RQ, RP> extends Asy
         public void onFailure(Throwable throwable) {
           log.error ("Http converter on failure with request {}", request.getRawRequest());
 
-          if (skipEmtptyRecord) {
+          if (skipFailedRecord) {
             AsyncHttpJoinConverterContext.this.future.complete(null);
           } else {
             AsyncHttpJoinConverterContext.this.future.completeExceptionally(throwable);


### PR DESCRIPTION
Some R2 request will fail due to invalid recource id (statusCode 410). Remove these bad request to prevent any retrying logic, which may lead to NPE.